### PR TITLE
WFLY-6965 Audit @Ignore-d clustering integration tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -108,7 +107,7 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
     }
 
     /**
-     * Associtation of node names to deployment,container names and client context
+     * Association of node names to deployment,container names and client context
      */
     @Test
     @InSequence(-1)
@@ -129,7 +128,6 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         log.info("URL2 nodename: " + nodeName2);
     }
 
-    @Ignore("JBPAPP-8774")
     @Test
     @InSequence(1)
     public void testPassivationBeanAnnotated(

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBaseBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/CounterBaseBean.java
@@ -1,4 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.CreateException;
 
 import org.jboss.as.test.clustering.NodeNameGetter;
 
@@ -8,7 +33,7 @@ import org.jboss.as.test.clustering.NodeNameGetter;
 public abstract class CounterBaseBean {
     private int count;
 
-    public void ejbCreate() throws java.rmi.RemoteException, javax.ejb.CreateException {
+    public void ejbCreate() throws RemoteException, CreateException {
         // Creating method for home interface...
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -81,14 +80,12 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClient
     }
 
     @Override
-    @InSequence(1)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception {
         failoverFromRemoteClient(false);
     }
 
     @Override
-    @InSequence(2)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeUndeploys() throws Exception {
         failoverFromRemoteClient(true);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover;
 
 import javax.naming.NamingException;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/CounterBeanDD.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/CounterBeanDD.java
@@ -40,6 +40,12 @@ public class CounterBeanDD extends CounterBaseBean implements SessionBean {
     private static final long serialVersionUID = 1L;
 
     @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+        log.info("ejbRemove() was called..");
+        CounterSingleton.destroyCounter.incrementAndGet();
+    }
+
+    @Override
     public void ejbActivate() throws EJBException, RemoteException {
 
     }
@@ -47,12 +53,6 @@ public class CounterBeanDD extends CounterBaseBean implements SessionBean {
     @Override
     public void ejbPassivate() throws EJBException, RemoteException {
 
-    }
-
-    @Override
-    public void ejbRemove() throws EJBException, RemoteException {
-        log.info("ejbRemove() was called..");
-        CounterSingleton.destroyCounter.intValue();
     }
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -26,19 +26,16 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterBaseBean;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterRemote;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterRemoteHome;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.CounterResult;
 import org.jboss.as.test.clustering.extended.ejb2.stateful.remote.failover.RemoteEJBClientStatefulFailoverTestBase;
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,7 +45,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBClientStatefulFailoverTestBase {
-    private static final Logger log = Logger.getLogger(RemoteEJB2ClientStatefulBeanFailoverDDTestCase.class);
 
     @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -80,21 +76,16 @@ public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBCli
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(RemoteEJB2ClientStatefulBeanFailoverDDTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment." + ARCHIVE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
-        log.info(jar.toString(true));
         return jar;
     }
 
-    @Ignore("JBPAPP-8726")
     @Override
-    @InSequence(1)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeGoesDown() throws Exception {
         failoverFromRemoteClient(false);
     }
 
-    @Ignore("JBPAPP-8726")
     @Override
-    @InSequence(2)
     @Test
     public void testFailoverFromRemoteClientWhenOneNodeUndeploys() throws Exception {
         failoverFromRemoteClient(true);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/dd/ejb-jar.xml
@@ -32,13 +32,5 @@
             <session-type>Stateful</session-type>
             <transaction-type>Container</transaction-type>
         </session>
-        <session>
-            <ejb-name>ViewChangeListenerBean</ejb-name>
-            <home>org.jboss.as.test.clustering.ViewChangeListenerHome</home>
-            <remote>org.jboss.as.test.clustering.ViewChangeListener</remote>
-            <ejb-class>org.jboss.as.test.clustering.ViewChangeListenerBean</ejb-class>
-            <session-type>Stateless</session-type>
-            <transaction-type>Bean</transaction-type>
-        </session>
     </enterprise-beans>
 </ejb-jar>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -115,13 +114,11 @@ public class XSiteSimpleTestCase extends ExtendedClusterAbstractTestCase {
      *   arrives at SFO-0 on site SFO
      */
     @Test
-    @Ignore("https://issues.jboss.org/browse/WFLY-5239")
     public void testPutRelayedToBackups(
             @ArquillianResource(CacheAccessServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(CacheAccessServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
             @ArquillianResource(CacheAccessServlet.class) @OperateOnDeployment(DEPLOYMENT_3) URL baseURL3,
             @ArquillianResource(CacheAccessServlet.class) @OperateOnDeployment(DEPLOYMENT_4) URL baseURL4)
-
             throws IllegalStateException, IOException, URISyntaxException {
 
         String value = "100";


### PR DESCRIPTION
Unignores 3 test cases by fixing the test cases or removing no longer necessary ignores.

Jira
https://issues.jboss.org/browse/WFLY-6965
