### PR TITLE
[WFLY-6771] Add a server suspend helper for suspending and resuming a server

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/suspend/EjbRemoteSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/suspend/EjbRemoteSuspendTestCase.java
@@ -33,8 +33,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.dmr.ModelNode;
+import org.jboss.as.test.shared.ServerSuspend;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -83,9 +82,7 @@ public class EjbRemoteSuspendTestCase {
         Assert.assertEquals(message, echo);
 
 
-        ModelNode op = new ModelNode();
-        op.get(ModelDescriptionConstants.OP).set("suspend");
-        managementClient.getControllerClient().execute(op);
+        ServerSuspend.suspend(managementClient.getControllerClient());
 
         try {
             echo = localEcho.echo(message);
@@ -93,9 +90,7 @@ public class EjbRemoteSuspendTestCase {
         } catch (IllegalStateException expected) {
 
         } finally {
-            op = new ModelNode();
-            op.get(ModelDescriptionConstants.OP).set("resume");
-            managementClient.getControllerClient().execute(op);
+            ServerSuspend.resume(managementClient.getControllerClient());
             //we need to make sure the module availbility message has been recieved
             //(this is why we have InSequence, so avoid two sleep() calls)
             //otherwise the test might fail intermittently if the message has not been recieved when the
@@ -123,9 +118,7 @@ public class EjbRemoteSuspendTestCase {
     @InSequence(2)
     public void testStatefulEjbCreationRejected() throws Exception {
 
-        ModelNode op = new ModelNode();
-        op.get(ModelDescriptionConstants.OP).set("suspend");
-        managementClient.getControllerClient().execute(op);
+        ServerSuspend.suspend(managementClient.getControllerClient());
 
         try {
             Echo localEcho = (Echo) context.lookup("ejb:" + APP_NAME + "/" + MODULE_NAME + "/" + DISTINCT_NAME + "/" + EchoBean.class.getSimpleName() + "!" + Echo.class.getName() + "?stateful");
@@ -133,9 +126,7 @@ public class EjbRemoteSuspendTestCase {
         } catch (NamingException expected) {
 
         } finally {
-            op = new ModelNode();
-            op.get(ModelDescriptionConstants.OP).set("resume");
-            managementClient.getControllerClient().execute(op);
+            ServerSuspend.resume(managementClient.getControllerClient());
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -45,10 +45,9 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.ServerSuspend;
 import org.wildfly.naming.java.permission.JndiPermission;
 import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
-import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -203,9 +202,7 @@ public class RemoteNamingEjbTestCase {
     @Test
     public void testRemoteNamingGracefulShutdown() throws Exception {
 
-        ModelNode op = new ModelNode();
-        op.get(ModelDescriptionConstants.OP).set("suspend");
-        managementClient.getControllerClient().execute(op);
+        ServerSuspend.suspend(managementClient.getControllerClient());
 
         Thread.currentThread().setContextClassLoader(Remote.class.getClassLoader());
 
@@ -233,9 +230,7 @@ public class RemoteNamingEjbTestCase {
             } catch (NamingException expected) {
             }
         } finally {
-            op = new ModelNode();
-            op.get(ModelDescriptionConstants.OP).set("resume");
-            managementClient.getControllerClient().execute(op);
+            ServerSuspend.resume(managementClient.getControllerClient());
 
             ctx.close();
             Thread.currentThread().setContextClassLoader(current);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSuspend.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSuspend.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.shared;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class ServerSuspend {
+    private static final ModelNode READ_SUSPEND_STATE_OP = Operations.createReadAttributeOperation(new ModelNode().setEmptyList(), "suspend-state");
+
+    /**
+     * Suspends the server with the default timeout.
+     *
+     * @param client the client used to execute the operation
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static void suspend(final ModelControllerClient client) throws IOException {
+        final ModelNode result = client.execute(Operations.createOperation("suspend"));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to suspend server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    /**
+     * Suspends the server with the timeout.
+     *
+     * @param client  the client used to execute the operation
+     * @param timeout the timeout, in seconds, the suspend operation will wait
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static void suspend(final ModelControllerClient client, final int timeout) throws IOException {
+        final ModelNode op = Operations.createOperation("suspend");
+        op.get("timeout").set(timeout);
+        final ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to suspend server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    /**
+     * Resumes a suspended server.
+     *
+     * @param client the client used to execute the operation
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static void resume(final ModelControllerClient client) throws IOException {
+        final ModelNode result = client.execute(Operations.createOperation("resume"));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to resume server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    /**
+     * Checks to see if the server is in a suspended state.
+     *
+     * @param client the client used to execute the operation
+     *
+     * @return {@code true} if the server is in a suspended state, otherwise {@code false}
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static boolean isSuspended(final ModelControllerClient client) throws IOException {
+        return isSuspendState(client, "SUSPENDED");
+    }
+
+    /**
+     * Checks to see if the server is in a resumed, {@code RUNNING}, state.
+     *
+     * @param client the client used to execute the operation
+     *
+     * @return {@code true} if the server is in a resumed state, otherwise {@code false}
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static boolean isResumed(final ModelControllerClient client) throws IOException {
+        return isSuspendState(client, "RUNNING");
+    }
+
+    /**
+     * Reads the current value of the {@code suspend-state} attribute.
+     *
+     * @param client the client used to execute the operation
+     *
+     * @return the value of the {@code suspend-state} attribute
+     *
+     * @throws IOException if an error occurs with client communications
+     */
+    public static String getSuspendState(final ModelControllerClient client) throws IOException {
+        final ModelNode result = client.execute(READ_SUSPEND_STATE_OP);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed read suspend state: " + Operations.getFailureDescription(result).asString());
+        }
+        return Operations.readResult(result).asString();
+    }
+
+    private static boolean isSuspendState(final ModelControllerClient client, final String state) throws IOException {
+        return getSuspendState(client).equalsIgnoreCase(state);
+    }
+}


### PR DESCRIPTION
This was mainly to satisfy waiting until a server was fully suspended or resumed before continuing through the test. However per https://issues.jboss.org/browse/WFCORE-1616 these operations were to be blocking operations. It looks like `resume` already was and `suspend` has been fixed in upstream core to be blocking.

I'd already done the work to make the utility and it could be useful. If not feel free to close/reject it.
