### PR TITLE
Add PMD plugin to detect and report use of Thread.sleep() in tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
@@ -46,7 +46,7 @@ public class ClusterTestUtil {
         }
         // TODO: Instead of dummy waiting, we could attach a listener and notify the test framework the replication has happened. millis value can be used as timeout in that case.
         try {
-            Thread.sleep(millis);
+            Thread.sleep(millis); //NOPMD
         } catch (InterruptedException iex) {
         }
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -73,7 +73,7 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
 
             deploy(DEPLOYMENT_2);
 
-            Thread.sleep(VIEW_CHANGE_WAIT);
+            Thread.sleep(VIEW_CHANGE_WAIT); //NOPMD
 
             topology = bean.getClusterTopology();
             assertEquals(2, topology.getNodes().size());
@@ -91,7 +91,7 @@ public class CommandDispatcherTestCase extends ClusterAbstractTestCase {
 
             start(CONTAINER_1);
 
-            Thread.sleep(VIEW_CHANGE_WAIT);
+            Thread.sleep(VIEW_CHANGE_WAIT); //NOPMD
 
             topology = bean.getClusterTopology();
             assertEquals(topology.getNodes().toString(), 2, topology.getNodes().size());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -127,13 +127,13 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             Incrementor bean = context.lookupStateless(beanClass, Incrementor.class);
 
             // Allow sufficient time for client to receive full topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             List<String> results = new ArrayList<>(COUNT);
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
                 results.add(result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                Thread.sleep(INVOCATION_WAIT); //NOPMD
             }
 
             for (String node: NODES) {
@@ -146,7 +146,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
                 results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                Thread.sleep(INVOCATION_WAIT); //NOPMD
             }
 
             Assert.assertEquals(0, Collections.frequency(results, NODE_1));
@@ -155,12 +155,12 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             deploy(DEPLOYMENT_1);
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
                 results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                Thread.sleep(INVOCATION_WAIT); //NOPMD
             }
 
             for (String node: NODES) {
@@ -173,7 +173,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
                 results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                Thread.sleep(INVOCATION_WAIT); //NOPMD
             }
 
             Assert.assertEquals(COUNT, Collections.frequency(results, NODE_1));
@@ -182,12 +182,12 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             start(CONTAINER_2);
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
                 results.set(i, result.getNode());
