### PR TITLE
WFLY-3854 - baseline jdk9 fixes

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -102,5 +102,10 @@
             <artifactId>jboss-el-api_3.0_spec</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -77,6 +77,12 @@
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-install</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jboss.byteman</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             Build configuration.  Override JBoss Parent settings as necessary.
             For example: <version.surefire.plugin>2.11</version.surefire.plugin>
           -->
-        <maven.min.version>3.2.1</maven.min.version>
+        <maven.min.version>3.2.5</maven.min.version>
 
         <version.surefire.plugin>2.18</version.surefire.plugin>
         <!-- use older version of checkstyle as otherwise lots of checks fail -->
@@ -242,7 +242,7 @@
         <!-- Surefire args -->
         <surefire.jpda.args/>
         <surefire.extra.args/>
-        <surefire.system.args>-Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=256m ${surefire.jpda.args} ${surefire.extra.args}</surefire.system.args>
+        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=256m ${surefire.jpda.args} ${surefire.extra.args}</surefire.system.args>
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1055,6 +1055,12 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-client-all</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>sun.jdk</groupId>
+                        <artifactId>jconsole</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>19</version>
+      <version>20</version>
     </parent>
 
     <groupId>org.wildfly</groupId>
@@ -64,10 +64,10 @@
             For example: <version.surefire.plugin>2.11</version.surefire.plugin>
           -->
         <maven.min.version>3.2.1</maven.min.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
 
         <version.surefire.plugin>2.18</version.surefire.plugin>
+        <!-- use older version of checkstyle as otherwise lots of checks fail -->
+        <version.checkstyle>6.8</version.checkstyle>
         <!--
             Dependency versions. Please keep alphabetical.
 
@@ -233,6 +233,10 @@
         <version.jacoco.plugin>0.6.3.201306030806</version.jacoco.plugin> <!-- Needs to be set explicitely to match with org.jacoco:org.jacoco.ant - see testsuite. -->
         <version.properties.plugin>2.0.1</version.properties.plugin>
         <version.xml.plugin>1.0</version.xml.plugin>
+
+        <!-- Modularized JDK support (various workarounds) - activated via profile -->
+        <modular.jdk.args/>
+        <modular.jdk.props/>
 
 
         <!-- Surefire args -->
@@ -406,6 +410,7 @@
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
                         <useFile/>
+                        <excludes>**/*$logger.java,**/*$bundle.java</excludes>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -6105,6 +6110,44 @@
 
     <!-- Profiles -->
     <profiles>
+        <!--
+                  Name: modularizedJdk
+                  Descr: various workarounds activation for modularized JDK
+                -->
+        <profile>
+            <id>modularizedJdk</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <!-- [WFCORE-1431] remove SASL workaround -->
+                <modular.jdk.args>-XaddExports:java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
+                    -XaddExports:java.security.sasl/com.sun.security.sasl=ALL-UNNAMED -XaddExports:jdk.unsupported/sun.reflect=ALL-UNNAMED
+                    -XaddExports:jdk.unsupported/sun.misc=ALL-UNNAMED
+                </modular.jdk.args>
+                <!-- [WFCORE-1494] remove JUL workaround -->
+                <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${version.compiler.plugin}</version>
+                        <configuration>
+                            <!-- fork is needed so compiler args can be used -->
+                            <fork>true</fork>
+                            <compilerArgs>
+                                <arg>-J-addmods</arg>
+                                <arg>-Jjava.annotations.common</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+
         <!--
           Name: jpda
           Descr: Enable JPDA remote debuging

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -67,6 +67,13 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
+            <!-- exclude woodstox as it is doesn't work right with adding new lines after document end -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
@@ -101,13 +108,11 @@
                         <module.path>${jboss.home}/modules</module.path>
                         <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                         <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                        <jboss.test.mixed.domain.versions>7.1.2.Final,7.1.3.Final</jboss.test.mixed.domain.versions>
                     </systemPropertyVariables>
                     <includes>
                          <!-- include>**/*TestCase.java</include -->
                          <include>**/*TestSuite.java</include>
                     </includes>
-                    
                 </configuration>                        
             </plugin>  
         </plugins>

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -123,10 +123,13 @@
 
     <dependency>
         <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-subsystem-test</artifactId>
-				<type>pom</type>
+        <artifactId>wildfly-subsystem-test</artifactId>
+        <type>pom</type>
         <scope>test</scope>
     </dependency>
-
+    <dependency>
+        <groupId>javax.jws</groupId>
+        <artifactId>jsr181-api</artifactId>
+    </dependency>
  </dependencies>
 </project>


### PR DESCRIPTION
This adds bare bones build support for WildFly full
- WFLY-6218 upgrade to jboss-parent 20
- WFLY-3854 - baseline jdk9 fixes
- [jdk9] remove permgen params & fix jconsole.jar / tools.jar deps
