### PR TITLE
[WFLY-6939] Follow up that upgrades the javax.el module so constants …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
         <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
-        <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.6.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
+        <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.7.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>2.2.13</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/DummyEnum.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/DummyEnum.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.jsp;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public enum DummyEnum {
+
+    VALUE
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/JspELTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/JspELTestCase.java
@@ -52,7 +52,7 @@ public class JspELTestCase {
     @Deployment(name = Servlet_Spec_3_1_War)
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClass(DummyConstants.class)
+                .addClasses(DummyConstants.class, DummyEnum.class)
                 .addAsWebInfResource(JspELTestCase.class.getResource("web-app_3_1.xml"), "web.xml")
                 .addAsWebResource(JspELTestCase.class.getResource("jsp-with-el.jsp"), "index.jsp");
     }
@@ -60,7 +60,7 @@ public class JspELTestCase {
     @Deployment(name = Servlet_Spec_3_0_War)
     public static WebArchive deploy30War() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClass(DummyConstants.class)
+                .addClasses(DummyConstants.class, DummyEnum.class)
                 .addAsWebInfResource(JspELTestCase.class.getResource("web-app_3_0.xml"), "web.xml")
                 .addAsWebResource(JspELTestCase.class.getResource("jsp-with-el.jsp"), "index.jsp");
     }
@@ -79,10 +79,8 @@ public class JspELTestCase {
         final String responseBody = HttpRequest.get(url + "index.jsp", 10, TimeUnit.SECONDS);
         Assert.assertTrue("Unexpected EL evaluation for ${Boolean.TRUE}", responseBody.contains("Boolean.TRUE: --- " + Boolean.TRUE + " ---"));
         Assert.assertTrue("Unexpected EL evaluation for ${Integer.MAX_VALUE}", responseBody.contains("Integer.MAX_VALUE: --- " + Integer.MAX_VALUE + " ---"));
-        // TODO: FIXME: Uncomment the next assertion once the EL API library fixes the issue where the ImportHandler implementation uses the right "current"
-        // classloader to import the application classes. Right now, it fails to load the DummyConstants class via ImportHandler#resolveClass method since
-        // it's implementation uses the classloader that loaded the ImportHandler class
-        // Assert.assertTrue("Unexpected EL evaluation for ${DummyConstants.FOO}", responseBody.contains("DummyConstants.FOO: --- " + DummyConstants.FOO + " ---"));
+        Assert.assertTrue("Unexpected EL evaluation for ${DummyConstants.FOO}", responseBody.contains("DummyConstants.FOO: --- " + DummyConstants.FOO + " ---"));
+        Assert.assertTrue("Unexpected EL evaluation for ${DummyEnum.VALUE}", responseBody.contains("DummyEnum.VALUE: --- " + DummyEnum.VALUE + " ---"));
     }
 
     /**
@@ -100,10 +98,7 @@ public class JspELTestCase {
         // instead they will have empty values wherever those EL expressions occur
         Assert.assertTrue("Unexpected EL evaluation for ${Boolean.TRUE}", responseBody.contains("Boolean.TRUE: --- " + " ---"));
         Assert.assertTrue("Unexpected EL evaluation for ${Integer.MAX_VALUE}", responseBody.contains("Integer.MAX_VALUE: --- " + " ---"));
-        // servlet spec doesn't matter in this case, this (application specific) constant MUST resolve in the EL expression
-        // TODO: FIXME: Uncomment the next assertion once the EL API library fixes the issue where the ImportHandler implementation uses the right "current"
-        // classloader to import the application classes. Right now, it fails to load the DummyConstants class via ImportHandler#resolveClass method since
-        // it's implementation uses the classloader that loaded the ImportHandler class
-        // Assert.assertTrue("Unexpected EL evaluation for ${DummyConstants.FOO}", responseBody.contains("DummyConstants.FOO: --- " + DummyConstants.FOO + " ---"));
+        Assert.assertTrue("Unexpected EL evaluation for ${DummyConstants.FOO}", responseBody.contains("DummyConstants.FOO: --- " + " ---"));
+        Assert.assertTrue("Unexpected EL evaluation for ${DummyEnum.VALUE}", responseBody.contains("DummyEnum.VALUE: --- " + " ---"));
     }
 }

--- a/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jsp/jsp-with-el.jsp
+++ b/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jsp/jsp-with-el.jsp
@@ -1,9 +1,11 @@
 <%@ page import="org.wildfly.test.integration.jsp.DummyConstants" %>
+<%@ page import="org.wildfly.test.integration.jsp.DummyEnum" %>
 
 <html>
    <body>
       Boolean.TRUE: --- ${Boolean.TRUE} ---<br/>
       Integer.MAX_VALUE: --- ${Integer.MAX_VALUE} ---<br/>
       DummyConstants.FOO: --- ${DummyConstants.FOO} ---<br/>
+      DummyEnum.VALUE: --- ${DummyEnum.VALUE} ---<br/>
    </body>
 </html>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ImportedClassELResolver.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ImportedClassELResolver.java
@@ -28,6 +28,9 @@ import javax.el.ELResolver;
 import javax.el.ImportHandler;
 import java.beans.FeatureDescriptor;
 import java.util.Iterator;
+import java.util.Objects;
+
+import org.wildfly.extension.undertow.logging.UndertowLogger;
 
 /**
  * An {@link ELResolver} which supports resolution of EL expressions which use imported classes (for static field/method references)
@@ -40,9 +43,7 @@ public class ImportedClassELResolver extends ELResolver {
 
     @Override
     public Object getValue(final ELContext context, final Object base, final Object property) {
-        if (context == null) {
-            throw new NullPointerException("ELContext cannot be null");
-        }
+        Objects.requireNonNull(context, UndertowLogger.ROOT_LOGGER.nullNotAllowed("ELContext"));
         if (base != null) {
             return null;
         }
@@ -71,9 +72,7 @@ public class ImportedClassELResolver extends ELResolver {
 
     @Override
     public void setValue(final ELContext context, final Object base, final Object property, final Object value) {
-        if (context == null) {
-            throw new NullPointerException("ELContext cannot be null");
-        }
+        Objects.requireNonNull(context, UndertowLogger.ROOT_LOGGER.nullNotAllowed("ELContext"));
         // we don't allow setting any value so this method
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -349,4 +349,7 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 82, value = "Could not start '%s' listener.")
     StartException couldNotStartListener(String name, @Cause IOException e);
+
+    @Message(id = 83, value = "%s is not allowed to be null")
+    String nullNotAllowed(String name);
 }


### PR DESCRIPTION
…and enums from the deployment can be used. Also enabled tests for deployment constants.

Follows up on https://github.com/wildfly/wildfly/pull/9115
