### PR TITLE
[WFLY-5863] When a ControlPoint is present scheduled tasks will be forced ran via the ControlPoint

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ControlledTaskManager.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ControlledTaskManager.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.ee.concurrent;
+
+import java.util.concurrent.Executor;
+
+import org.wildfly.extension.requestcontroller.ControlPoint;
+
+/**
+ * Allows access to the {@link ControlPoint} for this task manager. Tasks submitted via {@link Executor#execute(Runnable)}
+ * may be queued if the server {@linkplain #isSuspended() suspended}. When the server resumes any queued tasks will be
+ * executed.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface ControlledTaskManager {
+
+    /**
+     * Returns the {@link ControlPoint} used or {@code null} if request controlling is not required.
+     *
+     * @return the {@code ControlPoint} to use or {@code null}
+     */
+    ControlPoint getControlPoint();
+
+    /**
+     * Submits a runnable to the executor. If the server {@linkplain #isSuspended() is suspended} the task will be
+     * queued and ran when the server has resumed.
+     *
+     * @param task the task to submit
+     */
+    void submitTask(Runnable task, Executor executor);
+
+    /**
+     * Indicates whether or not the server has been suspended.
+     *
+     * @return {@code true} if the server is suspended, or suspending, otherwise {@code false}
+     */
+    boolean isSuspended();
+}

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -21,20 +21,19 @@
  */
 package org.jboss.as.ee.concurrent;
 
-import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
-import org.wildfly.extension.requestcontroller.ControlPoint;
+import static org.jboss.as.ee.concurrent.ControlPointUtils.doWrap;
 
-import javax.enterprise.concurrent.LastExecution;
-import javax.enterprise.concurrent.Trigger;
 import java.util.Date;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.Trigger;
 
-import static org.jboss.as.ee.concurrent.ControlPointUtils.doScheduledWrap;
-import static org.jboss.as.ee.concurrent.ControlPointUtils.doWrap;
+import org.glassfish.enterprise.concurrent.ContextServiceImpl;
+import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 
 /**
  * WildFly's extension of Java EE 7 RI {@link org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl}.
@@ -43,71 +42,72 @@ import static org.jboss.as.ee.concurrent.ControlPointUtils.doWrap;
  */
 public class ManagedScheduledExecutorServiceImpl extends org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceImpl {
 
-    private final ControlPoint controlPoint;
+    private final ControlledTaskManager taskManager;
 
-    public ManagedScheduledExecutorServiceImpl(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, ContextServiceImpl contextService, RejectPolicy rejectPolicy, ControlPoint controlPoint) {
+    public ManagedScheduledExecutorServiceImpl(String name, ManagedThreadFactoryImpl managedThreadFactory, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, ContextServiceImpl contextService, RejectPolicy rejectPolicy, ControlledTaskManager taskManager) {
         super(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, contextService, rejectPolicy);
-        this.controlPoint = controlPoint;
+        this.taskManager = taskManager;
     }
 
     @Override
     public void execute(Runnable command) {
-        super.execute(doWrap(command, controlPoint));
+        Objects.requireNonNull(command);
+        taskManager.submitTask(command, ManagedScheduledExecutorServiceImpl.super::execute);
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return super.submit(doWrap(task, controlPoint));
+        return super.submit(doWrap(task, taskManager.getControlPoint()));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return super.submit(doWrap(task, controlPoint), result);
+        return super.submit(doWrap(task, taskManager.getControlPoint()), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return super.submit(doWrap(task, controlPoint));
+        return super.submit(doWrap(task, taskManager.getControlPoint()));
     }
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, Trigger trigger) {
         final CancellableTrigger ctrigger = new CancellableTrigger(trigger);
-        ctrigger.future = super.schedule(doScheduledWrap(command, controlPoint), ctrigger);
+        ctrigger.future = super.schedule(doWrap(command, taskManager.getControlPoint()), ctrigger);
         return ctrigger.future;
     }
 
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, Trigger trigger) {
         final CancellableTrigger ctrigger = new CancellableTrigger(trigger);
-        ctrigger.future = super.schedule(doScheduledWrap(callable, controlPoint), ctrigger);
+        ctrigger.future = super.schedule(doWrap(callable, taskManager.getControlPoint()), ctrigger);
         return ctrigger.future;
     }
 
     @Override
     public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        return super.schedule(doScheduledWrap(command, controlPoint), delay, unit);
+        return super.schedule(doWrap(command, taskManager.getControlPoint()), delay, unit);
     }
 
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        return super.schedule(doScheduledWrap(callable, controlPoint), delay, unit);
+        return super.schedule(doWrap(callable, taskManager.getControlPoint()), delay, unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        return super.scheduleAtFixedRate(doScheduledWrap(command, controlPoint), initialDelay, period, unit);
+        return super.scheduleAtFixedRate(doWrap(command, taskManager.getControlPoint()), initialDelay, period, unit);
     }
 
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        return super.scheduleWithFixedDelay(doScheduledWrap(command, controlPoint), initialDelay, delay, unit);
+        return super.scheduleWithFixedDelay(doWrap(command, taskManager.getControlPoint()), initialDelay, delay, unit);
     }
 
     /**
      * A {@link javax.enterprise.concurrent.Trigger} wrapper that stops scheduling if the related {@link java.util.concurrent.ScheduledFuture} is cancelled.
      */
