### PR TITLE
[WFLY-6950] Parser should create an OBJECT param for an OBJECT attribute so WFCOR…

### DIFF
--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemParser.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemParser.java
@@ -680,7 +680,7 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
         if (!required.isEmpty()) {
             throw missingRequired(reader, required);
         }
-        node.add(name, val);
+        node.get(name).set(val);
         requireNoContent(reader);
     }
 
@@ -722,7 +722,7 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
         if (!required.isEmpty()) {
             throw missingRequired(reader, required);
         }
-        node.add(name, val);
+        node.get(name).set(val);
         requireNoContent(reader);
     }
 


### PR DESCRIPTION
…E-1581 doesn't result in transformer test failures when the attribute doesn't match the param

This is required for https://github.com/wildfly/wildfly-core/pull/1599 to pass.
