### PR TITLE
[WFLY-6934] ParticipantTestCase fails with security manager

### DIFF
--- a/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/ParticipantTestCase.java
+++ b/testsuite/integration/rts/src/test/java/org/wildfly/test/extension/rts/ParticipantTestCase.java
@@ -22,6 +22,7 @@
 package org.wildfly.test.extension.rts;
 
 import java.io.File;
+import java.lang.reflect.ReflectPermission;
 import java.net.SocketPermission;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,6 +75,9 @@ public final class ParticipantTestCase extends AbstractTestCase {
                         new PropertyPermission("management.address", "read"),
                         new PropertyPermission("node0", "read"),
                         new PropertyPermission("jboss.http.port", "read"),
+                        new PropertyPermission("arquillian.debug", "read"),
+                        new ReflectPermission("suppressAccessChecks"),
+                        new RuntimePermission("accessDeclaredMembers"),
                         // Permissions required to access SERVER_HOST_PORT
                         new SocketPermission(SERVER_HOST_PORT, "connect,resolve")
                 ), "permissions.xml");


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-6934