-    private static class CancellableTrigger implements Trigger {
+    private class CancellableTrigger implements Trigger {
         private final Trigger trigger;
         private ScheduledFuture future;
 
@@ -127,7 +127,7 @@ public class ManagedScheduledExecutorServiceImpl extends org.glassfish.enterpris
 
         @Override
         public boolean skipRun(LastExecution lastExecution, Date date) {
-            return trigger.skipRun(lastExecution, date);
+            return taskManager.isSuspended() || trigger.skipRun(lastExecution, date);
         }
     }
 

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ControlledTaskManagerService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ControlledTaskManagerService.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.ee.concurrent.service;
+
+import java.util.Deque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.enterprise.concurrent.ManagedTask;
+
+import org.jboss.as.ee.concurrent.ControlPointUtils;
+import org.jboss.as.ee.concurrent.ControlledTaskManager;
+import org.jboss.as.ee.logging.EeLogger;
+import org.jboss.as.server.suspend.ServerActivity;
+import org.jboss.as.server.suspend.ServerActivityCallback;
+import org.jboss.as.server.suspend.SuspendController;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.requestcontroller.ControlPoint;
+import org.wildfly.extension.requestcontroller.RequestController;
+import org.wildfly.extension.requestcontroller.RunResult;
+
+/**
+ * A service which implements the {@link ControlledTaskManager}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ControlledTaskManagerService implements Service<ControlledTaskManager>, ControlledTaskManager {
+    private final InjectedValue<SuspendController> suspendControllerInjector = new InjectedValue<>();
+    private final InjectedValue<RequestController> requestControllerInjector = new InjectedValue<>();
+
+    private final String entryPointName;
+    private final String name;
+    private final AtomicBoolean serverSuspended = new AtomicBoolean(false);
+    private final Deque<QueuedTask> taskQueue = new LinkedBlockingDeque<>();
+    private ServerActivity serverActivity;
+    private ControlPoint controlPoint;
+
+    /**
+     * Creates a new service.
+     *
+     * @param entryPointName the entry point name for the control point
+     * @param name           the name used for the deployment name of the control point
+     */
+    public ControlledTaskManagerService(final String entryPointName, final String name) {
+        this.entryPointName = entryPointName;
+        this.name = name;
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        final ServerActivity serverActivity = new ConcurrentServerActivity();
+        suspendControllerInjector.getValue().registerActivity(serverActivity);
+        final RequestController requestController = requestControllerInjector.getOptionalValue();
+        if (requestController != null) {
+            controlPoint = requestController.getControlPoint(name, entryPointName);
+        }
+        this.serverActivity = serverActivity;
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        taskQueue.clear();
+        if (serverActivity != null) {
+            suspendControllerInjector.getValue().unRegisterActivity(serverActivity);
+        }
+        if (controlPoint != null) {
+            requestControllerInjector.getValue().removeControlPoint(controlPoint);
+        }
+    }
+
+    @Override
+    public ControlledTaskManager getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public synchronized ControlPoint getControlPoint() {
+        return controlPoint;
+    }
+
+    @Override
+    public void submitTask(final Runnable task, final Executor executor) {
+        if (getControlPoint() == null) {
+            executor.execute(task);
+        } else {
+            // If the server is suspended the task should be queued, otherwise it can be submitted
+            final QueuedTask queuedTask = new QueuedTask(task, executor);
+            if (serverSuspended.get()) {
+                queueTask(queuedTask);
+            } else {
+                queuedTask.submit();
+            }
+        }
+    }
+
+    @Override
+    public boolean isSuspended() {
+        return serverSuspended.get();
+    }
+
+    public InjectedValue<SuspendController> getSuspendControllerInjector() {
+        return suspendControllerInjector;
+    }
+
+    public InjectedValue<RequestController> getRequestControllerInjector() {
+        return requestControllerInjector;
+    }
+
+    private void queueTask(final QueuedTask task) {
+        if (task.queued.compareAndSet(false, true)) {
+            taskQueue.addLast(task);
+        }
+    }
+
+    private class ConcurrentServerActivity implements ServerActivity {
+
+
+        @Override
+        public void preSuspend(final ServerActivityCallback serverActivityCallback) {
+            serverActivityCallback.done();
+        }
+
+        @Override
+        public void suspended(final ServerActivityCallback serverActivityCallback) {
+            serverSuspended.set(true);
+            serverActivityCallback.done();
+        }
+
+        @Override
+        public void resume() {
+            // Process tasks that have been queued while the server was suspended
+            if (serverSuspended.compareAndSet(true, false)) {
+                QueuedTask task;
+                while ((task = taskQueue.poll()) != null) {
+                    task.submit();
+                }
+            }
+        }
+    }
+
+    private class QueuedTask implements Runnable {
+        final Runnable runnable;
+        final Executor executor;
+        final AtomicBoolean queued;
+
+        private QueuedTask(final Runnable runnable, final Executor executor) {
+            this.runnable = runnable;
+            this.executor = executor;
+            queued = new AtomicBoolean(false);
+        }
+
+        @Override
+        public void run() {
+            final ControlPoint controlPoint = getControlPoint();
+            try {
+                if (controlPoint.beginRequest() == RunResult.RUN) {
+                    runnable.run();
+                } else {
+                    queueTask(this);
+                }
+            } catch (Exception e) {
+                EeLogger.ROOT_LOGGER.failedToRunTask(e);
+            } finally {
+                controlPoint.requestComplete();
+            }
+        }
+
+        void submit() {
+            Runnable task = runnable;
+            if (task instanceof ManagedTask) {
+                task = ControlPointUtils.doWrapMangedTask(this, (ManagedTask) runnable);
+            }
+            executor.execute(task);
+        }
+    }
+}

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedScheduledExecutorServiceService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedScheduledExecutorServiceService.java
@@ -26,6 +26,7 @@ import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceAdapter;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.jboss.as.ee.concurrent.ControlledTaskManager;
 import org.jboss.as.ee.concurrent.ManagedScheduledExecutorServiceImpl;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;
@@ -33,15 +34,13 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.wildfly.extension.requestcontroller.ControlPoint;
-import org.wildfly.extension.requestcontroller.RequestController;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Service responsible for creating, starting and stopping a ManagedScheduledExecutorServiceImpl.
  * <p/>
- * Note that the service's value is the executor's adapter, which does not allows lifecyle related invocations.
+ * Note that the service's value is the executor's adapter, which does not allows lifecycle related invocations.
  *
  * @author Eduardo Martins
  */
@@ -59,8 +58,7 @@ public class ManagedScheduledExecutorServiceService extends EEConcurrentAbstract
     private final long threadLifeTime;
     private final InjectedValue<ContextServiceImpl> contextService;
     private final AbstractManagedExecutorService.RejectPolicy rejectPolicy;
-    private final InjectedValue<RequestController> requestController = new InjectedValue<>();
-    private ControlPoint controlPoint;
+    private final InjectedValue<ControlledTaskManager> taskManagerInjector = new InjectedValue<>();
 
     /**
      * @param name
@@ -72,7 +70,7 @@ public class ManagedScheduledExecutorServiceService extends EEConcurrentAbstract
      * @param keepAliveTimeUnit
      * @param threadLifeTime
      * @param rejectPolicy
-     * @see ManagedScheduledExecutorServiceImpl#ManagedScheduledExecutorServiceImpl(String, org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl, long, boolean, int, long, java.util.concurrent.TimeUnit, long, org.glassfish.enterprise.concurrent.ContextServiceImpl, org.glassfish.enterprise.concurrent.AbstractManagedExecutorService.RejectPolicy, org.wildfly.extension.requestcontroller.ControlPoint)
+     * @see ManagedScheduledExecutorServiceImpl#ManagedScheduledExecutorServiceImpl(String, org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl, long, boolean, int, long, java.util.concurrent.TimeUnit, long, org.glassfish.enterprise.concurrent.ContextServiceImpl, org.glassfish.enterprise.concurrent.AbstractManagedExecutorService.RejectPolicy, org.jboss.as.ee.concurrent.ControlledTaskManager)
      */
     public ManagedScheduledExecutorServiceService(String name, String jndiName, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, AbstractManagedExecutorService.RejectPolicy rejectPolicy) {
         super(jndiName);
@@ -96,10 +94,7 @@ public class ManagedScheduledExecutorServiceService extends EEConcurrentAbstract
             final String threadFactoryName = "EE-ManagedScheduledExecutorService-" + name;
             managedThreadFactory = new ManagedThreadFactoryImpl(threadFactoryName, null, Thread.NORM_PRIORITY);
         }
