### PR TITLE
[WFLY-6579] When JASPIC's register session is used, Subject not propa…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICAuthenticationMechanism.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICAuthenticationMechanism.java
@@ -203,7 +203,7 @@ public class JASPICAuthenticationMechanism implements AuthenticationMechanism {
         // SAM handled the same principal found in the cached account: indicates we must use the cached account.
         if (cachedAccount != null && cachedAccount.getPrincipal() == userPrincipal) {
             // populate the security context using the cached account data.
-            jbossSct.getUtil().createSubjectInfo(userPrincipal, ((AccountImpl) cachedAccount).getCredential(), null);
+            jbossSct.getUtil().createSubjectInfo(userPrincipal, ((AccountImpl) cachedAccount).getCredential(), jbossSct.getUtil().getSubject());
             RoleGroup roleGroup = new SimpleRoleGroup(SecurityConstants.ROLES_IDENTIFIER);
             for (String role : cachedAccount.getRoles())
                 roleGroup.addRole(new SimpleRole(role));


### PR DESCRIPTION
…gated to EJB

This implements the fix suggested by the Arjan Tims in WFLY-6579.

It fixes the errors in the register-sessions module of the jaspic test suite at
https://github.com/javaee-samples/javaee7-samples/tree/master/jaspic
