### PR TITLE
[WFLY-6971] : MDB cannot be deployed after migration due to invalid cache configuration. Log a message in order to detect and reject any invalid configuration.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3127,4 +3127,8 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 488, value = "Unauthenticated (anonymous) access to this EJB method is not authorized")
     SecurityException ejbAuthenticationRequired();
 
+    @LogMessage(level = WARN)
+    @Message(id = 489, value = "Cache configuration is errorous. Passivation store was not added.")
+    void cachePassivationStoreNotAdded();
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreAdd.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.ejb3.cache.distributable.DistributableCacheFactoryBuilderService;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
@@ -85,8 +86,12 @@ public class PassivationStoreAdd extends AbstractAddStepHandler {
                 this.maxSize = size;
             }
         };
-        new DistributableCacheFactoryBuilderService<>(context.getCapabilityServiceSupport(), name, config).build(context.getServiceTarget())
+
+        if (config.getCacheName() != null)
+            new DistributableCacheFactoryBuilderService<>(context.getCapabilityServiceSupport(), name, config).build(context.getServiceTarget())
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install();
+        else
+            EjbLogger.ROOT_LOGGER.cachePassivationStoreNotAdded();
     }
 }


### PR DESCRIPTION
[WFLY-6971] : https://issues.jboss.org/browse/WFLY-6971
