### PR TITLE
WFLY-835 Upgrade jboss-transaction-spi to 7.3.3.Final and renable ej…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.3.4.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
-        <version.org.jboss.jboss-transaction-spi>7.3.0.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.3.3.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.narayana>5.3.3.Final</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.3.Final</version.org.jboss.mod_cluster>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
@@ -58,7 +58,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -173,7 +172,6 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
      * Validates failover on redeploy of a simple @Stateful bean
      */
     @Test
-    @Ignore("WFLY-835 @Resource UserTransaction error when file passivation store is selected")
     public void persistenceFailover(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2) throws Exception {


### PR DESCRIPTION
…b passivation test

Fix for https://issues.jboss.org/browse/WFLY-835
- needed an upgrade of jboss-transaction-spi (to 7.3.3.Final)
- the PR also removes the @Ignore for test persistenceFailover
