### PR TITLE
[10.x] WFLY-6808 DistributableSession validate method throw misleading exception message

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSession.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSession.java
@@ -53,7 +53,7 @@ public class DistributableSession implements io.undertow.server.session.Session 
 
     private static void validate(Session<LocalSessionContext> session) {
         if (!session.isValid()) {
-            throw UndertowMessages.MESSAGES.sessionNotFound(session.getId());
+            throw UndertowMessages.MESSAGES.sessionAlreadyInvalidated();
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6808

Trivial fix.
