### PR TITLE
WFLY-6610 Default singleton policy capability needs distinct name

### DIFF
--- a/clustering/common/pom.xml
+++ b/clustering/common/pom.xml
@@ -47,43 +47,6 @@
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.threads</groupId>
-            <artifactId>jboss-threads</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.modules</groupId>
-            <artifactId>jboss-modules</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.msc</groupId>
-            <artifactId>jboss-msc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-dmr</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>staxmapper</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.marshalling</groupId>
-            <artifactId>jboss-marshalling-river</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
             <type>pom</type>

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityProvider.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,20 +20,33 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.as.clustering.controller.ResourceServiceBuilder;
-import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.controller.PathAddress;
-import org.wildfly.clustering.singleton.SingletonPolicy;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.msc.service.ServiceName;
 
 /**
+ * Provides a capability instance.
+ * Additionally implements {@link Capability}, delegating all methods to the provided capability instance.
  * @author Paul Ferraro
  */
-public class SingletonPolicyBuilderFactory implements ResourceServiceBuilderFactory<SingletonPolicy> {
+public interface CapabilityProvider extends Capability {
+
+    Capability getCapability();
 
     @Override
-    public ResourceServiceBuilder<SingletonPolicy> createBuilder(PathAddress address) {
-        return new SingletonPolicyBuilder(address.getLastElement().getValue());
+    default RuntimeCapability<Void> getDefinition() {
+        return this.getCapability().getDefinition();
+    }
+
+    @Override
+    default RuntimeCapability<Void> resolve(PathAddress address) {
+        return this.getCapability().resolve(address);
+    }
+
+    @Override
+    default ServiceName getServiceName(PathAddress address) {
+        return this.getCapability().getServiceName(address);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
@@ -28,7 +28,7 @@ import org.wildfly.clustering.service.Requirement;
 import org.jboss.as.controller.OperationContext;
 
 /**
- * {@link CapabilityReferenceRecorder} that delegates to {@link Capability#getRuntimeCapability(org.jboss.as.controller.PathAddress)} to generate the name of the dependent capability.
+ * {@link CapabilityReferenceRecorder} that delegates to {@link Capability#resolve(org.jboss.as.controller.PathAddress)} to generate the name of the dependent capability.
  * @author Paul Ferraro
  */
 public class CapabilityReference implements CapabilityReferenceRecorder {
@@ -48,7 +48,7 @@ public class CapabilityReference implements CapabilityReferenceRecorder {
 
     @Override
     public void addCapabilityRequirements(OperationContext context, String attributeName, String... attributeValues) {
-        String dependentName = this.capability.getRuntimeCapability(context.getCurrentAddress()).getName();
+        String dependentName = this.capability.resolve(context.getCurrentAddress()).getName();
         for (String attributeValue : attributeValues) {
             String requirementName = RuntimeCapability.buildDynamicCapabilityName(this.requirement.getName(), attributeValue);
             context.registerAdditionalCapabilityRequirement(requirementName, dependentName, attributeName);
@@ -57,7 +57,7 @@ public class CapabilityReference implements CapabilityReferenceRecorder {
 
     @Override
     public void removeCapabilityRequirements(OperationContext context, String attributeName, String... attributeValues) {
-        String dependentName = this.capability.getRuntimeCapability(context.getCurrentAddress()).getName();
+        String dependentName = this.capability.resolve(context.getCurrentAddress()).getName();
         for (String attributeValue : attributeValues) {
             String requirementName = RuntimeCapability.buildDynamicCapabilityName(this.requirement.getName(), attributeValue);
             context.deregisterCapabilityRequirement(requirementName, dependentName);
@@ -76,6 +76,6 @@ public class CapabilityReference implements CapabilityReferenceRecorder {
 
     @Override
     public boolean isDynamicDependent() {
-        return true;
+        return this.capability.getDefinition().isDynamicallyNamed();
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CommonUnaryRequirement.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CommonUnaryRequirement.java
@@ -22,25 +22,42 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.wildfly.clustering.service.Requirement;
+import javax.sql.DataSource;
+
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.as.network.SocketBinding;
+import org.wildfly.clustering.service.UnaryRequirement;
 
 /**
- * Enumerates capability requirements for clustering resources
+ * Enumerates common unary requirements for clustering resources
  * @author Paul Ferraro
  */
-public enum RequiredCapability implements Requirement {
-    DATA_SOURCE("org.wildfly.data-source"),
-    OUTBOUND_SOCKET_BINDING("org.wildfly.network.outbound-socket-binding"),
-    SOCKET_BINDING("org.wildfly.network.socket-binding"),
+public enum CommonUnaryRequirement implements UnaryRequirement, UnaryServiceNameFactoryProvider {
+    DATA_SOURCE("org.wildfly.data-source", DataSource.class),
+    OUTBOUND_SOCKET_BINDING("org.wildfly.network.outbound-socket-binding", OutboundSocketBinding.class),
+    SOCKET_BINDING("org.wildfly.network.socket-binding", SocketBinding.class),
     ;
     private final String name;
+    private final Class<?> type;
+    private final UnaryServiceNameFactory factory = new UnaryRequirementServiceNameFactory(this);
 
-    RequiredCapability(String name) {
+    CommonUnaryRequirement(String name, Class<?> type) {
         this.name = name;
+        this.type = type;
     }
 
     @Override
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public Class<?> getType() {
+        return this.type;
+    }
+
+    @Override
+    public UnaryServiceNameFactory getServiceNameFactory() {
+        return this.factory;
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/DefaultableUnaryServiceNameFactoryProvider.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/DefaultableUnaryServiceNameFactoryProvider.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Provides a factory for generating a {@link ServiceName} for a unary requirement
+ * as well as a factory generating a {@link ServiceName} for a default requirement.
+ * @author Paul Ferraro
+ */
+public interface DefaultableUnaryServiceNameFactoryProvider extends UnaryServiceNameFactoryProvider {
+
+    /**
+     * The factory from which to generate a {@link ServiceName} if the requested name is null.
+     * @return a factory for generating service names
+     */
+    ServiceNameFactory getDefaultServiceNameFactory();
+
+    @Override
+    default ServiceName getServiceName(OperationContext context, String name) {
+        return (name != null) ? this.getServiceNameFactory().getServiceName(context, name) : this.getDefaultServiceNameFactory().getServiceName(context);
+    }
+
+    @Override
+    default ServiceName getServiceName(CapabilityServiceSupport support, String name) {
+        return (name != null) ? this.getServiceNameFactory().getServiceName(support, name) : this.getDefaultServiceNameFactory().getServiceName(support);
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
@@ -70,7 +70,7 @@ public class RemoveStepHandler extends AbstractRemoveStepHandler implements Regi
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         PathAddress address = context.getCurrentAddress();
         // The super implementation assumes that the capability name is a simple extension of the base name - we do not.
-        this.descriptor.getCapabilities().forEach(capability -> context.deregisterCapability(capability.getRuntimeCapability(address).getName()));
+        this.descriptor.getCapabilities().forEach(capability -> context.deregisterCapability(capability.resolve(address).getName()));
 
         ModelNode model = resource.getModel();
         ImmutableManagementResourceRegistration registration = context.getResourceRegistration();

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementCapability.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,25 +20,32 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
+import java.util.stream.Stream;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.clustering.service.Requirement;
 
 /**
- * Enumerates capability requirements for singleton resources
+ * Provides a capability definition provider built from a requirement.
  * @author Paul Ferraro
  */
-public enum RequiredCapability implements Requirement {
-    SINGLETON_POLICY("org.wildfly.clustering.singleton.policy"),
-    ;
-    private final String name;
+public class RequirementCapability implements Capability {
 
-    RequiredCapability(String name) {
-        this.name = name;
+    private final RuntimeCapability<Void> definition;
+
+    /**
+     * Creates a new capability based on the specified requirement
+     * @param requirement the requirement basis
+     * @param requirements a list of requirements of this capability
+     */
+    public RequirementCapability(Requirement requirement, Requirement... requirements) {
+        this.definition = RuntimeCapability.Builder.of(requirement.getName(), requirement.getType()).addRequirements(Stream.of(requirements).map(r -> r.getName()).toArray(String[]::new)).build();
     }
 
     @Override
-    public String getName() {
-        return this.name;
+    public RuntimeCapability<Void> getDefinition() {
+        return this.definition;
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementServiceNameFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementServiceNameFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,20 +20,31 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.as.clustering.controller.ResourceServiceBuilder;
-import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
-import org.jboss.as.controller.PathAddress;
-import org.wildfly.clustering.singleton.SingletonElectionPolicy;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.msc.service.ServiceName;
+import org.wildfly.clustering.service.Requirement;
 
 /**
  * @author Paul Ferraro
  */
-public class SimpleElectionPolicyBuilderFactory implements ResourceServiceBuilderFactory<SingletonElectionPolicy> {
+public class RequirementServiceNameFactory implements ServiceNameFactory {
+
+    private final Requirement requirement;
+
+    public RequirementServiceNameFactory(Requirement requirement) {
+        this.requirement = requirement;
+    }
 
     @Override
-    public ResourceServiceBuilder<SingletonElectionPolicy> createBuilder(PathAddress address) {
-        return new SimpleElectionPolicyBuilder(address.getParent().getLastElement().getValue());
+    public ServiceName getServiceName(OperationContext context) {
+        return context.getCapabilityServiceName(this.requirement.getName(), this.requirement.getType());
+    }
+
+    @Override
+    public ServiceName getServiceName(CapabilityServiceSupport support) {
+        return support.getCapabilityServiceName(this.requirement.getName());
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceServiceNameFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceServiceNameFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,20 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.msc.service.Service;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
 
 /**
- * Defines a singleton policy.
+ * Generates the {@link ServiceName} for a resource service.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
+public interface ResourceServiceNameFactory {
     /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
+     * Returns {@link ServiceName} for the specified resource address.
+     * @param address a resource address
+     * @return a server name
      */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
-
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    ServiceName getServiceName(PathAddress address);
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ServiceNameFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ServiceNameFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,20 +20,30 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.as.clustering.controller.ResourceServiceBuilder;
-import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
-import org.jboss.as.controller.PathAddress;
-import org.wildfly.clustering.singleton.SingletonElectionPolicy;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.msc.service.ServiceName;
 
 /**
+ * Factory for generating a {@link ServiceName} for a requirement.
  * @author Paul Ferraro
  */
-public class RandomElectionPolicyBuilderFactory implements ResourceServiceBuilderFactory<SingletonElectionPolicy> {
+public interface ServiceNameFactory {
+    /**
+     * Creates a {@link ServiceName} appropriate for the specified name.
+     * @param context an operation context
+     * @param name a potentially null name
+     * @return a {@link ServiceName}
+     */
+    ServiceName getServiceName(OperationContext context);
 
-    @Override
-    public ResourceServiceBuilder<SingletonElectionPolicy> createBuilder(PathAddress address) {
-        return new RandomElectionPolicyBuilder(address.getParent().getLastElement().getValue());
-    }
+    /**
+     * Creates a {@link ServiceName} appropriate for the specified name.
+     * @param support support for capability services
+     * @param name a potentially null name
+     * @return a {@link ServiceName}
+     */
+    ServiceName getServiceName(CapabilityServiceSupport support);
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ServiceNameFactoryProvider.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ServiceNameFactoryProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,27 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.msc.service.Service;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
 
 /**
- * Defines a singleton policy.
+ * Provides a factory for generating a {@link ServiceName} for a capability.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public interface ServiceNameFactoryProvider extends ServiceNameFactory {
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    ServiceNameFactory getServiceNameFactory();
+
+    @Override
+    default ServiceName getServiceName(OperationContext context) {
+        return this.getServiceNameFactory().getServiceName(context);
+    }
+
+    @Override
+    default ServiceName getServiceName(CapabilityServiceSupport support) {
+        return this.getServiceNameFactory().getServiceName(support);
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,27 +22,31 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.controller.PathAddress;
+import java.util.stream.Stream;
+
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.msc.service.ServiceName;
+import org.wildfly.clustering.service.Requirement;
+import org.wildfly.clustering.service.UnaryRequirement;
 
 /**
- * Interface to be implemented by capability enumerations.
+ * Provides a capability definition provider built from a unary requirement.
  * @author Paul Ferraro
  */
-public interface Capability extends Definable<RuntimeCapability<Void>>, ResourceServiceNameFactory {
+public class UnaryRequirementCapability implements Capability {
+
+    private final RuntimeCapability<Void> definition;
+
     /**
-     * Resolves this capability against the specified path address
-     * @param address a path address
-     * @return a resolved runtime capability
+     * Creates a new capability based on the specified unary requirement
+     * @param requirement the unary requirement basis
+     * @param requirements a list of requirements of this capability
      */
-    default RuntimeCapability<Void> resolve(PathAddress address) {
-        RuntimeCapability<Void> definition = this.getDefinition();
-        return definition.isDynamicallyNamed() ? definition.fromBaseCapability(address.getLastElement().getValue()) : definition;
+    public UnaryRequirementCapability(UnaryRequirement requirement, Requirement... requirements) {
+        this.definition = RuntimeCapability.Builder.of(requirement.getName(), true, requirement.getType()).addRequirements(Stream.of(requirements).map(r -> r.getName()).toArray(String[]::new)).build();
     }
 
     @Override
-    default ServiceName getServiceName(PathAddress address) {
-        return this.resolve(address).getCapabilityServiceName();
+    public RuntimeCapability<Void> getDefinition() {
+        return this.definition;
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementServiceNameFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementServiceNameFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,32 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.msc.service.Service;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.UnaryRequirement;
 
 /**
- * Defines a singleton policy.
+ * Factory for generating a {@link ServiceName} for a {@link UnaryRequirement}.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public class UnaryRequirementServiceNameFactory implements UnaryServiceNameFactory {
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    private final UnaryRequirement requirement;
+
+    public UnaryRequirementServiceNameFactory(UnaryRequirement requirement) {
+        this.requirement = requirement;
+    }
+
+    @Override
+    public ServiceName getServiceName(OperationContext context, String name) {
+        return context.getCapabilityServiceName(this.requirement.resolve(name), this.requirement.getType());
+    }
+
+    @Override
+    public ServiceName getServiceName(CapabilityServiceSupport support, String name) {
+        return support.getCapabilityServiceName(this.requirement.resolve(name));
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryServiceNameFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryServiceNameFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,30 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.msc.service.Service;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
 
 /**
- * Defines a singleton policy.
+ * Factory for generating a {@link ServiceName} for a unary requirement.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
+public interface UnaryServiceNameFactory {
     /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
+     * Creates a {@link ServiceName} appropriate for the specified name.
+     * @param context an operation context
+     * @param name a potentially null name
+     * @return a {@link ServiceName}
      */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+    ServiceName getServiceName(OperationContext context, String name);
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    /**
+     * Creates a {@link ServiceName} appropriate for the specified name.
+     * @param support support for capability services
+     * @param name a potentially null name
+     * @return a {@link ServiceName}
+     */
+    ServiceName getServiceName(CapabilityServiceSupport support, String name);
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryServiceNameFactoryProvider.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryServiceNameFactoryProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,27 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
+package org.jboss.as.clustering.controller;
 
-import org.jboss.msc.service.Service;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
 
 /**
- * Defines a singleton policy.
+ * Provides a factory for generating a {@link ServiceName} for a unary requirement.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public interface UnaryServiceNameFactoryProvider extends UnaryServiceNameFactory {
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    UnaryServiceNameFactory getServiceNameFactory();
+
+    @Override
+    default ServiceName getServiceName(OperationContext context, String name) {
+        return this.getServiceNameFactory().getServiceName(context, name);
+    }
+
+    @Override
+    default ServiceName getServiceName(CapabilityServiceSupport support, String name) {
+        return this.getServiceNameFactory().getServiceName(support, name);
+    }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ChannelTransport.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ChannelTransport.java
@@ -59,7 +59,7 @@ public class ChannelTransport extends JGroupsTransport {
         GlobalConfigurationBuilder builder = new GlobalConfigurationBuilder();
         // WFLY-6685 Prevent Infinispan from registering channel mbeans
         // The JGroups subsystem already does this
-        builder.globalJmxStatistics().disable();
+        builder.globalJmxStatistics().read(config.globalJmxStatistics()).disable();
         // ISPN-4755 workaround
         TransportConfiguration transport = config.transport();
         builder.transport()

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreBuilder.java
@@ -32,8 +32,7 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.jdbc.DatabaseType;
 import org.infinispan.persistence.jdbc.configuration.AbstractJdbcStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.AbstractJdbcStoreConfigurationBuilder;
-import org.jboss.as.clustering.controller.CapabilityDependency;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.clustering.infinispan.DataSourceConnectionFactoryConfigurationBuilder;
 import org.jboss.as.controller.OperationContext;
@@ -41,6 +40,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.service.ValueDependency;
 
 /**
@@ -65,7 +65,7 @@ public abstract class JDBCStoreBuilder<C extends AbstractJdbcStoreConfiguration,
     @Override
     B createStore(OperationContext context, ModelNode model) throws OperationFailedException {
         String dataSource = DATA_SOURCE.getDefinition().resolveModelAttribute(context, model).asString();
-        this.dataSourceDepencency = new CapabilityDependency<>(context, RequiredCapability.DATA_SOURCE, dataSource, DataSource.class);
+        this.dataSourceDepencency = new InjectedValueDependency<>(CommonUnaryRequirement.DATA_SOURCE.getServiceName(context, dataSource), DataSource.class);
         B storeBuilder = new ConfigurationBuilder().persistence().addStore(this.builderClass).dialect(ModelNodes.asEnum(DIALECT.getDefinition().resolveModelAttribute(context, model), DatabaseType.class));
         storeBuilder.connectionFactory(DataSourceConnectionFactoryConfigurationBuilder.class).setDataSourceDependency(this.dataSourceDepencency);
         return storeBuilder;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
@@ -24,11 +24,9 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.Arrays;
 
-import javax.sql.DataSource;
-
 import org.infinispan.persistence.jdbc.DatabaseType;
 import org.jboss.as.clustering.controller.CapabilityReference;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleAttributeConverter;
 import org.jboss.as.clustering.controller.transform.SimpleAttributeConverter.Converter;
@@ -64,12 +62,12 @@ import org.jboss.dmr.ModelType;
 public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinition {
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        DATA_SOURCE("org.wildfly.clustering.infinispan.cache-container.cache.store.jdbc.data-source", DataSource.class),
+        DATA_SOURCE("org.wildfly.clustering.infinispan.cache-container.cache.store.jdbc.data-source"),
         ;
         private final RuntimeCapability<Void> definition;
 
-        Capability(String name, Class<?> serviceType) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(serviceType).build();
+        Capability(String name) {
+            this.definition = RuntimeCapability.Builder.of(name, true).build();
         }
 
         @Override
@@ -78,7 +76,7 @@ public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinitio
         }
 
         @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        public RuntimeCapability<Void> resolve(PathAddress address) {
             PathAddress cacheAddress = address.getParent();
             PathAddress containerAddress = cacheAddress.getParent();
             return this.definition.fromBaseCapability(containerAddress.getLastElement().getValue() + "." + cacheAddress.getLastElement().getValue());
@@ -86,7 +84,7 @@ public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinitio
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DATA_SOURCE("data-source", ModelType.STRING, new CapabilityReference(RequiredCapability.DATA_SOURCE, Capability.DATA_SOURCE)),
+        DATA_SOURCE("data-source", ModelType.STRING, new CapabilityReference(CommonUnaryRequirement.DATA_SOURCE, Capability.DATA_SOURCE)),
         DIALECT("dialect", ModelType.STRING, new EnumValidatorBuilder<>(DatabaseType.class)),
         ;
         private final AttributeDefinition definition;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
@@ -84,7 +84,7 @@ public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinitio
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DATA_SOURCE("data-source", ModelType.STRING, new CapabilityReference(CommonUnaryRequirement.DATA_SOURCE, Capability.DATA_SOURCE)),
+        DATA_SOURCE("data-source", ModelType.STRING, new CapabilityReference(Capability.DATA_SOURCE, CommonUnaryRequirement.DATA_SOURCE)),
         DIALECT("dialect", ModelType.STRING, new EnumValidatorBuilder<>(DatabaseType.class)),
         ;
         private final AttributeDefinition definition;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreBuilder.java
@@ -32,8 +32,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.configuration.cache.StoreConfigurationBuilder;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
-import org.jboss.as.clustering.controller.CapabilityDependency;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -44,6 +43,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.Value;
 import org.wildfly.clustering.service.Dependency;
+import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.service.ValueDependency;
 
 /**
@@ -89,7 +89,7 @@ public class RemoteStoreBuilder extends StoreBuilder {
                 .tcpNoDelay(TCP_NO_DELAY.getDefinition().resolveModelAttribute(context, model).asBoolean())
         ;
         for (String binding : StringListAttributeDefinition.unwrapValue(context, SOCKET_BINDINGS.getDefinition().resolveModelAttribute(context, model))) {
-            this.bindings.add(new CapabilityDependency<>(context, RequiredCapability.OUTBOUND_SOCKET_BINDING, binding, OutboundSocketBinding.class));
+            this.bindings.add(new InjectedValueDependency<>(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING.getServiceName(context, binding), OutboundSocketBinding.class));
         }
         return this.storeBuilder;
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -110,7 +110,7 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
         Attribute(String name) {
             this.definition = new StringListAttributeDefinition.Builder(name)
                     .setAttributeParser(AttributeParsers.COLLECTION)
-                    .setCapabilityReference(new CapabilityReference(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, Capability.OUTBOUND_SOCKET_BINDING))
+                    .setCapabilityReference(new CapabilityReference(Capability.OUTBOUND_SOCKET_BINDING, CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING))
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setMinSize(1)
                     .build();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -28,8 +28,8 @@ import org.infinispan.commons.api.BasicCacheContainer;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.AttributeParsers;
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -51,7 +51,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -69,12 +68,12 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
     static final PathElement PATH = pathElement("remote");
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        OUTBOUND_SOCKET_BINDING("org.wildfly.clustering.infinispan.cache-container.cache.store.remote.outbound-socket-binding", OutboundSocketBinding.class),
+        OUTBOUND_SOCKET_BINDING("org.wildfly.clustering.infinispan.cache-container.cache.store.remote.outbound-socket-binding"),
         ;
         private final RuntimeCapability<Void> definition;
 
-        Capability(String name, Class<?> serviceType) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(serviceType).build();
+        Capability(String name) {
+            this.definition = RuntimeCapability.Builder.of(name, true).build();
         }
 
         @Override
@@ -83,7 +82,7 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
         }
 
         @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        public RuntimeCapability<Void> resolve(PathAddress address) {
             PathAddress cacheAddress = address.getParent();
             PathAddress containerAddress = cacheAddress.getParent();
             return this.definition.fromBaseCapability(containerAddress.getLastElement().getValue() + "." + cacheAddress.getLastElement().getValue());
@@ -111,7 +110,7 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
         Attribute(String name) {
             this.definition = new StringListAttributeDefinition.Builder(name)
                     .setAttributeParser(AttributeParsers.COLLECTION)
-                    .setCapabilityReference(new CapabilityReference(RequiredCapability.OUTBOUND_SOCKET_BINDING, Capability.OUTBOUND_SOCKET_BINDING))
+                    .setCapabilityReference(new CapabilityReference(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, Capability.OUTBOUND_SOCKET_BINDING))
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setMinSize(1)
                     .build();

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
@@ -28,8 +28,8 @@ import java.io.IOException;
 import java.util.Collections;
 
 import org.jboss.as.clustering.controller.Attribute;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.jgroups.subsystem.JGroupsSubsystemInitialization;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
@@ -57,7 +57,7 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
     }
 
     AdditionalInitialization createAdditionalInitialization() {
-        return new JGroupsSubsystemInitialization().require(RequiredCapability.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2");
+        return new JGroupsSubsystemInitialization().require(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2");
     }
 
     // cache container access

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
@@ -25,8 +25,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.jgroups.subsystem.JGroupsSubsystemResourceDefinition;
 import org.jboss.as.clustering.subsystem.ClusteringSubsystemTest;
 import org.jboss.as.controller.PathAddress;
@@ -80,8 +80,8 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
         return new InfinispanSubsystemInitialization()
-                .require(RequiredCapability.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2")
-                .require(RequiredCapability.DATA_SOURCE, "ExampleDS")
+                .require(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2")
+                .require(CommonUnaryRequirement.DATA_SOURCE, "ExampleDS")
                 ;
     }
 

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.jgroups.subsystem.JGroupsSubsystemInitialization;
 import org.jboss.as.connector.subsystems.datasources.DataSourcesExtension;
 import org.jboss.as.controller.ModelVersion;
@@ -106,8 +106,8 @@ public class TransformersTestCase extends OperationTestCaseBase {
                 super.initializeExtraSubystemsAndModel(registry, root, registration, capabilityRegistry);
             }
         }
-                .require(RequiredCapability.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2")
-                .require(RequiredCapability.DATA_SOURCE, "ExampleDS")
+                .require(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, "hotrod-server-1", "hotrod-server-2")
+                .require(CommonUnaryRequirement.DATA_SOURCE, "ExampleDS")
                 ;
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
@@ -27,8 +27,7 @@ import static org.jboss.as.clustering.jgroups.subsystem.ProtocolResourceDefiniti
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jboss.as.clustering.controller.CapabilityDependency;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.controller.OperationContext;
@@ -46,6 +45,7 @@ import org.jboss.msc.value.Value;
 import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
 import org.wildfly.clustering.jgroups.spi.service.ProtocolStackServiceName;
 import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.service.ValueDependency;
 
 /**
@@ -84,7 +84,7 @@ public abstract class AbstractProtocolConfigurationBuilder<P extends ProtocolCon
         this.module = ModelNodes.asModuleIdentifier(MODULE.getDefinition().resolveModelAttribute(context, model));
         String binding = ModelNodes.asString(SOCKET_BINDING.getDefinition().resolveModelAttribute(context, model));
         if (binding != null) {
-            this.socketBinding = new CapabilityDependency<>(context, RequiredCapability.SOCKET_BINDING, binding, SocketBinding.class);
+            this.socketBinding = new InjectedValueDependency<>(CommonUnaryRequirement.SOCKET_BINDING.getServiceName(context, binding), SocketBinding.class);
         }
         for (Property property : ModelNodes.asPropertyList(PROPERTIES.getDefinition().resolveModelAttribute(context, model))) {
             this.properties.put(property.getName(), property.getValue().asString());

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -98,7 +98,7 @@ public abstract class ProtocolResourceDefinition extends ChildResourceDefinition
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(CommonUnaryRequirement.SOCKET_BINDING, Capability.SOCKET_BINDING)),
+        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING)),
         MODULE(ModelDescriptionConstants.MODULE, ModelType.STRING, new ModelNode(ProtocolConfiguration.DEFAULT_MODULE.getName()), new ModuleIdentifierValidatorBuilder()),
         PROPERTIES(ModelDescriptionConstants.PROPERTIES),
         ;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -26,8 +26,8 @@ import org.jboss.as.clustering.controller.AttributeMarshallers;
 import org.jboss.as.clustering.controller.AttributeParsers;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
@@ -57,7 +57,6 @@ import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
@@ -78,12 +77,12 @@ public abstract class ProtocolResourceDefinition extends ChildResourceDefinition
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        SOCKET_BINDING("org.wildfly.clustering.protocol.socket-binding", SocketBinding.class),
+        SOCKET_BINDING("org.wildfly.clustering.protocol.socket-binding"),
         ;
         private final RuntimeCapability<Void> definition;
 
-        Capability(String name, Class<?> serviceType) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(serviceType).build();
+        Capability(String name) {
+            this.definition = RuntimeCapability.Builder.of(name, true).build();
         }
 
         @Override
@@ -92,14 +91,14 @@ public abstract class ProtocolResourceDefinition extends ChildResourceDefinition
         }
 
         @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        public RuntimeCapability<Void> resolve(PathAddress address) {
             PathAddress stackAddress = address.getParent();
             return this.definition.fromBaseCapability(stackAddress.getLastElement().getValue() + "." + address.getLastElement().getValue());
         }
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(RequiredCapability.SOCKET_BINDING, Capability.SOCKET_BINDING)),
+        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(CommonUnaryRequirement.SOCKET_BINDING, Capability.SOCKET_BINDING)),
         MODULE(ModelDescriptionConstants.MODULE, ModelType.STRING, new ModelNode(ProtocolConfiguration.DEFAULT_MODULE.getName()), new ModuleIdentifierValidatorBuilder()),
         PROPERTIES(ModelDescriptionConstants.PROPERTIES),
         ;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
@@ -24,8 +24,7 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.clustering.jgroups.subsystem.TransportResourceDefinition.Attribute.*;
 
-import org.jboss.as.clustering.controller.CapabilityDependency;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -35,6 +34,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.clustering.jgroups.spi.TransportConfiguration;
 import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.service.ValueDependency;
 
 /**
@@ -89,7 +89,7 @@ public class TransportConfigurationBuilder extends AbstractProtocolConfiguration
 
         String diagnosticsBinding = ModelNodes.asString(DIAGNOSTICS_SOCKET_BINDING.getDefinition().resolveModelAttribute(context, transport));
         if (diagnosticsBinding != null) {
-            this.diagnosticsSocketBinding = new CapabilityDependency<>(context, RequiredCapability.SOCKET_BINDING, diagnosticsBinding, SocketBinding.class);
+            this.diagnosticsSocketBinding = new InjectedValueDependency<>(CommonUnaryRequirement.SOCKET_BINDING.getServiceName(context, diagnosticsBinding), SocketBinding.class);
         }
 
         for (ThreadPoolResourceDefinition pool : ThreadPoolResourceDefinition.values()) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -117,7 +117,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         @Deprecated SHARED("shared", ModelType.BOOLEAN, new ModelNode(false), JGroupsModel.VERSION_4_0_0),
-        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(CommonUnaryRequirement.SOCKET_BINDING, Capability.DIAGNOSTICS_SOCKET_BINDING)),
+        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(Capability.DIAGNOSTICS_SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING)),
         SITE("site", ModelType.STRING),
         RACK("rack", ModelType.STRING),
         MACHINE("machine", ModelType.STRING),

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -30,10 +30,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.ParentResourceServiceHandler;
 import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -75,7 +75,6 @@ import org.jboss.as.controller.transform.ResourceTransformationContext;
 import org.jboss.as.controller.transform.ResourceTransformer;
 import org.jboss.as.controller.transform.description.AttributeConverter.DefaultValueAttributeConverter;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
@@ -96,12 +95,12 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        DIAGNOSTICS_SOCKET_BINDING("org.wildfly.clustering.transport.diagnostics-socket-binding", SocketBinding.class),
+        DIAGNOSTICS_SOCKET_BINDING("org.wildfly.clustering.transport.diagnostics-socket-binding"),
         ;
         private final RuntimeCapability<Void> definition;
 
-        Capability(String name, Class<?> serviceType) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(serviceType).build();
+        Capability(String name) {
+            this.definition = RuntimeCapability.Builder.of(name, true).build();
         }
 
         @Override
@@ -110,7 +109,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
         }
 
         @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        public RuntimeCapability<Void> resolve(PathAddress address) {
             PathAddress stackAddress = address.getParent();
             return this.definition.fromBaseCapability(stackAddress.getLastElement().getValue() + "." + address.getLastElement().getValue());
         }
@@ -118,7 +117,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         @Deprecated SHARED("shared", ModelType.BOOLEAN, new ModelNode(false), JGroupsModel.VERSION_4_0_0),
-        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(RequiredCapability.SOCKET_BINDING, Capability.DIAGNOSTICS_SOCKET_BINDING)),
+        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(CommonUnaryRequirement.SOCKET_BINDING, Capability.DIAGNOSTICS_SOCKET_BINDING)),
         SITE("site", ModelType.STRING),
         RACK("rack", ModelType.STRING),
         MACHINE("machine", ModelType.STRING),

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -25,8 +25,8 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import java.io.IOException;
 
 import org.jboss.as.clustering.controller.Attribute;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.SimpleAttribute;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
 import org.jboss.as.controller.PathAddress;
@@ -275,7 +275,7 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
     }
 
     protected KernelServices buildKernelServices() throws Exception {
-        return createKernelServicesBuilder(new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "new-socket-binding")).setSubsystemXml(this.getSubsystemXml()).build();
+        return createKernelServicesBuilder(new AdditionalInitialization().require(CommonUnaryRequirement.SOCKET_BINDING, "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "new-socket-binding")).setSubsystemXml(this.getSubsystemXml()).build();
     }
 
 }

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
@@ -30,8 +30,8 @@ import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
 import org.jboss.as.clustering.subsystem.ClusteringSubsystemTest;
 import org.jboss.as.controller.PathAddress;
@@ -96,7 +96,7 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
-        return new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "jgroups-udp", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
+        return new AdditionalInitialization().require(CommonUnaryRequirement.SOCKET_BINDING, "jgroups-udp", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
     }
 
     /**

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
@@ -79,7 +79,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     protected AdditionalInitialization createAdditionalInitialization() {
-        return new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "jgroups-tcp", "jgroups-udp", "jgroups-udp-fd", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
+        return new AdditionalInitialization().require(CommonUnaryRequirement.SOCKET_BINDING, "jgroups-tcp", "jgroups-udp", "jgroups-udp-fd", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
     }
 
     @Test

--- a/clustering/service/src/main/java/org/wildfly/clustering/service/DefaultableUnaryRequirement.java
+++ b/clustering/service/src/main/java/org/wildfly/clustering/service/DefaultableUnaryRequirement.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,17 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
-
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
+package org.wildfly.clustering.service;
 
 /**
- * Defines a singleton policy.
+ * Identifies a requirement that provides a service and can reference some default requirement.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public interface DefaultableUnaryRequirement extends UnaryRequirement {
+    Requirement getDefaultRequirement();
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    @Override
+    default Class<?> getType() {
+        return this.getDefaultRequirement().getType();
+    }
 }

--- a/clustering/service/src/main/java/org/wildfly/clustering/service/Requirement.java
+++ b/clustering/service/src/main/java/org/wildfly/clustering/service/Requirement.java
@@ -23,10 +23,19 @@
 package org.wildfly.clustering.service;
 
 /**
- * Identifies a requirement.
+ * Identifies a requirement that provides a service.
  * @author Paul Ferraro
  */
 public interface Requirement {
-
+    /**
+     * The base name of this requirement.
+     * @return the requirement name.
+     */
     String getName();
+
+    /**
+     * The value type of the service provided by this requirement.
+     * @return a service value type
+     */
+    Class<?> getType();
 }

--- a/clustering/service/src/main/java/org/wildfly/clustering/service/UnaryRequirement.java
+++ b/clustering/service/src/main/java/org/wildfly/clustering/service/UnaryRequirement.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.singleton;
-
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
+package org.wildfly.clustering.service;
 
 /**
- * Defines a singleton policy.
+ * Identifies a requirement that provides a service.
+ * Includes a unary function for resolving its name.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public interface UnaryRequirement extends Requirement {
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    default String resolve(String name) {
+        return this.getName() + "." + name;
+    }
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonDefaultRequirement.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonDefaultRequirement.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,19 +20,32 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.clustering.controller;
+package org.wildfly.clustering.singleton;
 
-import org.jboss.as.controller.OperationContext;
-import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.service.Requirement;
 
 /**
- * Service dependency whose provided value is supplied by a {@link Capability}.
+ * Enumerates capability requirements for default singleton resources
  * @author Paul Ferraro
  */
-public class CapabilityDependency<T> extends InjectedValueDependency<T> {
+public enum SingletonDefaultRequirement implements Requirement {
+    SINGLETON_POLICY("org.wildfly.clustering.singleton.default-policy", SingletonPolicy.class),
+    ;
+    private final String name;
+    private final Class<?> type;
 
-    public CapabilityDependency(OperationContext context, Requirement requirement, String name, Class<T> targetClass) {
-        super(context.getCapabilityServiceName(requirement.getName(), name, targetClass), targetClass);
+    SingletonDefaultRequirement(String name, Class<?> type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Class<?> getType() {
+        return this.type;
     }
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonRequirement.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonRequirement.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,19 +22,30 @@
 
 package org.wildfly.clustering.singleton;
 
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.DefaultableUnaryRequirement;
+import org.wildfly.clustering.service.Requirement;
 
 /**
- * Defines a singleton policy.
  * @author Paul Ferraro
  */
-public interface SingletonPolicy {
-    /**
-     * @deprecated Use {@link SingletonRequirement#SINGLETON_POLICY} instead.
-     */
-    @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
+public enum SingletonRequirement implements DefaultableUnaryRequirement {
+    SINGLETON_POLICY("org.wildfly.clustering.singleton.policy", SingletonDefaultRequirement.SINGLETON_POLICY),
+    ;
+    private final String name;
+    private final Requirement defaultRequirement;
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    SingletonRequirement(String name, Requirement defaultRequirement) {
+        this.name = name;
+        this.defaultRequirement = defaultRequirement;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Requirement getDefaultRequirement() {
+        return this.defaultRequirement;
+    }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyBuilder.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyBuilder.java
@@ -27,12 +27,12 @@ import static org.wildfly.extension.clustering.singleton.ElectionPolicyResourceD
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.jboss.as.clustering.controller.CapabilityDependency;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
@@ -42,6 +42,7 @@ import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.Value;
 import org.wildfly.clustering.service.Builder;
 import org.wildfly.clustering.service.Dependency;
+import org.wildfly.clustering.service.InjectedValueDependency;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 import org.wildfly.clustering.singleton.election.NamePreference;
 import org.wildfly.clustering.singleton.election.Preference;
@@ -57,8 +58,8 @@ public abstract class ElectionPolicyBuilder extends ElectionPolicyServiceNamePro
     private final List<Preference> preferences = new CopyOnWriteArrayList<>();
     private final List<Dependency> dependencies = new CopyOnWriteArrayList<>();
 
-    protected ElectionPolicyBuilder(String name) {
-        super(name);
+    protected ElectionPolicyBuilder(PathAddress policyAddress) {
+        super(policyAddress);
     }
 
     @Override
@@ -83,7 +84,7 @@ public abstract class ElectionPolicyBuilder extends ElectionPolicyServiceNamePro
         this.preferences.clear();
         this.dependencies.clear();
         for (String bindingName : ModelNodes.asStringList(SOCKET_BINDING_PREFERENCES.getDefinition().resolveModelAttribute(context, model))) {
-            CapabilityDependency<OutboundSocketBinding> binding = new CapabilityDependency<>(context, RequiredCapability.OUTBOUND_SOCKET_BINDING, bindingName, OutboundSocketBinding.class);
+            InjectedValueDependency<OutboundSocketBinding> binding = new InjectedValueDependency<>(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING.getServiceName(context, bindingName), OutboundSocketBinding.class);
             this.preferences.add(new OutboundSocketBindingPreference(binding));
             this.dependencies.add(binding);
         }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
@@ -24,7 +24,7 @@ package org.wildfly.extension.clustering.singleton;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
-import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.PathAddress;
@@ -32,7 +32,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.network.OutboundSocketBinding;
 
 /**
  * Definition of an election policy resource.
@@ -47,12 +46,12 @@ public abstract class ElectionPolicyResourceDefinition extends ChildResourceDefi
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        SOCKET_BINDING_PREFERENCE("org.wildfly.clustering.singleton.singleton-policy.election-policy.socket-binding-preference", OutboundSocketBinding.class),
+        SOCKET_BINDING_PREFERENCE("org.wildfly.clustering.singleton.singleton-policy.election-policy.socket-binding-preference"),
         ;
         private final RuntimeCapability<Void> definition;
 
-        Capability(String name, Class<?> serviceType) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(serviceType).build();
+        Capability(String name) {
+            this.definition = RuntimeCapability.Builder.of(name, true).build();
         }
 
         @Override
@@ -61,14 +60,14 @@ public abstract class ElectionPolicyResourceDefinition extends ChildResourceDefi
         }
 
         @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        public RuntimeCapability<Void> resolve(PathAddress address) {
             return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue());
         }
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         NAME_PREFERENCES("name-preferences", "socket-binding-preferences"),
-        SOCKET_BINDING_PREFERENCES("socket-binding-preferences", "name-preferences", new CapabilityReference(RequiredCapability.OUTBOUND_SOCKET_BINDING, Capability.SOCKET_BINDING_PREFERENCE)),
+        SOCKET_BINDING_PREFERENCES("socket-binding-preferences", "name-preferences", new CapabilityReference(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, Capability.SOCKET_BINDING_PREFERENCE)),
         ;
         private final AttributeDefinition definition;
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
@@ -67,7 +67,7 @@ public abstract class ElectionPolicyResourceDefinition extends ChildResourceDefi
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         NAME_PREFERENCES("name-preferences", "socket-binding-preferences"),
-        SOCKET_BINDING_PREFERENCES("socket-binding-preferences", "name-preferences", new CapabilityReference(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, Capability.SOCKET_BINDING_PREFERENCE)),
+        SOCKET_BINDING_PREFERENCES("socket-binding-preferences", "name-preferences", new CapabilityReference(Capability.SOCKET_BINDING_PREFERENCE, CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING)),
         ;
         private final AttributeDefinition definition;
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyServiceNameProvider.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyServiceNameProvider.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.clustering.singleton;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.service.ServiceNameProvider;
 
@@ -31,14 +32,14 @@ import org.wildfly.clustering.service.ServiceNameProvider;
  */
 public class ElectionPolicyServiceNameProvider implements ServiceNameProvider {
 
-    private final String name;
+    private final PathAddress policyAddress;
 
-    public ElectionPolicyServiceNameProvider(String name) {
-        this.name = name;
+    public ElectionPolicyServiceNameProvider(PathAddress policyAddress) {
+        this.policyAddress = policyAddress;
     }
 
     @Override
     public ServiceName getServiceName() {
-        return new SingletonPolicyBuilder(this.name).getServiceName().append("election-policy");
+        return SingletonPolicyResourceDefinition.Capability.POLICY.getServiceName(this.policyAddress).append("election-policy");
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyBuilder.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyBuilder.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.clustering.singleton;
 
+import org.jboss.as.controller.PathAddress;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 import org.wildfly.clustering.singleton.election.RandomSingletonElectionPolicy;
 
@@ -30,8 +31,8 @@ import org.wildfly.clustering.singleton.election.RandomSingletonElectionPolicy;
  */
 public class RandomElectionPolicyBuilder extends ElectionPolicyBuilder {
 
-    public RandomElectionPolicyBuilder(String name) {
-        super(name);
+    public RandomElectionPolicyBuilder(PathAddress policyAddress) {
+        super(policyAddress);
     }
 
     @Override

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyResourceDefinition.java
@@ -50,7 +50,7 @@ public class RandomElectionPolicyResourceDefinition extends ElectionPolicyResour
                 .addAttributes(ElectionPolicyResourceDefinition.Attribute.class)
                 .addCapabilities(ElectionPolicyResourceDefinition.Capability.class)
                 ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new RandomElectionPolicyBuilderFactory());
+        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(address -> new RandomElectionPolicyBuilder(address.getParent()));
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
     }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyBuilder.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyBuilder.java
@@ -22,8 +22,11 @@
 
 package org.wildfly.extension.clustering.singleton;
 
+import static org.wildfly.extension.clustering.singleton.SimpleElectionPolicyResourceDefinition.Attribute.*;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.clustering.service.Builder;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
@@ -37,8 +40,8 @@ public class SimpleElectionPolicyBuilder extends ElectionPolicyBuilder {
 
     private volatile int position;
 
-    public SimpleElectionPolicyBuilder(String name) {
-        super(name);
+    public SimpleElectionPolicyBuilder(PathAddress policyAddress) {
+        super(policyAddress);
     }
 
     @Override
@@ -48,7 +51,7 @@ public class SimpleElectionPolicyBuilder extends ElectionPolicyBuilder {
 
     @Override
     public Builder<SingletonElectionPolicy> configure(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.position = SimpleElectionPolicyResourceDefinition.Attribute.POSITION.getDefinition().resolveModelAttribute(context, model).asInt();
+        this.position = POSITION.getDefinition().resolveModelAttribute(context, model).asInt();
         return super.configure(context, model);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyResourceDefinition.java
@@ -75,7 +75,7 @@ public class SimpleElectionPolicyResourceDefinition extends ElectionPolicyResour
                 .addAttributes(ElectionPolicyResourceDefinition.Attribute.class)
                 .addCapabilities(ElectionPolicyResourceDefinition.Capability.class)
                 ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new SimpleElectionPolicyBuilderFactory());
+        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(address -> new SimpleElectionPolicyBuilder(address.getParent()));
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
     }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
@@ -22,26 +22,27 @@
 
 package org.wildfly.extension.clustering.singleton;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.BoottimeAddStepHandler;
+import org.jboss.as.clustering.controller.CapabilityProvider;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
+import org.jboss.as.clustering.controller.RequirementCapability;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SubsystemResourceDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SubsystemRegistration;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.AttributeAccess.Flag;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelType;
-import org.wildfly.clustering.singleton.RequiredCapability;
-import org.wildfly.clustering.singleton.SingletonPolicy;
+import org.wildfly.clustering.service.Requirement;
+import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
+import org.wildfly.clustering.singleton.SingletonRequirement;
 
 /**
  * Definition of the singleton deployer resource.
@@ -51,28 +52,23 @@ public class SingletonResourceDefinition extends SubsystemResourceDefinition {
 
     static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SingletonExtension.SUBSYSTEM_NAME);
 
-    enum Capability implements org.jboss.as.clustering.controller.Capability {
-        DEFAULT_POLICY(RequiredCapability.SINGLETON_POLICY.getName(), SingletonPolicy.class),
+    enum Capability implements CapabilityProvider {
+        DEFAULT_POLICY(SingletonDefaultRequirement.SINGLETON_POLICY),
         ;
-        private final RuntimeCapability<Void> definition;
+        private final org.jboss.as.clustering.controller.Capability capability;
 
-        Capability(String name, Class<?> type) {
-            this.definition = RuntimeCapability.Builder.of(name, false).setServiceType(type).build();
+        Capability(Requirement requirement) {
+            this.capability = new RequirementCapability(requirement);
         }
 
         @Override
-        public RuntimeCapability<Void> getDefinition() {
-            return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
-            return this.getDefinition();
+        public org.jboss.as.clustering.controller.Capability getCapability() {
+            return this.capability;
         }
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DEFAULT("default", ModelType.STRING, new CapabilityReference(RequiredCapability.SINGLETON_POLICY, Capability.DEFAULT_POLICY)),
+        DEFAULT("default", ModelType.STRING, new CapabilityReference(SingletonRequirement.SINGLETON_POLICY, Capability.DEFAULT_POLICY)),
         ;
         private final SimpleAttributeDefinition definition;
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
@@ -68,7 +68,7 @@ public class SingletonResourceDefinition extends SubsystemResourceDefinition {
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DEFAULT("default", ModelType.STRING, new CapabilityReference(SingletonRequirement.SINGLETON_POLICY, Capability.DEFAULT_POLICY)),
+        DEFAULT("default", ModelType.STRING, new CapabilityReference(Capability.DEFAULT_POLICY, SingletonRequirement.SINGLETON_POLICY)),
         ;
         private final SimpleAttributeDefinition definition;
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceHandler.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceHandler.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.extension.clustering.singleton;
 
+import static org.wildfly.extension.clustering.singleton.SingletonResourceDefinition.Attribute.*;
+import static org.wildfly.extension.clustering.singleton.SingletonResourceDefinition.Capability.*;
+
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -34,7 +37,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.service.AliasServiceBuilder;
 import org.wildfly.clustering.singleton.SingletonPolicy;
-import org.wildfly.extension.clustering.singleton.SingletonPolicyResourceDefinition.Capability;
 import org.wildfly.extension.clustering.singleton.deployment.SingletonDeploymentDependencyProcessor;
 import org.wildfly.extension.clustering.singleton.deployment.SingletonDeploymentParsingProcessor;
 import org.wildfly.extension.clustering.singleton.deployment.SingletonDeploymentProcessor;
@@ -62,14 +64,14 @@ public class SingletonServiceHandler implements ResourceServiceHandler {
         };
         context.addStep(step, OperationContext.Stage.RUNTIME);
 
-        String defaultPolicy = SingletonResourceDefinition.Attribute.DEFAULT.getDefinition().resolveModelAttribute(context, model).asString();
-        ServiceName serviceName = Capability.POLICY.getDefinition().getCapabilityServiceName();
-        ServiceName targetServiceName = Capability.POLICY.getDefinition().getCapabilityServiceName(defaultPolicy);
+        String defaultPolicy = DEFAULT.getDefinition().resolveModelAttribute(context, model).asString();
+        ServiceName serviceName = DEFAULT_POLICY.getServiceName(context.getCurrentAddress());
+        ServiceName targetServiceName = SingletonServiceNameFactory.SINGLETON_POLICY.getServiceName(context, defaultPolicy);
         new AliasServiceBuilder<>(serviceName, targetServiceName, SingletonPolicy.class).build(context.getServiceTarget()).install();
     }
 
     @Override
     public void removeServices(OperationContext context, ModelNode model) {
-        context.removeService(Capability.POLICY.getDefinition().getCapabilityServiceName());
+        context.removeService(DEFAULT_POLICY.getServiceName(context.getCurrentAddress()));
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceNameFactory.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceNameFactory.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.clustering.singleton;
+
+import org.jboss.as.clustering.controller.DefaultableUnaryServiceNameFactoryProvider;
+import org.jboss.as.clustering.controller.RequirementServiceNameFactory;
+import org.jboss.as.clustering.controller.ServiceNameFactory;
+import org.jboss.as.clustering.controller.UnaryRequirementServiceNameFactory;
+import org.jboss.as.clustering.controller.UnaryServiceNameFactory;
+import org.wildfly.clustering.service.DefaultableUnaryRequirement;
+import org.wildfly.clustering.singleton.SingletonRequirement;
+
+/**
+ * @author Paul Ferraro
+ */
+public enum SingletonServiceNameFactory implements DefaultableUnaryServiceNameFactoryProvider {
+    SINGLETON_POLICY(SingletonRequirement.SINGLETON_POLICY)
+    ;
+    private final UnaryServiceNameFactory factory;
+    private final ServiceNameFactory defaultFactory;
+
+    SingletonServiceNameFactory(DefaultableUnaryRequirement requirement) {
+        this.factory = new UnaryRequirementServiceNameFactory(requirement);
+        this.defaultFactory = new RequirementServiceNameFactory(requirement.getDefaultRequirement());
+    }
+
+    @Override
+    public UnaryServiceNameFactory getServiceNameFactory() {
+        return this.factory;
+    }
+
+    @Override
+    public ServiceNameFactory getDefaultServiceNameFactory() {
+        return this.defaultFactory;
+    }
+}

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonDeploymentDependencyProcessor.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonDeploymentDependencyProcessor.java
@@ -22,12 +22,14 @@
 
 package org.wildfly.extension.clustering.singleton.deployment;
 
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-import org.wildfly.extension.clustering.singleton.SingletonPolicyBuilder;
+import org.wildfly.extension.clustering.singleton.SingletonServiceNameFactory;
 
 /**
  * DUP that adds a dependency on a configured deployment policy service to the next phase.
@@ -44,7 +46,8 @@ public class SingletonDeploymentDependencyProcessor implements DeploymentUnitPro
         // If this is a sub-deployment, any configuration will be attached to the parent deployment unit
         SingletonDeploymentConfiguration config = ((parent != null) ? parent : unit).getAttachment(CONFIGURATION_KEY);
         if (config != null) {
-            context.addDependency(new SingletonPolicyBuilder(config.getPolicy()).getServiceName(), SingletonDeploymentProcessor.POLICY_KEY);
+            CapabilityServiceSupport support = unit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+            context.addDependency(SingletonServiceNameFactory.SINGLETON_POLICY.getServiceName(support, config.getPolicy()), SingletonDeploymentProcessor.POLICY_KEY);
         }
     }
 

--- a/clustering/singleton/extension/src/test/java/org/wildfly/extension/clustering/singleton/SubsystemParsingTestCase.java
+++ b/clustering/singleton/extension/src/test/java/org/wildfly/extension/clustering/singleton/SubsystemParsingTestCase.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
 import org.jboss.as.clustering.subsystem.ClusteringSubsystemTest;
 import org.jboss.as.controller.PathAddress;
@@ -80,7 +80,7 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
 
     @Override
     protected org.jboss.as.subsystem.test.AdditionalInitialization createAdditionalInitialization() {
-        return new AdditionalInitialization().require(RequiredCapability.OUTBOUND_SOCKET_BINDING, "binding0", "binding1");
+        return new AdditionalInitialization().require(CommonUnaryRequirement.OUTBOUND_SOCKET_BINDING, "binding0", "binding1");
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -136,7 +136,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
-import org.wildfly.clustering.singleton.RequiredCapability;
+import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 import org.wildfly.iiop.openjdk.rmi.DelegatingStubFactoryFactory;
 import org.wildfly.iiop.openjdk.service.CorbaPOAService;
@@ -485,10 +485,10 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         ServiceTarget target = context.getServiceTarget();
         target.addService(RegistryCollectorService.SERVICE_NAME, new RegistryCollectorService<>()).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
         target.addService(CacheFactoryBuilderRegistryService.SERVICE_NAME, new CacheFactoryBuilderRegistryService<>()).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
-        if (context.hasOptionalCapability(RequiredCapability.SINGLETON_POLICY.getName(), CLUSTERED_SINGLETON_CAPABILITY.getName(), null)) {
+        if (context.hasOptionalCapability(SingletonDefaultRequirement.SINGLETON_POLICY.getName(), CLUSTERED_SINGLETON_CAPABILITY.getName(), null)) {
             final ClusteredSingletonServiceCreator singletonBarrierCreator = new ClusteredSingletonServiceCreator();
             target.addService(CLUSTERED_SINGLETON_CAPABILITY.getCapabilityServiceName().append("creator"), singletonBarrierCreator)
-                    .addDependency(context.getCapabilityServiceName(RequiredCapability.SINGLETON_POLICY.getName(), SingletonPolicy.class),
+                    .addDependency(context.getCapabilityServiceName(SingletonDefaultRequirement.SINGLETON_POLICY.getName(), SingletonDefaultRequirement.SINGLETON_POLICY.getType()),
                             SingletonPolicy.class, singletonBarrierCreator.getSingletonPolicy()).install();
         }
     }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.junit.Test;
-import org.wildfly.clustering.singleton.RequiredCapability;
+import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
 
 /**
  * Test case for testing the integrity of the EJB3 subsystem.
@@ -44,7 +44,7 @@ import org.wildfly.clustering.singleton.RequiredCapability;
 public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
     private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities(
-            RequiredCapability.SINGLETON_POLICY.getName());
+            SingletonDefaultRequirement.SINGLETON_POLICY.getName());
 
     public Ejb3SubsystemUnitTestCase() {
         super(EJB3Extension.SUBSYSTEM_NAME, new EJB3Extension());

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
@@ -35,13 +35,13 @@
         <module name="javax.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
+        <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.threads"/>
         <module name="org.wildfly.clustering.service"/>
     </dependencies>
 </module>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServicePolicyActivator.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/MyServicePolicyActivator.java
@@ -29,7 +29,7 @@ import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.value.InjectedValue;
-import org.wildfly.clustering.singleton.RequiredCapability;
+import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 
 /**
@@ -42,7 +42,7 @@ public class MyServicePolicyActivator implements ServiceActivator {
     @Override
     public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
         try {
-            SingletonPolicy policy = (SingletonPolicy) context.getServiceRegistry().getRequiredService(ServiceName.parse(RequiredCapability.SINGLETON_POLICY.getName())).awaitValue();
+            SingletonPolicy policy = (SingletonPolicy) context.getServiceRegistry().getRequiredService(ServiceName.parse(SingletonDefaultRequirement.SINGLETON_POLICY.getName())).awaitValue();
             InjectedValue<ServerEnvironment> env = new InjectedValue<>();
             MyService service = new MyService(env);
             policy.createSingletonServiceBuilder(SERVICE_NAME, service).build(context.getServiceTarget())


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6610

Previously, the "org.wildfly.clustering.singleton.policy" capability was used both to refer to a specific policy (using a dynamic name) and to refer to the default policy (using a static name).

Capability descriptions are here:
https://github.com/wildfly/wildfly-capabilities/pull/4

I've also tidied existing capability-related code in the clustering subsystems, in preparation for WFLY-6602, WFLY-6603, and WFLY-6604 (capability integration for jgroups, infinispan, and clustering api, respectively).
