### PR TITLE
WFLY-6996 High CPU usage when using attribute web session granularity

### DIFF
--- a/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/SetExternalizer.java
+++ b/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/SetExternalizer.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.marshalling.jboss;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.IntFunction;
+
+import org.wildfly.clustering.marshalling.Externalizer;
+
+/**
+ * Externalizers for implementations of {@link Set}.
+ * @author Paul Ferraro
+ */
+public class SetExternalizer<T extends Set<Object>> implements Externalizer<T> {
+
+    private final Class<T> targetClass;
+    private final IntFunction<T> factory;
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    SetExternalizer(Class targetClass, IntFunction<T> factory) {
+        this.targetClass = targetClass;
+        this.factory = factory;
+    }
+
+    @Override
+    public void writeObject(ObjectOutput output, T set) throws IOException {
+        writeSet(output, set);
+    }
+
+    static <T extends Set<Object>> void writeSet(ObjectOutput output, T set) throws IOException {
+        IndexExternalizer.VARIABLE.writeData(output, set.size());
+        for (Object e : set) {
+            output.writeObject(e);
+        }
+    }
+
+    @Override
+    public T readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        int size = IndexExternalizer.VARIABLE.readData(input);
+        return readSet(input, this.factory.apply(size), size);
+    }
+
+    static <T extends Set<Object>> T readSet(ObjectInput input, T set, int size) throws IOException, ClassNotFoundException {
+        for (int i = 0; i < size; ++i) {
+            set.add(input.readObject());
+        }
+        return set;
+    }
+
+    @Override
+    public Class<? extends T> getTargetClass() {
+        return this.targetClass;
+    }
+
+    public static class ConcurrentHashSetExternalizer extends SetExternalizer<ConcurrentHashMap.KeySetView<Object, Boolean>> {
+        public ConcurrentHashSetExternalizer() {
+            super(ConcurrentHashMap.KeySetView.class, capacity -> ConcurrentHashMap.newKeySet(capacity));
+        }
+    }
+
+    public static class HashSetExternalizer extends SetExternalizer<HashSet<Object>> {
+        public HashSetExternalizer() {
+            super(HashSet.class, HashSet::new);
+        }
+    }
+
+    public static class LinkedHashSetExternalizer extends SetExternalizer<LinkedHashSet<Object>> {
+        public LinkedHashSetExternalizer() {
+            super(LinkedHashSet.class, LinkedHashSet::new);
+        }
+    }
+}

--- a/clustering/marshalling/jboss/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
+++ b/clustering/marshalling/jboss/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
@@ -16,6 +16,9 @@ org.wildfly.clustering.marshalling.jboss.MapExternalizer$ConcurrentHashMapExtern
 org.wildfly.clustering.marshalling.jboss.MapExternalizer$HashMapExternalizer
 org.wildfly.clustering.marshalling.jboss.MapExternalizer$LinkedHashMapExternalizer
 org.wildfly.clustering.marshalling.jboss.SimpleMarshalledValueExternalizer
