### PR TITLE
[WFLY-7230] Update the application-security-domain to use the 'name' attribute as used in the latest version of the schema.

### DIFF
--- a/undertow/src/main/resources/subsystem-templates/undertow.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow.xml
@@ -69,7 +69,7 @@
         </replacement>
         <replacement placeholder="ELYTRON">
             <application-security-domains>
-                <application-security-domain security-domain="other" http-authentication-factory="application-http-authentication"/>
+                <application-security-domain name="other" http-authentication-factory="application-http-authentication"/>
             </application-security-domains>
         </replacement>
     </supplement>


### PR DESCRIPTION
:exclamation: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :exclamation:

The following issue can be resolved when merged: -
  https://issues.jboss.org/browse/WFLY-7230
