### PR TITLE
Use ENGLISH Locale while writing out the Infinispan subsystem namespace

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSchema.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSchema.java
@@ -23,6 +23,8 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.Schema;
 
+import java.util.Locale;
+
 /**
  * Enumeration of the supported subsystem xml schemas.
  * @author Paul Ferraro
@@ -61,6 +63,6 @@ public enum InfinispanSchema implements Schema<InfinispanSchema> {
 
     @Override
     public String getNamespaceUri() {
-        return String.format("urn:jboss:domain:infinispan:%d.%d", this.major, this.minor);
+        return String.format(Locale.ENGLISH, "urn:jboss:domain:infinispan:%d.%d", this.major, this.minor);
     }
 }


### PR DESCRIPTION
A user has reported an bug in the forum https://developer.jboss.org/message/960348#960348 where, while running the server under a non-English Locale and using the CLI to create resources, leads to Infinispan writing out a subsystem configuration which doesn't load on server reload.

The commit here fixes that issue by using the ENGLISH Locale for writing out to the configuration file. My minimal look at the code suggests that this is very specific to the Infinispan subsystem because of the way it keeps track of the namespace URIs. Someone might have to run tests or check the code extensively, to make sure there are no other subsystem doing something similar.
