### PR TITLE
io.undertow.js module depends on sun.scripting

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
@@ -37,5 +37,6 @@
         <module name="io.undertow.servlet"/>
         <module name="org.jboss.xnio"/>
         <module name="com.github.spullara.mustache" />
+        <module name="sun.scripting" />
     </dependencies>
 </module>


### PR DESCRIPTION
This allows ScriptManager.getEngine("JavaScript") to be called without any problems
Discussion in https://groups.google.com/forum/#!topic/wildfly-swarm/zI6ZClguceU
