### PR TITLE
[WFLY-7245] Ignore JMS client tests with a SecurityManager

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueFromWithinTransactionTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueFromWithinTransactionTest.java
@@ -41,6 +41,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,6 +84,9 @@ public class SendToQueueFromWithinTransactionTest {
 
     @Test
     public void sendSuccessfully() throws Exception {
+        // WFLY-7346 - Ignore the test if the security manager is installed
+        Assume.assumeTrue(System.getSecurityManager() == null);
+
         try {
             sender.sendToQueueSuccessfully();
             Thread.sleep(2000);
@@ -94,6 +98,9 @@ public class SendToQueueFromWithinTransactionTest {
 
     @Test
     public void sendAndRollback() {
+        // WFLY-7346 - Ignore the test if the security manager is installed
+        Assume.assumeTrue(System.getSecurityManager() == null);
+
         try {
             sender2.sendToQueueAndRollback();
             Thread.sleep(2000);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToTopicFromWithinTransactionTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToTopicFromWithinTransactionTest.java
@@ -35,6 +35,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,6 +84,9 @@ public class SendToTopicFromWithinTransactionTest {
 
     @Test
     public void sendSuccessfully() throws Exception {
+        // WFLY-7346 - Ignore the test if the security manager is installed
+        Assume.assumeTrue(System.getSecurityManager() == null);
+
         try {
             sender.sendToTopicSuccessfully();
             Thread.sleep(2000);
@@ -94,6 +98,9 @@ public class SendToTopicFromWithinTransactionTest {
 
     @Test
     public void sendAndRollback() {
+        // WFLY-7346 - Ignore the test if the security manager is installed
+        Assume.assumeTrue(System.getSecurityManager() == null);
+
         try {
             sender2.sendToTopicAndRollback();
             Thread.sleep(2000);


### PR DESCRIPTION
Ignore JMS tests that fails when a security manager is installed.
Artemis 1.4.0 introduced a regressions as it is missing a priviledged
block when a closing a JMS connection on the client side.

JIRA: https://issues.jboss.org/browse/WFLY-7346