### PR TITLE
Get mixed domain tests working for EAP 7 slaves

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.domain.mixed;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLONE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
@@ -38,6 +39,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROXIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART;
@@ -55,6 +57,7 @@ import static org.junit.Assert.assertEquals;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.clustering.jgroups.subsystem.JGroupsSubsystemResourceDefinition;
@@ -113,9 +116,12 @@ public abstract class SimpleMixedDomainTest  {
 
     @Test
     public void test00002_Versioning() throws Exception {
-        if (version == Version.AsVersion.EAP_6_2_0) {
-            //6.2.0 has the slave report back its own version, rather than the one from the DC,
-            //which is what happens in more recent slaves
+        if (version == Version.AsVersion.EAP_6_2_0
+                || version == Version.AsVersion.EAP_7_0_0) {
+            //6.2.0 (https://issues.jboss.org/browse/WFLY-3228) and
+            //7.0.0 (https://issues.jboss.org/browse/WFCORE-401)
+            // have the slave report back its own version, rather than the one from the DC,
+            //which is what should happen
             return;
         }
 
@@ -135,6 +141,7 @@ public abstract class SimpleMixedDomainTest  {
         }
 
         cleanupKnownDifferencesInModelsForVersioningCheck(masterModel, slaveModel);
+
         //The version fields should be the same
         assertEquals(masterModel, slaveModel);
     }
@@ -214,19 +221,30 @@ public abstract class SimpleMixedDomainTest  {
     //Do this one last since it changes the host model of the slaves
     @Test
     public void test99999_ProfileClone() throws Exception {
+        if (version.getMajor() == 6) {
+            //EAP 6 does not have the clone operation
+            profileCloneEap6x();
+        } else {
+            //EAP 7 does not have the clone operation
+            profileCloneEap7x();
+        }
+    }
+
+    private void profileCloneEap6x() throws Exception {
+        //EAP 6 does not have the clone operation
         //For an EAP 7 slave we will need another test since EAP 7 allows the clone operation.
         // However EAP 7 will need to take into account the ignore-unused-configuration
         // setting which does not exist in 6.x
         final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
         final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
         try {
-            final PathAddress fullHaAddress = PathAddress.pathAddress(PROFILE, "new-profile");
+            final PathAddress newProfileAddress = PathAddress.pathAddress(PROFILE, "new-profile");
 
             //Create a new profile (so that we can ignore it on the host later)
-            DomainTestUtils.executeForResult(Util.createAddOperation(fullHaAddress), masterClient);
+            DomainTestUtils.executeForResult(Util.createAddOperation(newProfileAddress), masterClient);
 
             //Attempt to clone it. It should fail since the transformers reject it.
-            final ModelNode clone = Util.createEmptyOperation(CLONE, fullHaAddress);
+            final ModelNode clone = Util.createEmptyOperation(CLONE, newProfileAddress);
             clone.get(TO_PROFILE).set("cloned");
             DomainTestUtils.executeForFailure(clone, masterClient);
 
@@ -257,6 +275,48 @@ public abstract class SimpleMixedDomainTest  {
         }
     }
 
+
+    private void profileCloneEap7x() throws Exception {
+        // EAP 7 allows the clone operation.
+        // However EAP 7 will need to take into account the ignore-unused-configuration
+        // setting which does not exist in 6.x
+        final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
+        final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
+        try {
+            final PathAddress newProfileAddress = PathAddress.pathAddress(PROFILE, "new-profile");
+
+            //Create a new profile (so that we can ignore it on the host later)
+            DomainTestUtils.executeForResult(Util.createAddOperation(newProfileAddress), masterClient);
+
+            //Attempt to clone it. It should work but not exist on the slave since unused configuration is ignored
+            final ModelNode clone = Util.createEmptyOperation(CLONE, newProfileAddress);
+            clone.get(TO_PROFILE).set("cloned");
+            DomainTestUtils.executeForResult(clone, masterClient);
+
+            //Check the new profile does not exist on the slave
+            final ModelNode readChildrenNames = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+            readChildrenNames.get(CHILD_TYPE).set(PROFILE);
+            ModelNode result = DomainTestUtils.executeForResult(readChildrenNames, slaveClient);
+            List<ModelNode> list = result.asList();
+            Assert.assertEquals(1, list.size());
+            Assert.assertEquals(list.toString(), "full-ha", list.get(0).asString());
+
+            //Update the server group to use the new profile
+            DomainTestUtils.executeForResult(
+                    Util.getWriteAttributeOperation(PathAddress.pathAddress(SERVER_GROUP, "other-server-group"), PROFILE, "new-profile"),
+                    masterClient);
+
+            //Check the profiles
+            result = DomainTestUtils.executeForResult(readChildrenNames, slaveClient);
+            list = result.asList();
+            Assert.assertEquals(1, list.size());
+            Assert.assertEquals(list.toString(), "new-profile", list.get(0).asString());
+
+        } finally {
+            IoUtils.safeClose(slaveClient);
+            IoUtils.safeClose(masterClient);
+        }
+    }
     /*
         !!!!!!!!! ADD TESTS IN NUMERICAL ORDER !!!!!!!!!!
         Please observe the test<5 digits>_ pattern for the names to ensure the order

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -41,16 +41,24 @@ public @interface Version {
     final String EAP = "jboss-eap-";
 
     enum AsVersion {
-        EAP_6_2_0(EAP, "6.2.0"),
-        EAP_6_3_0(EAP, "6.3.0"),
-        EAP_6_4_0(EAP, "6.4.0");
+        EAP_6_2_0(EAP, 6, 2, 0),
+        EAP_6_3_0(EAP, 6, 3, 0),
+        EAP_6_4_0(EAP, 6, 4, 0),
+        EAP_7_0_0(EAP, 7, 0, 0);
+
 
         final String basename;
+        private final int major;
+        private final int minor;
+        private final int micro;
         final String version;
 
-        AsVersion(String basename, String version){
+        AsVersion(String basename, int major, int minor, int micro){
             this.basename = basename;
-            this.version = version;
+            this.major = major;
+            this.minor = minor;
+            this.micro = micro;
+            this.version = major + "." + minor + "." + micro;
         }
 
         public String getBaseName() {
@@ -67,7 +75,17 @@ public @interface Version {
         public String getZipFileName() {
             return  getFullVersionName() + ".zip";
         }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public int getMicro() {
+            return micro;
+        }
     }
-
-
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/DomainAdjuster640.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/DomainAdjuster640.java
@@ -44,8 +44,8 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.ee.subsystem.EeExtension;
 import org.jboss.as.ejb3.subsystem.EJB3Extension;
 import org.jboss.as.remoting.RemotingExtension;
-import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
 import org.jboss.as.test.integration.domain.mixed.LegacySubsystemConfigurationUtil;
+import org.jboss.as.test.integration.domain.mixed.eap700.DomainAdjuster700;
 import org.jboss.as.weld.WeldExtension;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.batch.jberet.BatchSubsystemDefinition;
@@ -63,11 +63,11 @@ import org.wildfly.iiop.openjdk.IIOPExtension;
  *
  * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class DomainAdjuster640 extends DomainAdjuster {
+public class DomainAdjuster640 extends DomainAdjuster700 {
 
     @Override
     protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress) throws Exception {
-        final List<ModelNode> list = new ArrayList<>();
+        final List<ModelNode> list = super.adjustForVersion(client, profileAddress);
 
         list.addAll(replaceActiveMqWithMessaging(profileAddress.append(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME)));
         list.addAll(removeBatch(profileAddress.append(SUBSYSTEM, BatchSubsystemDefinition.NAME)));

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
@@ -25,7 +25,7 @@ import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
-import org.jboss.as.test.integration.domain.mixed.LegacyConfigAdjuster;
+import org.jboss.as.test.integration.domain.mixed.eap700.LegacyConfigAdjuster700;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 
@@ -34,7 +34,7 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Brian Stansberry
  */
-public class LegacyConfigAdjuster640 extends LegacyConfigAdjuster {
+public class LegacyConfigAdjuster640 extends LegacyConfigAdjuster700 {
     @Override
     protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
         List<ModelNode> result = super.adjustForVersion(client, profileAddress);

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/DomainAdjuster700.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/DomainAdjuster700.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Does adjustments to the domain model for 7.0.0 legacy slaves.
+ *
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class DomainAdjuster700 extends DomainAdjuster {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress) throws Exception {
+        final List<ModelNode> list = new ArrayList<>();
+
+        return list;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/KernelBehavior700TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/KernelBehavior700TestSuite.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.KernelBehaviorTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {WildcardReads700TestCase.class})
+@Version(Version.AsVersion.EAP_7_0_0)
+public class KernelBehavior700TestSuite extends KernelBehaviorTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        KernelBehaviorTestSuite.getSupport(KernelBehavior700TestSuite.class);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfig700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfig700TestCase.java
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 7.0 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_0_0)
+public class LegacyConfig700TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig700TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfig700TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfig700TestSuite.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 7.0 domain.xml with a current DC and a 6.4 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig700TestCase.class})
+@Version(Version.AsVersion.EAP_7_0_0)
+public class LegacyConfig700TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig700TestSuite.class, Version.AsVersion.EAP_7_0_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfigAdjuster700.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/LegacyConfigAdjuster700.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigAdjuster;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.4 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster700 extends LegacyConfigAdjuster {
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomain700TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomain700TestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@RunWith(Suite.class)
+@SuiteClasses(value= {SimpleMixedDomain700TestCase.class, MixedDomainDeployment700TestCase.class})
+@Version(AsVersion.EAP_7_0_0)
+public class MixedDomain700TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupport(MixedDomain700TestSuite.class);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomainDeployment700TestCase.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainDeploymentTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Version(AsVersion.EAP_7_0_0)
+public class MixedDomainDeployment700TestCase extends MixedDomainDeploymentTest {
+    @BeforeClass
+    public static void beforeClass() {
+        MixedDomain700TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/SimpleMixedDomain700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/SimpleMixedDomain700TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.SimpleMixedDomainTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Version(AsVersion.EAP_7_0_0)
+public class SimpleMixedDomain700TestCase extends SimpleMixedDomainTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        MixedDomain700TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/WildcardReads700TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/WildcardReads700TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap700;
+
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.WildcardReadsTestCase;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_0_0)
+public class WildcardReads700TestCase extends WildcardReadsTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        KernelBehavior700TestSuite.initializeDomain();
+    }
+
+}


### PR DESCRIPTION
DomainHostExcludes700TestCase has not been ported, this is tracked in https://issues.jboss.org/browse/WFLY-6616 (some WIP in my https://github.com/kabir/wildfly/tree/WFLY-6616)
