### PR TITLE
Prepare for new legacy test controllers

### DIFF
--- a/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
+++ b/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
@@ -45,27 +45,19 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.List;
 
-import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
-import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.ModelTestControllerVersion;
-import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
-import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * @author Manuel Fehlhammer
  */
 public class CmpKeyGeneratorSubsystem11TestCase extends CmpKeyGeneratorSubsystem10TestCase {
-
-    private static final PathAddress SUBSYSTEM_PATH = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, CmpExtension.SUBSYSTEM_NAME));
 
     @Override
     protected String getSubsystemXml() throws IOException {
@@ -121,67 +113,6 @@ public class CmpKeyGeneratorSubsystem11TestCase extends CmpKeyGeneratorSubsystem
         assertEquals(lastElement.getValue(), element.getValue());
     }
 
-    @Test
-    public void testTransformers_6_0_0() throws Exception {
-        ignoreThisTestIfEAPRepositoryIsNotReachable();
-        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
-    }
-
-    @Test
-    public void testTransformers_6_0_1() throws Exception {
-        ignoreThisTestIfEAPRepositoryIsNotReachable();
-        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_1);
-    }
-
-    private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
-        ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
-
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-cmp:" + controllerVersion.getMavenGavVersion())
-                .configureReverseControllerCheck(createAdditionalInitialization(), null);
-
-        KernelServices mainServices = builder.build();
-        Assert.assertTrue(mainServices.isSuccessfulBoot());
-        Assert.assertTrue(mainServices.getLegacyServices(modelVersion).isSuccessfulBoot());
-
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, parse(getSubsystemXml()),
-                new FailedOperationTransformationConfig()
-                        .addFailedAttribute(SUBSYSTEM_PATH.append(CmpSubsystemModel.UUID_KEY_GENERATOR_PATH),
-                                new FailedOperationTransformationConfig.NewAttributesConfig(AbstractKeyGeneratorResourceDefinition.JNDI_NAME))
-                        .addFailedAttribute(SUBSYSTEM_PATH.append(CmpSubsystemModel.HILO_KEY_GENERATOR_PATH),
-                                new FailedOperationTransformationConfig.NewAttributesConfig(AbstractKeyGeneratorResourceDefinition.JNDI_NAME))
-
-        );
-    }
-
-    @Test
-    public void testTransformers_6_1_0() throws Exception {
-        ignoreThisTestIfEAPRepositoryIsNotReachable();
-        testTransformers_1_1_0(ModelTestControllerVersion.EAP_6_1_0);
-    }
-    @Test
-    public void testTransformers_6_1_1() throws Exception {
-        ignoreThisTestIfEAPRepositoryIsNotReachable();
-        testTransformers_1_1_0(ModelTestControllerVersion.EAP_6_1_1);
-    }
-
-    private void testTransformers_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
-        ModelVersion modelVersion = ModelVersion.create(1, 1, 0);
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
-                .setSubsystemXml(getSubsystemXml());
-
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-cmp:" + controllerVersion.getMavenGavVersion())
-                .configureReverseControllerCheck(createAdditionalInitialization(), null);
-
-        KernelServices mainServices = builder.build();
-        Assert.assertTrue(mainServices.isSuccessfulBoot());
-        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        Assert.assertTrue(legacyServices.isSuccessfulBoot());
-
-        checkSubsystemModelTransformation(mainServices, modelVersion);
-    }
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {


### PR DESCRIPTION
This change just prepares code for upcoming PRs that will add legacy controller for EAP7 (and remove the unused and no longer tested ones)
