### PR TITLE
WFLY-3639 default-web-module doesn't work for non default hosts & servers

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/VirtualServerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/web/VirtualServerTestCase.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+//todo this test could probably be done in manual mode test with wildfly runner, also could be merged into VirtualHostTestCase
 public class VirtualServerTestCase extends ContainerResourceMgmtTestBase {
 
     @ArquillianResource
@@ -127,6 +128,7 @@ public class VirtualServerTestCase extends ContainerResourceMgmtTestBase {
     private void addVirtualServer() throws IOException, MgmtOperationException {
         ModelNode addOp = createOpNode("subsystem=undertow/server=default-server/host=test", "add");
         addOp.get("alias").add(virtualHost);
+        addOp.get("default-web-module").set("some-test.war");
 
         ModelNode rewrite = new ModelNode();
         rewrite.get("condition").setEmptyList();

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.web;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that default-web-module works as it should for scenarios:
+ * - default host on of single server
+ * - non-default host of single server
+ * - non default server
+ *
+ * @author Tomaz Cerar (c) 2015 Red Hat Inc.
+ */
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(VirtualHostTestCase.VirtualHostSetupTask.class)
+//todo this test could probably be done in manual mode test with wildfly runner
+public class VirtualHostTestCase {
+
+    public static class VirtualHostSetupTask implements ServerSetupTask {
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient client = managementClient.getControllerClient();
+            ModelNode addOp = createOpNode("subsystem=undertow/server=default-server/host=test", "add");
+            addOp.get("default-web-module").set("test.war");
+            addOp.get("alias").add(TestSuiteEnvironment.getServerAddress()); //either 127.0.0.1 or ::1
+            execute(client, addOp);
+
+            addOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=myserver", "add");
+            addOp.get("port").set(8181);
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver", "add");
+            addOp.get("default-host").set("another");
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver/host=another", "add");
+            addOp.get("default-web-module").set("another-server.war");
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver/http-listener=myserver", "add");
+            addOp.get("socket-binding").set("myserver");
+            execute(client, addOp); //this one is runtime addable
+        }
+
+        private void execute(ModelControllerClient client, ModelNode op) throws IOException {
+            op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            ModelNode response = client.execute(op);
+            if (!SUCCESS.equals(response.get(OUTCOME).asString())) {
+                Assert.fail("Could not execute op: '" + op + "', result: " + response);
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient client = managementClient.getControllerClient();
+            execute(client, createOpNode("subsystem=undertow/server=default-server/host=test", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver/host=another", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver/http-listener=myserver", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver", "remove"));
+            execute(client, createOpNode("socket-binding-group=standard-sockets/socket-binding=myserver", "remove"));
+        }
+    }
+
+    private static WebArchive createDeployment(String name) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war");
+        war.addAsWebResource(new StringAsset(name), "index.html");
+        return war;
+    }
+
+    @Deployment(name = "ROOT")
+    public static Archive<?> getDefaultHostDeployment() {
+        return createDeployment("ROOT");
+    }
+
+    @Deployment(name = "test")
+    public static Archive<?> getAnotherHostDeployment() {
+        return createDeployment("test");
+    }
+
+    @Deployment(name = "another-server")
+    public static Archive<?> getAnotherServerDeployment() {
+        return createDeployment("another-server");
+    }
+
+    private void callAndTest(String uri, String expectedResult) throws IOException {
+        HttpClient client = HttpClients.createDefault();
+        HttpGet get = new HttpGet(uri);
+        HttpResponse response = client.execute(get);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        String result = EntityUtils.toString(response.getEntity());
+        Assert.assertEquals("Got response from wrong deployment", expectedResult, result);
+    }
+
+    @Test
+    public void testDefaultHost() throws IOException {
+        callAndTest("http://localhost:8080/", "ROOT"); //this needs to be localhost, as it is by host mapping
+    }
+
+    @Test
+    public void testNonDefaultHost() throws IOException {
+        callAndTest("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/", "test"); //second host on first server has alias 127.0.0.1 or ::1
+    }
+
+    @Test
+    public void testAnotherServerHost() throws IOException {
+        callAndTest("http://" + TestSuiteEnvironment.getServerAddress() + ":8181/", "another-server");
+    }
+
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextUtil.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextUtil.java
@@ -37,8 +37,9 @@ import java.util.List;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationBuilder;
@@ -48,13 +49,12 @@ import org.jboss.logging.Logger;
 /**
  * @author lbarreiro@redhat.com
  */
-public class RootContextUtil {
+    public class RootContextUtil {
 
     private static Logger log = Logger.getLogger(RootContextUtil.class);
     private static String SERVER = "server";
     private static String HOST = "host";
 
-    private static String ENABLE_WELCOME_ROOT = "enable-welcome-root";
     private static final String WEB_SUBSYSTEM_NAME = "undertow";
 
     public static void createVirutalHost(ModelControllerClient client, String virtualHost) throws Exception {
@@ -65,6 +65,7 @@ public class RootContextUtil {
         op.get(OP_ADDR).add(SUBSYSTEM, WEB_SUBSYSTEM_NAME);
         op.get(OP_ADDR).add(SERVER, "default-server");
         op.get(OP_ADDR).add(HOST, virtualHost);
+        op.get("default-web-module").set("somewar.war");
 
         updates.add(op);
 
@@ -115,7 +116,7 @@ public class RootContextUtil {
      */
     public static String hitRootContext(Logger log, URL url, String serverName) throws Exception {
         HttpGet httpget = new HttpGet(url.toURI());
-        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpClient httpclient = HttpClients.createDefault();
         httpget.setHeader("Host", serverName);
 
         log.info("executing request" + httpget.getRequestLine());

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
@@ -186,7 +186,7 @@ public class Host implements Service<Host>, FilterLocation {
         String path = getDeployedContextPath(deploymentInfo);
         registerHandler(path, handler);
         deployments.add(deployment);
-        UndertowLogger.ROOT_LOGGER.registerWebapp(path);
+        UndertowLogger.ROOT_LOGGER.registerWebapp(path, getServer().getName());
         undertowService.getValue().fireEvent(new EventInvoker() {
             @Override
             public void invoke(UndertowEventListener listener) {
@@ -206,7 +206,7 @@ public class Host implements Service<Host>, FilterLocation {
         });
         unregisterHandler(path);
         deployments.remove(deployment);
-        UndertowLogger.ROOT_LOGGER.unregisterWebapp(path);
+        UndertowLogger.ROOT_LOGGER.unregisterWebapp(path, getServer().getName());
     }
 
     public void registerHandler(String path, HttpHandler handler) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -40,6 +40,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.undertow.deployment.DefaultDeploymentMappingProvider;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -57,8 +58,8 @@ class HostAdd extends AbstractAddStepHandler {
         final PathAddress address = context.getCurrentAddress();
         final PathAddress serverAddress = address.getParent();
         final PathAddress subsystemAddress = serverAddress.getParent();
-        final ModelNode subsystemModel = Resource.Tools.readModel(context.readResourceFromRoot(subsystemAddress, false), 1);
-        final ModelNode serverModel = Resource.Tools.readModel(context.readResourceFromRoot(serverAddress, false), 1);
+        final ModelNode subsystemModel = Resource.Tools.readModel(context.readResourceFromRoot(subsystemAddress, false), 0);
+        final ModelNode serverModel = Resource.Tools.readModel(context.readResourceFromRoot(serverAddress, false), 0);
 
         final String name = address.getLastElement().getValue();
         final List<String> aliases = HostDefinition.ALIAS.unwrap(context, model);
@@ -69,6 +70,7 @@ class HostAdd extends AbstractAddStepHandler {
         final boolean isDefaultHost = defaultServerName.equals(serverName) && name.equals(defaultHostName);
         final int defaultResponseCode = HostDefinition.DEFAULT_RESPONSE_CODE.resolveModelAttribute(context, model).asInt();
         final boolean enableConsoleRedirect = !HostDefinition.DISABLE_CONSOLE_REDIRECT.resolveModelAttribute(context, model).asBoolean();
+        DefaultDeploymentMappingProvider.instance().addMapping(defaultWebModule, serverName, name);
 
         final ServiceName virtualHostServiceName = UndertowService.virtualHostName(serverName, name);
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -26,12 +26,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
-import org.jboss.as.controller.DefaultAttributeMarshaller;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -53,21 +51,7 @@ class HostDefinition extends PersistentResourceDefinition {
             .setElementValidator(new StringLengthValidator(1))
             .setAllowExpression(true)
             .setAttributeParser(AttributeParser.COMMA_DELIMITED_STRING_LIST)
-            .setAttributeMarshaller(new DefaultAttributeMarshaller() {
-                @Override
-                public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
-
-                    StringBuilder builder = new StringBuilder();
-                    if (resourceModel.hasDefined(attribute.getName())) {
-                        for (ModelNode p : resourceModel.get(attribute.getName()).asList()) {
-                            builder.append(p.asString()).append(", ");
-                        }
-                    }
-                    if (builder.length() > 0) {
-                        writer.writeAttribute(attribute.getXmlName(), builder.substring(0, builder.length() - 2));
-                    }
-                }
-            })
+            .setAttributeMarshaller(AttributeMarshaller.COMMA_STRING_LIST)
             .build();
     static final SimpleAttributeDefinition DEFAULT_WEB_MODULE = new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_WEB_MODULE, ModelType.STRING, true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostRemove.java
@@ -22,8 +22,6 @@
 
 package org.wildfly.extension.undertow;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -31,6 +29,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.web.host.WebHost;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.undertow.deployment.DefaultDeploymentMappingProvider;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -38,9 +37,9 @@ import org.jboss.msc.service.ServiceName;
 class HostRemove extends AbstractRemoveStepHandler {
 
     @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
-        final PathAddress parent = address.subAddress(0, address.size() - 1);
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        final PathAddress address = context.getCurrentAddress();
+        final PathAddress parent = address.getParent();
         final String name = address.getLastElement().getValue();
         final String serverName = parent.getLastElement().getValue();
         final ServiceName virtualHostServiceName = UndertowService.virtualHostName(serverName, name);
@@ -49,6 +48,8 @@ class HostRemove extends AbstractRemoveStepHandler {
         context.removeService(consoleRedirectName);
         final ServiceName commonHostName = WebHost.SERVICE_NAME.append(name);
         context.removeService(commonHostName);
+        final String defaultWebModule = HostDefinition.DEFAULT_WEB_MODULE.resolveModelAttribute(context, model).asString();
+        DefaultDeploymentMappingProvider.instance().removeMapping(defaultWebModule);
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServerAdd.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.extension.undertow;
 
-import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -38,16 +38,16 @@ import org.jboss.msc.service.ServiceName;
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
  */
-class ServerAdd extends AbstractBoottimeAddStepHandler {
+class ServerAdd extends AbstractAddStepHandler {
 
     ServerAdd() {
         super(ServerDefinition.ATTRIBUTES);
     }
 
     @Override
-    protected void performBoottime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+    protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         final PathAddress address = context.getCurrentAddress();
-        final PathAddress parentAddress = address.subAddress(0, address.size() - 1);
+        final PathAddress parentAddress = address.getParent();
         final ModelNode subsystemModel = Resource.Tools.readModel(context.readResourceFromRoot(parentAddress));
 
         final String name = context.getCurrentAddressValue();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_4_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_4_0.java
@@ -24,14 +24,10 @@ package org.wildfly.extension.undertow;
 
 import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 
-import java.util.List;
-
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.undertow.filters.CustomFilterDefinition;
 import org.wildfly.extension.undertow.filters.ErrorPageDefinition;
 import org.wildfly.extension.undertow.filters.ExpressionFilterDefinition;
@@ -55,7 +51,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
     private static final PersistentResourceXMLDescription xmlDescription;
 
     static {
-        xmlDescription = builder(UndertowRootDefinition.INSTANCE, Namespace.UNDERTOW_4_0.getUriString())
+        xmlDescription = builder(UndertowRootDefinition.INSTANCE.getPathElement(), Namespace.UNDERTOW_4_0.getUriString())
                 .addAttributes(
                         UndertowRootDefinition.DEFAULT_SERVER,
                         UndertowRootDefinition.DEFAULT_VIRTUAL_HOST,
@@ -64,10 +60,10 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                         UndertowRootDefinition.DEFAULT_SECURITY_DOMAIN,
                         UndertowRootDefinition.STATISTICS_ENABLED)
                 .addChild(
-                        builder(BufferCacheDefinition.INSTANCE)
+                        builder(BufferCacheDefinition.INSTANCE.getPathElement())
                                 .addAttributes(BufferCacheDefinition.BUFFER_SIZE, BufferCacheDefinition.BUFFERS_PER_REGION, BufferCacheDefinition.MAX_REGIONS)
                 )
-                .addChild(builder(ServerDefinition.INSTANCE)
+                .addChild(builder(ServerDefinition.INSTANCE.getPathElement())
                                 .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
                                 .addChild(
                                         listenerBuilder(AjpListenerResourceDefinition.INSTANCE)
@@ -114,14 +110,14 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         HttpListenerResourceDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
                                                         HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11)
                                 ).addChild(
-                                        builder(HostDefinition.INSTANCE)
+                                        builder(HostDefinition.INSTANCE.getPathElement())
                                                 .addAttributes(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE, HostDefinition.DEFAULT_RESPONSE_CODE, HostDefinition.DISABLE_CONSOLE_REDIRECT)
                                                 .addChild(
-                                                        builder(LocationDefinition.INSTANCE)
+                                                        builder(LocationDefinition.INSTANCE.getPathElement())
                                                                 .addAttributes(LocationDefinition.HANDLER)
                                                                 .addChild(filterRefBuilder())
                                                 ).addChild(
-                                                builder(AccessLogDefinition.INSTANCE)
+                                                builder(AccessLogDefinition.INSTANCE.getPathElement())
                                                         .addAttributes(
                                                                 AccessLogDefinition.PATTERN,
                                                                 AccessLogDefinition.WORKER,
@@ -135,13 +131,13 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                                 AccessLogDefinition.PREDICATE)
                                         ).addChild(filterRefBuilder())
                                                 .addChild(
-                                                    builder(SingleSignOnDefinition.INSTANCE)
+                                                    builder(SingleSignOnDefinition.INSTANCE.getPathElement())
                                                         .addAttributes(SingleSignOnDefinition.DOMAIN, SingleSignOnDefinition.PATH, SingleSignOnDefinition.HTTP_ONLY, SingleSignOnDefinition.SECURE, SingleSignOnDefinition.COOKIE_NAME)
                                         )
                                 )
                 )
                 .addChild(
-                        builder(ServletContainerDefinition.INSTANCE)
+                        builder(ServletContainerDefinition.INSTANCE.getPathElement())
                                 .addAttribute(ServletContainerDefinition.ALLOW_NON_STANDARD_WRAPPERS)
                                 .addAttribute(ServletContainerDefinition.DEFAULT_BUFFER_CACHE)
                                 .addAttribute(ServletContainerDefinition.STACK_TRACE_ON_ERROR)
@@ -157,7 +153,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                 .addAttribute(ServletContainerDefinition.MAX_SESSIONS)
                                 .addAttribute(ServletContainerDefinition.DISABLE_FILE_WATCH_SERVICE)
                                 .addChild(
-                                        builder(JspDefinition.INSTANCE)
+                                        builder(JspDefinition.INSTANCE.getPathElement())
                                                 .setXmlElementName(Constants.JSP_CONFIG)
                                                 .addAttributes(
                                                         JspDefinition.DISABLED,
@@ -182,7 +178,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         JspDefinition.OPTIMIZE_SCRIPTLETS)
                                 )
                                 .addChild(
-                                        builder(SessionCookieDefinition.INSTANCE)
+                                        builder(SessionCookieDefinition.INSTANCE.getPathElement())
                                                 .addAttributes(
                                                         SessionCookieDefinition.NAME,
                                                         SessionCookieDefinition.DOMAIN,
@@ -193,14 +189,14 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                 )
                                 )
                                 .addChild(
-                                        builder(PersistentSessionsDefinition.INSTANCE)
+                                        builder(PersistentSessionsDefinition.INSTANCE.getPathElement())
                                                 .addAttributes(
                                                         PersistentSessionsDefinition.PATH,
                                                         PersistentSessionsDefinition.RELATIVE_TO
                                                 )
                                 )
                                 .addChild(
-                                        builder(WebsocketsDefinition.INSTANCE)
+                                        builder(WebsocketsDefinition.INSTANCE.getPathElement())
                                                 .addAttributes(
                                                         WebsocketsDefinition.WORKER,
                                                         WebsocketsDefinition.BUFFER_POOL,
@@ -209,21 +205,21 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         WebsocketsDefinition.DEFLATER_LEVEL
                                                 )
                                 )
-                                .addChild(builder(MimeMappingDefinition.INSTANCE)
+                                .addChild(builder(MimeMappingDefinition.INSTANCE.getPathElement())
                                         .setXmlWrapperElement("mime-mappings")
                                         .addAttributes(
                                                 MimeMappingDefinition.VALUE
                                         ))
-                                .addChild(builder(WelcomeFileDefinition.INSTANCE).setXmlWrapperElement("welcome-files"))
-                                .addChild(builder(CrawlerSessionManagementDefinition.INSTANCE)
+                                .addChild(builder(WelcomeFileDefinition.INSTANCE.getPathElement()).setXmlWrapperElement("welcome-files"))
+                                .addChild(builder(CrawlerSessionManagementDefinition.INSTANCE.getPathElement())
                                         .addAttributes(CrawlerSessionManagementDefinition.USER_AGENTS, CrawlerSessionManagementDefinition.SESSION_TIMEOUT))
                 )
                 .addChild(
-                        builder(HandlerDefinitions.INSTANCE)
+                        builder(HandlerDefinitions.INSTANCE.getPathElement())
                                 .setXmlElementName(Constants.HANDLERS)
                                 .setNoAddOperation(true)
                                 .addChild(
-                                        builder(FileHandler.INSTANCE)
+                                        builder(FileHandler.INSTANCE.getPathElement())
                                                 .addAttributes(
                                                         FileHandler.PATH,
                                                         FileHandler.CACHE_BUFFER_SIZE,
@@ -235,7 +231,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                 )
                                 )
                                 .addChild(
-                                        builder(ReverseProxyHandler.INSTANCE)
+                                        builder(ReverseProxyHandler.INSTANCE.getPathElement())
                                                 .addAttributes(
                                                         ReverseProxyHandler.CONNECTIONS_PER_THREAD,
                                                         ReverseProxyHandler.SESSION_COOKIE_NAMES,
@@ -244,7 +240,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                                         ReverseProxyHandler.REQUEST_QUEUE_SIZE,
                                                         ReverseProxyHandler.CACHED_CONNECTIONS_PER_THREAD,
                                                         ReverseProxyHandler.CONNECTION_IDLE_TIMEOUT)
-                                                .addChild(builder(ReverseProxyHandlerHost.INSTANCE)
+                                                .addChild(builder(ReverseProxyHandlerHost.INSTANCE.getPathElement())
                                                         .setXmlElementName(Constants.HOST)
                                                         .addAttributes(
                                                                 ReverseProxyHandlerHost.OUTBOUND_SOCKET_BINDING,
@@ -258,22 +254,22 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
 
                 )
                 .addChild(
-                        builder(FilterDefinitions.INSTANCE)
+                        builder(FilterDefinitions.INSTANCE.getPathElement())
                                 .setXmlElementName(Constants.FILTERS)
                                 .setNoAddOperation(true)
                                 .addChild(
-                                        builder(RequestLimitHandler.INSTANCE)
+                                        builder(RequestLimitHandler.INSTANCE.getPathElement())
                                                 .addAttributes(RequestLimitHandler.MAX_CONCURRENT_REQUESTS, RequestLimitHandler.QUEUE_SIZE)
                                 ).addChild(
-                                builder(ResponseHeaderFilter.INSTANCE)
+                                builder(ResponseHeaderFilter.INSTANCE.getPathElement())
                                         .addAttributes(ResponseHeaderFilter.NAME, ResponseHeaderFilter.VALUE)
                         ).addChild(
-                                builder(GzipFilter.INSTANCE)
+                                builder(GzipFilter.INSTANCE.getPathElement())
                         ).addChild(
-                                builder(ErrorPageDefinition.INSTANCE)
+                                builder(ErrorPageDefinition.INSTANCE.getPathElement())
                                         .addAttributes(ErrorPageDefinition.CODE, ErrorPageDefinition.PATH)
                         ).addChild(
-                                builder(ModClusterDefinition.INSTANCE)
+                                builder(ModClusterDefinition.INSTANCE.getPathElement())
                                 .addAttributes(ModClusterDefinition.MANAGEMENT_SOCKET_BINDING,
                                         ModClusterDefinition.ADVERTISE_SOCKET_BINDING,
                                         ModClusterDefinition.SECURITY_KEY,
@@ -301,30 +297,27 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                         ModClusterDefinition.HTTP2_MAX_FRAME_SIZE,
                                         ModClusterDefinition.HTTP2_MAX_HEADER_LIST_SIZE)
                         ).addChild(
-                                builder(CustomFilterDefinition.INSTANCE)
+                                builder(CustomFilterDefinition.INSTANCE.getPathElement())
                                         .addAttributes(CustomFilterDefinition.CLASS_NAME, CustomFilterDefinition.MODULE, CustomFilterDefinition.PARAMETERS)
                                         .setXmlElementName("filter")
                         ).addChild(
-                                builder(ExpressionFilterDefinition.INSTANCE)
+                                builder(ExpressionFilterDefinition.INSTANCE.getPathElement())
                                         .addAttributes(ExpressionFilterDefinition.EXPRESSION, ExpressionFilterDefinition.MODULE)
                         ).addChild(
-                                builder(RewriteFilterDefinition.INSTANCE)
+                                builder(RewriteFilterDefinition.INSTANCE.getPathElement())
                                         .addAttributes(RewriteFilterDefinition.TARGET, RewriteFilterDefinition.REDIRECT)
                         )
 
                 )
                 .addChild(
-                        builder(ApplicationSecurityDomainDefinition.INSTANCE)
+                        builder(ApplicationSecurityDomainDefinition.INSTANCE.getPathElement())
                             .setXmlWrapperElement(Constants.APPLICATION_SECURITY_DOMAINS)
                             .addAttributes(ApplicationSecurityDomainDefinition.HTTP_AUTHENTICATION_FACTORY, ApplicationSecurityDomainDefinition.OVERRIDE_DEPLOYMENT_CONFIG)
                 )
                  //here to make sure we always add filters & handlers path to mgmt model
-                .setAdditionalOperationsGenerator(new PersistentResourceXMLDescription.AdditionalOperationsGenerator() {
-                        @Override
-                        public void additionalOperations(final PathAddress address, final ModelNode addOperation, final List<ModelNode> operations) {
-                                operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_FILTERS)));
-                                operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_HANDLERS)));
-                        }
+                .setAdditionalOperationsGenerator((address, addOperation, operations) -> {
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_FILTERS)));
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_HANDLERS)));
                 })
                 .build();
     }
@@ -339,7 +332,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
 
     /** Registers attributes common across listener types */
     private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder listenerBuilder(PersistentResourceDefinition resource) {
-        return builder(resource)
+        return builder(resource.getPathElement())
                 // xsd socket-optionsType
                 .addAttributes(
                         ListenerResourceDefinition.RECEIVE_BUFFER,
@@ -376,7 +369,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
     }
 
     private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder filterRefBuilder() {
-        return builder(FilterRefDefinition.INSTANCE)
+        return builder(FilterRefDefinition.INSTANCE.getPathElement())
                 .addAttributes(FilterRefDefinition.PREDICATE, FilterRefDefinition.PRIORITY);
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/DefaultDeploymentMappingProvider.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/DefaultDeploymentMappingProvider.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow.deployment;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.wildfly.extension.undertow.logging.UndertowLogger;
+
+/**
+ * @author Tomaz Cerar (c) 2016 Red Hat Inc.
+ */
+public final class DefaultDeploymentMappingProvider {
+
+    private static DefaultDeploymentMappingProvider INSTANCE = new DefaultDeploymentMappingProvider();
+
+    public static DefaultDeploymentMappingProvider instance() {
+        return INSTANCE;
+    }
+
+    private final ConcurrentHashMap<String, Map.Entry<String, String>> mappings;
+
+    private DefaultDeploymentMappingProvider() {
+        this.mappings = new ConcurrentHashMap<>();
+    }
+
+
+    public Map.Entry<String, String> getMapping(String deploymentName) {
+        return mappings.get(deploymentName);
+    }
+
+    public void removeMapping(String deploymentName) {
+        mappings.remove(deploymentName);
+    }
+
+    public void addMapping(String deploymentName, String serverName, String hostName) {
+        if (mappings.putIfAbsent(deploymentName, new AbstractMap.SimpleEntry<>(serverName, hostName)) != null) {
+            throw UndertowLogger.ROOT_LOGGER.duplicateDefaultWebModuleMapping(deploymentName, serverName, hostName);
+        }
+    }
+    public void clear(){
+        mappings.clear();
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ErrorPageDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ErrorPageDefinition.java
@@ -71,7 +71,7 @@ public class ErrorPageDefinition extends Filter{
     public HttpHandler createHttpHandler(Predicate predicate, ModelNode model, HttpHandler next) {
         int code = model.get(CODE.getName()).asInt();
         String path = model.get(PATH.getName()).asString();
-        FileErrorPageHandler handler = new FileErrorPageHandler(Paths.get(path).toFile(), code);
+        FileErrorPageHandler handler = new FileErrorPageHandler(Paths.get(path), code);
         handler.setNext(next);
         if(predicate == null) {
             return handler;

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -151,12 +151,12 @@ public interface UndertowLogger extends BasicLogger {
 
 
     @LogMessage(level = INFO)
-    @Message(id = 21, value = "Registered web context: %s")
-    void registerWebapp(String webappPath);
+    @Message(id = 21, value = "Registered web context: '%s' for server '%s'")
+    void registerWebapp(String webappPath, String serverName);
 
     @LogMessage(level = INFO)
-    @Message(id = 22, value = "Unregistered web context: %s")
-    void unregisterWebapp(String webappPath);
+    @Message(id = 22, value = "Unregistered web context: '%s' from server '%s'")
+    void unregisterWebapp(String webappPath, String serverName);
 
     @LogMessage(level = INFO)
     @Message(id = 23, value = "Skipped SCI for jar: %s.")
@@ -362,4 +362,6 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 86, value = "No authentication mechanisms have been selected.")
     IllegalStateException noMechanismsSelected();
 
+    @Message(id = 87, value = "Duplicate default web module '%s' configured on server '%s', host '%s'")
+    IllegalArgumentException duplicateDefaultWebModuleMapping(String defaultDeploymentName, String serverName, String hostName);
 }

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
@@ -43,7 +43,7 @@
             <access-log pattern="REQ %{i,test-header}" directory="${jboss.server.server.dir}" prefix="access"/>
             <single-sign-on domain="${prop.domain:myDomain}"/>
         </host>
-        <host name="other-host" alias="www.mysite.com" default-web-module="something.war">
+        <host name="other-host" alias="www.mysite.com" default-web-module="something-else.war">
             <location name="/" handler="welcome-content">
                 <filter-ref name="limit-connections"/>
                 <filter-ref name="headers"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
@@ -43,7 +43,7 @@
             <access-log pattern="REQ %{i,test-header}" directory="${jboss.server.server.dir}" prefix="access"/>
             <single-sign-on domain="${prop.domain:myDomain}" http-only="true" secure="true" path="/" cookie-name="SSOID"/>
         </host>
-        <host name="other-host" alias="www.mysite.com" default-web-module="something.war">
+        <host name="other-host" alias="www.mysite.com" default-web-module="something-else.war">
             <location name="/" handler="welcome-content">
                 <filter-ref name="limit-connections"/>
                 <filter-ref name="headers"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.2.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.2.xml
@@ -35,7 +35,7 @@
         <https-listener name="https" socket-binding="https-non-default" security-realm="UndertowRealm" verify-client="REQUESTED" record-request-start-time="true" max-buffered-request-size="50000" resolve-peer-address="true"/>
         <https-listener name="https-2" socket-binding="https-2" security-realm="UndertowRealm" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" read-timeout="-1" write-timeout="-1"/>
 
-        <host name="default-host" alias="localhost, some.host" default-web-module="something.war">
+        <host name="default-host" alias="localhost, some.host" default-web-module="something-else.war">
             <location name="/" handler="welcome-content">
                 <!--<filter-ref name="security-other"/>-->
                 <filter-ref name="limit-connections"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-2.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-2.0.xml
@@ -36,7 +36,7 @@
         <https-listener name="https" socket-binding="https-non-default" security-realm="UndertowRealm" verify-client="REQUESTED" record-request-start-time="true" max-buffered-request-size="50000" resolve-peer-address="true"/>
         <https-listener name="https-2" socket-binding="https-2" security-realm="UndertowRealm" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" read-timeout="-1" write-timeout="-1"/>
 
-        <host name="default-host" alias="localhost, some.host" default-web-module="something.war">
+        <host name="default-host" alias="localhost, some.host" default-web-module="something-else.war">
             <location name="/" handler="welcome-content">
                 <!--<filter-ref name="security-other"/>-->
                 <filter-ref name="limit-connections"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
@@ -34,7 +34,7 @@
         <https-listener name="https" disallowed-methods="" socket-binding="https-non-default" security-realm="UndertowRealm" verify-client="REQUESTED" record-request-start-time="true" max-buffered-request-size="50000" resolve-peer-address="true" max-connections="100"/>
         <https-listener name="https-2" socket-binding="https-2" security-realm="UndertowRealm" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" read-timeout="-1" write-timeout="-1"/>
 
-        <host name="default-host" alias="localhost, some.host" default-web-module="something.war" default-response-code="503">
+        <host name="default-host" alias="localhost, some.host" default-web-module="something-else.war" default-response-code="503">
             <location name="/" handler="welcome-content">
                 <!--<filter-ref name="security-other"/>-->
                 <filter-ref name="limit-connections"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.1.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.1.xml
@@ -45,7 +45,7 @@
             <access-log pattern="REQ %{i,test-header}" directory="${jboss.server.server.dir}" prefix="access" rotate="false" predicate="not path-suffix[*.css]"/>
             <single-sign-on domain="${prop.domain:myDomain}" http-only="true" secure="true" path="/path" cookie-name="SSOID"/>
         </host>
-        <host name="other-host" alias="www.mysite.com, ${prop.value:default-alias}" default-web-module="something.war" disable-console-redirect="true">
+        <host name="other-host" alias="www.mysite.com, ${prop.value:default-alias}" default-web-module="something-else.war" disable-console-redirect="true" default-response-code="501">
             <location name="/" handler="welcome-content">
                 <filter-ref name="limit-connections"/>
                 <filter-ref name="headers"/>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-4.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-4.0.xml
@@ -47,7 +47,7 @@
             <access-log pattern="REQ %{i,test-header}" directory="${jboss.server.server.dir}" prefix="access" rotate="false" predicate="not path-suffix[*.css]"/>
             <single-sign-on domain="${prop.domain:myDomain}" http-only="true" secure="true" path="/path" cookie-name="SSOID"/>
         </host>
-        <host name="other-host" alias="www.mysite.com, ${prop.value:default-alias}" default-web-module="something.war" disable-console-redirect="true">
+        <host name="other-host" alias="www.mysite.com, ${prop.value:default-alias}" default-web-module="something-else.war" disable-console-redirect="true" default-response-code="501">
             <location name="/" handler="welcome-content">
                 <filter-ref name="limit-connections"/>
                 <filter-ref name="headers"/>


### PR DESCRIPTION
replaces #8953
- improve deployment message to include server on which it was deployed to
- add test to verify default-web-module works for all possible scenarios
- server addition doesn't require reload anymore

this is follow up on #8422 with different implementation that uses model instead of services for getting list of available hosts / servers. As result it shouldn't be racy anymore.
