### PR TITLE
[WFLY-7132] Deprecate the org.slf4j.ext module as it's no longer requ…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/ext/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/ext/main/module.xml
@@ -23,6 +23,11 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.slf4j.ext">
+
+    <properties>
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
+
     <resources>
         <artifact name="${org.slf4j:slf4j-ext}"/>
     </resources>


### PR DESCRIPTION
…ired by any internal modules.

JIRA: https://issues.jboss.org/browse/WFLY-7132
