### PR TITLE
IIOP: remove deprecated security attributes

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
@@ -49,28 +49,6 @@ public class IIOPExtension implements Extension {
 
     protected static final PathElement PATH_SUBSYSTEM = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
 
-    protected static final PathElement PATH_ORB = PathElement.pathElement(Constants.CONFIGURATION,
-            Constants.ORB);
-    protected static final PathElement PATH_TCP = PathElement.pathElement(Constants.SETTING,
-            Constants.ORB_TCP);
-    protected static final PathElement PATH_INITIALIZERS = PathElement.pathElement(Constants.SETTING,
-            Constants.ORB_INIT);
-    protected static final PathElement PATH_NAMING = PathElement.pathElement(Constants.CONFIGURATION,
-            Constants.NAMING);
-    protected static final PathElement PATH_SECURITY = PathElement.pathElement(Constants.CONFIGURATION,
-            Constants.SECURITY);
-    protected static final PathElement PATH_IOR_SETTINGS = PathElement.pathElement(Constants.CONFIGURATION,
-            Constants.IOR_SETTINGS);
-    protected static final PathElement PATH_IOR_TRANSPORT = PathElement.pathElement(Constants.SETTING,
-            Constants.IOR_TRANSPORT_CONFIG);
-    protected static final PathElement PATH_IOR_AS = PathElement.pathElement(Constants.SETTING,
-            Constants.IOR_AS_CONTEXT);
-    protected static final PathElement PATH_IOR_SAS = PathElement.pathElement(Constants.SETTING,
-            Constants.IOR_SAS_CONTEXT);
-    protected static final PathElement PATH_PROPERTIES = PathElement.pathElement(Constants.CONFIGURATION,
-            Constants.PROPERTIES);
-    protected static final PathElement PATH_PROPERTY = PathElement.pathElement(Constants.PROPERTY);
-
     private static final String RESOURCE_NAME = IIOPExtension.class.getPackage().getName() + ".LocalDescriptions";
 
     public static final ModelVersion MODEL_VERSION_1_1_0 = ModelVersion.create(1, 1, 0);

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPExtension.java
@@ -48,6 +48,7 @@ public class IIOPExtension implements Extension {
     public static final String SUBSYSTEM_NAME = "iiop-openjdk";
 
     protected static final PathElement PATH_SUBSYSTEM = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+
     protected static final PathElement PATH_ORB = PathElement.pathElement(Constants.CONFIGURATION,
             Constants.ORB);
     protected static final PathElement PATH_TCP = PathElement.pathElement(Constants.SETTING,
@@ -72,7 +73,9 @@ public class IIOPExtension implements Extension {
 
     private static final String RESOURCE_NAME = IIOPExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 0, 0);
+    public static final ModelVersion MODEL_VERSION_1_1_0 = ModelVersion.create(1, 1, 0);
+
+    private static final ModelVersion CURRENT_MODEL_VERSION = MODEL_VERSION_1_1_0;
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {
         StringBuilder prefix = new StringBuilder(IIOPExtension.SUBSYSTEM_NAME);
@@ -94,5 +97,6 @@ public class IIOPExtension implements Extension {
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME,Namespace.IIOP_OPENJDK_1_0.getUriString(), IIOPSubsystemParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME,Namespace.IIOP_OPENJDK_1_1.getUriString(), IIOPSubsystemParser.INSTANCE);
     }
 }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -147,6 +147,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     @Deprecated
     public static final AttributeDefinition ADD_COMPONENT_INTERCEPTOR = new SimpleAttributeDefinitionBuilder(
             Constants.SECURITY_ADD_COMP_VIA_INTERCEPTOR, ModelType.BOOLEAN, true)
+            .setDeprecated(IIOPExtension.MODEL_VERSION_1_1_0)
             .setAttributeGroup(Constants.SECURITY)
             .setDefaultValue(new ModelNode(true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
@@ -157,6 +158,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     @Deprecated
     public static final AttributeDefinition CLIENT_SUPPORTS = new SimpleAttributeDefinitionBuilder(
             Constants.SECURITY_CLIENT_SUPPORTS, ModelType.STRING, true)
+            .setDeprecated(IIOPExtension.MODEL_VERSION_1_1_0)
             .setAttributeGroup(Constants.SECURITY)
             .setDefaultValue(new ModelNode().set(SSLConfigValue.MUTUALAUTH.toString()))
             .setValidator(SSL_CONFIG_VALIDATOR)
@@ -178,6 +180,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     @Deprecated
     public static final AttributeDefinition SERVER_SUPPORTS = new SimpleAttributeDefinitionBuilder(
             Constants.SECURITY_SERVER_SUPPORTS, ModelType.STRING, true)
+            .setDeprecated(IIOPExtension.MODEL_VERSION_1_1_0)
             .setAttributeGroup(Constants.SECURITY)
             .setDefaultValue(new ModelNode().set(SSLConfigValue.MUTUALAUTH.toString()))
             .setValidator(SSL_CONFIG_VALIDATOR)
@@ -189,6 +192,7 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     @Deprecated
     public static final AttributeDefinition SERVER_REQUIRES = new SimpleAttributeDefinitionBuilder(
             Constants.SECURITY_SERVER_REQUIRES, ModelType.STRING, true)
+            .setDeprecated(IIOPExtension.MODEL_VERSION_1_1_0)
             .setAttributeGroup(Constants.SECURITY)
             .setDefaultValue(new ModelNode().set(SSLConfigValue.NONE.toString()))
             .setValidator(SSL_CONFIG_VALIDATOR)

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -382,6 +382,6 @@ public class IIOPSubsystemAdd extends AbstractAddStepHandler {
     private void configureClientSecurity(final Properties props) {
         final SSLConfigValue clientRequiresSSL = SSLConfigValue
                 .fromValue(props.getProperty(Constants.SECURITY_CLIENT_REQUIRES));
-        CSIV2IORToSocketInfo.setClientTransportConfigMetaData(clientRequiresSSL);
+        CSIV2IORToSocketInfo.setClientRequiresSSL(clientRequiresSSL);
     }
 }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/Namespace.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/Namespace.java
@@ -2,7 +2,7 @@ package org.wildfly.iiop.openjdk;
 
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -31,9 +31,9 @@ import java.util.Map;
 
 enum Namespace {
 
-    UNKNOWN(null), IIOP_OPENJDK_1_0("urn:jboss:domain:iiop-openjdk:1.0");
+    UNKNOWN(null), IIOP_OPENJDK_1_0("urn:jboss:domain:iiop-openjdk:1.0"),  IIOP_OPENJDK_1_1("urn:jboss:domain:iiop-openjdk:1.1");
 
-    static final Namespace CURRENT = IIOP_OPENJDK_1_0;
+    static final Namespace CURRENT = IIOP_OPENJDK_1_1;
 
     private final String namespaceURI;
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/csiv2/CSIV2IORToSocketInfo.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/csiv2/CSIV2IORToSocketInfo.java
@@ -74,7 +74,7 @@ public class CSIV2IORToSocketInfo implements IORToSocketInfo {
 
     private static SSLConfigValue clientRequiresSsl;
 
-    public static void setClientTransportConfigMetaData(final SSLConfigValue clientRequiresSSL) {
+    public static void setClientRequiresSSL(final SSLConfigValue clientRequiresSSL) {
         CSIV2IORToSocketInfo.clientRequiresSsl = clientRequiresSSL;
     }
 

--- a/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
+++ b/iiop-openjdk/src/main/resources/org/wildfly/iiop/openjdk/LocalDescriptions.properties
@@ -27,10 +27,14 @@ iiop-openjdk.export-corbaloc=Indicates whether the root context should be export
 iiop-openjdk.support-ssl=Indicates whether SSL is to be supported (on) or not (off).
 iiop-openjdk.security-domain=The name of the security domain that holds the key and trust stores that will be used to establish SSL connections.
 iiop-openjdk.add-component-via-interceptor=Indicates whether SSL components should be added by an IOR interceptor (on) or not (off).
+iiop-openjdk.add-component-via-interceptor.deprecated=Indicates whether SSL components should be added by an IOR interceptor (on) or not (off).
 iiop-openjdk.client-supports=Value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
+iiop-openjdk.client-supports.deprecated=Value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
 iiop-openjdk.client-requires=Value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth, MutualAuth).
 iiop-openjdk.server-supports=Value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
+iiop-openjdk.server-supports.deprecated=Value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth, MutualAuth).
 iiop-openjdk.server-requires=Value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth, MutualAuth).
+iiop-openjdk.server-requires.deprecated=Value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth, MutualAuth).
 
 # IOR settings properties.
 iiop-openjdk.trust-in-client=Indicates if the transport must require trust in client to be established. Valid values are 'none', 'supported' and 'required'.

--- a/iiop-openjdk/src/main/resources/schema/wildfly-iiop-openjdk_1_0.xsd
+++ b/iiop-openjdk/src/main/resources/schema/wildfly-iiop-openjdk_1_0.xsd
@@ -80,7 +80,7 @@
                 <![CDATA[
                 The orbTCPConfigType specifies the attributes used to configure the TCP connections.
 
-                * high-water-mark: each time the number of connections exceeds this value ORB tries to reclaim connections. 
+                * high-water-mark: each time the number of connections exceeds this value ORB tries to reclaim connections.
                 * number-to-reclaim: number of reclaimed connections is specified by this property.
                         ]]>
             </xs:documentation>

--- a/iiop-openjdk/src/main/resources/schema/wildfly-iiop-openjdk_1_1.xsd
+++ b/iiop-openjdk/src/main/resources/schema/wildfly-iiop-openjdk_1_1.xsd
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:iiop-openjdk:1.1"
+           xmlns="urn:jboss:domain:iiop-openjdk:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.1">
+
+    <!-- The iiop subsystem root element -->
+    <xs:element name="subsystem" type="iiopSubsystemType"/>
+
+    <xs:complexType name="iiopSubsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iiopSubsystemType specifies the elements that can be used to configure the various aspects of the
+                iiop subsystem.
+
+                * orb: holds the attributes used to configure the Object Request Broker (ORB).
+                * naming: holds the attributes used to configure the CORBA Naming Service.
+                * security: holds the attributes that control the ORB security features.
+                * properties: allows for the specification of generic name/value properties.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="properties" minOccurs="0" maxOccurs="1" type="genericPropertiesType"/>
+            <xs:element name="orb" minOccurs="0" maxOccurs="1" type="orbConfigType"/>
+            <xs:element name="tcp" minOccurs="0" maxOccurs="1" type="tcpConfigType"/>
+            <xs:element name="initializers" minOccurs="0" maxOccurs="1" type="initializersConfigType"/>
+            <xs:element name="naming" minOccurs="0" maxOccurs="1" type="namingConfigType"/>
+            <xs:element name="security" minOccurs="0" maxOccurs="1" type="securityConfigType"/>
+            <xs:element name="transport-config" type="iorTransportConfigType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="as-context" minOccurs="0" maxOccurs="1" type="iorASContextType"/>
+            <xs:element name="sas-context" minOccurs="0" maxOccurs="1" type="iorSASContextType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="orbConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                the orbConfigType specifies the elements and attributes that can be used to configure the behavior of the
+                Object Request Broker (ORB).
+                * giop-version-version: the GIOP version to be used.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="giop-version" type="xs:string" use="optional" default="1.2"/>
+        <xs:attribute name="socket-binding" type="xs:string" use="optional" default="iiop"/>
+        <xs:attribute name="ssl-socket-binding" type="xs:string" use="optional" default="iiop-ssl"/>
+        <xs:attribute name="persistent-server-id" type="xs:string" use="optional" default="1"/>
+    </xs:complexType>
+
+    <xs:complexType name="tcpConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The orbTCPConfigType specifies the attributes used to configure the TCP connections.
+
+                * high-water-mark: each time the number of connections exceeds this value ORB tries to reclaim connections. 
+                * number-to-reclaim: number of reclaimed connections is specified by this property.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="high-water-mark" type="xs:integer" use="optional"/>
+        <xs:attribute name="number-to-reclaim" type="xs:integer" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="initializersConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The initializersConfigType specifies the attributes used to configure the ORB initializers.
+
+                * security: indicates whether the security (SAS and CSIv2) initializers should be installed. There are three possibilities:
+                    identity - The server will just send the current username. The recieving server must trust this
+                               server.
+                    client   - The client interceptor will be installed. Remote calls from this server will propagate
+                               by sending the current username and password
+                    none      - Security interceptors are not installed
+                * transactions: indicates which transaction initializers should be installed. There are three possibilities:
+                    full   - This requires JTS to be enabled in the transactions subsystem config, and will enable full transaction
+                           interaoprability with other JBoss AS instances.
+                    spec - This does not require JTS to be enabled, but will install the minimum set of transaction interceptors
+                           required for EJB spec compliance. These interceptors detect an incoming transaction and throw an
+                           exception if the invocation should be run in the incoming transaction context.
+                    none  - No transaction initalizers will be installed.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="security" type="securityEnabledType" use="optional" default="none"/>
+        <xs:attribute name="transactions" type="transactionEnabledType" use="optional" default="none"/>
+    </xs:complexType>
+
+    <xs:complexType name="namingConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The namingConfigType specifies the attributes used to configure the naming service.
+
+                * root-context: the naming service root context.
+                * export-corbaloc: indicates whether the root context should be exported as corbaloc::address:port/NameService
+                                   (true) or not (false).
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="root-context" type="xs:string" use="optional" default="NameService"/>
+        <xs:attribute name="export-corbaloc" type="trueFalseType" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="securityConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The securityConfigType specifies the attributes used to configure the ORB security features.
+
+                * support-ssl: indicates whether SSL is to be supported (true) or not (false).
+                * security-domain: the name of the security domain that holds the key and trust stores that will be used
+                                   to establish SSL connections.
+                * client-requires: value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="support-ssl" type="trueFalseType" use="optional" default="false"/>
+        <xs:attribute name="security-domain" type="xs:string" use="optional"/>
+        <xs:attribute name="client-requires" type="sslConfigType" use="optional" default="None"/>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               Enclosing element for a list of generic properties.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded" type="genericPropertyType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertyType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               The property element allows for the specification of generic name/value properties. It is useful to specify
+               configuration attributes that have not been covered in this schema.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="iorTransportEnum">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for IOR transport config fields.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="supported"/>
+            <xs:enumeration value="required"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="iorTransportConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorTransportconfigType specifies the attributes used to setup the IOR transport settings.
+
+                * integrity: indicates whether the transport must require integrity protection or not. Valid values are
+                             "none", "supported" and "required".
+                * confidentiality: indicates whether the transport must require confidentiality protection or not. Valid
+                             values are "none", "supported" and "required".
+                * trust-in-target: indicates if the transport must require trust in target to be established. Valid values
+                             are "none" and "supported".
+                * trust-in-client: indicates if the transport must require trust in client to be established. Valid values
+                             are "none", "supported" and "required".
+                * detect-replay: indicates whether the transport must require replay detection or not. Valid values are
+                             "none", "supported" and "required".
+                * detect-misordering: indicates whether the transport must require misordering detection or not. Valid
+                             values are "none", "supported" and "required".
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="integrity" type="iorTransportEnum" use="optional" default="none"/>
+        <xs:attribute name="confidentiality" type="iorTransportEnum" use="optional" default="none"/>
+        <xs:attribute name="trust-in-target" type="iorTransportEnum" use="optional" default="none"/>
+        <xs:attribute name="trust-in-client" type="iorTransportEnum" use="optional" default="none"/>
+        <xs:attribute name="detect-replay" type="iorTransportEnum" use="optional" default="none"/>
+        <xs:attribute name="detect-misordering" type="iorTransportEnum" use="optional" default="none"/>
+    </xs:complexType>
+
+    <xs:simpleType name="authMethodEnum">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for AS Context auth method.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="username_password"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="iorASContextType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorASContextType specifies the attributes used to setup the IOR Authentication Service settings.
+
+                * auth-method: the authentication method. Valid values are "none" and "username_password".
+                * realm: the Authentication Service realm name. If not provided it will be set to "Default".
+                * requires: indicates if authentication is required (true) or not (false).
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="auth-method" type="authMethodEnum" use="optional" default="username_password"/>
+        <xs:attribute name="realm" type="xs:string" use="optional"/>
+        <xs:attribute name="required" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:simpleType name="callerPropagationEnum">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for SAS Context caller propagation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="supported"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="iorSASContextType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorSASContextType specifies the attributes used to setup the IOR Secure Attribute Service settings.
+
+                * caller-propagation: indicates whether the caller should be propagated in the SAS context or not. Valid
+                                      values are "none" and "supported".
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="caller-propagation" type="callerPropagationEnum" use="optional" default="none"/>
+    </xs:complexType>
+
+    <xs:simpleType name="trueFalseType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Enumeration of allowed values for the standard IIOP attributes.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transactionEnabledType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the transaction interceptor config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="full"/>
+            <xs:enumeration value="none"/>
+            <xs:enumeration value="spec"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="securityEnabledType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the security interceptor config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="identity"/>
+            <xs:enumeration value="client"/>
+            <xs:enumeration value="none"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sslConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the SSL config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="None"/>
+            <xs:enumeration value="ServerAuth"/>
+            <xs:enumeration value="ClientAuth"/>
+            <xs:enumeration value="MutualAuth"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/iiop-openjdk/src/main/resources/subsystem-templates/iiop-openjdk.xml
+++ b/iiop-openjdk/src/main/resources/subsystem-templates/iiop-openjdk.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.wildfly.iiop-openjdk</extension-module>
-   <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
+   <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.1">
        <orb socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
        <initializers transactions="spec" security="identity"/>
    </subsystem>

--- a/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
+++ b/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
@@ -41,8 +41,6 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
-import org.wildfly.iiop.openjdk.IIOPExtension;
-import org.wildfly.iiop.openjdk.Namespace;
 
 /**
  * <ṕ>
@@ -61,7 +59,7 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem-1.0.xml");
+        return readResource("subsystem-1.1.xml");
     }
 
     @Override
@@ -71,12 +69,12 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testExpressions() throws Exception {
-        standardSubsystemTest("expressions-1.0.xml");
+        standardSubsystemTest("expressions-1.1.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-iiop-openjdk_1_0.xsd";
+        return "schema/wildfly-iiop-openjdk_1_1.xsd";
     }
 
     @Override
@@ -122,7 +120,7 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         // now try parsing a valid element in an invalid position.
         subsystemXml =
-                "<subsystem xmlns=\"urn:jboss:domain:iiop-openjdk:1.0\">" +
+                "<subsystem xmlns=\"urn:jboss:domain:iiop-openjdk:1.1\">" +
                 "    <orb>" +
                 "        <poa/>" +
                 "    </orb>" +
@@ -190,12 +188,22 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testSubsystemWithSecurityIdentity() throws Exception {
-        super.standardSubsystemTest("subsystem-1.0-security-identity.xml");
+        super.standardSubsystemTest("subsystem-1.1-security-identity.xml");
     }
 
     @Test
     public void testSubsystemWithSecurityClient() throws Exception {
-        super.standardSubsystemTest("subsystem-1.0-security-client.xml");
+        super.standardSubsystemTest("subsystem-1.1-security-client.xml");
+    }
+
+    @Test
+    public void testSubsystem_1_0() throws Exception {
+        super.standardSubsystemTest("subsystem-1.0.xml", false);
+    }
+
+    @Test
+    public void testExpressions_1_0() throws Exception {
+        super.standardSubsystemTest("expressions-1.0.xml", false);
     }
 
 }

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.1.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.1.xml
@@ -1,0 +1,10 @@
+<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.1">
+    <properties>
+        <property name="${test.exp:some_property}" value="${test.exp:some_value}"/>
+    </properties>
+    <orb giop-version="${test.exp:1.2}" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
+    <tcp high-water-mark="${test.exp:100}" number-to-reclaim="${test.exp:30}"/>
+    <initializers security="${test.exp:off}" transactions="${test.exp:spec}"/>
+    <naming root-context="${test.exp:JBoss/Naming/root}" export-corbaloc="${test.exp:false}"/>
+    <security support-ssl="${test.exp:false}" client-requires="${test.exp:None}"/>
+</subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1-security-client.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1-security-client.xml
@@ -1,8 +1,7 @@
-<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
+<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.1">
     <properties>
         <property name="some_property" value="some_value"/>
     </properties>
-    <orb giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1-security-identity.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1-security-identity.xml
@@ -1,7 +1,8 @@
-<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
+<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.1">
     <properties>
         <property name="some_property" value="some_value"/>
     </properties>
+    <orb giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.1.xml
@@ -1,0 +1,15 @@
+<subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.1">
+   <properties>
+        <property name="some_property" value="some_value"/>
+    </properties>
+   <orb persistent-server-id="wildfly" giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2" />
+    <tcp high-water-mark="500" number-to-reclaim="30"/>
+    <initializers security="client" transactions="spec"/>
+    <naming root-context="JBoss/Naming/root2" export-corbaloc="false"/>
+    <security support-ssl="true" security-domain="my-domain" client-requires="MutualAuth"/>
+    <transport-config integrity="required" confidentiality="required" detect-replay="supported"
+                      detect-misordering="supported"
+                      trust-in-client="supported" trust-in-target="supported"/>
+    <as-context auth-method="none" realm="test_realm2" required="true"/>
+    <sas-context caller-propagation="supported"/>
+</subsystem>

--- a/testsuite/integration/src/test/xslt/setupIiopSslSupport.xsl
+++ b/testsuite/integration/src/test/xslt/setupIiopSslSupport.xsl
@@ -55,7 +55,7 @@
                     <xsl:element name="security" namespace="{namespace-uri()}">
                         <xsl:attribute name="security-domain"><xsl:value-of select="$domainName"/></xsl:attribute>
                         <xsl:attribute name="support-ssl">true</xsl:attribute>
-                        <xsl:attribute name="client-supports">ServerAuth</xsl:attribute>
+                        <xsl:attribute name="client-requires">ServerAuth</xsl:attribute>
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>

--- a/testsuite/integration/src/test/xslt/setupLegacyIiopSslSupport.xsl
+++ b/testsuite/integration/src/test/xslt/setupLegacyIiopSslSupport.xsl
@@ -55,7 +55,6 @@
                     <xsl:element name="security" namespace="{namespace-uri()}">
                         <xsl:attribute name="security-domain"><xsl:value-of select="$domainName"/></xsl:attribute>
                         <xsl:attribute name="support-ssl">true</xsl:attribute>
-                        <xsl:attribute name="server-requires">ServerAuth</xsl:attribute>
                     </xsl:element>
                 </xsl:when>
             </xsl:choose>


### PR DESCRIPTION
I'm removing deprecated security attributes, which were jacorb specific and are no longer used with openjdk-orb.
