### PR TITLE
WFLY-7108 UNSYNCHRONIZED extended persistence context associated but not joined with JTA transaction and target component is persistence context of SYNCHRONIZED, IllegalStateException should be thrown

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -262,7 +262,7 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
 
     @Override // SynchronizationTypeAccess
     public SynchronizationType getSynchronizationType() {
-        return SynchronizationType.SYNCHRONIZED;
+        return synchronizationType;
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/BMTEPCStatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/BMTEPCStatefulBean.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.epcpropagation.unsync;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
+import javax.persistence.SynchronizationType;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+/**
+ * "
+ * If there is a persistence context of type SynchronizationType.UNSYNCHRONIZED
+ * associated with the JTA transaction and the target component specifies a persistence context of
+ * type SynchronizationType.SYNCHRONIZED, the IllegalStateException is
+ * thrown by the container.
+ * "
+ *
+ * @author Scott Marlow
+ */
+@ApplicationScoped
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class BMTEPCStatefulBean {
+
+    @PersistenceContext(synchronization= SynchronizationType.UNSYNCHRONIZED, type = PersistenceContextType.EXTENDED, unitName = "mypc")
+    EntityManager em;
+
+    @Resource
+    SessionContext sessionContext;
+
+    @Inject
+    private CMTPCStatefulBean cmtpcStatefulBean;
+
+    public void willThrowError() throws SystemException, NotSupportedException, HeuristicRollbackException, HeuristicMixedException, RollbackException {
+        em.isJoinedToTransaction();
+        //Begin transaction (before Joining)
+        UserTransaction userTxn = sessionContext.getUserTransaction();
+        userTxn.begin();
+        try {
+            //Join Transaction to force unsynchronized persistence context to be associated with jta tx
+            // em.joinTransaction();
+            cmtpcStatefulBean.getEmp(1);    // show throw IllegalStateException
+            throw new RuntimeException("did not get expected IllegalStateException when transaction scoped entity manager used existing unsynchronized xpc");
+        } finally {
+            userTxn.rollback();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/CMTPCStatefulBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/CMTPCStatefulBean.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.epcpropagation.unsync;
+
+import static javax.ejb.TransactionAttributeType.REQUIRED;
+
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.PersistenceContextType;
+
+/**
+ * CMT stateful bean
+ *
+ * @author Scott Marlow
+ */
+@Stateful
+public class CMTPCStatefulBean {
+    @PersistenceContext(type = PersistenceContextType.TRANSACTION, unitName = "mypc")
+    EntityManager em;
+
+    @TransactionAttribute(REQUIRED)
+    public Employee getEmp(int id) {
+        return em.find(Employee.class, id);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/Employee.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.epcpropagation.unsync;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/TestForMixedSynchronizationTypes.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/TestForMixedSynchronizationTypes.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.epcpropagation.unsync;
+
+import static org.junit.Assert.fail;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * "
+ * If there is a persistence context of type SynchronizationType.UNSYNCHRONIZED
+ * associated with the JTA transaction and the target component specifies a persistence context of
+ * type SynchronizationType.SYNCHRONIZED, the IllegalStateException is
+ * thrown by the container.
+ * "
+ *
+ * @author Scott Marlow
+ */
+@RunWith(Arquillian.class)
+public class TestForMixedSynchronizationTypes {
+    private static final String ARCHIVE_NAME = "jpa_testForMixedSynchronizationTypes";
+
+
+    @Deployment
+    public static Archive<?> deploy() {
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+        jar.addClasses(
+                TestForMixedSynchronizationTypes.class,
+                Employee.class,
+                BMTEPCStatefulBean.class,
+                CMTPCStatefulBean.class);
+        jar.addAsManifestResource(TestForMixedSynchronizationTypes.class.getPackage(), "persistence.xml", "persistence.xml");
+
+        return jar;
+    }
+
+    @ArquillianResource
+    private InitialContext iniCtx;
+
+    protected <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + beanName + "!" + interfaceType.getName()));
+    }
+
+    @Test
+    public void testShouldGetEjbExceptionBecauseEPCIsAddedToTxAfterPc() throws Exception {
+        BMTEPCStatefulBean stateful = lookup("BMTEPCStatefulBean", BMTEPCStatefulBean.class);
+        try {
+            stateful.willThrowError();
+        } catch (Throwable expected) {
+            Throwable cause = expected.getCause();
+            while(cause != null) {
+                if( cause instanceof IllegalStateException && cause.getMessage().contains("JTA transaction already has a 'SynchronizationType.UNSYNCHRONIZED'")) {
+                    break;  // success
+                }
+                cause = cause.getCause();
+                if (cause == null) {
+                    fail("didn't throw IllegalStateException that contains 'JTA transaction already has a 'SynchronizationType.UNSYNCHRONIZED'', instead got message chain: " + messages(expected));
+                }
+            }
+        }
+    }
+
+    private String messages(Throwable exception) {
+        String message = exception.getMessage();
+        while(exception != null) {
+            message = message + " => " + exception.getMessage();
+            exception = exception.getCause();
+        }
+        return message;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/persistence.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="mypc">
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
This pr is for https://issues.jboss.org/browse/WFLY-7108.  Since this fix introduces a compatibility issue, I think that we will also need a form of the https://issues.jboss.org/browse/WFLY-7075 change, that allows the current application behaviour.  This pull request shouldn't be merged until we have a WFLY-7075 pull request to go with it.

We will have product jiras after we get further along on this change.
