### PR TITLE
[10.x] WFLY-6651 Deprecate servlet 'check-interval' attribute

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/JspDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/JspDefinition.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.undertow;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -83,11 +84,13 @@ class JspDefinition extends PersistentResourceDefinition {
                     .setDefaultValue(new ModelNode(true))
                     .setAllowExpression(true)
                     .build();
+    @Deprecated
     protected static final SimpleAttributeDefinition CHECK_INTERVAL =
             new SimpleAttributeDefinitionBuilder(Constants.CHECK_INTERVAL, ModelType.INT, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(0))
                     .setAllowExpression(true)
+                    .setDeprecated(ModelVersion.create(3, 1, 0), false)
                     .build();
     protected static final SimpleAttributeDefinition MODIFICATION_TEST_INTERVAL =
             new SimpleAttributeDefinitionBuilder(Constants.MODIFICATION_TEST_INTERVAL, ModelType.INT, true)
@@ -228,7 +231,6 @@ class JspDefinition extends PersistentResourceDefinition {
         boolean trimSpaces = TRIM_SPACES.resolveModelAttribute(context, model).asBoolean();
         boolean tagPooling = TAG_POOLING.resolveModelAttribute(context, model).asBoolean();
         boolean mappedFile = MAPPED_FILE.resolveModelAttribute(context, model).asBoolean();
-        int checkInterval = CHECK_INTERVAL.resolveModelAttribute(context, model).asInt();
         int modificationTestInterval = MODIFICATION_TEST_INTERVAL.resolveModelAttribute(context, model).asInt();
         boolean recompileOnFile = RECOMPILE_ON_FAIL.resolveModelAttribute(context, model).asBoolean();
         boolean snap = SMAP.resolveModelAttribute(context, model).asBoolean();
@@ -243,7 +245,7 @@ class JspDefinition extends PersistentResourceDefinition {
         boolean xPoweredBy = X_POWERED_BY.resolveModelAttribute(context, model).asBoolean();
         boolean displaySourceFragment = DISPLAY_SOURCE_FRAGMENT.resolveModelAttribute(context, model).asBoolean();
         boolean optimizeScriptlets = OPTIMIZE_SCRIPTLETS.resolveModelAttribute(context, model).asBoolean();
-        return new JSPConfig(development, disabled, keepGenerated, trimSpaces, tagPooling, mappedFile, checkInterval, modificationTestInterval,
+        return new JSPConfig(development, disabled, keepGenerated, trimSpaces, tagPooling, mappedFile, -1, modificationTestInterval,
                 recompileOnFile, snap, dumpSnap, generateStringsAsCharArrays, errorOnUseBeanInvalidClassAttribute, scratchDir,
                 sourceVm, targetVm, javaEncoding, xPoweredBy, displaySourceFragment, optimizeScriptlets);
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_3_1.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_3_1.java
@@ -152,7 +152,7 @@ public class UndertowSubsystemParser_3_1 extends PersistentResourceXMLParser {
                                                         JspDefinition.TRIM_SPACES,
                                                         JspDefinition.TAG_POOLING,
                                                         JspDefinition.MAPPED_FILE,
-                                                        JspDefinition.CHECK_INTERVAL,
+                                                        //JspDefinition.CHECK_INTERVAL,
                                                         JspDefinition.MODIFICATION_TEST_INTERVAL,
                                                         JspDefinition.RECOMPILE_ON_FAIL,
                                                         JspDefinition.SMAP,

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -200,6 +200,7 @@ undertow.setting.jsp.trim-spaces=Trim some spaces from the generated Servlet.
 undertow.setting.jsp.tag-pooling=Enable tag pooling.
 undertow.setting.jsp.mapped-file=Map to the JSP source.
 undertow.setting.jsp.check-interval=Check interval for JSP updates using a background thread.
+undertow.setting.jsp.check-interval.deprecated=Attribute is no longer in use, as changes are applied as soon as they are detected on file system
 undertow.setting.jsp.modification-test-interval=Minimum amount of time between two tests for updates, in seconds.
 undertow.setting.jsp.recompile-on-fail=Retry failed JSP compilations on each request.
 undertow.setting.jsp.smap=Enable SMAP.

--- a/undertow/src/main/resources/schema/wildfly-undertow_3_1.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_3_1.xsd
@@ -285,7 +285,6 @@
         <xs:attribute name="trim-spaces" default="false" type="xs:boolean"/>
         <xs:attribute name="tag-pooling" default="true" type="xs:boolean"/>
         <xs:attribute name="mapped-file" default="true" type="xs:boolean"/>
-        <xs:attribute name="check-interval" default="0" type="xs:int"/>
         <xs:attribute name="modification-test-interval" default="4" type="xs:int"/>
         <xs:attribute name="recompile-on-fail" default="false" type="xs:boolean"/>
         <xs:attribute name="smap" default="true" type="xs:boolean"/>

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem30TestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem30TestCase.java
@@ -43,6 +43,7 @@ import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.as.subsystem.test.ModelDescriptionValidator;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
@@ -61,7 +61,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
@@ -61,7 +61,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.2.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.2.xml
@@ -66,7 +66,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-2.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-2.0.xml
@@ -68,7 +68,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
@@ -66,7 +66,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.1.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.1.xml
@@ -66,7 +66,6 @@
                 trim-spaces="${prop.trim-spaces:true}"
                 tag-pooling="${prop.tag-pooling:true}"
                 mapped-file="${prop.mapped-file:true}"
-                check-interval="${prop.check-interval:20}"
                 modification-test-interval="${prop.modification-test-interval:1000}"
                 recompile-on-fail="${prop.recompile-on-fail:true}"
                 smap="${prop.smap:true}"


### PR DESCRIPTION
This should go to 10.1 as it is minor model change, delaying it would need bump to 4.0.0 model.
it is also related to https://issues.jboss.org/browse/JBEAP-4224
