### PR TITLE
[WFLY-7300]: OperationHandlers that register DeploymentProcessor should do it only on boot.

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -28,7 +28,7 @@ import java.util.Collections;
 
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.JobExecutor;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -154,7 +154,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     /**
      * Handler responsible for adding the subsystem resource to the model.
      */
-    static class BatchSubsystemAdd extends AbstractAddStepHandler {
+    static class BatchSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         static final BatchSubsystemAdd INSTANCE = new BatchSubsystemAdd();
 
@@ -163,7 +163,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model)
+        protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model)
                 throws OperationFailedException {
             // Check if the request-controller subsystem exists
             final boolean rcPresent = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS).hasChild(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RequestControllerExtension.SUBSYSTEM_NAME));

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
@@ -28,7 +28,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.jberet.spi.JobExecutor;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.DefaultAttributeMarshaller;
 import org.jboss.as.controller.ModelVersion;
@@ -163,7 +163,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     /**
      * Handler responsible for adding the subsystem resource to the model.
      */
-    static class BatchSubsystemAdd extends AbstractAddStepHandler {
+    static class BatchSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         static final BatchSubsystemAdd INSTANCE = new BatchSubsystemAdd();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
@@ -25,7 +25,7 @@ import org.jboss.as.connector.deployers.ra.processors.CachedConnectionManagerSet
 import org.jboss.as.connector.services.jca.CachedConnectionManagerService;
 import org.jboss.as.connector.services.jca.NonTxCachedConnectionManagerService;
 import org.jboss.as.connector.util.ConnectorServices;
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -39,7 +39,7 @@ import org.jboss.msc.service.ServiceTarget;
  * @author <a href="jesper.pedersen@jboss.org">Jesper Pedersen</a>
  * @author <a href="stefano.maestri@redhat.com">Stefano Maestri</a>
  */
-public class CachedConnectionManagerAdd extends AbstractAddStepHandler {
+public class CachedConnectionManagerAdd extends AbstractBoottimeAddStepHandler {
 
     public static final CachedConnectionManagerAdd INSTANCE = new CachedConnectionManagerAdd();
 
@@ -51,7 +51,7 @@ public class CachedConnectionManagerAdd extends AbstractAddStepHandler {
     }
 
     @Override
-    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+    protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
         final boolean debug = JcaCachedConnectionManagerDefinition.CcmParameters.DEBUG.getAttribute().resolveModelAttribute(context, model).asBoolean();
         final boolean error = JcaCachedConnectionManagerDefinition.CcmParameters.ERROR.getAttribute().resolveModelAttribute(context, model).asBoolean();

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -28,7 +28,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -69,6 +68,7 @@ import org.wildfly.iiop.openjdk.service.IORSecConfigMetaDataService;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 import com.sun.corba.se.impl.orbutil.ORBConstants;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 
 /**
  * <p>
@@ -85,7 +85,7 @@ import com.sun.corba.se.impl.orbutil.ORBConstants;
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
  */
-public class IIOPSubsystemAdd extends AbstractAddStepHandler {
+public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
 //    static final IIOPSubsystemAdd INSTANCE = new IIOPSubsystemAdd();
 //
@@ -100,7 +100,7 @@ public class IIOPSubsystemAdd extends AbstractAddStepHandler {
             "security-domain");
 
     @Override
-    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+    protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
         // This needs to run after all child resources so that they can detect a fresh state
         context.addStep(new OperationStepHandler() {

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemAdd.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemAdd.java
@@ -29,8 +29,8 @@ import static org.jboss.as.jsr77.subsystem.Constants.MODULE_NAME;
 
 import javax.management.MBeanServer;
 import javax.management.j2ee.ManagementHome;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationContext.Stage;
@@ -61,7 +61,7 @@ import org.jboss.msc.value.Values;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-class JSR77ManagementSubsystemAdd extends AbstractAddStepHandler {
+class JSR77ManagementSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     JSR77ManagementSubsystemAdd(boolean appclient) {
         super(appclient ? JSR77ManagementRootResource.JSR77_APPCLIENT_CAPABILITY : JSR77ManagementRootResource.JSR77_CAPABILITY);
@@ -73,7 +73,7 @@ class JSR77ManagementSubsystemAdd extends AbstractAddStepHandler {
     }
 
     @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
@@ -36,7 +36,7 @@ import java.security.Permission;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -64,7 +64,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  *
  * @author <a href="sguilhen@jboss.com">Stefan Guilhen</a>
  */
-class SecurityManagerSubsystemAdd extends AbstractAddStepHandler {
+class SecurityManagerSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     static final SecurityManagerSubsystemAdd INSTANCE = new SecurityManagerSubsystemAdd();
 
@@ -76,7 +76,7 @@ class SecurityManagerSubsystemAdd extends AbstractAddStepHandler {
     }
 
     @Override
-    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model)
+    protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model)
             throws OperationFailedException {
 
         // This needs to run after all child resources so that they can detect a fresh state


### PR DESCRIPTION
Extending AbstractBoottimeAddStepHandler instead of AbstractAddStepHandler.

Jira: https://issues.jboss.org/browse/WFLY-7300
