### PR TITLE
CMTTxInterceptor transaction comparison fix

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/tx/CMTTxInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/tx/CMTTxInterceptor.java
@@ -79,7 +79,7 @@ public class CMTTxInterceptor implements Interceptor {
      */
     protected void endTransaction(final TransactionManager tm, final Transaction tx) {
         try {
-            if (tx != tm.getTransaction()) {
+            if (! tx.equals(tm.getTransaction())) {
                 throw EjbLogger.ROOT_LOGGER.wrongTxOnThread(tx, tm.getTransaction());
             }
             final int txStatus = tx.getStatus();


### PR DESCRIPTION
We could not compare transaction objects using == opeator as there is no guarantee that the objects will be the same if they represent the same transaction. Specifically if the transaction is canceled because of timeout but it stays associated with the tread the transaction manager will create the new transaction object when the TransactionManager#getTransaction method is called. We should use equals operator instead.
