### PR TITLE
Fix potential NPE in DeploymentDefinition

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -102,13 +102,12 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
                 return;
             }
 
-            final UndertowDeploymentService deploymentService = (UndertowDeploymentService) controller.getService();
             SessionStat stat = SessionStat.getStat(operation.require(ModelDescriptionConstants.NAME).asString());
-
             if (stat == null) {
                 context.getFailureDescription().set(UndertowLogger.ROOT_LOGGER.unknownMetric(operation.require(ModelDescriptionConstants.NAME).asString()));
             } else {
                 ModelNode result = new ModelNode();
+                UndertowDeploymentService deploymentService = (UndertowDeploymentService) controller.getService();
                 Deployment deployment = deploymentService.getDeployment();
                 SessionManager sessionManager = deployment.getSessionManager();
                 SessionManagerStatistics sms = sessionManager.getStatistics();


### PR DESCRIPTION
I applied fix from a2eab9e8e70af1aee9585bda90a1bce3ee6276dd , went through the same scenario, but got another NPE:

```
 ERROR [org.jboss.as.controller.management-operation] (External Management Request Threads -- 5) WFLYCTL0013: Operation ("read-attribute") failed - address: ([
    ("deployment" => "XXXX.war"),
    ("subsystem" => "undertow")
]): java.lang.NullPointerException
        at org.wildfly.extension.undertow.DeploymentDefinition$SessionManagerStatsHandler.executeRuntimeStep(DeploymentDefinition.java:105)
        at org.jboss.as.controller.AbstractRuntimeOnlyHandler$1.execute(AbstractRuntimeOnlyHandler.java:53)
        at org.jboss.as.controller.AbstractOperationContext.executeStep(AbstractOperationContext.java:890)
        at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:659)
        at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:370)
        at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1329)
        at org.jboss.as.controller.ModelControllerImpl.internalExecute(ModelControllerImpl.java:400)
        at org.jboss.as.controller.ModelControllerImpl.execute(ModelControllerImpl.java:222)
        at org.jboss.as.domain.http.server.DomainApiHandler.handleRequest(DomainApiHandler.java:219)
        at io.undertow.server.handlers.encoding.EncodingHandler.handleRequest(EncodingHandler.java:72)
        at org.jboss.as.domain.http.server.security.SubjectDoAsHandler$1.run(SubjectDoAsHandler.java:72)
        at org.jboss.as.domain.http.server.security.SubjectDoAsHandler$1.run(SubjectDoAsHandler.java:68)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.jboss.as.controller.AccessAuditContext.doAs(AccessAuditContext.java:149)
        at org.jboss.as.domain.http.server.security.SubjectDoAsHandler.handleRequest(SubjectDoAsHandler.java:68)
        at org.jboss.as.domain.http.server.security.SubjectDoAsHandler.handleRequest(SubjectDoAsHandler.java:63)
        at io.undertow.server.handlers.BlockingHandler.handleRequest(BlockingHandler.java:56)
        at org.jboss.as.domain.http.server.DomainApiCheckHandler.handleRequest(DomainApiCheckHandler.java:95)
        at io.undertow.server.Connectors.executeRootHandler(Connectors.java:202)
        at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:802)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
        at org.jboss.threads.JBossThread.run(JBossThread.java:320)
```

Hopefully this will be enough this time.
