### PR TITLE
[WFLY-6886] To make WFCORE-1671 fix safer drop ServiceLoader config for vault rea…

### DIFF
--- a/security/subsystem/src/main/resources/META-INF/services/org.jboss.as.server.services.security.AbstractVaultReader
+++ b/security/subsystem/src/main/resources/META-INF/services/org.jboss.as.server.services.security.AbstractVaultReader
@@ -1,1 +1,0 @@
-org.jboss.as.server.services.security.RuntimeVaultReader


### PR DESCRIPTION
…der that's provided by core since WFCORE-114

Having this META-INF/services file here means a caller could potentially try and load core's RuntimeVaultReader via this module instead of via core's server module. Which might work, or might partly work or... Since no code in full needs to load an AbstractVaultReader via this module I see no reason to support it.

The vault resources in the security subsystem do not provide an AbstractVaultReader; they provide a Service<SecurityVault> (SecurityVault being the picketbox class.)
