### PR TITLE
[WFLY-7220] fix queue-size default value discrepancy

### DIFF
--- a/undertow/src/main/resources/schema/wildfly-undertow_4_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_4_0.xsd
@@ -562,7 +562,7 @@
     <xs:complexType name="request-limitType">
         <xs:attribute name="name" use="required" type="xs:string"/>
         <xs:attribute name="max-concurrent-requests" use="required" type="xs:integer"/>
-        <xs:attribute name="queue-size" use="optional" type="xs:integer"/>
+        <xs:attribute name="queue-size" use="optional" type="xs:integer" default="0"/>
     </xs:complexType>
     <xs:complexType name="response-headerType">
         <xs:attribute name="name" use="required" type="xs:string"/>


### PR DESCRIPTION
WFLY https://issues.jboss.org/browse/WFLY-7220

After https://issues.jboss.org/browse/WFLY-6336 queue-size of request-limit has a default value of zero

JBEAP https://issues.jboss.org/browse/JBEAP-5956
