### PR TITLE
[WFLY-6698] Do not flag migrate operations as runtime-only

### DIFF
--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/MigrateOperation.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/MigrateOperation.java
@@ -92,12 +92,10 @@ public class MigrateOperation implements OperationStepHandler {
 
     static void registerOperation(final ManagementResourceRegistration registry, final ResourceDescriptionResolver resourceDescriptionResolver) {
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(MIGRATE, resourceDescriptionResolver)
-                        .setRuntimeOnly()
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR, MIGRATION_ERROR_ATTR)
                         .build(),
                 new MigrateOperation(false));
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(DESCRIBE_MIGRATION, resourceDescriptionResolver)
-                        .setRuntimeOnly()
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR, MIGRATION_ERROR_ATTR)
                         .build(),
                 new MigrateOperation(true));

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -177,14 +177,12 @@ public class MigrateOperation implements OperationStepHandler {
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(MIGRATE, resourceDescriptionResolver)
                         .setParameters(ADD_LEGACY_ENTRIES)
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR, MIGRATION_ERROR_ATTR)
-                        .setRuntimeOnly()
                         .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
                         .build(),
                 MigrateOperation.MIGRATE_INSTANCE);
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(DESCRIBE_MIGRATION, resourceDescriptionResolver)
                         .addParameter(ADD_LEGACY_ENTRIES)
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR)
-                        .setRuntimeOnly()
                         .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
                         .build(),
                 MigrateOperation.DESCRIBE_MIGRATION_INSTANCE);

--- a/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
@@ -161,13 +161,11 @@ public class WebMigrateOperation implements OperationStepHandler {
 
     static void registerOperations(ManagementResourceRegistration registry, ResourceDescriptionResolver resourceDescriptionResolver) {
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(MIGRATE, resourceDescriptionResolver)
-                        .setRuntimeOnly()
                         .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR, MIGRATION_ERROR_ATTR)
                         .build(),
                 WebMigrateOperation.MIGRATE_INSTANCE);
         registry.registerOperationHandler(new SimpleOperationDefinitionBuilder(DESCRIBE_MIGRATION, resourceDescriptionResolver)
-                        .setRuntimeOnly()
                         .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
                         .setReplyParameters(MIGRATION_WARNINGS_ATTR)
                         .build(),


### PR DESCRIPTION
The :migrate operation for the legacy subsystems (messaging, web, iiop)
are erroneously flagged as runtime-only.
They impact the management model and do not require any runtime (they
are not running if the server is not in admin-only mode).

JIRA: https://issues.jboss.org/browse/WFLY-6698
