### PR TITLE
[WFLY-7139] Handle "Component is stopped" exception better on undeploy for EJB client.

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentIsStoppedException.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentIsStoppedException.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.component;
+
+/**
+ * Exception indicating that a component receiving a method call has stopped.
+ *
+ * @author Richard Achmatowicz
+ */
+public class ComponentIsStoppedException extends IllegalStateException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a <code>ComponentIsStoppedException</code> with no detail message.
+     */
+    public ComponentIsStoppedException() {
+    }
+
+    /**
+     * Constructs a <code>ComponentIsStoppedException</code> with the specified
+     * detail message.
+     *
+     * @param message the detail message
+     */
+    public ComponentIsStoppedException(String message) {
+        super(message);
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.ee.component.BindingConfiguration;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ComponentInstance;
+import org.jboss.as.ee.component.ComponentIsStoppedException;
 import org.jboss.as.ee.component.InjectionSource;
 import org.jboss.as.ee.concurrent.ConcurrentContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -500,7 +501,7 @@ public interface EeLogger extends BasicLogger {
      * @return an {@link IllegalStateException} for the error.
      */
     @Message(id = 43, value = "Component is stopped")
-    IllegalStateException componentIsStopped();
+    ComponentIsStoppedException componentIsStopped();
 
     /**
      * Creates an exception indicating the component is not available.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
 import org.jboss.as.ee.component.Component;
+import org.jboss.as.ee.component.ComponentIsStoppedException;
 import org.jboss.as.ee.component.ComponentView;
 import org.jboss.as.ee.component.interceptors.InvocationType;
 import org.jboss.as.ejb3.logging.EjbLogger;
@@ -205,6 +206,10 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
                             // a "no such EJB" failure so that it can retry the invocation on a different node if possible.
                             if (throwable instanceof EJBComponentUnavailableException) {
                                 EjbLogger.EJB3_INVOCATION_LOGGER.debugf("Cannot handle method invocation: %s on bean: %s due to EJB component unavailability exception. Returning a no such EJB available message back to client", invokedMethod, beanName);
+                                MethodInvocationMessageHandler.this.writeNoSuchEJBFailureMessage(channelAssociation, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
+                                // WFLY-7139
+                            } else if (throwable instanceof ComponentIsStoppedException) {
+                                EjbLogger.EJB3_INVOCATION_LOGGER.debugf("Cannot handle method invocation: %s on bean: %s due to EJB component stopped exception. Returning a no such EJB available message back to client", invokedMethod, beanName);
                                 MethodInvocationMessageHandler.this.writeNoSuchEJBFailureMessage(channelAssociation, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
                             } else {
                                 // write out the failure


### PR DESCRIPTION
This PR addresses: https://issues.jboss.org/browse/WFLY-7139
The downstream issue is: https://issues.jboss.org/browse/JBEAP-5764
