### PR TITLE
[WFLY-6817] JASPICSecureResponseHandler.handleRequest throws NullPointerException when redirecting for CONFIDENTIAL transport guarantee

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecureResponseHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecureResponseHandler.java
@@ -30,7 +30,7 @@ public class JASPICSecureResponseHandler implements HttpHandler {
                 ServletRequestContext requestContext = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
                 String applicationIdentifier = JASPICAuthenticationMechanism.buildApplicationIdentifier(requestContext);
 
-                if (!JASPICAuthenticationMechanism.wasAuthExceptionThrown(exchange)) {
+                if (!JASPICAuthenticationMechanism.wasAuthExceptionThrown(exchange) && context != null) {
                     UndertowLogger.ROOT_LOGGER.debugf("secureResponse for layer [%s] and applicationContextIdentifier [%s].", JASPICAuthenticationMechanism.JASPI_HTTP_SERVLET_LAYER, applicationIdentifier);
                     context.getSam().secureResponse(context.getMessageInfo(), new Subject(), JASPICAuthenticationMechanism.JASPI_HTTP_SERVLET_LAYER, applicationIdentifier, context.getCbh());
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6817
