### PR TITLE
[WFLY-6680] :read-proxies-configuration and :read-proxies-info fail when there is no httpd

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterGetProxyConfiguration.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterGetProxyConfiguration.java
@@ -68,7 +68,7 @@ public class ModClusterGetProxyConfiguration implements OperationStepHandler {
                         InetSocketAddress[] addr = map.keySet().toArray(new InetSocketAddress[map.size()]);
                         for (InetSocketAddress address : addr) {
                             result.add(address.getHostName() + ":" + address.getPort());
-                            result.add(map.get(address));
+                            result.add(map.get(address) != null ? map.get(address) : "proxy down");
                         }
                         context.getResult().set(result);
                     }

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterGetProxyInfo.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterGetProxyInfo.java
@@ -69,7 +69,7 @@ public class ModClusterGetProxyInfo implements OperationStepHandler {
                         InetSocketAddress[] addr = map.keySet().toArray(new InetSocketAddress[map.size()]);
                         for (InetSocketAddress address : addr) {
                             result.add(address.getHostName() + ":" + address.getPort());
-                            result.add(map.get(address));
+                            result.add(map.get(address) != null ? map.get(address) : "proxy down");
                         }
                         context.getResult().set(result);
                     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6680
