### PR TITLE
[WFLY-7043] Upgrade Elytron subsystem to version 1.0.0.Alpha10

### DIFF
--- a/dist/server-provisioning.xml
+++ b/dist/server-provisioning.xml
@@ -19,7 +19,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true" copy-module-artifacts="true" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core org.jboss.metadata">
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true" copy-module-artifacts="true" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core org.wildfly.security org.jboss.metadata">
     <feature-packs>
         <feature-pack groupId="org.wildfly" artifactId="wildfly-feature-pack" version="${project.version}"/>
     </feature-packs>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Alpha7</version.org.wildfly.core>
         <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.security.elytron-subsystem>1.0.0.Alpha9</version.org.wildfly.security.elytron-subsystem>
+        <version.org.wildfly.security.elytron-subsystem>1.0.0.Alpha10</version.org.wildfly.security.elytron-subsystem>
         <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>


### PR DESCRIPTION
:exclamation: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :exclamation:

Also WFLY-7060, include the Elytron subsystem schema in the WildFly distribution.

The following issues can all be closed on merging: -

https://issues.jboss.org/browse/WFLY-7043
https://issues.jboss.org/browse/WFLY-7073
https://issues.jboss.org/browse/WFLY-7065
https://issues.jboss.org/browse/WFLY-7066
https://issues.jboss.org/browse/WFLY-7097
https://issues.jboss.org/browse/WFLY-7071
https://issues.jboss.org/browse/WFLY-7103
https://issues.jboss.org/browse/WFLY-7060
