### PR TITLE
[WFLY-2217] - enable reload tests

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/bootstrap/NamedBootstrapContext.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/bootstrap/NamedBootstrapContext.java
@@ -41,9 +41,14 @@ public class NamedBootstrapContext extends BaseCloneableBootstrapContext {
      * Constructor
      * @param name The name of the WorkManager
      */
-    public NamedBootstrapContext(String name) {
+    public NamedBootstrapContext(final String name) {
         super();
         setName(name);
+    }
+
+    public NamedBootstrapContext(final String name, final String workManagerName) {
+        this(name);
+        this.setWorkManagerName(workManagerName);
     }
 
     /**
@@ -66,7 +71,7 @@ public class NamedBootstrapContext extends BaseCloneableBootstrapContext {
     public CloneableBootstrapContext clone() throws CloneNotSupportedException {
         NamedBootstrapContext nbc = (NamedBootstrapContext)super.clone();
         nbc.setName(getName());
-
+        nbc.setWorkManagerName(getWorkManagerName());
         return nbc;
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
@@ -59,13 +59,16 @@ public class BootstrapContextAdd extends AbstractAddStepHandler {
         String name = JcaBootstrapContextDefinition.BootstrapCtxParameters.NAME.getAttribute().resolveModelAttribute(context, model).asString();
         String workmanager = JcaBootstrapContextDefinition.BootstrapCtxParameters.WORKMANAGER.getAttribute().resolveModelAttribute(context, model).asString();
         boolean usingDefaultWm = false;
+        CloneableBootstrapContext ctx;
         if (DEFAULT_NAME.equals( workmanager)) {
             usingDefaultWm = true;
+            ctx = new NamedBootstrapContext(name);
+        } else {
+            ctx = new NamedBootstrapContext(name,workmanager);
         }
 
         ServiceTarget serviceTarget = context.getServiceTarget();
 
-        CloneableBootstrapContext ctx = new NamedBootstrapContext(name);
                 final BootStrapContextService bootCtxService = new BootStrapContextService(ctx, name, usingDefaultWm);
                 serviceTarget
                         .addService(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append(name), bootCtxService)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/BootstrapContextAdd.java
@@ -60,11 +60,11 @@ public class BootstrapContextAdd extends AbstractAddStepHandler {
         String workmanager = JcaBootstrapContextDefinition.BootstrapCtxParameters.WORKMANAGER.getAttribute().resolveModelAttribute(context, model).asString();
         boolean usingDefaultWm = false;
         CloneableBootstrapContext ctx;
-        if (DEFAULT_NAME.equals( workmanager)) {
+        if (DEFAULT_NAME.equals(workmanager)) {
             usingDefaultWm = true;
             ctx = new NamedBootstrapContext(name);
         } else {
-            ctx = new NamedBootstrapContext(name,workmanager);
+            ctx = new NamedBootstrapContext(name, workmanager);
         }
 
         ServiceTarget serviceTarget = context.getServiceTarget();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/CustomBootstrapContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/CustomBootstrapContextTestCase.java
@@ -49,7 +49,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,7 +57,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(CustomBootstrapContextTestCase.CustomBootstrapDeploymentTestCaseSetup.class)
-@Ignore("AS7-4185")
 public class CustomBootstrapContextTestCase extends JcaMgmtBase {
 
     public static String ctx = "customContext";

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
@@ -38,14 +38,15 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.WebUtil;
 import org.jboss.as.test.shared.RetryTaskExecutor;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -67,7 +68,6 @@ import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNo
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("ARQ-791")
 public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase {
 
     private static final Logger logger = Logger.getLogger(SocketsAndInterfacesTestCase.class);
@@ -75,6 +75,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
     @ArquillianResource
     URL url;
     private NetworkInterface testNic;
+    private  String testHost;
     private static final int TEST_PORT = 9091;
 
     @Deployment
@@ -87,6 +88,31 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
     @Before
     public void before() throws IOException {
         testNic = getNonDefaultNic();
+        // test the connector
+        testHost = NetworkUtils.canonize(testNic.getInetAddresses().nextElement().getHostName());
+    }
+
+    @After
+    public void after() throws Exception{
+     // remove connector
+        ModelNode op = createOpNode("subsystem=undertow/server=default-server/http-listener=test", REMOVE);
+        ModelNode result = executeOperation(op);
+
+        try {
+            // check that the connector is down
+            Assert.assertFalse("Could not connect to created connector.",WebUtil.testHttpURL(new URL(
+                    "http", testHost, TEST_PORT, "/").toString()));
+        } finally {
+            // remove socket binding
+            op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", REMOVE);
+            result = executeOperation(op);
+
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
+            // remove interface
+            op = createOpNode("interface=test-interface", REMOVE);
+            result = executeOperation(op);
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
+        }
     }
 
     @Test
@@ -114,8 +140,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
         op.get("socket-binding").set("test-binding");
         result = executeOperation(op);
 
-        // test the connector
-        String testHost = NetworkUtils.canonize(testNic.getInetAddresses().nextElement().getHostName());
+
         Assert.assertTrue("Could not connect to created connector.",WebUtil.testHttpURL(new URL(
                 "http", testHost, TEST_PORT, "/").toString()));
 
@@ -129,9 +154,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
 
         logger.info("Restarting server.");
 
-        // reload server
-        op = createOpNode(null, "reload");
-        result = executeOperation(op);
+        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
 
         // wait until the connector is available on the new port
         final String testUrl = new URL("http", testHost, TEST_PORT + 1, "/").toString();
@@ -160,21 +183,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
         result = executeOperation(op, false);
         Assert.assertFalse("Removed socked binding with connector still using it.", SUCCESS.equals(result.get(OUTCOME).asString()));
 
-        // remove connector
-        op = createOpNode("subsystem=undertow/server=default-server/http-listener=test", REMOVE);
-        result = executeOperation(op);
 
-        // check that the connector is down
-        Assert.assertFalse("Could not connect to created connector.",WebUtil.testHttpURL(new URL(
-                "http", testHost, TEST_PORT, "/").toString()));
-
-        // remove socket binding
-        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", REMOVE);
-        result = executeOperation(op);
-
-        // remove interface
-        op = createOpNode("interface=test-interface", REMOVE);
-        result = executeOperation(op);
 
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
@@ -75,12 +75,12 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
     @ArquillianResource
     URL url;
     private NetworkInterface testNic;
-    private  String testHost;
-    private static final int TEST_PORT = 9091;
+    private String testHost;
+    private static final int TEST_PORT = 9695;
 
     @Deployment
     public static Archive<?> getDeployment() {
-        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "SocketsAndInterfacesTestCase-dummy.jar");
         ja.addClass(SocketsAndInterfacesTestCase.class);
         return ja;
     }
@@ -89,12 +89,12 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
     public void before() throws IOException {
         testNic = getNonDefaultNic();
         // test the connector
-        testHost = NetworkUtils.canonize(testNic.getInetAddresses().nextElement().getHostName());
+        testHost = NetworkUtils.canonize(testNic.getInetAddresses().nextElement().getHostAddress());
     }
 
     @After
     public void after() throws Exception{
-     // remove connector
+        // remove connector
         ModelNode op = createOpNode("subsystem=undertow/server=default-server/http-listener=test", REMOVE);
         ModelNode result = executeOperation(op);
 
@@ -104,12 +104,12 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
                     "http", testHost, TEST_PORT, "/").toString()));
         } finally {
             // remove socket binding
-            op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", REMOVE);
+            op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test123-binding", REMOVE);
             result = executeOperation(op);
 
             ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
             // remove interface
-            op = createOpNode("interface=test-interface", REMOVE);
+            op = createOpNode("interface=test123-interface", REMOVE);
             result = executeOperation(op);
             ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
@@ -124,28 +124,32 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
         }
 
         // add interface
-        ModelNode op = createOpNode("interface=test-interface", ADD);
+        ModelNode op = createOpNode("interface=test123-interface", ADD);
         op.get("nic").set(testNic.getName());
+        op.get("inet-address").set(testHost);
         ModelNode result = executeOperation(op);
 
         // add socket binding using created interface
-        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", ADD);
-        op.get("interface").set("test-interface");
+        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test123-binding", ADD);
+        op.get("interface").set("test123-interface");
         op.get("port").set(TEST_PORT);
         result = executeOperation(op);
 
 
         // add a web connector so we can test the interface
         op = createOpNode("subsystem=undertow/server=default-server/http-listener=test", ADD);
-        op.get("socket-binding").set("test-binding");
+        op.get("socket-binding").set("test123-binding");
+        result = executeOperation(op);
+        op = createOpNode("/", "read-resource");
+        op.get("recursive").set(true);
+        op.get("include-runtime").set(true);
         result = executeOperation(op);
 
-
-        Assert.assertTrue("Could not connect to created connector.",WebUtil.testHttpURL(new URL(
-                "http", testHost, TEST_PORT, "/").toString()));
+        final URL url =new URL("http", testHost, TEST_PORT, "/");
+        Assert.assertTrue("Could not connect to created connector: "+url+"<>"+InetAddress.getByName(url.getHost())+"..."+getNonDefaultNic()+".>"+result,WebUtil.testHttpURL(url.toString()));
 
         // change socket binding port
-        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", WRITE_ATTRIBUTE_OPERATION);
+        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test123-binding", WRITE_ATTRIBUTE_OPERATION);
         op.get(NAME).set("port");
         op.get(VALUE).set(TEST_PORT + 1);
         result = executeOperation(op, false);
@@ -174,12 +178,12 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
                 "http", testHost, TEST_PORT, "/").toString()));
 
         // try to remove the interface while the socket binding is still  bound to it - should fail
-        op = createOpNode("interface=test-interface", REMOVE);
+        op = createOpNode("interface=test123-interface", REMOVE);
         result = executeOperation(op, false);
         Assert.assertFalse("Removed interface with socket binding bound to it.", SUCCESS.equals(result.get(OUTCOME).asString()));
 
         // try to remove socket binding while the connector is still using it - should fail
-        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test-binding", REMOVE);
+        op = createOpNode("socket-binding-group=standard-sockets/socket-binding=test123-binding", REMOVE);
         result = executeOperation(op, false);
         Assert.assertFalse("Removed socked binding with connector still using it.", SUCCESS.equals(result.get(OUTCOME).asString()));
 
@@ -188,7 +192,6 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
     }
 
     private NetworkInterface getNonDefaultNic() throws SocketException, UnknownHostException {
-
         InetAddress defaultAddr = InetAddress.getByName(url.getHost());
 
         Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
@@ -203,5 +206,4 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
         }
         return null; // no interface found
     }
-
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2217

some tests are still disabled because of "reloading issues". This is no longer true. This PR enables two. 
https://issues.jboss.org/browse/WFLY-5606 handle another one.

Upstream: https://issues.jboss.org/browse/WFLY-2217 , https://issues.jboss.org/browse/WFLY-5606
EAP7.x: https://issues.jboss.org/browse/JBEAP-2160
EAP7.0.x: https://issues.jboss.org/browse/JBEAP-6272
EAP6.4.x: https://bugzilla.redhat.com/show_bug.cgi?id=900065

PRs:
Upstream: wildfly/wildfly#9234 , wildfly/wildfly#8367
EAP7.x: https://github.com/jbossas/jboss-eap7/pull/738
EAP7.0.x: https://github.com/jbossas/jboss-eap7/pull/835
EAP 6.4.x: none atm.
