### PR TITLE
Fix potential NPE in DeploymentDefinition

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -98,7 +98,7 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
             final String server = SERVER.resolveModelAttribute(context, subModel).asString();
 
             final ServiceController<?> controller = context.getServiceRegistry(false).getService(UndertowService.deploymentServiceName(server, host, path));
-            if (controller.getState() != ServiceController.State.UP){//check if deployment is active at all
+            if (controller != null && controller.getState() != ServiceController.State.UP){//check if deployment is active at all
                 return;
             }
 


### PR DESCRIPTION
I just saw that stack trace multiple time when stopping Wildfly with 20 "heavy weight" war deployed on it.

```
WFLYCTL0013: Operation ("read-attribute") failed - address: ([
    ("deployment" => "XXXXX.war"),
    ("subsystem" => "undertow")
]): java.lang.NullPointerException
    at org.wildfly.extension.undertow.DeploymentDefinition$SessionManagerStatsHandler.executeRuntimeStep(DeploymentDefinition.java:101)
    at org.jboss.as.controller.AbstractRuntimeOnlyHandler$1.execute(AbstractRuntimeOnlyHandler.java:53)
    at org.jboss.as.controller.AbstractOperationContext.executeStep(AbstractOperationContext.java:890)
    at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:659)
    at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:370)
    at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1329)
    at org.jboss.as.controller.ModelControllerImpl.internalExecute(ModelControllerImpl.java:400)
    at org.jboss.as.controller.ModelControllerImpl.execute(ModelControllerImpl.java:222)
    at org.jboss.as.domain.http.server.DomainApiHandler.handleRequest(DomainApiHandler.java:219)
    at io.undertow.server.handlers.encoding.EncodingHandler.handleRequest(EncodingHandler.java:72)
    at org.jboss.as.domain.http.server.security.SubjectDoAsHandler$1.run(SubjectDoAsHandler.java:72)
    at org.jboss.as.domain.http.server.security.SubjectDoAsHandler$1.run(SubjectDoAsHandler.java:68)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:422)
    at org.jboss.as.controller.AccessAuditContext.doAs(AccessAuditContext.java:149)
    at org.jboss.as.domain.http.server.security.SubjectDoAsHandler.handleRequest(SubjectDoAsHandler.java:68)
    at org.jboss.as.domain.http.server.security.SubjectDoAsHandler.handleRequest(SubjectDoAsHandler.java:63)
    at io.undertow.server.handlers.BlockingHandler.handleRequest(BlockingHandler.java:56)
    at org.jboss.as.domain.http.server.DomainApiCheckHandler.handleRequest(DomainApiCheckHandler.java:95)
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:802)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
    at org.jboss.threads.JBossThread.run(JBossThread.java:320)
```

I think it is safe to simply skip the execution if we ever get in a state where the controller is null.
