### PR TITLE
verify resource existence before remove in RemotingProfileChildResour…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceRemoveHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceRemoveHandler.java
@@ -33,6 +33,9 @@ import org.jboss.dmr.ModelNode;
 
 public class RemotingProfileChildResourceRemoveHandler extends RemotingProfileChildResourceHandlerBase{
     protected void updateModel(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        // verify that the resource exist before removing it
+        context.readResource(PathAddress.EMPTY_ADDRESS, false);
+
         context.removeResource(PathAddress.EMPTY_ADDRESS);
     }
 }


### PR DESCRIPTION
…ceRemoveHandler
remove non-existing child resources under ejb remoting-profile finishes with success.

Apply same fix in https://issues.jboss.org/browse/WFCORE-1523
