### PR TITLE
WFLY-5537: Use Singleton Component instead of Container Manager Concurrency Interceptor to get a view method to bean method mapping

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -31,6 +31,7 @@ import javax.transaction.UserTransaction;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,6 +111,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
+    private final List<Map<Method, Method>> viewMethodToComponentMethodMapList;
+
     /**
      * Construct a new instance.
      *
@@ -150,6 +153,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
             timeoutInterceptors = Collections.emptyMap();
         }
 
+        this.viewMethodToComponentMethodMapList = new ArrayList<>();
         List<ViewConfiguration> views = componentConfiguration.getViews();
         if (views != null) {
             for (ViewConfiguration view : views) {
@@ -167,6 +171,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
                         this.processTxAttr(ejbComponentDescription, viewType, method);
                     }
                 }
+
+                this.viewMethodToComponentMethodMapList.add(view.getViewToComponentMethodMap());
             }
         }
 
@@ -416,5 +422,9 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     public ShutDownInterceptorFactory getShutDownInterceptorFactory() {
         return shutDownInterceptorFactory;
+    }
+
+    public List<Map<Method, Method>> getViewMethodToComponentMethodMapList() {
+        return viewMethodToComponentMethodMapList;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
@@ -69,6 +69,8 @@ public class SingletonComponent extends SessionBeanComponent implements Lockable
 
     private Interceptor interceptor;
 
+    private final List<Map<Method, Method>> viewMethodToComponentMethodMapList;
+
     /**
      * We can't lock on <code>this</code> because the {@link org.jboss.as.ee.component.BasicComponent#waitForComponentStart()}
      * also synchronizes on it, and calls {@link #wait()}.
@@ -91,6 +93,7 @@ public class SingletonComponent extends SessionBeanComponent implements Lockable
         this.methodLockTypes = singletonComponentCreateService.getMethodApplicableLockTypes();
         this.methodAccessTimeouts = singletonComponentCreateService.getMethodApplicableAccessTimeouts();
         this.defaultAccessTimeoutProvider = singletonComponentCreateService.getDefaultAccessTimeoutService();
+        this.viewMethodToComponentMethodMapList = singletonComponentCreateService.getViewMethodToComponentMethodMapList();
     }
 
     @Override
@@ -210,5 +213,9 @@ public class SingletonComponent extends SessionBeanComponent implements Lockable
             return CurrentServiceContainer.getServiceContainer();
         }
         return AccessController.doPrivileged(CurrentServiceContainer.GET_ACTION);
+    }
+
+    public List<Map<Method, Method>> getViewMethodToComponentMethodMapList() {
+        return viewMethodToComponentMethodMapList;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -24,7 +24,6 @@ package org.jboss.as.ejb3.component.singleton;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -100,7 +99,7 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
                 configuration.addTimeoutViewInterceptor(SingletonComponentInstanceAssociationInterceptor.FACTORY, InterceptorOrder.View.ASSOCIATING_INTERCEPTOR);
                 ConcurrencyManagementType concurrencyManagementType = getConcurrencyManagementType();
                 if (concurrencyManagementType == null || concurrencyManagementType == ConcurrencyManagementType.CONTAINER) {
-                    configuration.addTimeoutViewInterceptor(new ContainerManagedConcurrencyInterceptorFactory(Collections.emptyMap()), InterceptorOrder.View.SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR);
+                    configuration.addTimeoutViewInterceptor(new ContainerManagedConcurrencyInterceptorFactory(), InterceptorOrder.View.SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR);
                 }
 
             }
@@ -277,7 +276,7 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
                 if (singletonComponentDescription.getConcurrencyManagementType() == ConcurrencyManagementType.BEAN) {
                     return;
                 }
-                configuration.addViewInterceptor(new ContainerManagedConcurrencyInterceptorFactory(configuration.getViewToComponentMethodMap()), InterceptorOrder.View.SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR);
+                configuration.addViewInterceptor(new ContainerManagedConcurrencyInterceptorFactory(), InterceptorOrder.View.SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR);
             }
         });
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptor.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.ejb3.concurrency;
 
+import org.jboss.as.ejb3.component.singleton.SingletonComponent;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
@@ -47,10 +48,8 @@ public class ContainerManagedConcurrencyInterceptor implements Interceptor {
 
     private final LockableComponent lockableComponent;
 
-    private final Map<Method, Method> viewMethodToComponentMethodMap;
 
-    public ContainerManagedConcurrencyInterceptor(LockableComponent component, Map<Method, Method> viewMethodToComponentMethodMap) {
-        this.viewMethodToComponentMethodMap = viewMethodToComponentMethodMap;
+    public ContainerManagedConcurrencyInterceptor(LockableComponent component) {
         if (component == null) {
             throw EjbLogger.ROOT_LOGGER.componentIsNull(LockableComponent.class.getName());
         }
@@ -70,7 +69,13 @@ public class ContainerManagedConcurrencyInterceptor implements Interceptor {
         if (method == null) {
             throw EjbLogger.ROOT_LOGGER.invocationNotApplicableForMethodInvocation(invocationContext);
         }
-        Method invokedMethod = viewMethodToComponentMethodMap.get(method);
+        Method invokedMethod = null;
+        for (Map<Method, Method> methodMethodMap : ((SingletonComponent) lockableComponent).getViewMethodToComponentMethodMapList()) {
+            invokedMethod = methodMethodMap.get(method);
+            if ( invokedMethod != null ){
+                break;
+            }
+        }
         if(invokedMethod == null) {
             invokedMethod = method;
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptorFactory.java
@@ -27,9 +27,6 @@ import org.jboss.as.ee.component.ComponentInstanceInterceptorFactory;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorFactoryContext;
 
-import java.lang.reflect.Method;
-import java.util.Map;
-
 /**
  * An {@link org.jboss.invocation.InterceptorFactory} which returns a new instance of {@link ContainerManagedConcurrencyInterceptor} on each
  * invocation to {@link #create(org.jboss.invocation.InterceptorFactoryContext)}. This {@link org.jboss.invocation.InterceptorFactory} can be used
@@ -39,13 +36,6 @@ import java.util.Map;
  */
 public class ContainerManagedConcurrencyInterceptorFactory extends ComponentInstanceInterceptorFactory {
 
-    private final Map<Method, Method> viewMethodToComponentMethodMap;
-
-    public ContainerManagedConcurrencyInterceptorFactory(Map<Method, Method> viewMethodToComponentMethodMap) {
-
-        this.viewMethodToComponentMethodMap = viewMethodToComponentMethodMap;
-    }
-
     @Override
     protected Interceptor create(final Component component, final InterceptorFactoryContext context) {
         final LockableComponent lockableComponent = (LockableComponent) component;
@@ -54,7 +44,7 @@ public class ContainerManagedConcurrencyInterceptorFactory extends ComponentInst
             if(interceptor != null) {
                 return interceptor;
             }
-            interceptor = new ContainerManagedConcurrencyInterceptor((LockableComponent) component, viewMethodToComponentMethodMap);
+            interceptor = new ContainerManagedConcurrencyInterceptor((LockableComponent) component);
             lockableComponent.setConcurrencyManagementInterceptor(interceptor);
             return interceptor;
         }


### PR DESCRIPTION
It looks necessary be able to get the information of all views in a container manager concurrency interceptor to get correctly the lock type for Singleton Component, currently the interceptor is initialized with the information of just one view. 

Jira issue is:
https://issues.jboss.org/browse/WFLY-5537
