### PR TITLE
WFLY-7291: InfinispanCacheDeploymentListener fix

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/InfinispanCacheDeploymentListener.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/InfinispanCacheDeploymentListener.java
@@ -145,7 +145,10 @@ public class InfinispanCacheDeploymentListener implements EventListener {
             if(ROOT_LOGGER.isTraceEnabled()) {
                 ROOT_LOGGER.tracef("stop second level cache by removing dependency on service '%s'", cacheWrapper.serviceName.getCanonicalName());
             }
-            ServiceContainerHelper.remove(currentServiceContainer().getRequiredService(cacheWrapper.serviceName));
+            ServiceController<?> service = currentServiceContainer().getService(cacheWrapper.serviceName);
+            if (service != null) {
+                ServiceContainerHelper.remove(service);
+            }
         } else if(ROOT_LOGGER.isTraceEnabled()){
             CacheWrapper cacheWrapper = (CacheWrapper) wrapper;
             ROOT_LOGGER.tracef("skipping stop of second level cache, will keep dependency on service '%s'", cacheWrapper.serviceName.getCanonicalName());


### PR DESCRIPTION
InfinispanCacheDeploymentListener doesn't need to throw ServiceNotFoundException when stopping the container
