### PR TITLE
WFLY-6402 EJBs accessible too early (spec violation)

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/StartupCountdown.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/StartupCountdown.java
@@ -1,30 +1,45 @@
 package org.jboss.as.ee.component.deployers;
 
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
 /**
  * Countdown tracker with capabilities similar to SE CountDownLatch, but allowing threads
- * to mark and unmark themselves as privileged. Privileged threads, when entering await method,
+ * to mark and unmark themselves as privileged and allowing counting up. Privileged threads, when entering await method,
  * will immediately proceed without checking latch's state. This reentrant behaviour allows to work around situations
  * where there is a possibility of a deadlock.
  * @author Fedor Gavrilov
  */
 public final class StartupCountdown {
-  private static final ThreadLocal<Boolean> isPrivileged = new ThreadLocal<Boolean>();
+  private final ThreadLocal<Boolean> isPrivileged = new ThreadLocal<Boolean>();
+  private final AbstractQueuedSynchronizer counter = new AbstractQueuedSynchronizer() {
+    @Override
+    protected int tryAcquireShared(final int acquires) {
+      return getState() == 0 ? 1 : -1;
+    }
 
-  private final CountDownLatch latch;
+    // passed arg could only be +1 or -1 to avoid deadlock
+    @Override
+    protected boolean tryReleaseShared(final int modification) {
+      while (true) {
+        int state = getState();
+        int newState = state - modification;
+        if (compareAndSetState(state, newState)) return newState == 0;
+      }
+    }
+  };
 
-  public StartupCountdown(int count) {
-    this.latch = new CountDownLatch(count);
+  public void increment(final int n) {
+    if (n < 0) throw new IllegalArgumentException();
+    for (int i = n; i > 0; i--) counter.releaseShared(-1);
   }
 
-  public void countDown() {
-    latch.countDown();
+  public void decrement() {
+    counter.releaseShared(1);
   }
 
   public void await() throws InterruptedException {
     if (Boolean.TRUE.equals(isPrivileged.get())) return;
-    latch.await();
+    counter.acquireSharedInterruptibly(1);
   }
 
   public void markAsPrivileged() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -58,6 +58,7 @@ import org.jboss.as.ejb3.tx.EjbBMTInterceptor;
 import org.jboss.as.ejb3.tx.LifecycleCMTTxInterceptor;
 import org.jboss.as.ejb3.tx.TimerCMTTxInterceptor;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
@@ -123,7 +124,9 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
                 if (isInitOnStartup()) {
-                    final StartupCountdown startupCountdown = context.getDeploymentUnit().getAttachment(Attachments.STARTUP_COUNTDOWN);
+                    DeploymentUnit top = context.getDeploymentUnit();
+                    while (top.getParent() != null) top = top.getParent();
+                    final StartupCountdown startupCountdown = top.getAttachment(Attachments.STARTUP_COUNTDOWN);
                     configuration.addPostConstructInterceptor(new ImmediateInterceptorFactory(new StartupCountDownInterceptor(startupCountdown)), InterceptorOrder.ComponentPostConstruct.STARTUP_COUNTDOWN_INTERCEPTOR);
                 }
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/StartupCountDownInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/StartupCountDownInterceptor.java
@@ -25,7 +25,7 @@ public class StartupCountDownInterceptor implements Interceptor {
       return context.proceed();
     } finally {
       countdown.unmarkAsPrivileged();
-      countdown.countDown();
+      countdown.decrement();
     }
   }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitDeploymentUnitProcessor.java
@@ -39,7 +39,9 @@ public class StartupAwaitDeploymentUnitProcessor implements DeploymentUnitProces
         component.getConfigurators().add(new ComponentConfigurator() {
           @Override
           public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) {
-            StartupCountdown countdown = context.getDeploymentUnit().getAttachment(Attachments.STARTUP_COUNTDOWN);
+            DeploymentUnit top = context.getDeploymentUnit();
+            while (top.getParent() != null) top = top.getParent();
+            StartupCountdown countdown = top.getAttachment(Attachments.STARTUP_COUNTDOWN);
             for (ViewConfiguration view : configuration.getViews()) {
               EJBViewConfiguration ejbView = (EJBViewConfiguration) view;
               if (INTFS.contains(ejbView.getMethodIntf())) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6402

this PR in addition to the one already merged should fix the corner case when @Startup beans have access to beans in other deployments no matter when