-                Thread.sleep(INVOCATION_WAIT);
+                Thread.sleep(INVOCATION_WAIT); //NOPMD
             }
 
             for (String node: NODES) {
@@ -232,7 +232,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             deploy(this.findDeployment(target));
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             result = bean.increment();
             String failbackTarget = result.getNode();
@@ -265,7 +265,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             start(this.findContainer(target));
 
             // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             result = bean.increment();
             failbackTarget = result.getNode();
@@ -308,7 +308,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
             AtomicInteger count = new AtomicInteger();
 
             // Allow sufficient time for client to receive full topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT); //NOPMD
 
             String target = bean.increment().getNode();
             count.incrementAndGet();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
@@ -104,14 +104,14 @@ public class StatefulTimeoutTestCase extends ClusterAbstractTestCase {
             assertEquals(3, queryCount(client, uri2));
             assertEquals(4, queryCount(client, uri2));
 
-            Thread.sleep(WAIT_FOR_TIMEOUT);
+            Thread.sleep(WAIT_FOR_TIMEOUT); //NOPMD
 
             // SFSB should have timed out
             assertEquals(0, queryCount(client, uri1));
             // Subsequent request will create it again
             assertEquals(1, queryCount(client, uri1));
 
-            Thread.sleep(WAIT_FOR_TIMEOUT);
+            Thread.sleep(WAIT_FOR_TIMEOUT); //NOPMD
 
             // Make sure SFSB times out on other node too
             assertEquals(0, queryCount(client, uri2));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
@@ -94,9 +94,9 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
                     throws IOException, URISyntaxException, InterruptedException {
 
         this.deploy(SINGLETON_DEPLOYMENT_1);
-        Thread.sleep(DELAY);
+        Thread.sleep(DELAY); //NOPMD
         this.deploy(SINGLETON_DEPLOYMENT_2);
-        Thread.sleep(DELAY);
+        Thread.sleep(DELAY); //NOPMD
 
         URI uri1 = TraceServlet.createURI(new URL(baseURL1.getProtocol(), baseURL1.getHost(), baseURL1.getPort(), "/" + this.deploymentName + "/"));
         URI uri2 = TraceServlet.createURI(new URL(baseURL2.getProtocol(), baseURL2.getHost(), baseURL2.getPort(), "/" + this.deploymentName + "/"));
@@ -118,7 +118,7 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
 
             this.undeploy(SINGLETON_DEPLOYMENT_1);
 
-            Thread.sleep(DELAY);
+            Thread.sleep(DELAY); //NOPMD
 
             response = client.execute(new HttpGet(uri1));
             try {
@@ -136,7 +136,7 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
 
             this.deploy(SINGLETON_DEPLOYMENT_1);
 
-            Thread.sleep(DELAY);
+            Thread.sleep(DELAY); //NOPMD
 
             response = client.execute(new HttpGet(uri1));
             try {
@@ -154,7 +154,7 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
 
             this.undeploy(SINGLETON_DEPLOYMENT_2);
 
-            Thread.sleep(DELAY);
+            Thread.sleep(DELAY); //NOPMD
 
             response = client.execute(new HttpGet(uri1));
             try {
@@ -172,7 +172,7 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
 
             this.deploy(SINGLETON_DEPLOYMENT_2);
 
-            Thread.sleep(DELAY);
+            Thread.sleep(DELAY); //NOPMD
 
             response = client.execute(new HttpGet(uri1));
             try {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
@@ -207,7 +207,7 @@ public class DistributableTestCase extends ClusterAbstractTestCase {
             Future<HttpResponse> future = executor.submit(new RequestTask(client, longRunningURI));
 
             // Make sure long request has started
-            Thread.sleep(1000);
+            Thread.sleep(1000); //NOPMD
 
             if (undeployOnly) {
                 // Undeploy the app only.

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -374,7 +374,7 @@ public abstract class SessionExpirationTestCase extends ClusterAbstractTestCase 
             }
 
             // Trigger timeout of sessionId
-            Thread.sleep(2000);
+            Thread.sleep(2000); //NOPMD
 
             // Timeout should trigger session destroyed event and valueUnbound binding event
             response = client.execute(new HttpGet(SessionOperationServlet.createGetURI(baseURL2, "a")));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -116,7 +116,7 @@ public abstract class ClusterPassivationTestBase {
         do {
             clusterContext = ejbClientContext.getClusterContext(CLUSTER_NAME);
             counter--;
-            Thread.sleep(CLUSTER_ESTABLISHMENT_WAIT_MS);
+            Thread.sleep(CLUSTER_ESTABLISHMENT_WAIT_MS); //NOPMD
         } while (clusterContext == null && counter < CLUSTER_ESTABLISHMENT_LOOP_COUNT);
         Assert.assertNotNull("Cluster context for " + CLUSTER_NAME + " was not taken in "
                 + (CLUSTER_ESTABLISHMENT_LOOP_COUNT * CLUSTER_ESTABLISHMENT_WAIT_MS) + " ms", clusterContext);
@@ -136,7 +136,7 @@ public abstract class ClusterPassivationTestBase {
         Assert.assertEquals(++clientNumber, statefulBean.getNumber()); // 41
         // nodeName of nested bean should be the same as the node of parent
         log.info("Called node name first: " + calledNodeFirst);
-        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
+        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation //NOPMD
 
         // A small hack - deleting node (by name) from cluster which this client knows
         // It means that the next request (ejb call) will be passed to the server #2
@@ -147,7 +147,7 @@ public abstract class ClusterPassivationTestBase {
         String calledNodeSecond = statefulBean.incrementNumber(); // 42
         statefulBean.setPassivationNode(calledNodeSecond);
         log.info("Called node name second: " + calledNodeSecond);
-        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
+        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation //NOPMD
 
         // Resetting cluster context to know both cluster nodes
         setupEJBClientContextSelector();
@@ -167,7 +167,7 @@ public abstract class ClusterPassivationTestBase {
 
         Assert.assertEquals("Supposing to get passivation node which was set", calledNodeSecond, statefulBean.getPassivatedBy());
 
-        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation
+        Thread.sleep(WAIT_FOR_PASSIVATION_MS); // waiting for passivation //NOPMD
         Assert.assertEquals(++clientNumber, statefulBean.getNumber()); // 43
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
@@ -137,7 +137,7 @@ public class ClusteredMessagingTestCase {
         String text = UUID.randomUUID().toString();
 
         // WIP test if the problem is that the view is not yet propagated
-        Thread.sleep(ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE);
+        Thread.sleep(ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE); //NOPMD
 
         // send to the queue on server 0
         sendMessage(contextFromServer0, jmsQueueLookup, text);
@@ -167,7 +167,7 @@ public class ClusteredMessagingTestCase {
             String text = UUID.randomUUID().toString();
 
             // WIP test if the problem is that the view is not yet propagated
-            Thread.sleep(ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE);
+            Thread.sleep(ClusteringTestConstants.GRACE_TIME_TO_MEMBERSHIP_CHANGE); //NOPMD
 
             // send a message to the topic on server 0
             sendMessage(contextFromServer0, jmsTopicLookup, text);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -75,7 +75,7 @@ public class SimpleServlet extends HttpServlet {
         if (req.getParameter(REQUEST_DURATION_PARAM) != null) {
             int duration = Integer.valueOf(req.getParameter(REQUEST_DURATION_PARAM));
             try {
-                Thread.sleep(duration);
+                Thread.sleep(duration); //NOPMD
             } catch (InterruptedException ex) {
             }
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/tunnel/singleton/SingletonTunnelTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/tunnel/singleton/SingletonTunnelTestCase.java
@@ -206,7 +206,7 @@ public class SingletonTunnelTestCase extends ClusterAbstractTestCase {
     private static void waitForView(URL baseURL, String... members) throws IOException, URISyntaxException {
         ClusterHttpClientUtil.establishTopology(baseURL, CONTAINER, "default", TOPOLOGY_CHANGE_TIMEOUT, members);
         try {
-            Thread.sleep(5000); // it takes a little extra time after merge for the singleton service to migrate
+            Thread.sleep(5000); // it takes a little extra time after merge for the singleton service to migrate //NOPMD
         } catch (InterruptedException e) {
             Assert.fail("Interrupted.");
         }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToJMSQueueTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToJMSQueueTest.java
@@ -101,7 +101,7 @@ public class SendToJMSQueueTest {
             connection.close();
 
             try {
-                Thread.sleep(2000);
+                Thread.sleep(2000); //NOPMD
             } catch (InterruptedException ex) {
             }
 
@@ -250,7 +250,7 @@ public class SendToJMSQueueTest {
             logger.info("Receiving");
             receivedMessage = consumer.receive(5000);
             try {
-                Thread.sleep(1000);
+                Thread.sleep(1000); //NOPMD
             } catch (InterruptedException ex) {
             }
             consumerSession.recover();

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueFromWithinTransactionTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueFromWithinTransactionTest.java
@@ -85,7 +85,7 @@ public class SendToQueueFromWithinTransactionTest {
     public void sendSuccessfully() throws Exception {
         try {
             sender.sendToQueueSuccessfully();
-            Thread.sleep(2000);
+            Thread.sleep(2000); //NOPMD
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -96,7 +96,7 @@ public class SendToQueueFromWithinTransactionTest {
     public void sendAndRollback() {
         try {
             sender2.sendToQueueAndRollback();
-            Thread.sleep(2000);
+            Thread.sleep(2000); //NOPMD
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToTopicFromWithinTransactionTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToTopicFromWithinTransactionTest.java
@@ -85,7 +85,7 @@ public class SendToTopicFromWithinTransactionTest {
     public void sendSuccessfully() throws Exception {
         try {
             sender.sendToTopicSuccessfully();
-            Thread.sleep(2000);
+            Thread.sleep(2000); //NOPMD
         } catch (Exception ex) {
             ex.printStackTrace();
         }
@@ -96,7 +96,7 @@ public class SendToTopicFromWithinTransactionTest {
     public void sendAndRollback() {
         try {
             sender2.sendToTopicAndRollback();
-            Thread.sleep(2000);
+            Thread.sleep(2000); // NOPMD
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/sar/ProcessMonitorService.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/sar/ProcessMonitorService.java
@@ -57,7 +57,7 @@ public class ProcessMonitorService implements ProcessMonitorServiceMBean {
 
                     log.info(config.getExampleName() + "-Montitor: System using " + usedmemory + " Mb of " + totalmemory + " Mb after " + seconds + " seconds");
                     try {
-                        Thread.sleep(config.getIntervalSeconds() * 1000);
+                        Thread.sleep(config.getIntervalSeconds() * 1000); //NOPMD
                     } catch (InterruptedException e) {
                         stop.set(true);
                     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
@@ -177,7 +177,7 @@ public abstract class RequestDumpingHandlerTestImpl {
                 hasFound = true;
                 break;
             }
-            Thread.sleep(SLEEP_TIMEOUT);
+            Thread.sleep(SLEEP_TIMEOUT); //NOPMD
         } while (currTime - startTime < TOTAL_DELAY);
 
         log.info("I have read following content of the file '" + logFilePath + "':\n" + content + "\n---END-OF-FILE-OUTPUT---");

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/threads/RaceyServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/threads/RaceyServlet.java
@@ -41,7 +41,7 @@ public class RaceyServlet extends HttpServlet {
         int value = this.value;
         //incremement the value, with a little sleep to increase the chance of a racey update
         try {
-            Thread.sleep(2);
+            Thread.sleep(2); //NOPMD
         } catch (InterruptedException e) {
 
         }

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -371,6 +371,22 @@
                    <artifactId>maven-install-plugin</artifactId>
                    <executions><execution><id>default-install</id><phase>none</phase></execution></executions>
                </plugin>
+
+               <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.5</version>
+                <configuration>
+                    <rulesets>
+                        <ruleset>https://raw.githubusercontent.com/wildfly/wildfly/master/testsuite/shared/src/main/config/pmd.xml</ruleset>
+                    </rulesets>
+                    <linkXref>true</linkXref>
+                    <sourceEncoding>utf-8</sourceEncoding>
+                    <failOnViolation>true</failOnViolation>
+                    <includeTests>true</includeTests>
+                </configuration>
+	        </plugin>
+
             </plugins>
         </pluginManagement>
     </build>
@@ -1298,4 +1314,15 @@
         </profile>
 
     </profiles>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.5</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
 </project>

--- a/testsuite/shared/src/main/config/pmd.xml
+++ b/testsuite/shared/src/main/config/pmd.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset name="Tests Best Programming Practises"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+This rulesets regroups some checks that aims at reducing the "instability" of tests by, for instance, detecting use of Thread.sleep().
+    </description>
+
+    <rule   name="DontUseThreadSleep"
+            message="Don't use Thread.sleep() - use more stable alternative as barrier"
+            language="java"
+            class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+Don't use Thread.sleep() - use more stable alternative as barrier (or other implementation). Rationale behind this is that Thread.sleep tends to make test fails intermittently.
+        </description>
+        <properties>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//PrimaryPrefix/Name[contains(@Image, "Thread.sleep") ]
+]]>
+                </value>
+            </property>
+        </properties>
+        <priority>3</priority>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
Some tests in CI fails intermittently, and one of the cause of that is use of Thread.sleep(). Plugin configuration will cause build to fails on calling pmd:check if code contains calls to Thread.sleep().

Also, add no //NOPMD to existing calls to Thread.sleep() to ensure builds does not fails because of them (until we can remove them).

If merge, the pmd:check should be added to the continous build to ensure that build fails if new Thread.sleep() are added.

(This PR superseeds [PR8281](https://github.com/wildfly/wildfly/pull/8281) )
