### PR TITLE
change default name for long-running-threads and short-running-threads.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/DistributedWorkManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/DistributedWorkManagerAdd.java
@@ -150,8 +150,8 @@ public class DistributedWorkManagerAdd extends AbstractAddStepHandler {
         builder.addDependency(ChannelServiceName.FACTORY.getServiceName(), ChannelFactory.class, wmService.getJGroupsChannelFactoryInjector());
 
 
-        builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name), Executor.class, wmService.getExecutorLongInjector());
-        builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name), Executor.class, wmService.getExecutorShortInjector());
+        builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name + "-" + WORKMANAGER_LONG_RUNNING), Executor.class, wmService.getExecutorLongInjector());
+        builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name + "-" + WORKMANAGER_SHORT_RUNNING), Executor.class, wmService.getExecutorShortInjector());
 
         builder.addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, wmService.getXaTerminatorInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -493,14 +493,14 @@ public class JcaExtension implements Extension {
 
                         org.jboss.as.threads.Namespace ns = org.jboss.as.threads.Namespace.THREADS_1_1;
                         ThreadsParser.getInstance().parseBlockingBoundedQueueThreadPool(reader, readerNS.getUriString(),
-                                ns, workManagerAddress, list, WORKMANAGER_LONG_RUNNING, name);
+                                ns, workManagerAddress, list, WORKMANAGER_LONG_RUNNING, name + "-" + WORKMANAGER_LONG_RUNNING);
                         break;
                     }
                     case SHORT_RUNNING_THREADS: {
 
                         org.jboss.as.threads.Namespace ns = org.jboss.as.threads.Namespace.THREADS_1_1;
                         ThreadsParser.getInstance().parseBlockingBoundedQueueThreadPool(reader, readerNS.getUriString(),
-                                ns, workManagerAddress, list, WORKMANAGER_SHORT_RUNNING, name);
+                                ns, workManagerAddress, list, WORKMANAGER_SHORT_RUNNING, name + "-" + WORKMANAGER_SHORT_RUNNING);
 
                         break;
                     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/WorkManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/WorkManagerAdd.java
@@ -76,8 +76,8 @@ public class WorkManagerAdd extends AbstractAddStepHandler {
                 .addService(ConnectorServices.WORKMANAGER_SERVICE.append(name), wmService);
 
 
-        builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name), Executor.class, wmService.getExecutorLongInjector());
-        builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name), Executor.class, wmService.getExecutorShortInjector());
+        builder.addDependency(ServiceBuilder.DependencyType.OPTIONAL, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING).append(name + "-" + WORKMANAGER_LONG_RUNNING), Executor.class, wmService.getExecutorLongInjector());
+        builder.addDependency(ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING).append(name + "-" + WORKMANAGER_SHORT_RUNNING), Executor.class, wmService.getExecutorShortInjector());
 
         builder.addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, wmService.getXaTerminatorInjector())
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6630
change default name for long-running-threads and short-running-threads.

```
/subsystem=jca/workmanager=default/short-running-threads=default-short-running-threads
/subsystem=jca/workmanager=default/long-running-threads=default-long-running-threads
```