+org.wildfly.clustering.marshalling.jboss.SetExternalizer$ConcurrentHashSetExternalizer
+org.wildfly.clustering.marshalling.jboss.SetExternalizer$HashSetExternalizer
+org.wildfly.clustering.marshalling.jboss.SetExternalizer$LinkedHashSetExternalizer
 org.wildfly.clustering.marshalling.jboss.SortedMapExternalizer$ConcurrentSkipListMapExternalizer
 org.wildfly.clustering.marshalling.jboss.SortedMapExternalizer$TreeMapExternalizer
 org.wildfly.clustering.marshalling.jboss.SortedSetExternalizer$ConcurrentSkipListSetExternalizer

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -174,7 +174,7 @@ public class InfinispanSessionManagerFactory implements SessionManagerFactory<Tr
 
         switch (this.config.getSessionManagerFactoryConfiguration().getAttributePersistenceStrategy()) {
             case FINE: {
-                return new FineSessionAttributesFactory(this.config.getCache(), new MarshalledValueMarshaller<>(factory, context), properties);
+                return new FineSessionAttributesFactory(this.config.getCache(), this.config.getCache(), new MarshalledValueMarshaller<>(factory, context), properties);
             }
             case COARSE: {
                 return new CoarseSessionAttributesFactory(this.config.getCache(), new MarshalledValueMarshaller<>(factory, context), properties);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributesFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributesFactory.java
@@ -26,6 +26,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
@@ -59,21 +60,18 @@ public class CoarseSessionAttributesFactory implements SessionAttributesFactory<
 
     @Override
     public Map.Entry<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> createValue(String id, Void context) {
-        SessionAttributesKey attributesKey = new SessionAttributesKey(id);
-        MarshalledValue<Map<String, Object>, MarshallingContext> value = this.cache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).computeIfAbsent(attributesKey, key -> this.marshaller.write(this.properties.isLockOnRead() ? new HashMap<>() : new ConcurrentHashMap<>()));
-        try {
-            Map<String, Object> attributes = this.marshaller.read(value);
-            return new SimpleImmutableEntry<>(attributes, value);
-        } catch (InvalidSerializedFormException e) {
-            InfinispanWebLogger.ROOT_LOGGER.failedToActivateSession(e, id);
-            this.cache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES).remove(attributesKey);
-            return this.createValue(id, context);
-        }
+        Map.Entry<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> value = this.getValue(id, key -> this.cache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).computeIfAbsent(key, k -> this.marshaller.write(this.properties.isLockOnRead() ? new HashMap<>() : new ConcurrentHashMap<>())));
+        return (value != null) ? value : this.createValue(id, context);
     }
 
     @Override
     public Map.Entry<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> findValue(String id) {
-        MarshalledValue<Map<String, Object>, MarshallingContext> value = this.cache.get(new SessionAttributesKey(id));
+        return this.getValue(id, key -> this.cache.get(key));
+    }
+
+    private Map.Entry<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> getValue(String id, Function<SessionAttributesKey, MarshalledValue<Map<String, Object>, MarshallingContext>> supplier) {
+        SessionAttributesKey key = new SessionAttributesKey(id);
+        MarshalledValue<Map<String, Object>, MarshallingContext> value = supplier.apply(key);
         if (value != null) {
             try {
                 Map<String, Object> attributes = this.marshaller.read(value);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineImmutableSessionAttributes.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineImmutableSessionAttributes.java
@@ -21,8 +21,8 @@
  */
 package org.wildfly.clustering.web.infinispan.session.fine;
 
+import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.infinispan.Cache;
 import org.wildfly.clustering.marshalling.jboss.InvalidSerializedFormException;
@@ -37,28 +37,30 @@ import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
  */
 public class FineImmutableSessionAttributes<V> implements ImmutableSessionAttributes {
     private final String id;
+    private final Map<String, Integer> names;
     private final Cache<SessionAttributeKey, V> cache;
     private final Marshaller<Object, V, MarshallingContext> marshaller;
 
-    public FineImmutableSessionAttributes(String id, Cache<SessionAttributeKey, V> attributeCache, Marshaller<Object, V, MarshallingContext> marshaller) {
+    public FineImmutableSessionAttributes(String id, Map<String, Integer> names, Cache<SessionAttributeKey, V> attributeCache, Marshaller<Object, V, MarshallingContext> marshaller) {
         this.id = id;
+        this.names = names;
         this.cache = attributeCache;
         this.marshaller = marshaller;
     }
 
     @Override
     public Set<String> getAttributeNames() {
-        return this.cache.getAdvancedCache().getGroup(this.id).keySet().stream().filter((Object object) -> object instanceof SessionAttributeKey).map(key -> key.getAttribute()).collect(Collectors.toSet());
+        return this.names.keySet();
     }
 
     @Override
     public Object getAttribute(String name) {
-        SessionAttributeKey key = this.createKey(name);
-        return this.read(name, this.cache.get(key));
+        Integer attributeId = this.names.get(name);
+        return (attributeId != null) ? this.read(name, this.cache.get(this.createKey(attributeId))) : null;
     }
 
-    protected SessionAttributeKey createKey(String attribute) {
-        return new SessionAttributeKey(this.id, attribute);
+    protected SessionAttributeKey createKey(int attributeId) {
+        return new SessionAttributeKey(this.id, attributeId);
     }
 
     protected Object read(String name, V value) {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionAttributesFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionAttributesFactory.java
@@ -22,12 +22,20 @@
 
 package org.wildfly.clustering.web.infinispan.session.fine;
 
+import java.util.AbstractMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
+import org.wildfly.clustering.ee.infinispan.CacheEntryMutator;
 import org.wildfly.clustering.ee.infinispan.CacheProperties;
+import org.wildfly.clustering.ee.infinispan.Mutator;
 import org.wildfly.clustering.marshalling.jboss.InvalidSerializedFormException;
 import org.wildfly.clustering.marshalling.jboss.MarshalledValue;
 import org.wildfly.clustering.marshalling.jboss.Marshaller;
@@ -39,78 +47,92 @@ import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
 
 /**
  * {@link SessionAttributesFactory} for fine granularity sessions.
- * A given session's attributes are mapped to N co-located cache entries, where N is the number of session attributes.
+ * A given session's attributes are mapped to N+1 co-located cache entries, where N is the number of session attributes.
+ * A separate cache entry stores the activate attribute names for the session.
  * @author Paul Ferraro
  */
-public class FineSessionAttributesFactory implements SessionAttributesFactory<Object> {
+public class FineSessionAttributesFactory implements SessionAttributesFactory<Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>>> {
 
-    private static final Object VALUE = new Object();
-
-    private final Cache<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>> cache;
+    private final Cache<SessionAttributeNamesKey, Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>>> namesCache;
+    private final Cache<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>> attributeCache;
     private final Marshaller<Object, MarshalledValue<Object, MarshallingContext>, MarshallingContext> marshaller;
-    private final Predicate<Map.Entry<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>>> invalidAttribute;
     private final CacheProperties properties;
 
-    public FineSessionAttributesFactory(Cache<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>> cache, Marshaller<Object, MarshalledValue<Object, MarshallingContext>, MarshallingContext> marshaller, CacheProperties properties) {
-        this.cache = cache;
+    public FineSessionAttributesFactory(Cache<SessionAttributeNamesKey, Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>>> namesCache, Cache<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>> attributeCache, Marshaller<Object, MarshalledValue<Object, MarshallingContext>, MarshallingContext> marshaller, CacheProperties properties) {
+        this.namesCache = namesCache;
+        this.attributeCache = attributeCache;
         this.marshaller = marshaller;
         this.properties = properties;
-        this.invalidAttribute = entry -> {
-            try {
-                this.marshaller.read(entry.getValue());
-                return false;
-            } catch (InvalidSerializedFormException e) {
-                InfinispanWebLogger.ROOT_LOGGER.failedToActivateSessionAttribute(e, entry.getKey().getValue(), entry.getKey().getAttribute());
-                return true;
+    }
+
+    @Override
+    public Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> createValue(String id, Void context) {
+        Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry = this.getAttributeNames(id, key -> this.namesCache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).computeIfAbsent(key, k -> new AbstractMap.SimpleImmutableEntry<>(new AtomicInteger(), new ConcurrentHashMap<>())));
+        return (entry != null) ? entry : this.createValue(id, context);
+    }
+
+    @Override
+    public Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> findValue(String id) {
+        return this.getAttributeNames(id, key -> this.namesCache.get(key));
+    }
+
+    private Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> getAttributeNames(String id, Function<SessionAttributeNamesKey, Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>>> provider) {
+        SessionAttributeNamesKey key = new SessionAttributeNamesKey(id);
+        Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry = provider.apply(key);
+        if (entry != null) {
+            ConcurrentMap<String, Integer> names = entry.getValue();
+            Map<SessionAttributeKey, MarshalledValue<Object, MarshallingContext>> attributes = this.attributeCache.getAdvancedCache().getAll(names.values().stream().map(attributeId -> new SessionAttributeKey(id, attributeId)).collect(Collectors.toSet()));
+            Predicate<Map.Entry<String, MarshalledValue<Object, MarshallingContext>>> invalidAttribute = attribute -> {
+                try {
+                    this.marshaller.read(attribute.getValue());
+                    return false;
+                } catch (InvalidSerializedFormException e) {
+                    InfinispanWebLogger.ROOT_LOGGER.failedToActivateSessionAttribute(e, id, attribute.getKey());
+                    return true;
+                }
+            };
+            if (names.entrySet().stream().map(name -> new AbstractMap.SimpleImmutableEntry<>(name.getKey(), attributes.get(new SessionAttributeKey(id, name.getValue())))).anyMatch(invalidAttribute)) {
+                // If any attributes are invalid - remove them all
+                this.remove(id);
+                return null;
             }
-        };
-    }
-
-    @Override
-    public Object createValue(String id, Void context) {
-        // Preemptively read all attributes to detect invalid session attributes
-        if (this.cache.getAdvancedCache().getGroup(id).entrySet().stream().filter(entry -> ((Map.Entry<?, ?>) entry).getKey() instanceof SessionAttributeKey).anyMatch(this.invalidAttribute)) {
-            // If any attributes are invalid - remove them all
-            this.remove(id);
         }
-        return VALUE;
-    }
-
-    @Override
-    public Object findValue(String id) {
-        // Preemptively read all attributes to detect invalid session attributes
-        if (this.cache.getAdvancedCache().getGroup(id).entrySet().stream().filter(entry -> ((Map.Entry<?, ?>) entry).getKey() instanceof SessionAttributeKey).anyMatch(this.invalidAttribute)) {
-            // Invalidate
-            this.remove(id);
-            return null;
-        }
-        return VALUE;
+        return entry;
     }
 
     @Override
     public boolean remove(String id) {
-        this.cache.getAdvancedCache().removeGroup(id);
+        Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry = this.namesCache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).remove(new SessionAttributeNamesKey(id));
+        if (entry == null) return false;
+        entry.getValue().values().forEach(attributeId -> this.attributeCache.getAdvancedCache().withFlags(Flag.IGNORE_RETURN_VALUES).remove(new SessionAttributeKey(id, attributeId)));
         return true;
     }
 
     @Override
     public void evict(String id) {
-        this.cache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).getGroup(id).keySet().stream().filter((Object key) -> key instanceof SessionAttributeKey).forEach(key -> {
-            try {
-                this.cache.evict(key);
-            } catch (Throwable e) {
-                InfinispanWebLogger.ROOT_LOGGER.failedToPassivateSessionAttribute(e, id, key.getAttribute());
-            }
-        });
+        SessionAttributeNamesKey key = new SessionAttributeNamesKey(id);
+        Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry = this.namesCache.getAdvancedCache().withFlags(Flag.SKIP_CACHE_LOAD).get(key);
+        if (entry != null) {
+            entry.getValue().entrySet().stream().forEach(attribute -> {
+                try {
+                    this.attributeCache.evict(new SessionAttributeKey(id, attribute.getValue()));
+                } catch (Throwable e) {
+                    InfinispanWebLogger.ROOT_LOGGER.failedToPassivateSessionAttribute(e, id, attribute.getKey());
+                }
+            });
+            this.namesCache.getAdvancedCache().withFlags(Flag.FAIL_SILENTLY).evict(key);
+        }
     }
 
     @Override
-    public SessionAttributes createSessionAttributes(String id, Object value) {
-        return new FineSessionAttributes<>(id, this.cache, this.marshaller, this.properties);
+    public SessionAttributes createSessionAttributes(String id, Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry) {
+        SessionAttributeNamesKey key = new SessionAttributeNamesKey(id);
+        Mutator mutator = this.properties.isTransactional() && this.namesCache.getAdvancedCache().getCacheEntry(key).isCreated() ? Mutator.PASSIVE : new CacheEntryMutator<>(this.namesCache, key, entry);
+        return new FineSessionAttributes<>(id, entry.getKey(), entry.getValue(), mutator, this.attributeCache, this.marshaller, this.properties);
     }
 
     @Override
-    public ImmutableSessionAttributes createImmutableSessionAttributes(String id, Object value) {
-        return new FineImmutableSessionAttributes<>(id, this.cache, this.marshaller);
+    public ImmutableSessionAttributes createImmutableSessionAttributes(String id, Map.Entry<AtomicInteger, ConcurrentMap<String, Integer>> entry) {
+        return new FineImmutableSessionAttributes<>(id, entry.getValue(), this.attributeCache, this.marshaller);
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeKeyExternalizer.java
@@ -22,9 +22,9 @@
 package org.wildfly.clustering.web.infinispan.session.fine;
 
 import java.io.IOException;
-import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
+import org.wildfly.clustering.marshalling.jboss.IndexExternalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
 /**
@@ -34,12 +34,12 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 public class SessionAttributeKeyExternalizer extends SessionKeyExternalizer<SessionAttributeKey> {
 
     public SessionAttributeKeyExternalizer() {
-        super(SessionAttributeKey.class, (String id, ObjectInput input) -> new SessionAttributeKey(id, input.readUTF()));
+        super(SessionAttributeKey.class, (id, input) -> new SessionAttributeKey(id, IndexExternalizer.VARIABLE.readData(input)));
     }
 
     @Override
     public void writeObject(ObjectOutput output, SessionAttributeKey key) throws IOException {
         super.writeObject(output, key);
-        output.writeUTF(key.getAttribute());
+        IndexExternalizer.VARIABLE.writeData(output, key.getAttributeId());
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKey.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKey.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -24,34 +24,12 @@ package org.wildfly.clustering.web.infinispan.session.fine;
 import org.wildfly.clustering.infinispan.spi.distribution.Key;
 
 /**
- * Cache key for session attributes.
+ * Cache key for session attribute names.
  * @author Paul Ferraro
  */
-public class SessionAttributeKey extends Key<String> {
+public class SessionAttributeNamesKey extends Key<String> {
 
-    private final int attributeId;
-
-    public SessionAttributeKey(String sessionId, int attributeId) {
-        super(sessionId);
-        this.attributeId = attributeId;
-    }
-
-    public int getAttributeId() {
-        return this.attributeId;
-    }
-
-    @Override
-    public int hashCode() {
-        return (31 * super.hashCode()) + this.attributeId;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        return super.equals(object) && (object instanceof SessionAttributeKey) && (this.attributeId == ((SessionAttributeKey) object).attributeId);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("%s(%s[%d])", SessionAttributeKey.class.getSimpleName(), this.getValue(), this.attributeId);
+    public SessionAttributeNamesKey(String id) {
+        super(id);
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyExternalizer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -21,37 +21,15 @@
  */
 package org.wildfly.clustering.web.infinispan.session.fine;
 
-import org.wildfly.clustering.infinispan.spi.distribution.Key;
+import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
 /**
- * Cache key for session attributes.
+ * Externalizer for {@link SessionAttributeNamesKey}.
  * @author Paul Ferraro
  */
-public class SessionAttributeKey extends Key<String> {
+public class SessionAttributeNamesKeyExternalizer extends SessionKeyExternalizer<SessionAttributeNamesKey> {
 
-    private final int attributeId;
-
-    public SessionAttributeKey(String sessionId, int attributeId) {
-        super(sessionId);
-        this.attributeId = attributeId;
-    }
-
-    public int getAttributeId() {
-        return this.attributeId;
-    }
-
-    @Override
-    public int hashCode() {
-        return (31 * super.hashCode()) + this.attributeId;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        return super.equals(object) && (object instanceof SessionAttributeKey) && (this.attributeId == ((SessionAttributeKey) object).attributeId);
-    }
-
-    @Override
-    public String toString() {
-        return String.format("%s(%s[%d])", SessionAttributeKey.class.getSimpleName(), this.getValue(), this.attributeId);
+    public SessionAttributeNamesKeyExternalizer() {
+        super(SessionAttributeNamesKey.class, SessionAttributeNamesKey::new);
     }
 }

--- a/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
+++ b/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
@@ -1,5 +1,6 @@
 org.wildfly.clustering.web.infinispan.session.coarse.SessionAttributesKeyExternalizer
 org.wildfly.clustering.web.infinispan.session.fine.SessionAttributeKeyExternalizer
+org.wildfly.clustering.web.infinispan.session.fine.SessionAttributeNamesKeyExternalizer
 org.wildfly.clustering.web.infinispan.session.SessionAccessMetaDataExternalizer
 org.wildfly.clustering.web.infinispan.session.SessionAccessMetaDataKeyExternalizer
 org.wildfly.clustering.web.infinispan.session.SessionCreationMetaDataEntryExternalizer


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6996

Replaces usage of AdvancedCache.getGroup(...), which is terribly slow, with separate cache entry containing attribute names.
