### PR TITLE
[WFLY-6840] import-journal's file attribute is a fs path

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ImportJournalOperation.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ImportJournalOperation.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
@@ -63,7 +64,7 @@ import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
  */
 public class ImportJournalOperation extends AbstractRuntimeOnlyHandler {
 
-    private static AttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", ModelType.STRING)
+    private static AttributeDefinition FILE = SimpleAttributeDefinitionBuilder.create("file", PathResourceDefinition.PATH)
             .setAllowExpression(false)
             .setAllowNull(false)
             .build();


### PR DESCRIPTION
Describe import-journal's file attribute as a filesystem path
to allow tab completion when invoking the operation from the command
line

JIRA: https://issues.jboss.org/browse/WFLY-6840