-        if(requestController.getOptionalValue() != null) {
-            controlPoint = requestController.getValue().getControlPoint(name, "managed-scheduled-executor-service");
-        }
-        executorService = new ManagedScheduledExecutorServiceImpl(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, contextService.getOptionalValue(), rejectPolicy, controlPoint);
+        executorService = new ManagedScheduledExecutorServiceImpl(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, contextService.getOptionalValue(), rejectPolicy, taskManagerInjector.getValue());
     }
 
     @Override
@@ -111,9 +106,6 @@ public class ManagedScheduledExecutorServiceService extends EEConcurrentAbstract
                 executorService.getManagedThreadFactory().stop();
             }
             this.executorService = null;
-        }
-        if(controlPoint != null) {
-            requestController.getValue().removeControlPoint(controlPoint);
         }
     }
 
@@ -132,7 +124,7 @@ public class ManagedScheduledExecutorServiceService extends EEConcurrentAbstract
         return contextService;
     }
 
-    public InjectedValue<RequestController> getRequestController() {
-        return requestController;
+    public InjectedValue<ControlledTaskManager> getTaskManagerInjector() {
+        return taskManagerInjector;
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/Capabilities.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/Capabilities.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.ee.subsystem;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.ee.concurrent.ControlledTaskManager;
+
+/**
+ * Capability references for the EE subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Capabilities {
+
+    /**
+     * The request controller capability name
+     */
+    static final String REQUEST_CONTROLLER_CAPABILITY_NAME = "org.wildfly.request-controller";
+
+    /**
+     * The capability for the {@link ControlledTaskManager} for a {@link javax.enterprise.concurrent.ManagedExecutorService}
+     */
+    static final RuntimeCapability<Void> CONTROLLED_TASK_MANAGER_CAPABILITY = RuntimeCapability.Builder
+            .of("org.wildfly.ee.concurrent.task.manager", true, ControlledTaskManager.class)
+            .build();
+
+    /**
+     * The capability for the {@link ControlledTaskManager} for a {@link javax.enterprise.concurrent.ManagedScheduledExecutorService}
+     */
+    static final RuntimeCapability<Void> CONTROLLED_SCHEDULED_TASK_MANAGER_CAPABILITY = RuntimeCapability.Builder
+            .of("org.wildfly.ee.concurrent.scheduled.task.manager", true, ControlledTaskManager.class)
+            .build();
+}

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
@@ -29,18 +29,20 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.ee.concurrent.ControlledTaskManager;
 import org.jboss.as.ee.concurrent.service.ConcurrentServiceNames;
+import org.jboss.as.ee.concurrent.service.ControlledTaskManagerService;
 import org.jboss.as.ee.concurrent.service.ManagedExecutorServiceService;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.as.ee.subsystem.ManagedExecutorServiceResourceDefinition.ExecutorQueueValidationStepHandler;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.common.cpu.ProcessorInfo;
 import org.wildfly.extension.requestcontroller.RequestController;
-import org.wildfly.extension.requestcontroller.RequestControllerExtension;
 
 import java.util.concurrent.TimeUnit;
 
@@ -106,10 +108,22 @@ public class ManagedExecutorServiceAdd extends AbstractAddStepHandler {
 
         final AbstractManagedExecutorService.RejectPolicy rejectPolicy = AbstractManagedExecutorService.RejectPolicy.valueOf(ManagedExecutorServiceResourceDefinition.REJECT_POLICY_AD.resolveModelAttribute(context, model).asString());
 
+        // Configure the task manager service
+        final ControlledTaskManagerService taskManager = new ControlledTaskManagerService("managed-executor-service", name);
+        final ServiceName taskManagerServiceName = context.getCapabilityServiceName(Capabilities.CONTROLLED_TASK_MANAGER_CAPABILITY.getName(), name, ControlledTaskManager.class);
+        final ServiceBuilder<ControlledTaskManager> tmServiceBuilder = context.getServiceTarget()
+                .addService(taskManagerServiceName, taskManager)
+                .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, taskManager.getSuspendControllerInjector());
+        // Check for the request
+        if (context.hasOptionalCapability(Capabilities.REQUEST_CONTROLLER_CAPABILITY_NAME, Capabilities.CONTROLLED_TASK_MANAGER_CAPABILITY.getDynamicName(name), null)) {
+            tmServiceBuilder.addDependency(context.getCapabilityServiceName(Capabilities.REQUEST_CONTROLLER_CAPABILITY_NAME, RequestController.class), RequestController.class, taskManager.getRequestControllerInjector());
+        }
+        tmServiceBuilder.install();
+
         final ManagedExecutorServiceService service = new ManagedExecutorServiceService(name, jndiName, hungTaskThreshold, longRunningTasks, coreThreads, maxThreads, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueLength, rejectPolicy);
         final ServiceBuilder<ManagedExecutorServiceAdapter> serviceBuilder = context.getServiceTarget().addService(ConcurrentServiceNames.getManagedExecutorServiceServiceName(name), service);
+        serviceBuilder.addDependency(taskManagerServiceName, ControlledTaskManager.class, service.getTaskManagerInjector());
 
-        boolean rcPresent = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS).hasChild(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RequestControllerExtension.SUBSYSTEM_NAME));
         String contextService = null;
         if(model.hasDefined(ManagedExecutorServiceResourceDefinition.CONTEXT_SERVICE)) {
             contextService = ManagedExecutorServiceResourceDefinition.CONTEXT_SERVICE_AD.resolveModelAttribute(context, model).asString();
@@ -123,9 +137,6 @@ public class ManagedExecutorServiceAdd extends AbstractAddStepHandler {
         }
         if (threadFactory != null) {
             serviceBuilder.addDependency(ConcurrentServiceNames.getManagedThreadFactoryServiceName(threadFactory), ManagedThreadFactoryImpl.class, service.getManagedThreadFactoryInjector());
-        }
-        if(rcPresent) {
-            serviceBuilder.addDependency(RequestController.SERVICE_NAME, RequestController.class, service.getRequestController());
         }
         serviceBuilder.install();
     }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
