### PR TITLE
make build work again on IBM JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2261,6 +2261,10 @@
                         <groupId>org.springframework</groupId>
                         <artifactId>spring-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>xalan</groupId>
+                        <artifactId>xalan</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
makes enforcer not complain on ibm jdk anymore.
