### PR TITLE
[WFLY-6873] Reload the server in WebCERTTestsSecurityDomainSetup tearDown

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
@@ -207,6 +207,9 @@ public class WebCERTTestsSecurityDomainSetup extends AbstractSecurityRealmsServe
             updates.add(op);
 
             applyUpdates(managementClient.getControllerClient(), updates);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+
             super.tearDown(managementClient, containerId);
         } catch (Exception e) {
             log.error("Failed to clean domain setup.", e);


### PR DESCRIPTION
WebCERTTestsSecurityDomainSetup doesn't reload a server after security related configuration tearDown actions making server instance unavailable to all subsequent tests in test.integration.web module (failed to deploy arquillian service).

Upstream issue:
https://issues.jboss.org/browse/WFLY-6873
