### PR TITLE
[WFLY-7309] - Make the authentication configurable in the testsuite

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
@@ -115,9 +116,8 @@ public class JMXPropertyEditorsTestCase {
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
         final String address = managementClient.getMgmtAddress()+":"+managementClient.getMgmtPort();
-        connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address));
+        connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address), DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();
-
     }
 
     private static Asset createServiceAsset(String attributeName, String attributeValue) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.jmx.model.ModelControllerMBeanHelper;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -105,7 +106,7 @@ public class ModelControllerMBeanTestCase {
         String urlString = System
                 .getProperty("jmx.service.url", "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
-        connector = JMXConnectorFactory.connect(serviceURL, null);
+        connector = JMXConnectorFactory.connect(serviceURL,DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -46,8 +46,8 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.wildfly.naming.java.permission.JndiPermission;
-import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -84,8 +84,7 @@ public class RemoteNamingEjbTestCase {
         env.put(Context.PROVIDER_URL, managementClient.getRemoteEjbURL().toString());
         env.put("jboss.naming.client.ejb.context", true);
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
-        env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());
-        return new InitialContext(env);
+        return new InitialContext(DefaultConfiguration.addSecurityProperties(env));
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -33,8 +33,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.wildfly.naming.java.permission.JndiPermission;
-import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -74,8 +74,7 @@ public class RemoteNamingTestCase {
         URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "" ,"");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
-        env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());
-        return new InitialContext(env);
+        return new InitialContext(DefaultConfiguration.addSecurityProperties(env));
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ public class JNDIBindingMBeanTestCase {
     @Test
     public void testMBeanStartup() throws Exception {
         // get mbean server
-        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials());
         try {
             final MBeanServerConnection mBeanServerConnection = connector.getMBeanServerConnection();
             // check the deployed MBeans

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/SarWithinEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/SarWithinEarTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -132,8 +133,7 @@ public class SarWithinEarTestCase {
     }
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
-        connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();
-
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/context/classloader/MBeanTCCLTestCase.java
@@ -13,6 +13,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.as.test.integration.sar.context.classloader.mbean.MBeanInAModuleService;
 import org.jboss.as.test.integration.sar.context.classloader.mbean.MBeanInAModuleServiceMBean;
 import org.jboss.logging.Logger;
@@ -119,9 +120,7 @@ public class MBeanTCCLTestCase {
     }
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
-        connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();
-
     }
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/depends/DependsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/depends/DependsTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -62,7 +63,7 @@ public final class DependsTestCase {
     @Test
     @SuppressWarnings("unchecked")
     public void testMBean() throws Exception {
-        final MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL()).getMBeanServerConnection();
+        final MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials()).getMBeanServerConnection();
         final ObjectName a1ObjectName = new ObjectName("test:service=A1");
         final ObjectName aObjectName =  (ObjectName) mbeanServer.getAttribute(a1ObjectName, "ObjectName");
         Assert.assertTrue(aObjectName.equals(new ObjectName("test:service=A")));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/resource/SarResourceInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/resource/SarResourceInjectionTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
@@ -61,7 +62,7 @@ public final class SarResourceInjectionTestCase {
 
     @Test
     public void testMBean() throws Exception {
-        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials());
         try {
             final MBeanServerConnection mbeanServer = connector.getMBeanServerConnection();
             final ObjectName objectName = new ObjectName("jboss:name=X");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.system.ServiceMBean;
@@ -94,7 +95,7 @@ public class ServiceMBeanSupportTestCase {
     @Test
     public void testSarWithServiceMBeanSupport() throws Exception {
         // get mbean server
-        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL(), DefaultConfiguration.credentials());
         final MBeanServerConnection mBeanServerConnection = connector.getMBeanServerConnection();
         try {
             // deploy the unmanaged sar
@@ -120,5 +121,4 @@ public class ServiceMBeanSupportTestCase {
             Assert.assertTrue("Unexpected result for " + attribute + ": " + result, result);
         }
     }
-
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/DefaultConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/DefaultConfiguration.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.common;
+
+import org.jboss.as.test.http.Authentication;
+import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
+
+import javax.management.remote.JMXConnector;
+import javax.naming.Context;
+import java.util.HashMap;
+import java.util.Properties;
+
+/**
+ * Created by fspolti on 10/20/16.
+ * WFLY-7309
+ */
+public class DefaultConfiguration {
+    private static final boolean isRemote = Boolean.parseBoolean(System.getProperty("org.jboss.as.test.integration.remote", "false"));
+    private static final String MBEAN_USERNAME = System.getProperty("jboss.mbean.username", Authentication.USERNAME);
+    private static final String MBEAN_PASSWORD = System.getProperty("jboss.mbean.username", Authentication.PASSWORD);
+    private static final String APPLICATION_USERNAME = System.getProperty("jboss.application.username", "guest");
+    private static final String APPLICATION_PASSWORD = System.getProperty("jboss.application.username", "guest");
+
+    /*
+    * Return the value of isRemote variable, it will be used to define
+    * if the tests are abring running in a local or remote container. If no value
+    * is provided then the default value is false (local)
+    */
+    public static boolean isRemote() {
+        return isRemote;
+    }
+
+    /*
+    * Return the application username, if none is provided it will return the default:
+    * guest
+    */
+    public static String applicationUsername() {
+        return APPLICATION_USERNAME;
+    }
+
+    /*
+    * Return the application password, if none is provided it will return the default:
+    * guest
+    */
+    public static String applicationPassword() {
+        return APPLICATION_PASSWORD;
+    }
+
+    /*
+    * Returns a HashMap containing the credentials for a JMX connection
+    * default user and pass is testSuite/testSuitePassword
+    */
+    public static HashMap<String, String[]> credentials () {
+        HashMap<String, String[]> propEnv = new HashMap<String, String[]>();
+        String[] credentials = {  MBEAN_USERNAME, MBEAN_PASSWORD };
+        propEnv.put(JMXConnector.CREDENTIALS, credentials);
+        return isRemote() ? propEnv : null;
+    }
+
+    /*
+    * Returns the env Properties updated with security configurations for ejb connections
+    * @param env the properties to be updated
+    * @return the Properties updated
+    */
+    public static Properties addSecurityProperties(Properties env) {
+        if (isRemote()){
+            env.put(Context.SECURITY_PRINCIPAL, applicationUsername());
+            env.put(Context.SECURITY_CREDENTIALS, applicationPassword());
+        } else {
+            env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());
+        }
+        return env;
+    }
+}


### PR DESCRIPTION
Issues:
WFLY: https://issues.jboss.org/browse/WFLY-7309
WFLY-CORE: https://issues.jboss.org/browse/WFCORE-1865

EAP7.0.x: https://issues.jboss.org/browse/JBEAP-6425
WFLY-CORE-EAP: https://issues.jboss.org/browse/JBEAP-6547

EAP7.x: https://issues.jboss.org/browse/JBEAP-6424
WFLY-CORE-EAP: https://issues.jboss.org/browse/JBEAP-6546

EAP6.4.x: https://bugzilla.redhat.com/show_bug.cgi?id=1384542

PRs:
WFLY: https://github.com/wildfly/wildfly/pull/9281
WFLY-CORE: https://github.com/wildfly/wildfly-core/pull/1868

EAP7.0.x: https://github.com/jbossas/jboss-eap7/pull/868
WFLY-CORE-EAP:  https://github.com/jbossas/wildfly-core-eap/pull/288

EAP7.1.x: https://github.com/jbossas/jboss-eap7/pull/871
WFLY-CORE-EAP: https://github.com/wildfly/wildfly-core/pull/1868

EAP 6.4.x: https://github.com/jbossas/jboss-eap/pull/2859