@@ -142,7 +142,12 @@ public class ManagedExecutorServiceResourceDefinition extends SimpleResourceDefi
     public static final ManagedExecutorServiceResourceDefinition INSTANCE = new ManagedExecutorServiceResourceDefinition();
 
     private ManagedExecutorServiceResourceDefinition() {
-        super(PathElement.pathElement(EESubsystemModel.MANAGED_EXECUTOR_SERVICE), EeExtension.getResourceDescriptionResolver(EESubsystemModel.MANAGED_EXECUTOR_SERVICE), ManagedExecutorServiceAdd.INSTANCE, ManagedExecutorServiceRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(EESubsystemModel.MANAGED_EXECUTOR_SERVICE),
+                EeExtension.getResourceDescriptionResolver(EESubsystemModel.MANAGED_EXECUTOR_SERVICE))
+                .setAddHandler(ManagedExecutorServiceAdd.INSTANCE)
+                .setRemoveHandler(ManagedExecutorServiceRemove.INSTANCE)
+                .setCapabilities(Capabilities.CONTROLLED_TASK_MANAGER_CAPABILITY)
+        );
     }
 
     @Override

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
@@ -121,7 +121,12 @@ public class ManagedScheduledExecutorServiceResourceDefinition extends SimpleRes
     public static final ManagedScheduledExecutorServiceResourceDefinition INSTANCE = new ManagedScheduledExecutorServiceResourceDefinition();
 
     private ManagedScheduledExecutorServiceResourceDefinition() {
-        super(PathElement.pathElement(EESubsystemModel.MANAGED_SCHEDULED_EXECUTOR_SERVICE), EeExtension.getResourceDescriptionResolver(EESubsystemModel.MANAGED_SCHEDULED_EXECUTOR_SERVICE), ManagedScheduledExecutorServiceAdd.INSTANCE, ManagedScheduledExecutorServiceRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(EESubsystemModel.MANAGED_SCHEDULED_EXECUTOR_SERVICE),
+                EeExtension.getResourceDescriptionResolver(EESubsystemModel.MANAGED_SCHEDULED_EXECUTOR_SERVICE))
+                .setAddHandler(ManagedScheduledExecutorServiceAdd.INSTANCE)
+                .setRemoveHandler(ManagedScheduledExecutorServiceRemove.INSTANCE)
+                .setCapabilities(Capabilities.CONTROLLED_SCHEDULED_TASK_MANAGER_CAPABILITY)
+        );
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedScheduledExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/ManagedScheduledExecutorServiceTestCase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.ee.concurrent;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.SkippedException;
+import javax.enterprise.concurrent.Trigger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@Singleton
+public class ManagedScheduledExecutorServiceTestCase {
+
+    @Resource
+    private ManagedScheduledExecutorService executorService;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClass(ManagedScheduledExecutorServiceTestCase.class);
+    }
+
+    @Test
+    public void triggerTest() throws Exception {
+        final ScheduledFuture<Integer> future = executorService.schedule(new CallCountingTask(), createTrigger(100, ChronoUnit.MILLIS));
+
+        // Make sure we run at least once
+        final int result = future.get(300, TimeUnit.MILLISECONDS);
+        Assert.assertTrue("Expected at least 1 runs, but found only " + result, result > 0);
+
+        // Cancel the future and ensure it's cancelled and done
+        future.cancel(true);
+        Assert.assertTrue("Future should be cancelled, but future.isCancelled() returned false", future.isCancelled());
+        Assert.assertTrue("Future should be done, but future.isDone() returned false", future.isDone());
+    }
+
+    @Test
+    public void triggerSkipTest() throws Exception {
+        long timeout = 5000L;
+        final ScheduledFuture<Integer> future = executorService.schedule(new CallCountingTask(), createTrigger(0, 100, ChronoUnit.MILLIS));
+        try {
+            while (!future.isDone()) {
+                final long before = System.currentTimeMillis();
+                try {
+                    future.get(100, TimeUnit.MILLISECONDS);
+                } catch (SkippedException ignore) {
+                    return;
+                } catch (TimeoutException ignore) {
+                }
+                timeout -= (System.currentTimeMillis() - before);
+                if (timeout < 0) {
+                    Assert.fail(String.format("Took longer than 5 seconds for %s to be thrown.", SkippedException.class.getName()));
+                }
+            }
+        } finally {
+            future.cancel(true);
+        }
+        Assert.fail(String.format("Expected a %s to be thrown.", SkippedException.class.getName()));
+    }
+
+    private static Trigger createTrigger(final int nextRunAmount, final TemporalUnit nextRunUnit) {
+        return new RunLimitTrigger(0, nextRunAmount, nextRunUnit) {
+
+            @Override
+            public boolean skipRun(final LastExecution lastExecutionInfo, final Date scheduledRunTime) {
+                return false;
+            }
+        };
+    }
+
+    private static Trigger createTrigger(final int maxRuns, final int nextRunAmount, final TemporalUnit nextRunUnit) {
+        return new RunLimitTrigger(maxRuns, nextRunAmount, nextRunUnit);
+    }
+
+    private static class CallCountingTask implements Callable<Integer> {
+        final AtomicInteger callCounter = new AtomicInteger();
+
+        @Override
+        public Integer call() throws Exception {
+            return callCounter.incrementAndGet();
+        }
+    }
+
+    private static class RunLimitTrigger implements Trigger {
+        private final int nextRunAmount;
+        private final TemporalUnit nextRunUnit;
+        private final int maxRuns;
+        final AtomicInteger counter = new AtomicInteger();
+
+        private RunLimitTrigger(final int maxRuns, final int nextRunAmount, final TemporalUnit nextRunUnit) {
+            this.nextRunAmount = nextRunAmount;
+            this.nextRunUnit = nextRunUnit;
+            this.maxRuns = maxRuns;
+        }
+
+        @Override
+        public Date getNextRunTime(final LastExecution lastExecutionInfo, final Date taskScheduledTime) {
+            if (lastExecutionInfo == null) {
+                return addTime(ZonedDateTime.now());
+            }
+            final Date date = lastExecutionInfo.getScheduledStart();
+            return addTime(date);
+        }
+
+        @Override
+        public boolean skipRun(final LastExecution lastExecutionInfo, final Date scheduledRunTime) {
+            return counter.incrementAndGet() > maxRuns;
+        }
+
+        private Date addTime(final Date date) {
+            return addTime(ZonedDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault()));
+        }
+
+        private Date addTime(final ChronoZonedDateTime date) {
+            return Date.from(date.plus(nextRunAmount, nextRunUnit).toInstant());
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/EEConcurrencySuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/EEConcurrencySuspendTestCase.java
@@ -67,7 +67,7 @@ public class EEConcurrencySuspendTestCase {
     public static WebArchive deployment() {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ee-suspend.war");
-        war.addPackage(EEConcurrencySuspendTestCase.class.getPackage());
+        war.addClasses(EEConcurrencySuspendTestCase.class, ShutdownServlet.class);
         war.addPackage(HttpRequest.class.getPackage());
         war.addClass(TestSuiteEnvironment.class);
         war.addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller\n"), "META-INF/MANIFEST.MF");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/ManagedExecutorServiceSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/ManagedExecutorServiceSuspendTestCase.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.ee.suspend;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"MagicNumber", "Duplicates"})
+@RunWith(Arquillian.class)
+@Singleton
+public class ManagedExecutorServiceSuspendTestCase {
+    private static final int MILLIS_WAIT_TIME = TimeoutUtil.adjust(300);
+    private static final int SECONDS_WAIT_TIME = TimeoutUtil.adjust(1);
+
+    @Resource
+    private ManagedExecutorService executorService;
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(ManagedExecutorServiceSuspendTestCase.class, TimeoutUtil.class)
+                .addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller-client\n"), "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    public void testExecutedQueuedRunnable() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // First submit a task with the server running
+        executorService.execute(new CountdownRunnable(latch, counter));
+        Assert.assertTrue("The runnable did not appear to be executed", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        int currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected a count of 1, but got a count of %d", currentCount), 1, currentCount);
+
+        // Suspend the server and attempt to submit the task again.
+        latch = new CountDownLatch(1);
+        suspend();
+        executorService.execute(new CountdownRunnable(latch, counter));
+        // We should timeout here
+        Assert.assertFalse("The runnable should not have ran", latch.await(MILLIS_WAIT_TIME, TimeUnit.MICROSECONDS));
+
+        // Resume the server
+        resume();
+        // Wait for the task to complete
+        latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected a count of 2, but got a count of %d", currentCount), 2, currentCount);
+    }
+
+    @Test
+    public void testSubmittedRunnable() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        // First submit a call that will just run
+        Future<?> future = executorService.submit(runnable);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(1, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(runnable);
+        future.get(MILLIS_WAIT_TIME, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(2, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(runnable);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(3, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testSubmittedCallable() throws Exception {
+        final CountingCallable callable = new CountingCallable();
+
+        // First submit a call that will just run
+        Future<Integer> future = executorService.submit(callable);
+        Assert.assertEquals(1, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(callable);
+        Assert.assertEquals(2, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(callable);
+        Assert.assertEquals(3, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testSubmittedRunnableFuture() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        // First submit a call that will just run
+        Future<AtomicInteger> future = executorService.submit(runnable, counter);
+        Assert.assertEquals(1, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(runnable, counter);
+        Assert.assertEquals(2, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(runnable, counter);
+        Assert.assertEquals(3, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testManagedTaskCompletion() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        CountDownLatch latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        Assert.assertTrue("Expected the ManagedTaskListener.taskDone() to be invoked.", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran once", 1, counter.get());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        // We should timeout here
+        Assert.assertTrue("The runnable should not have ran", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran twice", 2, counter.get());
+
+        // Resume the server
+        resume();
+        // Execute one more task after resume to ensure everything is still working correctly
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        Assert.assertTrue("Expected the ManagedTaskListener.taskDone() to be invoked.", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran 3 times", 3, counter.get());
+    }
+
+    private void suspend() throws IOException {
+        suspend(SECONDS_WAIT_TIME);
+    }
+
+    private void suspend(final int timeout) throws IOException {
+        final ModelNode op = Operations.createOperation("suspend");
+        op.get("timeout").set(timeout);
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to suspend server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private void resume() throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("resume"));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to resume server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private static class CountdownRunnable implements Runnable {
+        private final CountDownLatch latch;
+        private final AtomicInteger counter;
+
+        private CountdownRunnable(final CountDownLatch latch, final AtomicInteger counter) {
+            this.latch = latch;
+            this.counter = counter;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+            latch.countDown();
+        }
+    }
+
+    private static class CountingCallable implements Callable<Integer> {
+        private final AtomicInteger counter = new AtomicInteger();
+
+        @Override
+        public Integer call() throws Exception {
+            return counter.incrementAndGet();
+        }
+    }
+
+    private static class CountingRunnable implements Runnable {
+        private final AtomicInteger counter;
+
+        private CountingRunnable(final AtomicInteger counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+        }
+    }
+
+    private static class CountingRunnableManagedTask implements Runnable, ManagedTask {
+        private final AtomicInteger counter;
+        private final CountDownLatch latch;
+
+        private CountingRunnableManagedTask(final AtomicInteger counter, final CountDownLatch latch) {
+            this.counter = counter;
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+        }
+
+        @Override
+        public Map<String, String> getExecutionProperties() {
+            return null;
+        }
+
+        @Override
+        public ManagedTaskListener getManagedTaskListener() {
+            return new ManagedTaskListener() {
+                @Override
+                public void taskAborted(final Future<?> future, final ManagedExecutorService executor, final Object task, final Throwable exception) {
+                    final StringWriter writer = new StringWriter();
+                    exception.printStackTrace(new PrintWriter(writer));
+                    Assert.fail("Task was aborted: " + writer);
+                }
+
+                @Override
+                public void taskDone(final Future<?> future, final ManagedExecutorService executor, final Object task, final Throwable exception) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void taskStarting(final Future<?> future, final ManagedExecutorService executor, final Object task) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void taskSubmitted(final Future<?> future, final ManagedExecutorService executor, final Object task) {
+                    latch.countDown();
+                }
+            };
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/ManagedScheduledExecutorServiceSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/suspend/ManagedScheduledExecutorServiceSuspendTestCase.java
@@ -1,0 +1,618 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.ee.suspend;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.enterprise.concurrent.LastExecution;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.ManagedTask;
+import javax.enterprise.concurrent.ManagedTaskListener;
+import javax.enterprise.concurrent.SkippedException;
+import javax.enterprise.concurrent.Trigger;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"MagicNumber", "Duplicates"})
+@RunWith(Arquillian.class)
+@Singleton
+public class ManagedScheduledExecutorServiceSuspendTestCase {
+    private static final int MILLIS_SLEEP_TIME = TimeoutUtil.adjust(120);
+    private static final int MILLIS_WAIT_TIME = TimeoutUtil.adjust(300);
+    private static final int SECONDS_WAIT_TIME = TimeoutUtil.adjust(1);
+
+    @Resource
+    private ManagedScheduledExecutorService executorService;
+    @ArquillianResource
+    private ManagementClient client;
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(ManagedScheduledExecutorServiceSuspendTestCase.class, TimeoutUtil.class)
+                .addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller-client\n"), "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    public void testExecutedQueuedRunnable() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // First submit a task with the server running
+        executorService.execute(new CountdownRunnable(latch, counter));
+        Assert.assertTrue("The runnable did not appear to be executed", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        int currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected a count of 1, but got a count of %d", currentCount), 1, currentCount);
+
+        // Suspend the server and attempt to submit the task again.
+        latch = new CountDownLatch(1);
+        suspend();
+        executorService.execute(new CountdownRunnable(latch, counter));
+        // We should timeout here
+        Assert.assertFalse("The runnable should not have ran", latch.await(MILLIS_WAIT_TIME, TimeUnit.MICROSECONDS));
+
+        // Resume the server
+        resume();
+        // Wait for the task to complete
+        latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected a count of 2, but got a count of %d", currentCount), 2, currentCount);
+    }
+
+    @Test
+    public void testSubmittedRunnable() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        // First submit a call that will just run
+        Future<?> future = executorService.submit(runnable);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(1, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(runnable);
+        future.get(MILLIS_WAIT_TIME, TimeUnit.MILLISECONDS);
+        Assert.assertEquals(2, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(runnable);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(3, counter.get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testSubmittedCallable() throws Exception {
+        final CountingCallable callable = new CountingCallable();
+
+        // First submit a call that will just run
+        Future<Integer> future = executorService.submit(callable);
+        Assert.assertEquals(1, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(callable);
+        Assert.assertEquals(2, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(callable);
+        Assert.assertEquals(3, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).intValue());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testSubmittedRunnableFuture() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        // First submit a call that will just run
+        Future<AtomicInteger> future = executorService.submit(runnable, counter);
+        Assert.assertEquals(1, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        future = executorService.submit(runnable, counter);
+        Assert.assertEquals(2, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Just test once more after a resume to ensure everything seems normal
+        future = executorService.submit(runnable, counter);
+        Assert.assertEquals(3, future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS).get());
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testCancelQueuedScheduledTask() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+        final Trigger trigger = new TimedTrigger(100, ChronoUnit.MILLIS);
+
+        final ScheduledFuture<?> future = executorService.schedule(runnable, trigger);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        int currentCount = counter.get();
+        // We won't know the exact count, but we should have more than 1
+        Assert.assertTrue(String.format("Expected at least 1 run but found %d", currentCount), currentCount >= 1);
+
+        // Suspend the server
+        suspend();
+        // Get the count while the server is suspended as no more tasks should be run
+        final int finalCount = counter.get();
+
+        // Cancel the future while the server is suspended
+        Assert.assertTrue(future.cancel(true));
+
+        // Resume the server
+        resume();
+        // This is a weird case. When the server is suspended tasks are skipped. This results in the SkippedException
+        // being thrown on the Future.get() methods. Even if the Future is cancelled, the SkippedException will be
+        // thrown instead of the CancellationException.
+        try {
+            future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+            Assert.fail("Expected ScheduledFuture.get() to throw a javax.enterprise.concurrent.SkippedException");
+        } catch (SkippedException ignore) {
+        }
+        currentCount = counter.get();
+        // The counter should not have been incremented as during a suspend the Trigger should indicate runs were skipped
+        Assert.assertEquals(String.format("Expected at least %d run but found %d", finalCount, currentCount), finalCount, currentCount);
+        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(future.isDone());
+    }
+
+    @Test
+    public void testScheduledRunnableTrigger() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+        final Trigger trigger = new TimedTrigger(100, ChronoUnit.MILLIS);
+
+        final ScheduledFuture<?> future = executorService.schedule(runnable, trigger);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        // We won't know the exact count, but we should have more than 1
+        int currentCount = counter.get();
+        Assert.assertTrue(String.format("Expected at least 1 run but found %d", currentCount), currentCount >= 1);
+
+        // Suspend the server
+        suspend();
+        // Tasks should still be running, but should be skipped resulting in Future.get() throwing a SkippedException
+        try {
+            future.get(MILLIS_WAIT_TIME, TimeUnit.MILLISECONDS);
+            Assert.fail("Expected ScheduledFuture.get() to throw a javax.enterprise.concurrent.SkippedException");
+        } catch (SkippedException ignore) {
+        }
+        // Get the current count
+        final int minimumCount = counter.get();
+        final long start = System.currentTimeMillis();
+        resume();
+        // The resume as happened, but we need to wait to ensure another task will be executed, otherwise it's possible
+        // a SkippedException could be thrown on the get()
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        // We're going to guess at the range of the current runs, we'll know the minimum and the maximum will be a guess
+        currentCount = counter.get();
+        long maxCount = currentCount + ((System.currentTimeMillis() - start) / 100) + 2;
+        Assert.assertTrue(String.format("Expected between %d and %d runs but found %d", minimumCount, maxCount, currentCount),
+                (currentCount >= minimumCount && currentCount <= maxCount));
+
+        // We should be able to cancel this future, though it will likely return false since it did have a successful run.
+        // The isCancelled() and isDone() should return true.
+        final boolean cancelled = future.cancel(true);
+        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(future.isDone());
+        final int finalCount = counter.get();
+        // Wait at least until the next scheduled time to ensure it's really been cancelled
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        Assert.assertEquals(finalCount, counter.get());
+        // Test the get() to ensure it returns a value
+        if (!cancelled) {
+            future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        } else {
+            // If it was actually cancelled, get() should throw a CancellationException()
+            try {
+                future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+                Assert.fail("Expected ScheduledFuture.get() to throw a java.util.concurrent.CancellationException");
+            } catch (CancellationException ignore) {
+            }
+        }
+    }
+
+    @Test
+    public void testScheduledCallableTrigger() throws Exception {
+        final CountingCallable callable = new CountingCallable();
+        final Trigger trigger = new TimedTrigger(100, ChronoUnit.MILLIS);
+
+        final ScheduledFuture<Integer> future = executorService.schedule(callable, trigger);
+        int currentCount = future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        // We won't know the exact count, but we should have more than 1
+        Assert.assertTrue(String.format("Expected at least 1 run but found %d", currentCount), currentCount >= 1);
+
+        // Suspend the server
+        suspend();
+        // Tasks should still be running, but should be skipped resulting in Future.get() throwing a SkippedException
+        try {
+            future.get(MILLIS_WAIT_TIME, TimeUnit.MILLISECONDS);
+            Assert.fail("Expected the Future.get() to be skipped");
+        } catch (SkippedException ignore) {
+        }
+        final long start = System.currentTimeMillis();
+        resume();
+        // The resume as happened, but we need to wait to ensure another task will be executed, otherwise it's possible
+        // a SkippedException could be thrown on the get()
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        final int minimumCount = 1;
+        currentCount = future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        // We're going to guess at the range of the current runs, we'll know the minimum and the maximum will be a guess
+        long maxCount = currentCount + ((System.currentTimeMillis() - start) / 100) + 2;
+        Assert.assertTrue(String.format("Expected between %d and %d runs but found %d", minimumCount, maxCount, currentCount),
+                (currentCount >= minimumCount && currentCount <= maxCount));
+
+        // We should be able to cancel this future, though it will likely return false since it did have a successful run.
+        // The isCancelled() and isDone() should return true.
+        final boolean cancelled = future.cancel(true);
+        future.cancel(true);
+        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(future.isDone());
+        // Test the get() to ensure it returns a value
+        if (!cancelled) {
+            future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        } else {
+            // If it was actually cancelled, get() should throw a CancellationException()
+            try {
+                future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+                Assert.fail("Expected ScheduledFuture.get() to throw a java.util.concurrent.CancellationException");
+            } catch (CancellationException ignore) {
+            }
+        }
+    }
+
+    @Test
+    public void testScheduledRunnableDelay() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        ScheduledFuture<?> future = executorService.schedule(runnable, 10, TimeUnit.MILLISECONDS);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        // This should only have been run once
+        int currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected 1 run but found %d", currentCount), 1, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server
+        suspend();
+        // Schedule a new task while suspended which should run as the ControlPoint should force the run
+        future = executorService.schedule(runnable, 10, TimeUnit.MILLISECONDS);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected 2 run but found %d", currentCount), 2, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Schedule the task once more to ensure everything works correctly
+        future = executorService.schedule(runnable, 10, TimeUnit.MILLISECONDS);
+        future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        currentCount = counter.get();
+        Assert.assertEquals(String.format("Expected 3 runs run but found %d", currentCount), 3, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testScheduledCallableDelay() throws Exception {
+        final CountingCallable callable = new CountingCallable();
+
+        ScheduledFuture<Integer> future = executorService.schedule(callable, 10, TimeUnit.MILLISECONDS);
+        // This should only have been run once
+        int currentCount = future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(String.format("Expected 1 run but found %d", currentCount), 1, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Suspend the server
+        suspend();
+        // Schedule a new task while suspended which should run as the ControlPoint should force the run
+        future = executorService.schedule(callable, 10, TimeUnit.MILLISECONDS);
+        currentCount = future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(String.format("Expected 2 run but found %d", currentCount), 2, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+
+        // Resume the server
+        resume();
+        // Schedule the task once more to ensure everything works correctly
+        future = executorService.schedule(callable, 10, TimeUnit.MILLISECONDS);
+        currentCount = future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+        Assert.assertEquals(String.format("Expected 3 runs run but found %d", currentCount), 3, currentCount);
+        Assert.assertTrue("Expected to the future to be done.", future.isDone());
+    }
+
+    @Test
+    public void testScheduleAtFixedRate() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        final ScheduledFuture<?> future = executorService.scheduleAtFixedRate(runnable, 0, 100, TimeUnit.MILLISECONDS);
+        // Sleep for 120ms to ensure the task has been ran at least once
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        // We won't know the exact count, but we should have more than 1
+        int currentCount = counter.get();
+        Assert.assertTrue(String.format("Expected at least 1 run but found %d", currentCount), currentCount >= 1);
+
+        // Suspend the server
+        suspend();
+        // Get the current count
+        final int minimumCount = counter.get();
+        final long start = System.currentTimeMillis();
+        // Sleep for 120ms to ensure the task has been ran at least once more
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        Assert.assertTrue("Expected the tasks to continue running while the server is suspended.", counter.get() > minimumCount);
+
+        // Resume the server
+        resume();
+        // Sleep for 120ms to ensure the task has been ran at least once more
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        // We're going to guess at the range of the current runs, we'll know the minimum and the maximum will be a guess
+        currentCount = counter.get();
+        long maxCount = currentCount + ((System.currentTimeMillis() - start) / 100) + 2;
+        Assert.assertTrue(String.format("Expected between %d and %d runs but found %d", minimumCount, maxCount, currentCount),
+                (currentCount >= minimumCount && currentCount <= maxCount));
+
+        // We should be able to cancel this future
+        future.cancel(true);
+        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(future.isDone());
+        try {
+            future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+            Assert.fail("Expected ScheduledFuture.get() to throw a java.util.concurrent.CancellationException");
+        } catch (CancellationException ignore) {
+        }
+    }
+
+    @Test
+    public void testScheduleAWithFixedDelay() throws Exception {
+        //executorService.scheduleWithFixedDelay();
+        final AtomicInteger counter = new AtomicInteger();
+        final CountingRunnable runnable = new CountingRunnable(counter);
+
+        final ScheduledFuture<?> future = executorService.scheduleWithFixedDelay(runnable, 0, 100, TimeUnit.MILLISECONDS);
+        // Sleep for 120ms to ensure the task has been ran at least once
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        // We won't know the exact count, but we should have more than 1
+        int currentCount = counter.get();
+        Assert.assertTrue(String.format("Expected at least 1 run but found %d", currentCount), currentCount >= 1);
+
+        // Suspend the server
+        suspend();
+        // Get the current count
+        final int minimumCount = counter.get();
+        final long start = System.currentTimeMillis();
+        // Sleep for 120ms to ensure the task has been ran at least once more
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        Assert.assertTrue("Expected the tasks to continue running while the server is suspended.", counter.get() > minimumCount);
+
+        resume();
+        // Sleep for 120ms to ensure the task has been ran at least once more
+        TimeUnit.MILLISECONDS.sleep(MILLIS_SLEEP_TIME);
+        // We're going to guess at the range of the current runs, we'll know the minimum and the maximum will be a guess
+        currentCount = counter.get();
+        long maxCount = currentCount + ((System.currentTimeMillis() - start) / 100) + 2;
+        Assert.assertTrue(String.format("Expected between %d and %d runs but found %d", minimumCount, maxCount, currentCount),
+                (currentCount >= minimumCount && currentCount <= maxCount));
+
+        // We should be able to cancel this future
+        future.cancel(true);
+        Assert.assertTrue(future.isCancelled());
+        Assert.assertTrue(future.isDone());
+        try {
+            future.get(SECONDS_WAIT_TIME, TimeUnit.SECONDS);
+            Assert.fail("Expected ScheduledFuture.get() to throw a java.util.concurrent.CancellationException");
+        } catch (CancellationException ignore) {
+        }
+    }
+
+    @Test
+    public void testManagedTaskCompletion() throws Exception {
+        final AtomicInteger counter = new AtomicInteger();
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        CountDownLatch latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        Assert.assertTrue("Expected the ManagedTaskListener.taskDone() to be invoked.", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran once", 1, counter.get());
+
+        // Suspend the server and submit the task again, it should run as the ControlPoint should force the run
+        suspend();
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        // We should timeout here
+        Assert.assertTrue("The runnable should not have ran", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran twice", 2, counter.get());
+
+        // Resume the server
+        resume();
+        // Execute one more task after resume to ensure everything is still working correctly
+        // The latch should be hit 3 times; taskSubmitted(), taskStarting() and taskDone()
+        latch = new CountDownLatch(3);
+        executorService.submit(new CountingRunnableManagedTask(counter, latch));
+        Assert.assertTrue("Expected the ManagedTaskListener.taskDone() to be invoked.", latch.await(SECONDS_WAIT_TIME, TimeUnit.SECONDS));
+        Assert.assertEquals("Expected the task to be ran 3 times", 3, counter.get());
+    }
+
+    private void suspend() throws IOException {
+        suspend(SECONDS_WAIT_TIME);
+    }
+
+    private void suspend(final int timeout) throws IOException {
+        final ModelNode op = Operations.createOperation("suspend");
+        op.get("timeout").set(timeout);
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to suspend server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private void resume() throws IOException {
+        final ModelNode result = client.getControllerClient().execute(Operations.createOperation("resume"));
+        if (!Operations.isSuccessfulOutcome(result)) {
+            throw new RuntimeException("Failed to resume server: " + Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private static class CountdownRunnable implements Runnable {
+        private final CountDownLatch latch;
+        private final AtomicInteger counter;
+
+        private CountdownRunnable(final CountDownLatch latch, final AtomicInteger counter) {
+            this.latch = latch;
+            this.counter = counter;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+            latch.countDown();
+        }
+    }
+
+    private static class CountingCallable implements Callable<Integer> {
+        private final AtomicInteger counter = new AtomicInteger();
+
+        @Override
+        public Integer call() throws Exception {
+            return counter.incrementAndGet();
+        }
+    }
+
+    private static class CountingRunnable implements Runnable {
+        private final AtomicInteger counter;
+
+        private CountingRunnable(final AtomicInteger counter) {
+            this.counter = counter;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+        }
+    }
+
+    private static class TimedTrigger implements Trigger {
+        private final long offset;
+        private final TemporalUnit offsetUnit;
+
+        private TimedTrigger(final int offset, final TemporalUnit offsetUnit) {
+            this.offset = TimeoutUtil.adjust(offset);
+            this.offsetUnit = offsetUnit;
+        }
+
+        @Override
+        public Date getNextRunTime(final LastExecution lastExecutionInfo, final Date taskScheduledTime) {
+            return Date.from(ZonedDateTime.ofInstant(taskScheduledTime.toInstant(), ZoneId.systemDefault()).plus(offset, offsetUnit).toInstant());
+        }
+
+        @Override
+        public boolean skipRun(final LastExecution lastExecutionInfo, final Date scheduledRunTime) {
+            return false;
+        }
+    }
+
+    private static class CountingRunnableManagedTask implements Runnable, ManagedTask {
+        private final AtomicInteger counter;
+        private final CountDownLatch latch;
+
+        private CountingRunnableManagedTask(final AtomicInteger counter, final CountDownLatch latch) {
+            this.counter = counter;
+            this.latch = latch;
+        }
+
+        @Override
+        public void run() {
+            counter.incrementAndGet();
+        }
+
+        @Override
+        public Map<String, String> getExecutionProperties() {
+            return null;
+        }
+
+        @Override
+        public ManagedTaskListener getManagedTaskListener() {
+            return new ManagedTaskListener() {
+                @Override
+                public void taskAborted(final Future<?> future, final ManagedExecutorService executor, final Object task, final Throwable exception) {
+                    final StringWriter writer = new StringWriter();
+                    exception.printStackTrace(new PrintWriter(writer));
+                    Assert.fail("Task was aborted: " + writer);
+                }
+
+                @Override
+                public void taskDone(final Future<?> future, final ManagedExecutorService executor, final Object task, final Throwable exception) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void taskStarting(final Future<?> future, final ManagedExecutorService executor, final Object task) {
+                    latch.countDown();
+                }
+
+                @Override
+                public void taskSubmitted(final Future<?> future, final ManagedExecutorService executor, final Object task) {
+                    latch.countDown();
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5863

When a `ControlPoint` is present scheduled tasks will be forced ran via the`ControlPoint`. Tasks submitted via `Executor.execute(Runnable)` may be queued if the server is suspended and ran when the server is resumed.

Details about how the changes should work are outlined on the [analysis document](https://developer.jboss.org/docs/DOC-55616).

A brief summary is tasks should be allowed to be submitted and scheduled even if the server is suspended. The `Future` returned can't block until the server is resumed as other graceful shutdown points may be waiting for the result of the future.

There are two exceptions to this rule. Any task submitted via the `Executor.execute(Runnable)` method will be queued if the server is suspended and then executed when the server is resumed. One thing I hadn't considered until now is if there is if the `Runnable` is a `javax.enterprise.concurrent.ManagedTask` it's possible a `ManagedTaskListener` could be waiting for the task to complete. However this won't happen until the server is resumed. I'm not sure we need to worry about that, but it should be noted.

If a task is submitted with a `javax.enterprise.concurrent.Trigger` the `Trigger.skipRun(LastExecution lastExecutionInfo, Date scheduledRunTime)` will return `false` if the server is suspended. After the server is resumed the users implementation of the method will be used.
