### PR TITLE
[WFLY-6858] Add new job-xml-names attribute for deployment resources.

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
@@ -35,7 +35,7 @@ import org.wildfly.extension.batch.jberet.deployment.BatchJobResourceDefinition;
 public class BatchSubsystemExtension implements Extension {
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     /**

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/DeploymentJobDescriptors.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/DeploymentJobDescriptors.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * Describes the associated job XML descriptors and the job name the XML descriptor is associated with.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class DeploymentJobDescriptors {
+    private final Map<String, String> jobXmlDescriptors;
+    private final Map<String, Set<String>> jobNames;
+
+    DeploymentJobDescriptors() {
+        jobXmlDescriptors = new ConcurrentSkipListMap<>();
+        jobNames = new ConcurrentSkipListMap<>();
+    }
+
+    /**
+     * Adds the job XML descriptor name and the job name to the collection of descriptors.
+     *
+     * @param jobXml  the job XML descriptor name
+     * @param jobName the name of the job in the job XML
+     */
+    void add(final String jobXml, final String jobName) {
+        jobXmlDescriptors.put(jobXml, jobName);
+        final Set<String> xmlDescriptors = jobNames.computeIfAbsent(jobName, s -> {
+            Set<String> result = new ConcurrentSkipListSet<>();
+            final Set<String> appearing = jobNames.putIfAbsent(jobName, result);
+            if (appearing != null) {
+                result = appearing;
+            }
+            return result;
+        });
+        xmlDescriptors.add(jobXml);
+    }
+
+    /**
+     * Returns all the job names associated with this deployment.
+     *
+     * @return the job names
+     */
+    Set<String> getJobNames() {
+        return Collections.unmodifiableSet(jobNames.keySet());
+    }
+
+    /**
+     * Validates whether or not the job name exists for this deployment.
+     *
+     * @param jobName the job name to check
+     *
+     * @return {@code true} if the job exists, otherwise {@code false}
+     */
+    boolean isValidJobName(final String jobName) {
+        return jobName.contains(jobName);
+    }
+
+    /**
+     * Returns all the job XML descriptors associated with this deployment.
+     *
+     * @return the job XML descriptors
+     */
+    Set<String> getJobXmlNames() {
+        return Collections.unmodifiableSet(jobXmlDescriptors.keySet());
+    }
+
+    /**
+     * Returns the job XML descriptors associated with a job.
+     *
+     * @param jobName the job name to find the XML descriptors for
+     *
+     * @return the set of job XML descriptors the job can be run from
+     */
+    Set<String> getJobXmlNames(final String jobName) {
+        if (jobNames.containsKey(jobName)) {
+            return Collections.unmodifiableSet(jobNames.get(jobName));
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * Validates whether or not the job XML descriptor exists for this deployment.
+     *
+     * @param jobXmlName the job XML descriptor name
+     *
+     * @return {@code true} if the job XML descriptor exists for this deployment, otherwise {@code false}
+     */
+    boolean isValidJobXmlName(final String jobXmlName) {
+        return jobXmlDescriptors.containsKey(jobXmlName);
+    }
+}

--- a/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
+++ b/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
@@ -70,9 +70,10 @@ batch.jberet.thread-factory=The thread factory used for the thread-pool.
 
 # Batch deployment resource
 batch.jberet.deployment=Information about the batch subsystem for the deployment.
+batch.jberet.deployment.job-xml-names=A list of job XML job descriptors found for the deployment.
 # Batch deployment operations
 batch.jberet.deployment.start-job=Starts a batch job.
-batch.jberet.deployment.start-job.job-xml-name=The name of the job XML file to use when starting the job.
+batch.jberet.deployment.start-job.job-xml-name=The name of the job XML descriptor to use when starting the job.
 batch.jberet.deployment.start-job.properties=Optional properties to use when starting the batch job.
 
 batch.jberet.deployment.stop-job=Stops a running batch job.
@@ -86,6 +87,7 @@ batch.jberet.deployment.restart-job.properties=Optional properties to use when r
 batch.jberet.deployment.job=Information about a specific batch job.
 batch.jberet.deployment.job.running-executions=The number of currently running executions for the job.
 batch.jberet.deployment.job.instance-count=The number of instances for the job.
+batch.jberet.deployment.job.job-xml-names=A list of job XML job descriptors found that describe this job.
 batch.jberet.deployment.job.execution=The execution information for the job with the value of the path being the execution id.
 batch.jberet.deployment.job.execution.instance-id=The instance id for the execution.
 batch.jberet.deployment.job.execution.batch-status=The status of the execution.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -68,13 +69,25 @@ public abstract class AbstractBatchTestCase {
                                 .exportAsString()))
                 .addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "permissions.xml");
         for (String jobXml : jobXmls) {
-            deployment.addAsWebInfResource(pkg, jobXml, "classes/META-INF/batch-jobs/" + jobXml);
+            addJobXml(pkg, deployment, jobXml);
         }
         return deployment;
     }
 
     protected static String performCall(final String url) throws ExecutionException, IOException, TimeoutException {
-        return HttpRequest.get(url, 10, TimeUnit.MINUTES); // TODO (jrp) way to long only set for debugging
+        return HttpRequest.get(url, TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+    }
+
+    protected static WebArchive addJobXml(final Package pkg, final WebArchive deployment, final String jobXml) {
+        return addJobXml(pkg, deployment, jobXml, jobXml);
+    }
+
+    protected static WebArchive addJobXml(final Package pkg, final WebArchive deployment, final String fileName, final String jobXml) {
+        return deployment.addAsWebInfResource(pkg, fileName, "classes/META-INF/batch-jobs/" + jobXml);
+    }
+
+    protected static WebArchive addJobXml(final WebArchive deployment, final Asset asset, final String jobXml) {
+        return deployment.addAsWebInfResource(asset, "classes/META-INF/batch-jobs/" + jobXml);
     }
 
     public static class UrlBuilder {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/DeploymentResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/DeploymentResourceTestCase.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.batch.deployment;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
+import org.jboss.as.test.integration.batch.common.CountingItemReader;
+import org.jboss.as.test.integration.batch.common.CountingItemWriter;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the start, stop and restart functionality for deployments.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DeploymentResourceTestCase extends AbstractBatchTestCase {
+
+    private static final String DEPLOYMENT_NAME_1 = "test-batch-1.war";
+
+    private static final String DEPLOYMENT_NAME_2 = "test-batch-2.war";
+
+    @ArquillianResource
+    // @OperateOnDeployment is required until WFARQ-13 is resolved
+    @OperateOnDeployment(DEPLOYMENT_NAME_1)
+    private ManagementClient managementClient;
+
+    @Deployment(name = DEPLOYMENT_NAME_1)
+    public static WebArchive createDeployment1() {
+        final Package pkg = DeploymentResourceTestCase.class.getPackage();
+        final WebArchive deployment = createDefaultWar(DEPLOYMENT_NAME_1, pkg)
+                .addClasses(CountingItemReader.class, CountingItemWriter.class);
+        addJobXml(pkg, deployment, "test-chunk.xml");
+        addJobXml(pkg, deployment, "test-chunk.xml", "same-test-chunk.xml");
+        return deployment;
+    }
+
+    @Deployment(name = DEPLOYMENT_NAME_2)
+    public static WebArchive createDeployment2() {
+        final Package pkg = DeploymentResourceTestCase.class.getPackage();
+        final WebArchive deployment = createDefaultWar(DEPLOYMENT_NAME_2, pkg)
+                .addClasses(CountingItemReader.class, CountingItemWriter.class);
+        addJobXml(pkg, deployment, "test-chunk.xml");
+        addJobXml(pkg, deployment, "test-chunk.xml", "same-test-chunk.xml");
+        addJobXml(pkg, deployment, "test-chunk-other.xml");
+        addJobXml(deployment, EmptyAsset.INSTANCE, "invalid.xml");
+        return deployment;
+    }
+
+    @Test
+    public void testRootResourceJobXmlListing() throws Exception {
+        // First deployment should only have two available XML descriptors
+        validateJobXmlNames(DEPLOYMENT_NAME_1, "test-chunk.xml", "same-test-chunk.xml");
+        // Second deployment should have 3 available descriptors and one missing descriptor as it's invalid
+        validateJobXmlNames(DEPLOYMENT_NAME_2, Arrays.asList("test-chunk.xml", "same-test-chunk.xml", "test-chunk-other.xml"), Collections.singleton("invalid.xml"));
+    }
+
+    @Test
+    public void testDeploymentJobXmlListing() throws Exception {
+        // First deployment should have two available XML descriptors on the single job
+        ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME_1, "subsystem", "batch-jberet", "job", "test-chunk");
+        validateJobXmlNames(address, "test-chunk.xml", "same-test-chunk.xml");
+
+        // Second deployment should have two available jobs. The first job should have two available XML descriptors the
+        // second job should only have one descriptor.
+        address = Operations.createAddress("deployment", DEPLOYMENT_NAME_2, "subsystem", "batch-jberet", "job", "test-chunk");
+        validateJobXmlNames(address, "test-chunk.xml", "same-test-chunk.xml");
+        address = Operations.createAddress("deployment", DEPLOYMENT_NAME_2, "subsystem", "batch-jberet", "job", "test-chunk-other");
+        validateJobXmlNames(address, "test-chunk-other.xml");
+    }
+
+    private void validateJobXmlNames(final String deploymentName, final String... expectedDescriptors) throws IOException {
+        validateJobXmlNames(deploymentName, Arrays.asList(expectedDescriptors), Collections.emptyList());
+    }
+
+    private void validateJobXmlNames(final ModelNode address, final String... expectedDescriptors) throws IOException {
+        validateJobXmlNames(address, Arrays.asList(expectedDescriptors), Collections.emptyList());
+    }
+
+    private void validateJobXmlNames(final String deploymentName, final Collection<String> expectedDescriptors,
+                                     final Collection<String> unexpectedDescriptors) throws IOException {
+        final ModelNode address = Operations.createAddress("deployment", deploymentName, "subsystem", "batch-jberet");
+        validateJobXmlNames(address, expectedDescriptors, unexpectedDescriptors);
+    }
+
+    private void validateJobXmlNames(final ModelNode address, final Collection<String> expectedDescriptors,
+                                     final Collection<String> unexpectedDescriptors) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(address, "job-xml-names");
+        final ModelNode result = executeOperation(op);
+        final Collection<String> jobNames = result.asList()
+                .stream()
+                .map(ModelNode::asString)
+                .collect(Collectors.toSet());
+
+        Assert.assertEquals(expectedDescriptors.size(), jobNames.size());
+        for (String xmlDescriptor : expectedDescriptors) {
+            Assert.assertTrue(String.format("Expected %s to be in the list of job-xml-names.", xmlDescriptor),
+                    jobNames.contains(xmlDescriptor));
+        }
+
+        for (String xmlDescriptor : unexpectedDescriptors) {
+            Assert.assertFalse(String.format("Expected %s to NOT be in the list of job-xml-names.", xmlDescriptor),
+                    jobNames.contains(xmlDescriptor));
+        }
+    }
+
+    @SuppressWarnings("Duplicates")
+    private ModelNode executeOperation(final ModelNode op) throws IOException {
+        final ModelControllerClient client = managementClient.getControllerClient();
+        final ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return Operations.readResult(result);
+        }
+        Assert.fail(Operations.getFailureDescription(result).asString());
+        // Should never be reached
+        return new ModelNode();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/test-chunk-other.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/test-chunk-other.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<job id="test-chunk-other" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="step1">
+        <chunk item-count="3">
+            <reader ref="countingItemReader">
+                <properties>
+                    <property name="reader.start" value="#{jobParameters['reader.start']}"/>
+                    <property name="reader.end" value="#{jobParameters['reader.end']}"/>
+                </properties>
+            </reader>
+            <writer ref="countingItemWriter">
+                <properties>
+                    <property name="writer.sleep.time" value="#{jobParameters['writer.sleep.time']}"/>
+                </properties>
+            </writer>
+        </chunk>
+    </step>
+</job>


### PR DESCRIPTION
The attribute for all `job-xml-names` is listed on the root `deployment=*/subsystem=batch-jberet` subsystem. The job names also include the attribute which only list the job XML descriptors that job is associated with.

https://issues.jboss.org/browse/WFLY-6858
