### PR TITLE
WFLY-7365: Upgrade HAL to 2.9.0.Alpha4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.hal.release-stream>2.9.0.Alpha3</version.org.jboss.hal.release-stream>
+        <version.org.jboss.hal.release-stream>2.9.0.Alpha4</version.org.jboss.hal.release-stream>
         <version.org.jboss.ejb-client>2.1.4.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>1.0.8.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7365
