### PR TITLE
WFLY-6646: shade config corrects wildly-client-all-sources.jar manifest

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -78,6 +78,13 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <!-- Intentionally empty - can specify custom manifest entries here -->
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                             <createSourcesJar>true</createSourcesJar>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Updated maven shade plugin configuration to correct the manifest when building wildly-client-all-${version}-sources.jar.

https://issues.jboss.org/browse/WFLY-6646
