### PR TITLE
[i18n] Updates to the Zanata plugin and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ client/shade/dependency-reduced-pom.xml
 
 #OS X stuff
 .DS_Store
+
+# Zanata files
+**/.zanata-cache/

--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,12 @@
                                 <JBossAS-Release-Codename>${jboss.as.release.codename}</JBossAS-Release-Codename>
                             </manifestEntries>
                         </archive>
+                        <!-- Do not package the generated logging properties as the generated binaries will be packaged -->
+                        <!-- These files are not required at runtime -->
+                        <excludes>
+                            <exclude>**/*.i18n.properties</exclude>
+                            <exclude>**/*.i18n_*.properties</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <version.xom>1.2.10</version.xom>
 
         <!-- Non-default maven plugin versions and configuration -->
-        <version.org.zanata.plugin>3.1.1</version.org.zanata.plugin>
+        <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.6.3.201306030806</version.jacoco.plugin> <!-- Needs to be set explicitely to match with org.jacoco:org.jacoco.ant - see testsuite. -->
         <version.properties.plugin>2.0.1</version.properties.plugin>
@@ -329,6 +329,8 @@
                  <srcDir>target/classes</srcDir>
                  <transDir>src/main/resources</transDir>
                  <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
+                 <!-- In previous versions, 3.8.0 and lower, this defaulted to true -->
+                 <copyTrans>true</copyTrans>
               </configuration>
             </plugin>
             <plugin>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://translate.jboss.org/</url>
-    <project>jboss_as</project>
-    <project-version>master</project-version>
+    <project>jboss-eap</project>
+    <project-version>7.1</project-version>
     <project-type>properties</project-type>
-
-    <locales mapping="java">
-       <locale>de</locale>
-       <locale>es</locale>
-       <locale>fr</locale>
-       <locale>ja</locale>
-       <locale>pt-BR</locale>
-       <locale map-from="zh-CN">zh-Hans</locale>
-    </locales>
 
 </config>


### PR DESCRIPTION
The first commit just upgrades the Zanata plugin to align with the version the server is on as well as make the configuration changes necessary for the 7.1 repository.

The second commit is not required, but help help reduce the size of the final distribution a bit. It simply just excludes the files needed for the logging tooling to generate the i18n loggers and message bundles. These files are only required at compile time and not used at run time.

If the second commit is not desirable I can remove it.

Just to keep things linked together https://github.com/wildfly/wildfly-checkstyle-config/pull/8 will be needed once we start pulling down translations. Some of the files pulled down have trailing spaces which fails the build. Previously I just went through and fixed them, but I think this is a better solution as we don't have much control over what is pulled down.
