### PR TITLE
[WFLY-6757] Upgrade JBeret from 1.2.0.Final to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.org.infinispan>8.2.2.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
-        <version.org.jberet>1.2.0.Final</version.org.jberet>
+        <version.org.jberet>1.2.1.Final</version.org.jberet>
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
Tested on the Java EE 7 TCK. Passed all batch tests.
