### PR TITLE
[WFLY-7333] Recursive removal of messaging-activemq resources

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorRemove.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorRemove.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.LEGACY;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -39,10 +40,14 @@ public class HTTPAcceptorRemove extends AbstractRemoveStepHandler {
 
     static final HTTPAcceptorRemove INSTANCE = new HTTPAcceptorRemove();
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        final String name = address.getLastElement().getValue();
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        final String name = context.getCurrentAddressValue();
         context.removeService(HTTPUpgradeService.UPGRADE_SERVICE_NAME.append(name));
+
+        boolean upgradeLegacy = HTTPAcceptorDefinition.UPGRADE_LEGACY.resolveModelAttribute(context, model).asBoolean();
+        if (upgradeLegacy) {
+            context.removeService(HTTPUpgradeService.UPGRADE_SERVICE_NAME.append(name, LEGACY));
+        }
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.OperationContext;
@@ -106,13 +107,14 @@ public class PathDefinition extends PersistentResourceDefinition {
         }
     };
 
-    static final OperationStepHandler PATH_REMOVE = new OperationStepHandler() {
+    static final OperationStepHandler PATH_REMOVE = new AbstractRemoveStepHandler() {
 
         @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.removeResource(PathAddress.EMPTY_ADDRESS);
+        protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+            super.performRemove(context, operation, model);
             reloadRequiredStep(context);
         }
+
     };
 
     private final PathElement path;


### PR DESCRIPTION
- When a messaging-activemq's server is removed, it should not explicitly
  remove the services associated to its children resources. Instead it
  should do nothing as the default behaviour is to recursively remove any
  children resources (that in turn will stop their respective resources).
- Remove HTTPUpgrade legacy services when an http-acceptor with
  upgrade-legacy is removed.

JIRA: https://issues.jboss.org/browse/WFLY-7333
