### PR TITLE
[WFLY-6793] The thread-pool should require a reload since it's used i…

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -24,8 +24,6 @@ package org.wildfly.extension.batch.jberet;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
-import java.util.Collections;
-
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.JobExecutor;
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -158,7 +156,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
         static final BatchSubsystemAdd INSTANCE = new BatchSubsystemAdd();
 
         private BatchSubsystemAdd() {
-            super(Collections.singleton(Capabilities.BATCH_CONFIGURATION_CAPABILITY), DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME);
+            super(DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME);
         }
 
         @Override

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
@@ -55,9 +55,6 @@ public class InMemoryJobRepositoryDefinition extends SimpleResourceDefinition {
     }
 
     private static class InMemoryAddHandler extends AbstractAddStepHandler {
-        InMemoryAddHandler() {
-            super(Capabilities.JOB_REPOSITORY_CAPABILITY);
-        }
 
         @Override
         protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
@@ -62,7 +62,7 @@ public class JdbcJobRepositoryDefinition extends SimpleResourceDefinition {
 
     public JdbcJobRepositoryDefinition() {
         super(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME), new JdbcRepositoryAddHandler(),
-                new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY));
+                ReloadRequiredRemoveStepHandler.INSTANCE);
     }
 
     @Override
@@ -71,10 +71,15 @@ public class JdbcJobRepositoryDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(DATA_SOURCE, null, new ReloadRequiredWriteAttributeHandler(DATA_SOURCE));
     }
 
+    @Override
+    public void registerCapabilities(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(Capabilities.JOB_REPOSITORY_CAPABILITY);
+    }
+
     private static class JdbcRepositoryAddHandler extends AbstractAddStepHandler {
 
         JdbcRepositoryAddHandler() {
-            super(Capabilities.JOB_REPOSITORY_CAPABILITY, DATA_SOURCE);
+            super(DATA_SOURCE);
         }
 
         @Override

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -45,7 +46,6 @@ import org.jboss.as.threads.ThreadFactoryResolver;
 import org.jboss.as.threads.ThreadsServices;
 import org.jboss.as.threads.UnboundedQueueThreadPoolAdd;
 import org.jboss.as.threads.UnboundedQueueThreadPoolMetricsHandler;
-import org.jboss.as.threads.UnboundedQueueThreadPoolRemove;
 import org.jboss.as.threads.UnboundedQueueThreadPoolWriteAttributeHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
@@ -70,7 +70,7 @@ public class BatchThreadPoolResourceDefinition extends SimpleResourceDefinition 
 
     public BatchThreadPoolResourceDefinition(final boolean registerRuntimeOnly) {
         super(PATH, BatchThreadPoolDescriptionResolver.INSTANCE,
-                BatchThreadPoolAdd.INSTANCE, BatchThreadPoolRemove.INSTANCE);
+                BatchThreadPoolAdd.INSTANCE, ReloadRequiredRemoveStepHandler.INSTANCE);
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -107,21 +107,6 @@ public class BatchThreadPoolResourceDefinition extends SimpleResourceDefinition 
                     service);
             serviceBuilder.addDependency(serviceNameBase.append(name), ManagedJBossThreadPoolExecutorService.class, service.getThreadPoolInjector());
             serviceBuilder.install();
-        }
-    }
-
-    static class BatchThreadPoolRemove extends UnboundedQueueThreadPoolRemove {
-        static final BatchThreadPoolRemove INSTANCE = new BatchThreadPoolRemove();
-
-        public BatchThreadPoolRemove() {
-            super(BatchThreadPoolAdd.INSTANCE);
-        }
-
-        @Override
-        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            // First remove the JobExecutor service, then delegate
-            context.removeService(context.getCapabilityServiceName(Capabilities.THREAD_POOL_CAPABILITY.getName(), context.getCurrentAddressValue(), null));
-            super.performRuntime(context, operation, model);
         }
     }
 


### PR DESCRIPTION
…n deployments by the batch environment. Also cleanup the registration of capabilities.

The default thread-pool remove handler doesn't require a reload. However in batch this thread-pool configuration is used by deployments and therefore should require a reload as well.
