### PR TITLE
[WFLY-7183] 'name' attribute missing in XSD while required by web

### DIFF
--- a/legacy/web/src/main/resources/schema/jboss-as-web_2_2.xsd
+++ b/legacy/web/src/main/resources/schema/jboss-as-web_2_2.xsd
@@ -443,6 +443,7 @@
             <xs:attribute name="class-name" type="xs:string" use="required" />
             <xs:attribute name="module" type="xs:string" use="required" />
             <xs:attribute name="enabled" default="true" type="xs:boolean" />
+            <xs:attribute name="name" type="xs:string" use="required" />
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7192

Sorry for the mess. I accidentally moved (instead of cloned) WFLY-7183 to JBEAP-6140. Now because there is no way to resurrect WFLY-7183, I created a new WFLY issue WFLY-7192 to track the present WFLY effort.

downstream https://bugzilla.redhat.com/show_bug.cgi?id=1365939
