### PR TITLE
[WFLY-7008] Drop 'extension' from cap name as we don't use this patte…

### DIFF
--- a/sar/src/main/java/org/jboss/as/service/SarExtension.java
+++ b/sar/src/main/java/org/jboss/as/service/SarExtension.java
@@ -73,7 +73,7 @@ public class SarExtension implements Extension {
     private static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SarExtension.SUBSYSTEM_NAME);
 
     static final String JMX_CAPABILITY = "org.wildfly.management.jmx";
-    static final RuntimeCapability<Void> SAR_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.sar-deployment")
+    static final RuntimeCapability<Void> SAR_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.sar-deployment")
             .addRequirements(JMX_CAPABILITY)
             .build();
 


### PR DESCRIPTION
…rn elsewhere

This doesn't resolve the JIRA but I want to register the permanent name in the registry.

The cap isn't registered so we're free to change it at this point.
