### PR TITLE
WFLY-7382  Build tools 1.1.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
         <version.org.jboss.genericjms>1.0.8.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.3.4.Final</version.org.jboss.ironjacamar>
-        <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-transaction-spi>7.5.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.narayana>5.3.5.Final</version.org.jboss.narayana>
@@ -215,7 +214,7 @@
         <version.org.picketlink>2.5.5.SP3</version.org.picketlink>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.wildfly.build-tools>1.1.3.Final</version.org.wildfly.build-tools>
+        <version.org.wildfly.build-tools>1.1.7.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Alpha10</version.org.wildfly.core>
         <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
@@ -813,25 +812,11 @@
                     <groupId>org.wildfly.build</groupId>
                     <artifactId>wildfly-feature-pack-build-maven-plugin</artifactId>
                     <version>${version.org.wildfly.build-tools}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>${version.org.jboss.jandex}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.wildfly.build</groupId>
                     <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
                     <version>${version.org.wildfly.build-tools}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.jboss</groupId>
-                            <artifactId>jandex</artifactId>
-                            <version>${version.org.jboss.jandex}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -4210,12 +4195,6 @@
                         <artifactId>jboss-marshalling-osgi</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss</groupId>
-                <artifactId>jandex</artifactId>
-                <version>${version.org.jboss.jandex}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- removes jandex dependancy as it is managed in core

superceeds #9294 
