### PR TITLE
WFLY-6841 Add support for singleton backup services.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceContainerHelper.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/msc/ServiceContainerHelper.java
@@ -110,6 +110,11 @@ public class ServiceContainerHelper {
      */
     public static <T> void start(final ServiceController<T> controller) throws StartException {
         transition(controller, State.UP);
+
+        StartException exception = controller.getStartException();
+        if (exception != null) {
+            throw exception;
+        }
     }
 
     /**
@@ -117,12 +122,7 @@ public class ServiceContainerHelper {
      * @param controller a service controller
      */
     public static <T> void stop(ServiceController<T> controller) {
-        try {
-            transition(controller, State.DOWN);
-        } catch (StartException e) {
-            // This can't happen
-            throw new IllegalStateException(e);
-        }
+        transition(controller, State.DOWN);
     }
 
     /**
@@ -130,15 +130,10 @@ public class ServiceContainerHelper {
      * @param controller a service controller
      */
     public static <T> void remove(ServiceController<T> controller) {
-        try {
-            transition(controller, State.REMOVED);
-        } catch (StartException e) {
-            // This can't happen
-            throw new IllegalStateException(e);
-        }
+        transition(controller, State.REMOVED);
     }
 
-    private static <T> void transition(final ServiceController<T> targetController, final State targetState) throws StartException {
+    private static <T> void transition(final ServiceController<T> targetController, final State targetState) {
         // Short-circuit if the service is already at the target state
         if (targetController.getState() == targetState) return;
 
@@ -156,13 +151,6 @@ public class ServiceContainerHelper {
             Thread.currentThread().interrupt();
         } finally {
             monitor.removeController(targetController);
-        }
-
-        if (targetState == State.UP) {
-            StartException exception = targetController.getStartException();
-            if (exception != null) {
-                throw exception;
-            }
         }
     }
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/AddressableNodeExternalizer.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/AddressableNodeExternalizer.java
@@ -31,7 +31,7 @@ import org.jgroups.Address;
 import org.wildfly.clustering.marshalling.Externalizer;
 
 /**
- * Infinispan externalizer for an {@link AddressableNode}.
+ * Marshalling externalizer for an {@link AddressableNode}.
  * @author Paul Ferraro
  */
 public class AddressableNodeExternalizer implements Externalizer<AddressableNode> {

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/LocalNodeExternalizer.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/LocalNodeExternalizer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,40 +19,34 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.clustering.cluster.singleton.service;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+package org.wildfly.clustering.server.group;
 
-import org.jboss.as.server.ServerEnvironment;
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.Value;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 
-public class MyService implements Service<Environment> {
+import org.wildfly.clustering.marshalling.Externalizer;
 
-    private final Value<ServerEnvironment> env;
-    private final AtomicBoolean started = new AtomicBoolean(false);
+/**
+ * Marshalling externalizer for a {@link LocalNode}.
+ * @author Paul Ferraro
+ */
+public class LocalNodeExternalizer implements Externalizer<LocalNode> {
 
-    public MyService(Value<ServerEnvironment> env) {
-        this.env = env;
+    @Override
+    public void writeObject(ObjectOutput output, LocalNode node) throws IOException {
+        output.writeUTF(node.getCluster());
+        output.writeUTF(node.getName());
     }
 
     @Override
-    public Environment getValue() {
-        if (!this.started.get()) {
-            throw new IllegalStateException();
-        }
-        return new Environment(this.env.getValue().getNodeName());
+    public LocalNode readObject(ObjectInput input) throws IOException {
+        return new LocalNode(input.readUTF(), input.readUTF());
     }
 
     @Override
-    public void start(StartContext context) {
-        this.started.set(true);
-    }
-
-    @Override
-    public void stop(StopContext context) {
-        this.started.set(false);
+    public Class<? extends LocalNode> getTargetClass() {
+        return LocalNode.class;
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.notifications.cachelistener.event.Event;
+import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -45,7 +46,7 @@ import org.wildfly.clustering.group.Node;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 @MessageLogger(projectCode = "WFLYCLSV", length = 4)
-public interface ClusteringServerLogger {
+public interface ClusteringServerLogger extends BasicLogger {
     String ROOT_LOGGER_CATEGORY = "org.wildfly.clustering.server";
 
     /**

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.clustering.server.provider;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutionException;
 
 import org.infinispan.Cache;
 import org.infinispan.commons.util.CloseableIterator;
@@ -36,7 +38,6 @@ import org.infinispan.context.Flag;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
 import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
-import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.dispatcher.CommandDispatcher;
 import org.wildfly.clustering.ee.Batch;
 import org.wildfly.clustering.ee.Batcher;
@@ -50,7 +51,7 @@ import org.wildfly.clustering.provider.ServiceProviderRegistry;
 import org.wildfly.clustering.server.logging.ClusteringServerLogger;
 
 /**
- * Infinispan {@link Cache} based {@link ServiceProviderRegistrationFactory}.
+ * Infinispan {@link Cache} based {@link ServiceProviderRegistry}.
  * This factory can create multiple {@link ServiceProviderRegistration} instance,
  * all of which share the same {@link Cache} instance.
  * @author Paul Ferraro
@@ -58,10 +59,9 @@ import org.wildfly.clustering.server.logging.ClusteringServerLogger;
 @org.infinispan.notifications.Listener(sync = false)
 public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<T>, Group.Listener, AutoCloseable {
 
-    final ConcurrentMap<T, Listener> listeners = new ConcurrentHashMap<>();
-    final Batcher<? extends Batch> batcher;
-    final Cache<T, Set<Node>> cache;
-
+    private final ConcurrentMap<T, Listener> listeners = new ConcurrentHashMap<>();
+    private final Batcher<? extends Batch> batcher;
+    private final Cache<T, Set<Node>> cache;
     private final Group group;
     private final CommandDispatcher<Set<T>> dispatcher;
     private final ServiceExecutor executor = new StampedLockServiceExecutor();
@@ -102,29 +102,26 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
         try (Batch batch = this.batcher.createBatch()) {
             this.register(this.group.getLocalNode(), service);
         }
-        return new AbstractServiceProviderRegistration<T>(service, this) {
-            @Override
-            public void close() {
-                Node node = CacheServiceProviderRegistry.this.getGroup().getLocalNode();
-                try (Batch batch = CacheServiceProviderRegistry.this.batcher.createBatch()) {
-                    Set<Node> nodes = CacheServiceProviderRegistry.this.cache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK).get(service);
-                    if ((nodes != null) && nodes.remove(node)) {
-                        Cache<T, Set<Node>> cache = CacheServiceProviderRegistry.this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES);
-                        if (nodes.isEmpty()) {
-                            cache.remove(service);
-                        } else {
-                            cache.replace(service, nodes);
-                        }
+        return new SimpleServiceProviderRegistration<>(service, this, () -> {
+            Node node = CacheServiceProviderRegistry.this.getGroup().getLocalNode();
+            try (Batch batch = CacheServiceProviderRegistry.this.batcher.createBatch()) {
+                Set<Node> nodes = CacheServiceProviderRegistry.this.cache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK).get(service);
+                if ((nodes != null) && nodes.remove(node)) {
+                    Cache<T, Set<Node>> cache = CacheServiceProviderRegistry.this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES);
+                    if (nodes.isEmpty()) {
+                        cache.remove(service);
+                    } else {
+                        cache.replace(service, nodes);
                     }
-                } finally {
-                    CacheServiceProviderRegistry.this.listeners.remove(service);
                 }
+            } finally {
+                CacheServiceProviderRegistry.this.listeners.remove(service);
             }
-        };
+        });
     }
 
     void register(Node node, T service) {
-        Set<Node> nodes = this.cache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).computeIfAbsent(service, key -> new CopyOnWriteArraySet<>(Collections.singleton(node)));
+        Set<Node> nodes = this.cache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS, Flag.FORCE_WRITE_LOCK).computeIfAbsent(service, key -> new CopyOnWriteArraySet<>(Collections.singleton(node)));
         if (nodes.add(node)) {
             this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES).replace(service, nodes);
         }
@@ -163,10 +160,17 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
                     }
                 }
                 if (merged) {
+                    // Re-assert services for new members following merge since these may have been lost following split
                     try (Batch batch = this.batcher.createBatch()) {
                         for (Node node: newNodes) {
-                            // Re-assert services for new members following merge since these may have been lost following split
-                            CacheServiceProviderRegistry.this.getServices(node).forEach(service -> this.register(node, service));
+                            try {
+                                Collection<T> services = this.dispatcher.executeOnNode(new GetLocalServicesCommand<>(), node).get();
+                                services.forEach(service -> this.register(node, service));
+                            } catch (ExecutionException e) {
+                                ClusteringServerLogger.ROOT_LOGGER.warn(e.getCause().getLocalizedMessage(), e.getCause());
+                            } catch (Exception e) {
+                                ClusteringServerLogger.ROOT_LOGGER.warn(e.getLocalizedMessage(), e);
+                            }
                         }
                     }
                 }
@@ -176,7 +180,7 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
 
     @CacheEntryCreated
     @CacheEntryModified
-    public void modified(CacheEntryEvent<ServiceName, Set<Node>> event) {
+    public void modified(CacheEntryEvent<T, Set<Node>> event) {
         if (event.isPre()) return;
         this.executor.execute(() -> {
             Listener listener = this.listeners.get(event.getKey());
@@ -188,13 +192,5 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
                 }
             }
         });
-    }
-
-    List<T> getServices(Node node) {
-        try {
-            return this.dispatcher.executeOnNode(new GetLocalServicesCommand<>(), node).get();
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/GetLocalServicesCommand.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/GetLocalServicesCommand.java
@@ -22,7 +22,7 @@
 package org.wildfly.clustering.server.provider;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import java.util.Set;
 
 import org.wildfly.clustering.dispatcher.Command;
@@ -31,11 +31,11 @@ import org.wildfly.clustering.dispatcher.Command;
  * Command to obtain the service providers known to a node.
  * @author Paul Ferraro
  */
-public class GetLocalServicesCommand<T> implements Command<List<T>, Set<T>> {
+public class GetLocalServicesCommand<T> implements Command<Collection<T>, Set<T>> {
     private static final long serialVersionUID = -6038614943434229434L;
 
     @Override
-    public List<T> execute(Set<T> services) {
+    public Collection<T> execute(Set<T> services) {
         return new ArrayList<>(services);
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/SimpleServiceProviderRegistration.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/SimpleServiceProviderRegistration.java
@@ -32,14 +32,16 @@ import org.wildfly.clustering.provider.ServiceProviderRegistry;
  * {@link #getProviders()} back to the factory.
  * @author Paul Ferraro
  */
-public abstract class AbstractServiceProviderRegistration<T> implements ServiceProviderRegistration<T> {
+public class SimpleServiceProviderRegistration<T> implements ServiceProviderRegistration<T> {
 
     private final T service;
     private final ServiceProviderRegistry<T> registry;
+    private final Runnable closeTask;
 
-    public AbstractServiceProviderRegistration(T service, ServiceProviderRegistry<T> registry) {
+    public SimpleServiceProviderRegistration(T service, ServiceProviderRegistry<T> registry, Runnable closeTask) {
         this.service = service;
         this.registry = registry;
+        this.closeTask = closeTask;
     }
 
     @Override
@@ -50,5 +52,10 @@ public abstract class AbstractServiceProviderRegistration<T> implements ServiceP
     @Override
     public Set<Node> getProviders() {
         return this.registry.getProviders(this.service);
+    }
+
+    @Override
+    public void close() {
+        this.closeTask.run();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/CacheSingletonServiceBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/CacheSingletonServiceBuilder.java
@@ -22,22 +22,17 @@
 
 package org.wildfly.clustering.server.singleton;
 
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.clustering.msc.ServiceContainerHelper;
-import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceListener;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -45,7 +40,6 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.clustering.dispatcher.CommandDispatcher;
 import org.wildfly.clustering.dispatcher.CommandDispatcherFactory;
-import org.wildfly.clustering.dispatcher.CommandResponse;
 import org.wildfly.clustering.group.Group;
 import org.wildfly.clustering.group.Node;
 import org.wildfly.clustering.provider.ServiceProviderRegistration;
@@ -63,66 +57,50 @@ import org.wildfly.clustering.spi.GroupServiceName;
  * Decorates an MSC service ensuring that it is only started on one node in the cluster at any given time.
  * @author Paul Ferraro
  */
-@SuppressWarnings("deprecation")
 public class CacheSingletonServiceBuilder<T> implements SingletonServiceBuilder<T>, Service<T>, ServiceProviderRegistration.Listener, SingletonContext<T>, Singleton {
 
     @SuppressWarnings("rawtypes")
     private final InjectedValue<ServiceProviderRegistry> registry = new InjectedValue<>();
     private final InjectedValue<CommandDispatcherFactory> dispatcherFactory = new InjectedValue<>();
-    private final Service<T> service;
-    final ServiceName targetServiceName;
-    private final ServiceName singletonServiceName;
-    private final AtomicBoolean master = new AtomicBoolean(false);
+    private final InjectedValue<ServiceProviderRegistration<ServiceName>> registration = new InjectedValue<>();
+    private final InjectedValue<CommandDispatcher<SingletonContext<T>>> dispatcher = new InjectedValue<>();
+    private final Service<T> primaryService;
+    private final ServiceName serviceName;
+    private final AtomicBoolean primary = new AtomicBoolean(false);
     private final String containerName;
     private final String cacheName;
+    private final AtomicInteger quorum = new AtomicInteger(1);
 
-    private volatile Group group;
-    private volatile ServiceProviderRegistration<ServiceName> registration;
-    private volatile CommandDispatcher<SingletonContext<T>> dispatcher;
-    private volatile boolean started = false;
+    private volatile Service<T> backupService;
     private volatile SingletonElectionPolicy electionPolicy = new SimpleSingletonElectionPolicy();
-    private volatile ServiceRegistry serviceRegistry;
-    private volatile int quorum = 1;
+    private volatile ServiceController<T> primaryController;
+    private volatile ServiceController<T> backupController;
 
     public CacheSingletonServiceBuilder(ServiceName serviceName, Service<T> service, String containerName, String cacheName) {
-        this.singletonServiceName = serviceName;
-        this.targetServiceName = serviceName.append("service");
-        this.service = service;
+        this.serviceName = serviceName;
+        this.primaryService = service;
         this.containerName = containerName;
         this.cacheName = cacheName;
+        this.backupService = new PrimaryProxyService<>(this.serviceName, this.dispatcher, this.registration, this.quorum);
     }
 
     @Override
     public ServiceName getServiceName() {
-        return this.singletonServiceName;
+        return this.serviceName;
     }
 
     @Override
     public ServiceBuilder<T> build(ServiceTarget target) {
-        // Remove target service when this service is removed
-        ServiceListener<T> listener = new AbstractServiceListener<T>() {
-            @Override
-            public void serviceRemoveRequested(ServiceController<? extends T> controller) {
-                ServiceController<?> service = controller.getServiceContainer().getService(CacheSingletonServiceBuilder.this.targetServiceName);
-                if (service != null) {
-                    service.setMode(ServiceController.Mode.REMOVE);
-                    controller.removeListener(this);
-                }
-            }
-        };
-        target.addService(this.targetServiceName, this.service).setInitialMode(ServiceController.Mode.NEVER).install();
-        return new AsynchronousServiceBuilder<>(this.singletonServiceName, this).build(target)
-                .addAliases(this.singletonServiceName.append("singleton"))
+        return new AsynchronousServiceBuilder<>(this.serviceName, this).build(target)
                 .addDependency(CacheGroupServiceName.SERVICE_PROVIDER_REGISTRY.getServiceName(this.containerName, this.cacheName), ServiceProviderRegistry.class, this.registry)
                 .addDependency(GroupServiceName.COMMAND_DISPATCHER.getServiceName(this.containerName), CommandDispatcherFactory.class, this.dispatcherFactory)
-                .addListener(listener)
                 .setInitialMode(ServiceController.Mode.ACTIVE)
         ;
     }
 
     @Override
     public SingletonServiceBuilder<T> requireQuorum(int quorum) {
-        this.quorum = quorum;
+        this.quorum.set(quorum);
         return this;
     }
 
@@ -133,61 +111,70 @@ public class CacheSingletonServiceBuilder<T> implements SingletonServiceBuilder<
     }
 
     @Override
-    public void start(StartContext context) {
-        this.serviceRegistry = context.getController().getServiceContainer();
-        this.dispatcher = this.dispatcherFactory.getValue().<SingletonContext<T>>createCommandDispatcher(this.singletonServiceName, this);
-        ServiceProviderRegistry<ServiceName> registry = this.registry.getValue();
-        this.group = registry.getGroup();
-        this.registration = registry.register(this.singletonServiceName, this);
-        this.started = true;
+    public SingletonServiceBuilder<T> backupService(Service<T> backupService) {
+        this.backupService = backupService;
+        return this;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        ServiceTarget target = context.getChildTarget();
+        this.primaryController = target.addService(this.serviceName.append("primary"), this.primaryService).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
+        this.backupController = target.addService(this.serviceName.append("backup"), this.backupService).setInitialMode(ServiceController.Mode.PASSIVE).install();
+        this.dispatcher.inject(this.dispatcherFactory.getValue().<SingletonContext<T>>createCommandDispatcher(this.serviceName, this));
+        this.registration.inject(this.registry.getValue().register(this.serviceName, this));
     }
 
     @Override
     public void stop(StopContext context) {
-        this.started = false;
-        this.registration.close();
-        this.dispatcher.close();
+        this.registration.getValue().close();
+        this.registration.uninject();
+        this.dispatcher.getValue().close();
+        this.dispatcher.uninject();
     }
 
     @Override
-    public boolean isMaster() {
-        return this.master.get();
+    public boolean isPrimary() {
+        return this.primary.get();
     }
 
     @Override
     public void providersChanged(Set<Node> nodes) {
-        List<Node> candidates = this.group.getNodes();
+        Group group = this.registry.getValue().getGroup();
+        List<Node> candidates = group.getNodes();
         candidates.retainAll(nodes);
 
         // Only run election on a single node
-        if (candidates.isEmpty() || candidates.get(0).equals(this.group.getLocalNode())) {
+        if (candidates.isEmpty() || candidates.get(0).equals(group.getLocalNode())) {
             Node elected = null;
 
             // First validate that quorum was met
             int size = candidates.size();
-            if (size >= this.quorum) {
-                if ((this.quorum > 1) && (size == this.quorum)) {
-                    ClusteringServerLogger.ROOT_LOGGER.quorumJustReached(this.singletonServiceName.getCanonicalName(), this.quorum);
+            int quorum = this.quorum.intValue();
+            if (size >= quorum) {
+                if ((quorum > 1) && (size == quorum)) {
+                    ClusteringServerLogger.ROOT_LOGGER.quorumJustReached(this.serviceName.getCanonicalName(), quorum);
                 }
 
                 if (!candidates.isEmpty()) {
                     elected = this.electionPolicy.elect(candidates);
 
-                    ClusteringServerLogger.ROOT_LOGGER.elected(elected.getName(), this.singletonServiceName.getCanonicalName());
+                    ClusteringServerLogger.ROOT_LOGGER.elected(elected.getName(), this.serviceName.getCanonicalName());
                 }
-            } else if (this.quorum > 1) {
-                ClusteringServerLogger.ROOT_LOGGER.quorumNotReached(this.singletonServiceName.getCanonicalName(), this.quorum);
+            } else if (quorum > 1) {
+                ClusteringServerLogger.ROOT_LOGGER.quorumNotReached(this.serviceName.getCanonicalName(), quorum);
             }
 
+            CommandDispatcher<SingletonContext<T>> dispatcher = this.dispatcher.getValue();
             try {
                 if (elected != null) {
                     // Stop service on every node except elected node
-                    CacheSingletonServiceBuilder.this.dispatcher.executeOnCluster(new StopCommand<>(), elected);
+                    dispatcher.executeOnCluster(new StopCommand<>(), elected);
                     // Start service on elected node
-                    CacheSingletonServiceBuilder.this.dispatcher.executeOnNode(new StartCommand<>(), elected);
+                    dispatcher.executeOnNode(new StartCommand<>(), elected);
                 } else {
                     // Stop service on every node
-                    CacheSingletonServiceBuilder.this.dispatcher.executeOnCluster(new StopCommand<>());
+                    dispatcher.executeOnCluster(new StopCommand<>());
                 }
             } catch (Exception e) {
                 throw new IllegalStateException(e);
@@ -197,90 +184,45 @@ public class CacheSingletonServiceBuilder<T> implements SingletonServiceBuilder<
 
     @Override
     public void start() {
-        // If we were not already master
-        if (this.master.compareAndSet(false, true)) {
-            ClusteringServerLogger.ROOT_LOGGER.startSingleton(this.singletonServiceName.getCanonicalName());
-            ServiceController<?> service = this.serviceRegistry.getRequiredService(this.targetServiceName);
-            try {
-                ServiceContainerHelper.start(service);
-            } catch (StartException e) {
-                ClusteringServerLogger.ROOT_LOGGER.serviceStartFailed(e, this.targetServiceName.getCanonicalName());
-                ServiceContainerHelper.stop(service);
-            }
+        // If we were not already the primary node
+        if (this.primary.compareAndSet(false, true)) {
+            ClusteringServerLogger.ROOT_LOGGER.startSingleton(this.serviceName.getCanonicalName());
+            ServiceContainerHelper.stop(this.backupController);
+            start(this.primaryController);
         }
     }
 
     @Override
     public void stop() {
-        // If we were the previous master
-        if (this.master.compareAndSet(true, false)) {
-            ClusteringServerLogger.ROOT_LOGGER.stopSingleton(this.singletonServiceName.getCanonicalName());
-            ServiceContainerHelper.stop(this.serviceRegistry.getRequiredService(this.targetServiceName));
+        // If we were the previous the primary node
+        if (this.primary.compareAndSet(true, false)) {
+            ClusteringServerLogger.ROOT_LOGGER.stopSingleton(this.serviceName.getCanonicalName());
+            ServiceContainerHelper.stop(this.primaryController);
+            start(this.backupController);
+        }
+    }
+
+    private static void start(ServiceController<?> controller) {
+        try {
+            ServiceContainerHelper.start(controller);
+        } catch (StartException e) {
+            ClusteringServerLogger.ROOT_LOGGER.serviceStartFailed(e, controller.getName().getCanonicalName());
+            ServiceContainerHelper.stop(controller);
         }
     }
 
     @Override
     public T getValue() {
-        if (!this.started) {
-            throw ClusteringServerLogger.ROOT_LOGGER.notStarted(this.singletonServiceName.getCanonicalName());
-        }
-        // Save ourselves a remote call if we can
-        AtomicReference<T> ref = this.getValueRef();
-        if (ref == null) {
-            ref = this.getRemoteValueRef();
-        }
-        return ref.get();
+        return (this.primary.get() ? this.primaryController : this.backupController).getValue();
     }
 
     @Override
     public AtomicReference<T> getValueRef() {
         try {
-            return this.master.get() ? new AtomicReference<>(this.service.getValue()) : null;
+            return this.primary.get() ? new AtomicReference<>(this.primaryController.getValue()) : null;
         } catch (IllegalStateException e) {
-            // This might happen if master has not yet started, or if node is no longer master
+            // This might happen if primary service has not yet started, or if node is no longer the primary node
             return null;
-        }
-    }
-
-    private AtomicReference<T> getRemoteValueRef() {
-        try {
-            Map<Node, CommandResponse<AtomicReference<T>>> results = Collections.emptyMap();
-            while (results.isEmpty()) {
-                if (!this.started) {
-                    throw ClusteringServerLogger.ROOT_LOGGER.notStarted(this.singletonServiceName.getCanonicalName());
-                }
-                results = this.dispatcher.executeOnCluster(new SingletonValueCommand<T>());
-                Iterator<CommandResponse<AtomicReference<T>>> responses = results.values().iterator();
-                while (responses.hasNext()) {
-                    if (responses.next().get() == null) {
-                        // Prune non-master results
-                        responses.remove();
-                    }
-                }
-                // We expect only 1 result
-                int count = results.size();
-                if (count > 1) {
-                    // This would mean there are multiple masters!
-                    throw ClusteringServerLogger.ROOT_LOGGER.unexpectedResponseCount(this.singletonServiceName.getCanonicalName(), count);
-                }
-                if (count == 0) {
-                    ClusteringServerLogger.ROOT_LOGGER.noResponseFromMaster(this.singletonServiceName.getCanonicalName());
-                    // Verify whether there is no master because a quorum was not reached during the last election
-                    if (this.registration.getProviders().size() < this.quorum) {
-                        throw ClusteringServerLogger.ROOT_LOGGER.notStarted(this.targetServiceName.getCanonicalName());
-                    }
-                    if (Thread.currentThread().isInterrupted()) {
-                        throw new InterruptedException();
-                    }
-                    // Otherwise, we're in the midst of a new master election, so just try again
-                    Thread.yield();
-                }
-            }
-            return results.values().iterator().next().get();
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
         }
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/CacheSingletonServiceBuilderFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/CacheSingletonServiceBuilderFactory.java
@@ -32,8 +32,8 @@ import org.wildfly.clustering.singleton.SingletonServiceBuilderFactory;
  */
 public class CacheSingletonServiceBuilderFactory implements SingletonServiceBuilderFactory {
 
-    final String containerName;
-    final String cacheName;
+    private final String containerName;
+    private final String cacheName;
 
     public CacheSingletonServiceBuilderFactory(String containerName, String cacheName) {
         this.containerName = containerName;
@@ -41,7 +41,7 @@ public class CacheSingletonServiceBuilderFactory implements SingletonServiceBuil
     }
 
     @Override
-    public <T> SingletonServiceBuilder<T> createSingletonServiceBuilder(final ServiceName name, Service<T> service) {
+    public <T> SingletonServiceBuilder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service) {
         return new CacheSingletonServiceBuilder<>(name, service, this.containerName, this.cacheName);
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/LocalSingletonServiceBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/LocalSingletonServiceBuilder.java
@@ -55,6 +55,12 @@ public class LocalSingletonServiceBuilder<T> implements SingletonServiceBuilder<
     }
 
     @Override
+    public SingletonServiceBuilder<T> backupService(Service<T> backupService) {
+        // A backup service will never run on a local singleton
+        return this;
+    }
+
+    @Override
     public ServiceBuilder<T> build(ServiceTarget target) {
         return target.addService(this.name, this.service);
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/PrimaryProxyService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/PrimaryProxyService.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server.singleton;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.Value;
+import org.wildfly.clustering.dispatcher.CommandDispatcher;
+import org.wildfly.clustering.dispatcher.CommandResponse;
+import org.wildfly.clustering.group.Node;
+import org.wildfly.clustering.provider.ServiceProviderRegistration;
+import org.wildfly.clustering.server.logging.ClusteringServerLogger;
+
+/**
+ * Service that proxies the value from the primary node.
+ * @author Paul Ferraro
+ */
+public class PrimaryProxyService<T> implements Service<T> {
+    private final ServiceName serviceName;
+    private final Value<CommandDispatcher<SingletonContext<T>>> dispatcher;
+    private final Value<ServiceProviderRegistration<ServiceName>> registration;
+    private final Number quorum;
+
+    private volatile boolean started = false;
+
+    public PrimaryProxyService(ServiceName serviceName, Value<CommandDispatcher<SingletonContext<T>>> dispatcher, Value<ServiceProviderRegistration<ServiceName>> registration, Number quorum) {
+        this.serviceName = serviceName;
+        this.dispatcher = dispatcher;
+        this.registration = registration;
+        this.quorum = quorum;
+    }
+
+    @Override
+    public T getValue() {
+        try {
+            List<T> result = Collections.emptyList();
+            while (result.isEmpty()) {
+                if (!this.started) {
+                    throw ClusteringServerLogger.ROOT_LOGGER.notStarted(this.serviceName.getCanonicalName());
+                }
+                Map<Node, CommandResponse<AtomicReference<T>>> responses = this.dispatcher.getValue().executeOnCluster(new SingletonValueCommand<T>());
+                // Prune non-primary (i.e. null) results
+                result = responses.values().stream().map(response -> {
+                    try {
+                        return response.get();
+                    } catch (ExecutionException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                }).filter(ref -> ref != null).map(ref -> ref.get()).collect(Collectors.toList());
+                // We expect only 1 result
+                if (result.size() > 1) {
+                    // This would mean there are multiple primary nodes!
+                    throw ClusteringServerLogger.ROOT_LOGGER.unexpectedResponseCount(this.serviceName.getCanonicalName(), result.size());
+                }
+                if (result.isEmpty()) {
+                    ClusteringServerLogger.ROOT_LOGGER.noResponseFromMaster(this.serviceName.getCanonicalName());
+                    // Verify whether there is no primary node because a quorum was not reached during the last election
+                    if (this.registration.getValue().getProviders().size() < this.quorum.intValue()) {
+                        throw ClusteringServerLogger.ROOT_LOGGER.notStarted(this.serviceName.getCanonicalName());
+                    }
+                    if (Thread.currentThread().isInterrupted()) {
+                        throw new InterruptedException();
+                    }
+                    // Otherwise, we're in the midst of a new election, so just try again
+                    Thread.yield();
+                }
+            }
+            return result.get(0);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public void start(StartContext context) {
+        this.started = true;
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.started = false;
+    }
+}

--- a/clustering/server/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
+++ b/clustering/server/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
@@ -1,3 +1,4 @@
 org.wildfly.clustering.server.group.AddressableNodeExternalizer
+org.wildfly.clustering.server.group.LocalNodeExternalizer
 org.wildfly.clustering.server.registry.CacheRegistryFilterExternalizer
 org.wildfly.clustering.server.singleton.ServiceNameExternalizer

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonBuilder.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonBuilder.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,23 +19,20 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.clustering.singleton;
+
+import org.jboss.msc.service.Service;
+import org.wildfly.clustering.service.Builder;
 
 /**
  * @author Paul Ferraro
  */
-public interface Singleton {
+public interface SingletonBuilder<T> extends Builder<T> {
     /**
-     * @deprecated Use {@link #isPrimary()} instead.
+     * Defines an optional service to run while this node is not the primary singleton provider.
+     * @param service a service
+     * @return this builder
      */
-    @Deprecated
-    default boolean isMaster() {
-        return this.isPrimary();
-    }
-
-    /**
-     * Indicates whether this node is the primary provider of the singleton.
-     * @return true, if this node is the primary node, false if it is a backup node.
-     */
-    boolean isPrimary();
+    SingletonBuilder<T> backupService(Service<T> service);
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonElectionPolicy.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonElectionPolicy.java
@@ -27,8 +27,7 @@ import java.util.List;
 import org.wildfly.clustering.group.Node;
 
 /**
- * Used by a singleton service to elect the node which should run the service
- * from the list of nodes providing that service.
+ * Used by a singleton service to elect the primary node from among the list of nodes that can provide the given service.
  * @author Paul Ferraro
  */
 public interface SingletonElectionPolicy {

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonPolicy.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonPolicy.java
@@ -24,7 +24,6 @@ package org.wildfly.clustering.singleton;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.service.Builder;
 
 /**
  * Defines a singleton policy.
@@ -36,5 +35,11 @@ public interface SingletonPolicy {
      */
     @Deprecated String CAPABILITY_NAME = SingletonRequirement.SINGLETON_POLICY.getName();
 
-    <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
+    /**
+     * Creates a singleton service builder.
+     * @param name the name of the service
+     * @param service the service to run when elected as the primary node
+     * @return a builder
+     */
+    <T> SingletonBuilder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonServiceBuilder.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonServiceBuilder.java
@@ -21,23 +21,26 @@
  */
 package org.wildfly.clustering.singleton;
 
-import org.wildfly.clustering.service.Builder;
+import org.jboss.msc.service.Service;
 
 /**
  * Builds a singleton service.
  * @author Paul Ferraro
  * @param <T> the singleton service value type
  */
-public interface SingletonServiceBuilder<T> extends Builder<T> {
+public interface SingletonServiceBuilder<T> extends SingletonBuilder<T> {
+    @Override
+    SingletonServiceBuilder<T> backupService(Service<T> backupService);
+
     /**
-     * Defines the minimum number of members required before a singleton master election will take place.
-     * @param quorum the quorum required for electing a singleton master
+     * Defines the minimum number of members required before a singleton election will take place.
+     * @param quorum the quorum required for electing a primary singleton provider
      * @return a reference to this builder
      */
     SingletonServiceBuilder<T> requireQuorum(int quorum);
 
     /**
-     * Defines the policy for electing a singleton master.
+     * Defines the policy for electing a primary singleton provider.
      * @param policy an election policy
      * @return a reference to this builder
      */

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/election/SimpleSingletonElectionPolicy.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/election/SimpleSingletonElectionPolicy.java
@@ -27,7 +27,7 @@ import org.wildfly.clustering.group.Node;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 
 /**
- * A simple concrete policy service that decides which node in the cluster should be the master node to run certain HASingleton
+ * A simple concrete policy service that decides which node in the cluster should be the primary node to run certain HASingleton
  * service based on attribute "Position". The value will be divided by partition size and only remainder will be used.
  *
  * Let's say partition size is n: 0 means the first oldest node. 1 means the 2nd oldest node. ... n-1 means the nth oldest node.
@@ -37,7 +37,7 @@ import org.wildfly.clustering.singleton.SingletonElectionPolicy;
  * E.g. the following attribute says the singleton will be running on the 3rd oldest node of the current partition: <attribute
  * name="Position">2</attribute>
  *
- * If no election policy is defined, the oldest node in the cluster runs the singleton. This behaivour can be achieved with this
+ * If no election policy is defined, the oldest node in the cluster runs the singleton. This behavior can be achieved with this
  * policy when "position" is set to 0.
  *
  * @author <a href="mailto:Alex.Fu@novell.com">Alex Fu</a>

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyBuilder.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyBuilder.java
@@ -38,6 +38,7 @@ import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.singleton.SingletonBuilder;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 import org.wildfly.clustering.singleton.SingletonServiceBuilderFactory;
@@ -84,7 +85,7 @@ public class SingletonPolicyBuilder implements ResourceServiceBuilder<SingletonP
     }
 
     @Override
-    public <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service) {
+    public <T> SingletonBuilder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service) {
         return this.factory.getValue().createSingletonServiceBuilder(name, service).electionPolicy(this.policy.getValue()).requireQuorum(this.quorum);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonSubDeploymentUnitPhaseBuilder.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonSubDeploymentUnitPhaseBuilder.java
@@ -28,7 +28,7 @@ public class SingletonSubDeploymentUnitPhaseBuilder implements DeploymentUnitPha
     public <T> ServiceBuilder<T> build(ServiceTarget target, ServiceName name, Service<T> service) {
         // Install the actual phase service under some other name, and have it start automatically when the parent deployment's singleton service starts
         target.addService(name.append("service"), service)
-                .addDependency(DeploymentUtils.getDeploymentUnitPhaseServiceName(this.parent, this.phase).append("service"))
+                .addDependency(DeploymentUtils.getDeploymentUnitPhaseServiceName(this.parent, this.phase).append("primary"))
                 .setInitialMode(ServiceController.Mode.PASSIVE)
                 .install();
         // Return a dummy service builder

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
@@ -41,9 +41,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.server.security.ServerPermission;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyService;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyServiceActivator;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyServiceServlet;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeService;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeServiceActivator;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeServiceServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -71,177 +71,177 @@ public class SingletonServiceTestCase extends ClusterAbstractTestCase {
 
     private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
-        war.addPackage(MyService.class.getPackage());
+        war.addPackage(NodeService.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsManifestResource(createPermissionsXmlAsset(
                 new RuntimePermission("getClassLoader"), // See org.jboss.as.server.deployment.service.ServiceActivatorProcessor#deploy()
                 new ServerPermission("useServiceRegistry"), // See org.jboss.as.server.deployment.service.SecuredServiceRegistry
                 new ServerPermission("getCurrentServiceContainer")
         ), "permissions.xml");
-        war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, MyServiceActivator.class);
+        war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, NodeServiceActivator.class);
         return war;
     }
 
     @Test
     public void testSingletonService(
-            @ArquillianResource(MyServiceServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource(MyServiceServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
+            @ArquillianResource(NodeServiceServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+            @ArquillianResource(NodeServiceServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
             throws IOException, URISyntaxException {
 
         // Needed to be able to inject ArquillianResource
         stop(CONTAINER_2);
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
-            HttpResponse response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_1)));
+            HttpResponse response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_1)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_1, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_1, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.QUORUM_SERVICE_NAME)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.QUORUM_SERVICE_NAME)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertNull(response.getFirstHeader("node"));
+                Assert.assertNull(response.getFirstHeader(NodeServiceServlet.NODE_HEADER));
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             start(CONTAINER_2);
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             stop(CONTAINER_2);
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_1)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_1)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_1, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_1, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.QUORUM_SERVICE_NAME)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.QUORUM_SERVICE_NAME)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertNull(response.getFirstHeader("node"));
+                Assert.assertNull(response.getFirstHeader(NodeServiceServlet.NODE_HEADER));
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             start(CONTAINER_2);
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             stop(CONTAINER_1);
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.QUORUM_SERVICE_NAME)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.QUORUM_SERVICE_NAME)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertNull(response.getFirstHeader("node"));
+                Assert.assertNull(response.getFirstHeader(NodeServiceServlet.NODE_HEADER));
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             start(CONTAINER_1);
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL1, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL1, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.DEFAULT_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            response = client.execute(new HttpGet(MyServiceServlet.createURI(baseURL2, MyServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
+            response = client.execute(new HttpGet(NodeServiceServlet.createURI(baseURL2, NodeServiceActivator.QUORUM_SERVICE_NAME, NODE_2)));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(NODE_2, response.getFirstHeader("node").getValue());
+                Assert.assertEquals(NODE_2, response.getFirstHeader(NodeServiceServlet.NODE_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeService.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeService.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,24 +19,39 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.test.clustering.cluster.singleton.service;
 
-import java.io.Serializable;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.Value;
+import org.wildfly.clustering.group.Group;
+import org.wildfly.clustering.group.Node;
 
-/**
- * @author Paul Ferraro
- */
-public class Environment implements Serializable {
-    private static final long serialVersionUID = -7845251073515304583L;
+public class NodeService implements Service<Node> {
 
-    private final String nodeName;
+    private final Value<Group> group;
+    private volatile boolean started = false;
 
-    public Environment(String nodeName) {
-        this.nodeName = nodeName;
+    public NodeService(Value<Group> group) {
+        this.group = group;
     }
 
-    public String getNodeName() {
-        return this.nodeName;
+    @Override
+    public Node getValue() {
+        if (!this.started) {
+            throw new IllegalStateException();
+        }
+        return this.group.getValue().getLocalNode();
+    }
+
+    @Override
+    public void start(StartContext context) {
+        this.started = true;
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.started = false;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServiceActivator.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServiceActivator.java
@@ -28,6 +28,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.group.Group;
 import org.wildfly.clustering.singleton.SingletonServiceBuilderFactory;
 import org.wildfly.clustering.singleton.SingletonServiceName;
 import org.wildfly.clustering.singleton.election.NamePreference;
@@ -36,16 +37,13 @@ import org.wildfly.clustering.singleton.election.SimpleSingletonElectionPolicy;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.NODE_2;
 
-import org.jboss.as.server.ServerEnvironment;
-import org.jboss.as.server.ServerEnvironmentService;
-
 /**
  * @author Paul Ferraro
  */
-public class MyServiceActivator implements ServiceActivator {
+public class NodeServiceActivator implements ServiceActivator {
 
-    public static final ServiceName DEFAULT_SERVICE_NAME = ServiceName.JBOSS.append("test", "myservice", "default");
-    public static final ServiceName QUORUM_SERVICE_NAME = ServiceName.JBOSS.append("test", "myservice", "quorum");
+    public static final ServiceName DEFAULT_SERVICE_NAME = ServiceName.JBOSS.append("test", "service", "default");
+    public static final ServiceName QUORUM_SERVICE_NAME = ServiceName.JBOSS.append("test", "service", "quorum");
 
     private static final String CONTAINER_NAME = "server";
     public static final String PREFERRED_NODE = NODE_2;
@@ -63,13 +61,13 @@ public class MyServiceActivator implements ServiceActivator {
     }
 
     private static void install(ServiceTarget target, SingletonServiceBuilderFactory factory, ServiceName name, int quorum) {
-        InjectedValue<ServerEnvironment> env = new InjectedValue<>();
-        MyService service = new MyService(env);
+        InjectedValue<Group> group = new InjectedValue<>();
+        NodeService service = new NodeService(group);
         factory.createSingletonServiceBuilder(name, service)
             .electionPolicy(new PreferredSingletonElectionPolicy(new SimpleSingletonElectionPolicy(), new NamePreference(PREFERRED_NODE)))
             .requireQuorum(quorum)
             .build(target)
-                .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, env)
+                .addDependency(ServiceName.JBOSS.append("clustering", "group", "local"), Group.class, group)
                 .install();
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServicePolicyActivator.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServicePolicyActivator.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.singleton.service;
+
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.group.Group;
+import org.wildfly.clustering.singleton.SingletonDefaultRequirement;
+import org.wildfly.clustering.singleton.SingletonPolicy;
+
+/**
+ * @author Paul Ferraro
+ */
+public class NodeServicePolicyActivator implements ServiceActivator {
+
+    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("test", "service", "default-policy");
+
+    @Override
+    public void activate(ServiceActivatorContext context) throws ServiceRegistryException {
+        try {
+            SingletonPolicy policy = (SingletonPolicy) context.getServiceRegistry().getRequiredService(ServiceName.parse(SingletonDefaultRequirement.SINGLETON_POLICY.getName())).awaitValue();
+            InjectedValue<Group> group = new InjectedValue<>();
+            NodeService service = new NodeService(group);
+            policy.createSingletonServiceBuilder(SERVICE_NAME, service).build(context.getServiceTarget())
+                    .addDependency(ServiceName.JBOSS.append("clustering", "group", "default"), Group.class, group)
+                    .install();
+        } catch (InterruptedException e) {
+            throw new ServiceRegistryException(e);
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServiceServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/NodeServiceServlet.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster.singleton.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.wildfly.clustering.group.Node;
+
+@WebServlet(urlPatterns = { NodeServiceServlet.SERVLET_PATH })
+public class NodeServiceServlet extends HttpServlet {
+    private static final long serialVersionUID = -592774116315946908L;
+    public static final String NODE_HEADER = "node";
+    private static final String SERVLET_NAME = "node";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    private static final String SERVICE = "service";
+    private static final String EXPECTED = "expected";
+    private static final int RETRIES = 10;
+
+    public static URI createURI(URL baseURL, ServiceName serviceName) throws URISyntaxException {
+        return baseURL.toURI().resolve(buildQuery(serviceName).toString());
+    }
+
+    public static URI createURI(URL baseURL, ServiceName serviceName, String expected) throws URISyntaxException {
+        return baseURL.toURI().resolve(buildQuery(serviceName).append('&').append(EXPECTED).append('=').append(expected).toString());
+    }
+
+    private static StringBuilder buildQuery(ServiceName serviceName) {
+        return new StringBuilder(SERVLET_NAME).append('?').append(SERVICE).append('=').append(serviceName.getCanonicalName());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String serviceName = getRequiredParameter(req, SERVICE);
+        String expected = req.getParameter(EXPECTED);
+        this.log(String.format("Received request for %s, expecting %s", serviceName, expected));
+        @SuppressWarnings("unchecked")
+        ServiceController<Node> service = (ServiceController<Node>) CurrentServiceContainer.getServiceContainer().getService(ServiceName.parse(serviceName));
+        try {
+            Node node = service.getValue();
+            if (expected != null) {
+                for (int i = 0; i < RETRIES; ++i) {
+                    if ((node != null) && expected.equals(node.getName())) break;
+                    Thread.yield();
+                    node = service.getValue();
+                }
+            }
+            if (node != null) {
+                resp.setHeader(NODE_HEADER, node.getName());
+            }
+        } catch (IllegalStateException e) {
+            // Service was not started
+        }
+        resp.getWriter().write("Success");
+    }
+
+    private static String getRequiredParameter(HttpServletRequest req, String name) throws ServletException {
+        String value = req.getParameter(name);
+        if (value == null) {
+            throw new ServletException(String.format("No %s specified", name));
+        }
+        return value;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/ValueServiceServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/service/ValueServiceServlet.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,12 +19,15 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.jboss.as.test.clustering.cluster.singleton.service;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -36,20 +39,24 @@ import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
-@WebServlet(urlPatterns = { MyServiceServlet.SERVLET_PATH })
-public class MyServiceServlet extends HttpServlet {
-    private static final long serialVersionUID = -592774116315946908L;
-    private static final String SERVLET_NAME = "service";
+/**
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { ValueServiceServlet.SERVLET_PATH })
+public class ValueServiceServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+    private static final String SERVLET_NAME = "value";
     static final String SERVLET_PATH = "/" + SERVLET_NAME;
     private static final String SERVICE = "service";
+    public static final String PRIMARY_HEADER = "primary";
     private static final String EXPECTED = "expected";
-    private static final int RETRIES = 10;
+//    private static final int RETRIES = 10;
 
     public static URI createURI(URL baseURL, ServiceName serviceName) throws URISyntaxException {
         return baseURL.toURI().resolve(buildQuery(serviceName).toString());
     }
 
-    public static URI createURI(URL baseURL, ServiceName serviceName, String expected) throws URISyntaxException {
+    public static URI createURI(URL baseURL, ServiceName serviceName, boolean expected) throws URISyntaxException {
         return baseURL.toURI().resolve(buildQuery(serviceName).append('&').append(EXPECTED).append('=').append(expected).toString());
     }
 
@@ -58,32 +65,24 @@ public class MyServiceServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String serviceName = getRequiredParameter(req, SERVICE);
-        String expected = req.getParameter(EXPECTED);
-        this.log(String.format("Received request for %s, expecting %s", serviceName, expected));
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String serviceName = getRequiredParameter(request, SERVICE);
+        this.log(String.format("Received request for %s", serviceName));
         @SuppressWarnings("unchecked")
-        ServiceController<Environment> service = (ServiceController<Environment>) CurrentServiceContainer.getServiceContainer().getService(ServiceName.parse(serviceName));
+        ServiceController<Boolean> service = (ServiceController<Boolean>) CurrentServiceContainer.getServiceContainer().getService(ServiceName.parse(serviceName));
         try {
-            Environment env = service.getValue();
-            if (expected != null) {
-                for (int i = 0; i < RETRIES; ++i) {
-                    if ((env != null) && expected.equals(env.getNodeName())) break;
-                    Thread.yield();
-                    env = service.getValue();
-                }
-            }
-            if (env != null) {
-                resp.setHeader("node", env.getNodeName());
-            }
-        } catch (IllegalStateException e) {
+            Boolean primary = service.awaitValue(5, TimeUnit.SECONDS);
+            response.setHeader(PRIMARY_HEADER, primary.toString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
             // Service was not started
         }
-        resp.getWriter().write("Success");
+        response.getWriter().write("Success");
     }
 
-    private static String getRequiredParameter(HttpServletRequest req, String name) throws ServletException {
-        String value = req.getParameter(name);
+    private static String getRequiredParameter(HttpServletRequest request, String name) throws ServletException {
+        String value = request.getParameter(name);
         if (value == null) {
             throw new ServletException(String.format("No %s specified", name));
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
@@ -41,9 +41,9 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.server.security.ServerPermission;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyService;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyServiceActivator;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyServiceServlet;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeService;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeServiceActivator;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeServiceServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -64,23 +64,23 @@ public class SingletonServiceTestCase {
     @Deployment
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
-        war.addPackage(MyService.class.getPackage());
+        war.addPackage(NodeService.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsManifestResource(createPermissionsXmlAsset(
                 new RuntimePermission("getClassLoader"), // See org.jboss.as.server.deployment.service.ServiceActivatorProcessor#deploy()
                 new ServerPermission("useServiceRegistry"), // See org.jboss.as.server.deployment.service.SecuredServiceRegistry
                 new ServerPermission("getCurrentServiceContainer")
         ), "permissions.xml");
-        war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, MyServiceActivator.class);
+        war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, NodeServiceActivator.class);
         return war;
     }
 
     @Test
-    public void testSingletonService(@ArquillianResource(MyServiceServlet.class) URL baseURL) throws IOException, URISyntaxException {
+    public void testSingletonService(@ArquillianResource(NodeServiceServlet.class) URL baseURL) throws IOException, URISyntaxException {
 
         // URLs look like "http://IP:PORT/singleton/service"
-        URI defaultURI = MyServiceServlet.createURI(baseURL, MyServiceActivator.DEFAULT_SERVICE_NAME);
-        URI quorumURI = MyServiceServlet.createURI(baseURL, MyServiceActivator.QUORUM_SERVICE_NAME);
+        URI defaultURI = NodeServiceServlet.createURI(baseURL, NodeServiceActivator.DEFAULT_SERVICE_NAME);
+        URI quorumURI = NodeServiceServlet.createURI(baseURL, NodeServiceActivator.QUORUM_SERVICE_NAME);
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(defaultURI));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/tunnel/singleton/SingletonTunnelTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/tunnel/singleton/SingletonTunnelTestCase.java
@@ -42,8 +42,8 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
 import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyService;
-import org.jboss.as.test.clustering.cluster.singleton.service.MyServiceServlet;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeService;
+import org.jboss.as.test.clustering.cluster.singleton.service.NodeServiceServlet;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -86,7 +86,7 @@ public class SingletonTunnelTestCase extends ClusterAbstractTestCase {
 
     private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
-        war.addPackage(MyService.class.getPackage());
+        war.addPackage(NodeService.class.getPackage());
         war.addClass(SingletonServiceActivator.class);
         war.addAsServiceProvider(ServiceActivator.class, SingletonServiceActivator.class);
         ClusterTestUtil.addTopologyListenerDependencies(war);
@@ -116,11 +116,11 @@ public class SingletonTunnelTestCase extends ClusterAbstractTestCase {
             throws IOException, URISyntaxException {
 
         // URLs look like "http://IP:PORT/singleton/service"
-        URI serviceANode1Uri = MyServiceServlet.createURI(baseURL1, SingletonServiceActivator.SERVICE_A_NAME);
-        URI serviceANode2Uri = MyServiceServlet.createURI(baseURL2, SingletonServiceActivator.SERVICE_A_NAME);
+        URI serviceANode1Uri = NodeServiceServlet.createURI(baseURL1, SingletonServiceActivator.SERVICE_A_NAME);
+        URI serviceANode2Uri = NodeServiceServlet.createURI(baseURL2, SingletonServiceActivator.SERVICE_A_NAME);
 
-        URI serviceBNode1Uri = MyServiceServlet.createURI(baseURL1, SingletonServiceActivator.SERVICE_B_NAME);
-        URI serviceBNode2Uri = MyServiceServlet.createURI(baseURL2, SingletonServiceActivator.SERVICE_B_NAME);
+        URI serviceBNode1Uri = NodeServiceServlet.createURI(baseURL1, SingletonServiceActivator.SERVICE_B_NAME);
+        URI serviceBNode2Uri = NodeServiceServlet.createURI(baseURL2, SingletonServiceActivator.SERVICE_B_NAME);
 
         log.info("URLs are:\n" + serviceANode1Uri
                 + "\n" + serviceANode2Uri


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6841

Allows the user to specify a backup service to run on those nodes where the primary singleton service is not running.  This feature is intended for consumption by future HA domain controller logic (EAP7-99).

Additionally:
- Replaces usage of deprecated ServiceListener from singleton service implementation with installation into a child ServiceTarget
- Replaces usage of ServerEnvironment (private API) to obtain node name with local Group service (public API) in singleton tests.
