### PR TITLE
[10.x branch] Fix for WFLY-7247

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
@@ -57,6 +57,7 @@ import org.wildfly.extension.undertow.logging.UndertowLogger;
 public class Host implements Service<Host>, FilterLocation {
     private final PathHandler pathHandler = new PathHandler();
     private volatile HttpHandler rootHandler = null;
+    private volatile boolean ssoEnabled;
     private final Set<String> allAliases;
     private final String name;
     private final String defaultWebModule;
@@ -162,6 +163,14 @@ public class Host implements Service<Host>, FilterLocation {
 
     List<FilterRef> getFilters() {
         return Collections.unmodifiableList(filters);
+    }
+
+    void setSSOEnabled(final boolean ssoEnabled) {
+        this.ssoEnabled = ssoEnabled;
+    }
+
+    public boolean isSSOEnabled() {
+        return this.ssoEnabled;
     }
 
     protected HttpHandler getOrCreateRootHandler() {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnAdd.java
@@ -80,6 +80,9 @@ class SingleSignOnAdd extends AbstractAddStepHandler {
         } else {
             target.addService(managerServiceName, new ValueService<>(new ImmediateValue<>(new InMemorySingleSignOnManager()))).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
         }
+        // keep track that SSO is enabled for the target host
+        final Host host = (Host) context.getServiceRegistry(true).getRequiredService(virtualHostServiceName).getService();
+        host.setSSOEnabled(true);
 
         final SingleSignOnService service = new SingleSignOnService(domain, path, httpOnly, secure, cookieName);
         target.addService(serviceName, service)


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-7247.

Undertow subsystem allows enabling SSO for each web host at the subsystem level. The `SingleSignOnService` is what gets registered for each such SSO model. The (per web) `Host` service within undertow subsystem relies on this service to add additional auth mechanism when/if the `SingleSignOnService` gets registered.

The `UndertowDeploymentInfoService` which gets registered for each (web) deployment _depends_ on the `Host` service to tell the undertow deployment info, what authentication mechanisms are enabled. Since there's no dependency between this `UndertowDeploymentInfoService` and `SingleSignOnService` (whenever SSO is enabled), it leads to a race condition where the SSO authentication mechanism might end up being skipped for a particular deployment, even if SSO is enabled for the (web) host on which this deployment is being deployed.

The commit here adds a dependency on the `SingleSignOnService` for the `UndertowDeploymentInfoService` _if_ SSO is enabled for that particular (web) host.

Given, the nature of this issue, I don't have a way to add new tests to be sure this fixes the issue. But I have run the `ClusteredSingleSignOnTestCase` in `testsuite/integration/clustering` to make sure this doesn't introduce any regressions.

Related forum threads:
https://developer.jboss.org/message/962289#962289
https://developer.jboss.org/message/963592
