### PR TITLE
[WFLY-2640] Unable to add cached-connection-manager after removing it once

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
@@ -35,6 +35,8 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 import org.jboss.msc.service.ServiceTarget;
 
+import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
+
 /**
  * @author <a href="jesper.pedersen@jboss.org">Jesper Pedersen</a>
  * @author <a href="stefano.maestri@redhat.com">Stefano Maestri</a>
@@ -62,11 +64,14 @@ public class CachedConnectionManagerAdd extends AbstractBoottimeAddStepHandler {
         final ServiceTarget serviceTarget = context.getServiceTarget();
 
         if (install) {
+            ROOT_LOGGER.debug("Enabling the Cache Connection Manager valve and interceptor...");
             context.addStep(new AbstractDeploymentChainStep() {
                 protected void execute(DeploymentProcessorTarget processorTarget) {
                     processorTarget.addDeploymentProcessor(JcaExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_CACHED_CONNECTION_MANAGER, new CachedConnectionManagerSetupProcessor());
                 }
             }, OperationContext.Stage.RUNTIME);
+        } else {
+            ROOT_LOGGER.debug("Disabling the Cache Connection Manager valve and interceptor...");
         }
 
         CachedConnectionManagerService ccmService = new CachedConnectionManagerService(debug, error, ignoreUnknownConnections);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerRemove.java
@@ -1,0 +1,65 @@
+package org.jboss.as.connector.subsystems.jca;
+
+import static org.jboss.as.connector.subsystems.jca.JcaCachedConnectionManagerDefinition.CcmParameters.DEBUG;
+import static org.jboss.as.connector.subsystems.jca.JcaCachedConnectionManagerDefinition.CcmParameters.ERROR;
+import static org.jboss.as.connector.subsystems.jca.JcaCachedConnectionManagerDefinition.CcmParameters.IGNORE_UNKNOWN_CONNECTIONS;
+import static org.jboss.as.connector.subsystems.jca.JcaCachedConnectionManagerDefinition.CcmParameters.INSTALL;
+
+import java.util.Set;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.dmr.ModelNode;
+
+class CachedConnectionManagerRemove implements OperationStepHandler {
+
+    static final CachedConnectionManagerRemove INSTANCE = new CachedConnectionManagerRemove();
+
+    private CachedConnectionManagerRemove() {}
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        // This is an odd case where we do not actually do a remove; we just reset state to
+        // what it would be following parsing if the xml element does not exist.
+        // See discussion on PR with fix for WFLY-2640 .
+        ModelNode model = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
+
+        for (JcaCachedConnectionManagerDefinition.CcmParameters param : JcaCachedConnectionManagerDefinition.CcmParameters.values()) {
+            AttributeDefinition ad = param.getAttribute();
+            if (param == INSTALL) {
+                model.get(ad.getName()).set(false);
+            } else if (param == DEBUG || param == ERROR || param == IGNORE_UNKNOWN_CONNECTIONS) {
+                model.get(ad.getName()).clear();
+            } else {
+                // Someone added a new param since WFLY-2640 and did not account for it above
+                throw new IllegalStateException();
+            }
+        }
+
+        // At the time of WFLY-2640 there were no capabilities associated with this resource,
+        // but if anyone adds one, part of the task is to deal with deregistration.
+        // So here's an assert to ensure that is considered
+        Set<RuntimeCapability> capabilitySet = context.getResourceRegistration().getCapabilities();
+        assert capabilitySet.isEmpty();
+
+        if (context.isDefaultRequiresRuntime()) {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext operationContext, ModelNode modelNode) throws OperationFailedException {
+                    context.reloadRequired();
+                    context.completeStep(new OperationContext.RollbackHandler() {
+                        @Override
+                        public void handleRollback(OperationContext operationContext, ModelNode modelNode) {
+                            context.revertReloadRequired();
+                        }
+                    });
+                }
+            }, OperationContext.Stage.RUNTIME);
+        }
+    }
+}

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaCachedConnectionManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaCachedConnectionManagerDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.connector.subsystems.jca;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -32,6 +31,7 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -46,12 +46,17 @@ import static org.jboss.as.connector.subsystems.jca.Constants.CACHED_CONNECTION_
 public class JcaCachedConnectionManagerDefinition extends SimpleResourceDefinition {
     protected static final PathElement PATH_CACHED_CONNECTION_MANAGER = PathElement.pathElement(CACHED_CONNECTION_MANAGER, CACHED_CONNECTION_MANAGER);
     static final JcaCachedConnectionManagerDefinition INSTANCE = new JcaCachedConnectionManagerDefinition();
+    private static final SimpleOperationDefinition ADD_DEFINITION =
+            new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, JcaExtension.getResourceDescriptionResolver())
+            .setPrivateEntry()
+            .build();
+    private static final SimpleOperationDefinition REMOVE_DEFINITION =
+            new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.REMOVE, JcaExtension.getResourceDescriptionResolver(PATH_CACHED_CONNECTION_MANAGER.getKey()))
+            .build();
 
     private JcaCachedConnectionManagerDefinition() {
         super(PATH_CACHED_CONNECTION_MANAGER,
-                JcaExtension.getResourceDescriptionResolver(PATH_CACHED_CONNECTION_MANAGER.getKey()),
-                CachedConnectionManagerAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+                JcaExtension.getResourceDescriptionResolver(PATH_CACHED_CONNECTION_MANAGER.getKey()));
     }
 
     @Override
@@ -72,6 +77,8 @@ public class JcaCachedConnectionManagerDefinition extends SimpleResourceDefiniti
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(ADD_DEFINITION, CachedConnectionManagerAdd.INSTANCE);
+        resourceRegistration.registerOperationHandler(REMOVE_DEFINITION, CachedConnectionManagerRemove.INSTANCE);
         resourceRegistration.registerOperationHandler(CcmOperations.GET_NUMBER_OF_CONNECTIONS.getOperation(), GetNumberOfConnectionsHandler.INSTANCE);
         resourceRegistration.registerOperationHandler(CcmOperations.LIST_CONNECTIONS.getOperation(), ListOfConnectionsHandler.INSTANCE);
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-2640
