### PR TITLE
[JBJCA-1173] Test of JCA tracer functionality works when enabled

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/LogHandlerCreationSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/LogHandlerCreationSetup.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.tracer;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.File;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOGGER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE_HANDLER;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adding new log file handler wich is then bound to a logger with specific category.
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class LogHandlerCreationSetup implements ServerSetupTask {
+    public static String JCA_LOG_FILE_PARAM = "jca-server.log";
+    public static final String SERVER_LOG_DIR_PARAM = "jboss.server.log.dir";
+    public static String SERVER_LOG_DIR_VALUE;
+
+    private static final String HANDLER_NAME = "jca-log-handler";
+    private static final String LOGGER_CATEGORY_VALUE = "org.jboss.jca.core.tracer";
+    private static final ModelNode LOGGING_ADDRESS = new ModelNode()
+        .add(SUBSYSTEM, "logging");
+    private static final ModelNode FILE_HANDLER_ADDRESS = new ModelNode()
+        .set(LOGGING_ADDRESS)
+        .add(FILE_HANDLER, HANDLER_NAME);
+    private static final ModelNode LOGGER_ADDRESS = new ModelNode()
+        .set(LOGGING_ADDRESS)
+        .add(LOGGER, LOGGER_CATEGORY_VALUE);
+
+    static {
+        LOGGING_ADDRESS.protect();
+        FILE_HANDLER_ADDRESS.protect();
+        LOGGER_ADDRESS.protect();
+    }
+
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+
+        // /subsystem=logging/file-handler=jca-log-handler:add(append=false, file={relative-to=jboss.server.log.dir, path=jca-server.log})
+        ModelNode fileHandler = new ModelNode();
+        fileHandler.get(OP).set(ADD);
+        fileHandler.get(OP_ADDR).set(FILE_HANDLER_ADDRESS);
+
+        ModelNode file = new ModelNode();
+        file.get("relative-to").set(SERVER_LOG_DIR_PARAM);
+        file.get("path").set(JCA_LOG_FILE_PARAM);
+        fileHandler.get(FILE).set(file);
+        fileHandler.get("append").set("false");
+
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), fileHandler);
+
+        // /subsystem=logging/logger=org.jboss.jca.core.tracer:add(category=org.jboss.jca.core.tracer, level=TRACE, handlers=[jca-log-handler])
+        ModelNode logger = new ModelNode();
+        logger.get(OP).set(ADD);
+        logger.get(OP_ADDR).set(LOGGER_ADDRESS);
+        logger.get("category").set(LOGGER_CATEGORY_VALUE);
+        logger.get("level").set("TRACE");
+        ModelNode handlers = new ModelNode()
+            .add(HANDLER_NAME);
+        logger.get("handlers").set(handlers);
+
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), logger);
+
+        ModelNode getLogDir = new ModelNode();
+        getLogDir.get(OP).set("resolve-expression");
+        getLogDir.get("expression").set("${" + SERVER_LOG_DIR_PARAM + "}");
+        SERVER_LOG_DIR_VALUE = ManagementOperations
+            .executeOperation(managementClient.getControllerClient(), getLogDir).asString();
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        ModelNode logger = new ModelNode();
+        logger.get(OP).set(REMOVE);
+        logger.get(OP_ADDR).set(LOGGER_ADDRESS);
+
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), logger);
+
+        ModelNode fileHandler = new ModelNode();
+        fileHandler.get(OP).set(REMOVE);
+        fileHandler.get(OP_ADDR).set(FILE_HANDLER_ADDRESS);
+
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), fileHandler);
+
+        new File(SERVER_LOG_DIR_VALUE, JCA_LOG_FILE_PARAM).delete();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBean.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.tracer;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.sql.DataSource;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@Stateless
+public class StatelessBean implements StatelessBeanRemote {
+    private static final Logger log = Logger.getLogger(StatelessBean.class);
+
+    private static final String table = "tracer_table";
+    private static final String column = "id";
+
+    @Resource
+    private DataSource ds;
+
+    public void insertToDB() {
+        String sql = String.format("INSERT INTO %s (%s) VALUES (%s)", table, column, 1);
+        executeUpdate(sql);
+        log.infof("sql '%s' executed", sql);
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void createTable() {
+        String sql = String.format("CREATE TABLE IF NOT EXISTS %s (%s int)", table, column);
+        executeUpdate(sql);
+        log.infof("sql '%s' executed", sql);
+    }
+
+    private void executeUpdate(String sql) {
+        Connection conn = null;
+        try {
+            conn = ds.getConnection();
+            Statement statement = conn.createStatement();
+            statement.executeUpdate(sql);
+        } catch (Exception e) {
+            throw new RuntimeException("Can't run sql command '" + sql + "'", e);
+        } finally {
+            if(conn != null) {
+                try {
+                    conn.close();
+                } catch (SQLException e) {
+                    // ignore
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBeanRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBeanRemote.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.tracer;
+
+import javax.ejb.Remote;
+
+/**
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@Remote
+public interface StatelessBeanRemote {
+    void insertToDB();
+    void createTable();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/TracerEnableTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/TracerEnableTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.tracer;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Hashtable;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+    TracerEnableTestCase.TracerEnableSetup.class,
+    LogHandlerCreationSetup.class
+})
+public class TracerEnableTestCase {
+    private static final String ARCHIVE_NAME = "tracer-enable";
+
+    @Deployment
+    public static JavaArchive deploy() throws Exception {
+        return ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar")
+            .addClasses(StatelessBean.class, StatelessBeanRemote.class);
+    }
+
+    @Test
+    public void tracerEnabled() throws NamingException, IOException {
+        final Hashtable<String, Object> jndiProps = new Hashtable<String, Object>();
+        jndiProps.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context ctx = new InitialContext(jndiProps);
+        StatelessBeanRemote bean = (StatelessBeanRemote) ctx.lookup(
+            "ejb:/" + ARCHIVE_NAME + "/" + StatelessBean.class.getSimpleName() + "!" + StatelessBeanRemote.class.getName());
+
+        bean.createTable();
+        bean.insertToDB();
+
+        File logFile = new File(LogHandlerCreationSetup.SERVER_LOG_DIR_VALUE, LogHandlerCreationSetup.JCA_LOG_FILE_PARAM);
+        Assert.assertTrue("Log file " + logFile + " should exist", logFile.exists());
+        String logContent = new String(Files.readAllBytes(Paths.get(logFile.getPath())), StandardCharsets.UTF_8);
+        Assert.assertTrue("Log file " + logFile + " has to contain org.jboss.jca.core.tracer.Tracer",
+            logContent.contains("org.jboss.jca.core.tracer.Tracer"));
+        Assert.assertTrue("Log file " + logFile + " has to contain IJTRACER-ExampleDS",
+                logContent.contains("IJTRACER-ExampleDS"));
+    }
+
+    static final class TracerEnableSetup implements ServerSetupTask {
+        private static final ModelNode TRACER_ADDRESS = new ModelNode()
+            .add(SUBSYSTEM, "jca")
+            .add("tracer", "tracer");
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelNode operation = new ModelNode();
+            operation.get(OP).set(ADD);
+            operation.get(OP_ADDR).set(TRACER_ADDRESS);
+            operation.get("enabled").set("true");
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), operation);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 30_000);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ModelNode operation = new ModelNode();
+            operation.get(OP).set(REMOVE);
+            operation.get(OP_ADDR).set(TRACER_ADDRESS);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), operation);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 30_000);
+        }
+    }
+}


### PR DESCRIPTION
Adding test case which checks when jca tracer is enabled the tracer logs are involved in log file.

Upstream jira: https://issues.jboss.org/browse/JBJCA-1173

The test was written based on EAP 7.1 feature request: https://issues.jboss.org/browse/EAP7-500
