### PR TITLE
WFLY-7147 standardize access to node1's address in test suite and fix…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
@@ -222,7 +222,7 @@ public class ClusteredJPA2LCTestCase {
 
     protected static ModelControllerClient createClient1() throws UnknownHostException {
         return ModelControllerClient.Factory
-                .create(InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                .create(InetAddress.getByName(TestSuiteEnvironment.getServerAddressNode1()),
                         TestSuiteEnvironment.getServerPort() + 100,
                         Authentication.getCallbackHandler());
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -48,6 +48,7 @@ import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.NodeNameGetter;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
@@ -79,7 +80,7 @@ public class RemoteStatelessFailoverTestCase {
     private static final String ARCHIVE_NAME_DD = "stateless-ejb2-failover-dd-test";
 
     private static final Integer PORT_2 = 8180;
-    private static final String HOST_2 = System.getProperty("node1");
+    private static final String HOST_2 = TestSuiteEnvironment.getServerAddressNode1();
     private static final String REMOTE_PORT_PROPERTY_NAME = "remote.connection.default.port";
     private static final String REMOTE_HOST_PROPERTY_NAME = "remote.connection.default.host";
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -275,9 +275,9 @@ public class EJBClientClusterConfigurationTestCase {
 
     private static String getServerAddress(final String container) {
         if (JBOSSAS_WITH_REMOTE_OUTBOUND_CONNECTION.equals(container)) {
-            return TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node1", "localhost"));
+            return TestSuiteEnvironment.formatPossibleIpv6Address(TestSuiteEnvironment.getServerAddressNode1());
         }
-        return TestSuiteEnvironment.formatPossibleIpv6Address(System.getProperty("node0", "localhost"));
+        return TestSuiteEnvironment.formatPossibleIpv6Address(TestSuiteEnvironment.getServerAddress());
     }
 
 


### PR DESCRIPTION
… failing ClusteredJPA2LCTestCase

Issue: https://issues.jboss.org/browse/WFLY-7147
