### PR TITLE
[WFLY-6851] test for MODULES-218

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/AbsoluteResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/AbsoluteResource.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.modules;
+
+/**
+ * @author Martin Simka
+ */
+public class AbsoluteResource {
+    static final String ABSOLUTE_RESOURCE = "absoluteResource";
+
+    public static String test() {
+        return ABSOLUTE_RESOURCE;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/ModuleResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/ModuleResource.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.modules;
+
+/**
+ * @author Martin Simka
+ */
+public class ModuleResource {
+    static final String MODULE_RESOURCE = "moduleResource";
+
+    public static String test() {
+        return MODULE_RESOURCE;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/ModuleResourcesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/ModuleResourcesTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.modules;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test modules with resource-roots with absolute/relative paths (MODULES-218)
+ * @author Martin Simka
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ModuleResourcesTestCase extends AbstractCliTestBase {
+    private static final String MODULE_RESOURCE_MODULE_NAME = "module.resource.test";
+    private static final String ABSOLUTE_RESOURCE_MODULE_NAME = "absolute.resource.test";
+    private static final String MODULE_RESOURCE_JAR_NAME = "module-resource.jar";
+    private static final String ABSOLUTE_RESOURCE_JAR_NAME = "absolute-resource.jar";
+    private static File moduleResource;
+    private static File absoluteResource;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        createResources();
+        AbstractCliTestBase.initCLI();
+        addModule(MODULE_RESOURCE_MODULE_NAME, true, false);
+        addModule(ABSOLUTE_RESOURCE_MODULE_NAME, false, true);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        removeModule(ABSOLUTE_RESOURCE_MODULE_NAME);
+        removeModule(MODULE_RESOURCE_MODULE_NAME);
+        AbstractCliTestBase.closeCLI();
+        deleteResources();
+    }
+
+    @Deployment(name = "resourceTest", managed = false)
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, "Test.war")
+                .addClass(SimpleTestServlet.class)
+                .addAsManifestResource(new StringAsset("Dependencies: " + MODULE_RESOURCE_MODULE_NAME
+                        + "," + ABSOLUTE_RESOURCE_MODULE_NAME + "\n"), "MANIFEST.MF");
+    }
+
+    private static void addModule(String name, boolean addModuleResources, boolean addAbsoluteResources) throws IOException {
+        cli.sendLine("module add --name=" + name
+                + (addModuleResources ? " --resources=" + moduleResource.getCanonicalPath() : "")
+                + (addAbsoluteResources ? " --absolute-resources=" + absoluteResource.getCanonicalPath() : ""));
+    }
+
+    @Test
+    public void testResources() throws IOException, TimeoutException, ExecutionException {
+        deployer.deploy("resourceTest");
+
+        // test module resources
+        String address = "http://" + TestSuiteEnvironment.getServerAddress()
+                + ":8080/Test/SimpleTestServlet?action=" + SimpleTestServlet.ACTION_TEST_MODULE_RESOURCE;
+        String response = HttpRequest.get(address, 1000, 10, TimeUnit.SECONDS);
+        Assert.assertEquals(ModuleResource.MODULE_RESOURCE, response);
+
+        // test absolute resources
+        address = "http://" + TestSuiteEnvironment.getServerAddress()
+                + ":8080/Test/SimpleTestServlet?action=" + SimpleTestServlet.ACTION_TEST_ABSOLUTE_RESOURCE;
+        response = HttpRequest.get(address, 1000, 10, TimeUnit.SECONDS);
+        Assert.assertEquals(AbsoluteResource.ABSOLUTE_RESOURCE, response);
+
+        deployer.undeploy("resourceTest");
+    }
+
+    private static void removeModule(String name) {
+        cli.sendLine("module remove --name=" + name);
+    }
+
+    private static void createResources() {
+        final String tempDir = TestSuiteEnvironment.getTmpDir();
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class);
+        jar.addClasses(ModuleResource.class);
+        moduleResource = new File(tempDir, MODULE_RESOURCE_JAR_NAME);
+        jar.as(ZipExporter.class).exportTo(moduleResource, true);
+
+        jar = ShrinkWrap.create(JavaArchive.class);
+        jar.addClasses(AbsoluteResource.class);
+        absoluteResource = new File(tempDir, ABSOLUTE_RESOURCE_JAR_NAME);
+        jar.as(ZipExporter.class).exportTo(absoluteResource, true);
+    }
+
+    private static void deleteResources() {
+        moduleResource.delete();
+        absoluteResource.delete();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/SimpleTestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/modules/SimpleTestServlet.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.modules;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Martin Simka
+ */
+@WebServlet(name = "SimpleTestServlet", urlPatterns = "/SimpleTestServlet")
+public class SimpleTestServlet extends HttpServlet {
+    public static final String ACTION_TEST_MODULE_RESOURCE = "testModuleResource";
+    public static final String ACTION_TEST_ABSOLUTE_RESOURCE = "testAbsoluteResource";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String action = req.getParameter("action");
+        if(action == null) {
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        PrintWriter out = resp.getWriter();
+        if(action.equals(ACTION_TEST_MODULE_RESOURCE)) {
+            out.print(ModuleResource.test());
+            return;
+        } else if(action.equals(ACTION_TEST_ABSOLUTE_RESOURCE)) {
+            out.print(AbsoluteResource.test());
+            return;
+        }
+        resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6851

https://issues.jboss.org/browse/MODULES-218 - Support absolute paths for module.xml resource-root elements

this requires WFCORE-1628 ( https://github.com/wildfly/wildfly-core/pull/1677 )
