### PR TITLE
WFLY-6765 Add generic support for attribute aliases to wildfly-clustering-common

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandlerDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandlerDescriptor.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -52,4 +53,10 @@ public interface AddStepHandlerDescriptor extends WriteAttributeStepHandlerDescr
      * @return a collection of resource paths
      */
     Set<PathElement> getRequiredSingletonChildren();
+
+    /**
+     * Returns a mapping of attribute alias definition -> target attribute
+     * @return an attribute alias mapping
+     */
+    Map<AttributeDefinition, Attribute> getAttributeAliases();
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/Operations.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/Operations.java
@@ -91,6 +91,15 @@ public final class Operations {
     }
 
     /**
+     * Indicates whether or not this operation expects to include default values.
+     * @param operation an operation
+     * @return true, if default values are expected, false otherwise.
+     */
+    public static boolean isIncludeDefaults(ModelNode operation) {
+        return operation.hasDefined(ModelDescriptionConstants.INCLUDE_DEFAULTS) ? operation.get(ModelDescriptionConstants.INCLUDE_DEFAULTS).asBoolean() : true;
+    }
+
+    /**
      * Creates a composite operation using the specified operation steps.
      * @param operations steps
      * @return a composite operation

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
@@ -28,7 +28,9 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -49,12 +51,17 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
         return (result == 0) ? path1.getValue().compareTo(path2.getValue()) : result;
     };
 
+    private static final Comparator<AttributeDefinition> ATTRIBUTE_COMPARATOR = (AttributeDefinition attribute1, AttributeDefinition attribute2) -> {
+        return attribute1.getName().compareTo(attribute2.getName());
+    };
+
     private final ResourceDescriptionResolver resolver;
     private final List<Capability> capabilities = new LinkedList<>();
     private final List<AttributeDefinition> attributes = new LinkedList<>();
     private final List<AttributeDefinition> parameters = new LinkedList<>();
     private final Set<PathElement> requiredChildren = new TreeSet<>(PATH_COMPARATOR);
     private final Set<PathElement> requiredSingletonChildren = new TreeSet<>(PATH_COMPARATOR);
+    private final Map<AttributeDefinition, Attribute> aliases = new TreeMap<>(ATTRIBUTE_COMPARATOR);
 
     public ResourceDescriptor(ResourceDescriptionResolver resolver) {
         this.resolver = resolver;
@@ -88,6 +95,11 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     @Override
     public Set<PathElement> getRequiredSingletonChildren() {
         return this.requiredSingletonChildren;
+    }
+
+    @Override
+    public Map<AttributeDefinition, Attribute> getAttributeAliases() {
+        return this.aliases;
     }
 
     public <E extends Enum<E> & Attribute> ResourceDescriptor addAttributes(Class<E> enumClass) {
@@ -151,6 +163,11 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
 
     public ResourceDescriptor addRequiredSingletonChildren(PathElement... paths) {
         this.requiredSingletonChildren.addAll(Arrays.asList(paths));
+        return this;
+    }
+
+    public ResourceDescriptor addAlias(Attribute alias, Attribute target) {
+        this.aliases.put(alias.getDefinition(), target);
         return this;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6765

This PR presumes https://github.com/wildfly/wildfly/pull/8985
and is a prerequisite for https://issues.jboss.org/browse/WFLY-6415

I've extracted this work from https://github.com/wildfly/wildfly/pull/8820 in an effort to simplify the review process - as the original PR was deemed too overwhelming.
