### PR TITLE
WFLY-3854 / WFLY-6777 fix compat testsuite to not hang on jdk9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,8 @@
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.lucene>5.3.1</version.org.apache.lucene>
         <version.org.apache.myfaces.core>2.1.17</version.org.apache.myfaces.core>
-        <version.org.apache.openjpa>2.4.0</version.org.apache.openjpa>
-        <version.org.eclipselink.version>2.6.0</version.org.eclipselink.version>
+        <version.org.apache.openjpa>2.4.1</version.org.apache.openjpa>
+        <version.org.eclipselink.version>2.6.3</version.org.eclipselink.version>
         <version.org.apache.neethi>3.0.3</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.8</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.0.6</version.org.apache.santuario>
@@ -138,7 +138,7 @@
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.3</version.org.codehaus.jettison>
         <version.org.cryptacular>1.0</version.org.cryptacular>
-        <version.org.eclipse.jdt.core.compiler>4.4.2</version.org.eclipse.jdt.core.compiler>
+        <version.org.eclipse.jdt.core.compiler>4.5.1</version.org.eclipse.jdt.core.compiler>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -50,6 +50,7 @@
         <!-- Used to provide an absolute location for the XSLT scripts. -->
         <!-- This value is overridden in submodules with the correct relative path. -->
         <xslt.scripts.dir>${basedir}/../integration/src/test/xslt</xslt.scripts.dir>
+        <surefire.excludeTests />
     </properties>
 
     <!--
@@ -82,12 +83,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>net.sourceforge.serp</groupId>
-            <artifactId>serp</artifactId>
-            <version>1.14.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
@@ -159,20 +154,6 @@
             </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.apache.openjpa</groupId>
-                <artifactId>openjpa-all</artifactId>
-                <version>2.2.2</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>net.sourceforge.serp</groupId>
-                <artifactId>serp</artifactId>
-                <version>1.14.1</version>
-                <scope>test</scope>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 
@@ -217,7 +198,9 @@
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
-
+                    <excludes>
+                        <exclude>${surefire.excludeTests}</exclude>
+                    </excludes>
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
                         <node0>${node0}</node0>
@@ -244,52 +227,16 @@
 
     <profiles>
         <profile>
-            <id>default</id>
+            <id>jdk9</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <jdk>9</jdk>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>remote</id>
-            <activation>
-                <property>
-                    <name>remote</name>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
+            <properties>
+                <!--WFLY-6777 We disable OpenJPA test on JDK9, as openjdk-s serp bytecode enhancer hangs deployment. -->
+                <surefire.excludeTests>**/OpenJPASharedModuleProviderTestCase.java</surefire.excludeTests>
+            </properties>
         </profile>
     </profiles>
 
-  <repositories>
-
-    <repository>
-      <id>jboss-public-repository-group</id>
-      <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
 
 </project>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
@@ -56,7 +56,8 @@ public class OpenJPASharedModuleProviderTestCase {
         "       <properties>" +
         "           <property name=\"openjpa.jdbc.SynchronizeMappings\" value=\"buildSchema(SchemaAction='drop,add')\"/>" +
         "           <property name=\"openjpa.InitializeEagerly\" value=\"true\"/>" +
-        "           <property name=\"openjpa.RuntimeUnenhancedClasses\" value=\"supported\"/>" +
+        "           <property name=\"openjpa.RuntimeUnenhancedClasses\" value=\"unsupported\"/>" +
+        "           <property name=\"openjpa.DynamicEnhancementAgent\" value=\"false\"/>" +
         "           <property name=\"jboss.as.jpa.providerModule\" value=\"org.apache.openjpa:test\"/>" +
         "       </properties>" +
         "  </persistence-unit>" +

--- a/testsuite/compat/src/test/scripts/build-jars.xml
+++ b/testsuite/compat/src/test/scripts/build-jars.xml
@@ -71,8 +71,6 @@
     <!-- create the openjpa module to test with -->
     <copy file="${org.apache.openjpa:openjpa-all:jar}"         tofile="${tests.output.dir}/modules/org/apache/openjpa/test/openjpa-all.jar"/>
     <copy file="${org.wildfly:jipijapa-openjpa:jar}"      tofile="${tests.output.dir}/modules/org/apache/openjpa/test/jipijapa-openjpa.jar"/>
-    <copy file="${net.sourceforge.serp:serp:jar}"      tofile="${tests.output.dir}/modules/org/apache/openjpa/test/serp.jar"/>
-
     <echo file="${tests.output.dir}/modules/org/apache/openjpa/test/module.xml" append="false">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;module xmlns="urn:jboss:module:1.1" name="org.apache.openjpa" slot="test"&gt;
 &lt;resources&gt;
@@ -84,7 +82,6 @@
 &lt;/resource-root&gt;
 
 &lt;resource-root path="jipijapa-openjpa.jar"/&gt;
-&lt;resource-root path="serp.jar"/&gt;
 &lt;/resources&gt;
 
 &lt;dependencies&gt;

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -178,6 +178,10 @@
             <groupId>com.io7m.xom</groupId>
             <artifactId>xom</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
- upgrade to latest micro of openjpa & eclipse link (only used in testsuite)
- upgrade ecj compiler to latest avalible build in maven.
- cleanup compat testsuite pom.xml
