### PR TITLE
[WFLY-7129] Removing XA Datasources via CLI OR DMR does not de-register it from the context without reload.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
@@ -116,6 +116,12 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
     }
 
     @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        if (!deployed)
+            resourceRegistration.registerCapability(Capabilities.DATA_SOURCE_CAPABILITY);
+    }
+
+    @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         if (deployed) {
             for (final SimpleAttributeDefinition attribute : XA_DATASOURCE_ATTRIBUTE) {


### PR DESCRIPTION
Possible fix for:-
https://issues.jboss.org/browse/WFLY-7129
