### PR TITLE
[WFLY-6629]: Create test for [WFCORE-1479]: Jar sub deployment has as…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/ClassInJar.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/ClassInJar.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.deployment.classloading.ear.subdeployments;
+
+public class ClassInJar {
+    public String invokeToStringOnClassloaderOfClass (String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException{
+       ClassLoader cl = Class.forName(className).getClassLoader();
+       if(cl == null) {
+           return "bootstrap class loader";
+       }
+       return cl.toString();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/SubDeploymentAvailableInClassPathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/SubDeploymentAvailableInClassPathTestCase.java
@@ -22,20 +22,25 @@
 
 package org.jboss.as.test.integration.deployment.classloading.ear.subdeployments;
 
+import java.net.URL;
+import javax.naming.InitialContext;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.ejb.EJBBusinessInterface;
 import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.ejb.SimpleSLSB;
+import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.servlet.EjbInvokeClassloaderToStringServlet;
 import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.servlet.EjbInvokingServlet;
 import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.servlet.HelloWorldServlet;
 import org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.servlet.ServletInOtherWar;
@@ -55,7 +60,7 @@ import org.junit.runner.RunWith;
  * Tests various scenarios for class access between subdeployments within a .ear.
  *
  * @see https://issues.jboss.org/browse/AS7-306
- *      User: Jaikiran Pai
+ * User: Jaikiran Pai
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -63,31 +68,17 @@ public class SubDeploymentAvailableInClassPathTestCase {
 
     private static final Logger logger = Logger.getLogger(SubDeploymentAvailableInClassPathTestCase.class);
 
-    private static final String WEB_APP_CONTEXT_ONE = "war-access-to-ejb";
-
-    private static final String WEB_APP_CONTEXT_TWO = "war-access-to-war";
-
     private static final String OTHER_WEB_APP_CONTEXT = "other-war";
-
-    private static final String EXPLODED_WEB_APP_CONTEXT = "exploded";
-
-    @ContainerResource
-    private ManagementClient managementClient;
 
     @Deployment(name = "ear-with-single-war", testable = false)
     public static EnterpriseArchive createEar() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
         ejbJar.addClasses(EJBBusinessInterface.class, SimpleSLSB.class);
 
-        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_CONTEXT_ONE + ".war");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "war-access-to-ejb.war");
         war.addClasses(HelloWorldServlet.class, EjbInvokingServlet.class);
 
-        // TODO: Currently, due to an issue in AS7 integration with Arquillian, the web-app context and the
-        // .ear name should be the same or else you run into test deployment failures like:
-        // Caused by: java.lang.IllegalStateException: Error launching test at
-        // http://127.0.0.1:8080/<earname>/ArquillianServletRunner?outputMode=serializedObject&className=org.jboss.as.test.spec.ear.classpath.unit.SubDeploymentAvailableInClassPathTestCase&methodName=testEjbClassAvailableInServlet. Kept on getting 404s.
-        // @see https://issues.jboss.org/browse/AS7-367
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, WEB_APP_CONTEXT_ONE + ".ear");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "war-access-to-ejb.ear");
         ear.addAsModule(ejbJar);
         ear.addAsModule(war);
 
@@ -98,13 +89,13 @@ public class SubDeploymentAvailableInClassPathTestCase {
     public static EnterpriseArchive createEarWithExplodedWar() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
         ejbJar.addClasses(EJBBusinessInterface.class, SimpleSLSB.class);
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EXPLODED_WEB_APP_CONTEXT + ".ear");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "exploded.ear");
         ear.addAsModule(ejbJar);
-        ear.add(new StringAsset("OK!"), EXPLODED_WEB_APP_CONTEXT + ".war/index.jsp");
-        ear.add(new ClassAsset(EjbInvokingServlet.class), EXPLODED_WEB_APP_CONTEXT + ".war/WEB-INF/classes/" + EjbInvokingServlet.class.getName().replace('.', '/') + ".class");
+        ear.add(new StringAsset("OK!"), "exploded.war/index.jsp");
+        ear.add(new ClassAsset(EjbInvokingServlet.class), "exploded.war/WEB-INF/classes/" + EjbInvokingServlet.class.getName().replace('.', '/') + ".class");
         final JavaArchive servletJar = ShrinkWrap.create(JavaArchive.class, "servlet.jar");
         servletJar.addClass(HelloWorldServlet.class);
-        ear.add(servletJar, EXPLODED_WEB_APP_CONTEXT + ".war/WEB-INF/lib", ZipExporter.class);
+        ear.add(servletJar, "exploded.war/WEB-INF/lib", ZipExporter.class);
         return ear;
     }
 
@@ -113,21 +104,36 @@ public class SubDeploymentAvailableInClassPathTestCase {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
         ejbJar.addClasses(EJBBusinessInterface.class, SimpleSLSB.class);
 
-        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_CONTEXT_TWO + ".war");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "war-access-to-war.war");
         war.addClasses(HelloWorldServlet.class, EjbInvokingServlet.class);
 
         final WebArchive otherWar = ShrinkWrap.create(WebArchive.class, OTHER_WEB_APP_CONTEXT + ".war");
         otherWar.addClass(ServletInOtherWar.class);
 
-        // TODO: Currently, due to an issue in AS7 integration with Arquillian, the web-app context and the
-        // .ear name should be the same or else you run into test deployment failures like:
-        // Caused by: java.lang.IllegalStateException: Error launching test at
-        // http://127.0.0.1:8080/<earname>/ArquillianServletRunner?outputMode=serializedObject&className=org.jboss.as.test.spec.ear.classpath.unit.SubDeploymentAvailableInClassPathTestCase&methodName=testEjbClassAvailableInServlet. Kept on getting 404s.
-        // @see https://issues.jboss.org/browse/AS7-367
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, WEB_APP_CONTEXT_TWO + ".ear");
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "war-access-to-war.ear");
         ear.addAsModule(ejbJar);
         ear.addAsModule(war);
         ear.addAsModule(otherWar);
+
+        return ear;
+    }
+
+    @Deployment(name = "ear-with-war-and-jar", testable = false)
+    public static EnterpriseArchive createEarWithWarJarAndLib() {
+        final JavaArchive servletLogicJar = ShrinkWrap.create(JavaArchive.class, "servlet-logic.jar");
+        servletLogicJar.addClasses(ClassInJar.class);
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "war-access-to-jar.war");
+        war.addClasses(EjbInvokeClassloaderToStringServlet.class);
+        war.addAsManifestResource(new StringAsset("Class-Path: servlet-logic.jar"), "MANIFEST.MF");
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "war-access-to-jar.ear");
+        ear.addAsModule(servletLogicJar);
+        ear.addAsModule(war);
+
+        JavaArchive libraryJar = ShrinkWrap.create(JavaArchive.class, "javax-naming-test-impl.jar");
+        libraryJar.addClass(InitialContext.class);
+        ear.addAsLibrary(libraryJar);
 
         return ear;
     }
@@ -146,18 +152,18 @@ public class SubDeploymentAvailableInClassPathTestCase {
      */
     @Test
     @OperateOnDeployment("ear-with-single-war")
-    public void testEjbClassAvailableInServlet() throws Exception {
-        final HttpClient httpClient = new DefaultHttpClient();
-        final String message = "JBossAS7";
+    public void testEjbClassAvailableInServlet(@ArquillianResource(HelloWorldServlet.class) URL baseUrl) throws Exception {
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final String message = "JBossAS7";
 
-        final String requestURL = managementClient.getWebUri() + "/" + WEB_APP_CONTEXT_ONE + HelloWorldServlet.URL_PATTERN + "?" + HelloWorldServlet.PARAMETER_NAME + "=" + message;
-        final HttpGet request = new HttpGet(requestURL);
-        final HttpResponse response = httpClient.execute(request);
-        final HttpEntity entity = response.getEntity();
-        Assert.assertNotNull("Response message from servlet was null", entity);
-        final String responseMessage = EntityUtils.toString(entity);
-        Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
-
+            final String requestURL = baseUrl.toURI() + HelloWorldServlet.URL_PATTERN + "?" + HelloWorldServlet.PARAMETER_NAME + "=" + message;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
+        }
     }
 
     /**
@@ -172,28 +178,30 @@ public class SubDeploymentAvailableInClassPathTestCase {
      * <p/>
      * the classes within the web.war have access to the classes in the ejb.jar
      * web.war is a folder, not an archive.
+     *
      * @throws Exception
      */
     @Test
     @OperateOnDeployment("ear-with-exploded-war")
-    public void testExplodedWarInEar() throws Exception {
-        final HttpClient httpClient = new DefaultHttpClient();
-        String message = "OK!";
-        String requestURL = managementClient.getWebUri() + "/" + EXPLODED_WEB_APP_CONTEXT + "/index.jsp";
-        HttpGet request = new HttpGet(requestURL);
-        HttpResponse response = httpClient.execute(request);
-        HttpEntity entity = response.getEntity();
-        Assert.assertNotNull("Response message from servlet was null", entity);
-        String responseMessage = EntityUtils.toString(entity);
-        Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
-        message = "JBossAS7";
-        requestURL = managementClient.getWebUri() + "/" + EXPLODED_WEB_APP_CONTEXT + HelloWorldServlet.URL_PATTERN + "?" + HelloWorldServlet.PARAMETER_NAME + "=" + message;
-        request = new HttpGet(requestURL);
-        response = httpClient.execute(request);
-        entity = response.getEntity();
-        Assert.assertNotNull("Response message from servlet was null", entity);
-        responseMessage = EntityUtils.toString(entity);
-        Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
+    public void testExplodedWarInEar(@ArquillianResource(HelloWorldServlet.class) URL baseUrl) throws Exception {
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            String message = "OK!";
+            String requestURL = baseUrl.toURI() + "/index.jsp";
+            HttpGet request = new HttpGet(requestURL);
+            HttpResponse response = httpClient.execute(request);
+            HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
+            message = "JBossAS7";
+            requestURL = baseUrl.toURI() + HelloWorldServlet.URL_PATTERN + "?" + HelloWorldServlet.PARAMETER_NAME + "=" + message;
+            request = new HttpGet(requestURL);
+            response = httpClient.execute(request);
+            entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Unexpected echo message from servlet", message, responseMessage);
+        }
     }
 
     /**
@@ -211,18 +219,53 @@ public class SubDeploymentAvailableInClassPathTestCase {
      */
     @Test
     @OperateOnDeployment("ear-with-single-war")
-    public void testServletClassNotAvailableToEjbInEar() throws Exception {
-        final HttpClient httpClient = new DefaultHttpClient();
-        final String classInWar = HelloWorldServlet.class.getName();
-        final String requestURL = managementClient.getWebUri() + "/"  + WEB_APP_CONTEXT_ONE + EjbInvokingServlet.URL_PATTERN + "?" + EjbInvokingServlet.CLASS_IN_WAR_PARAMETER + "=" + classInWar;
-        final HttpGet request = new HttpGet(requestURL);
-        final HttpResponse response = httpClient.execute(request);
-        final HttpEntity entity = response.getEntity();
-        Assert.assertNotNull("Response message from servlet was null", entity);
-        final String responseMessage = EntityUtils.toString(entity);
-        Assert.assertEquals("Unexpected echo message from servlet", EjbInvokingServlet.SUCCESS_MESSAGE, responseMessage);
+    public void testServletClassNotAvailableToEjbInEar(@ArquillianResource(EjbInvokingServlet.class) URL baseUrl) throws Exception {
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final String classInWar = HelloWorldServlet.class.getName();
+            final String requestURL = baseUrl.toURI() + EjbInvokingServlet.URL_PATTERN + "?" + EjbInvokingServlet.CLASS_IN_WAR_PARAMETER + "=" + classInWar;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Unexpected echo message from servlet", EjbInvokingServlet.SUCCESS_MESSAGE, responseMessage);
+        }
     }
 
+
+    /**
+     * Tests that for a .ear like this one:
+     * myapp.ear
+     * |
+     * |--- lib/javax-naming-test-impl.jar this jar contains override for javax.naming.Binding class
+     * |                                   which has to be resolved from implicit modules
+     * |
+     * |--- war-access-to-jar.war
+     * |
+     * |--- servlet-logic.jar
+     * <p/>
+     * the classes within the war-access-to-jar.war have access to the classes in the servlet-logic.jar
+     * and servlet-logic.jar has implicit module dependencies first in class path
+     *
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment("ear-with-war-and-jar")
+    public void testWarSeeJarAndJarSeeImplicitModulesFirst(@ArquillianResource(EjbInvokeClassloaderToStringServlet.class) URL baseUrl) throws Exception {
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final String requestURL = baseUrl.toURI() + EjbInvokeClassloaderToStringServlet.URL_PATTERN
+                    + "?" + EjbInvokeClassloaderToStringServlet.CLASS_NAME_PARAMETER + "=javax.naming.InitialContext";
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+
+            // expected is that class is loaded from implicit module
+            // app's class loader toString returns: ModuleClassLoader for Module deployment.war-access-to-jar.ear:main from Service Module Loader
+            Assert.assertEquals("Unexpected response from servlet", "bootstrap class loader", responseMessage);
+        }
+    }
 
     /**
      * Tests that for a .ear like this one:
@@ -239,18 +282,18 @@ public class SubDeploymentAvailableInClassPathTestCase {
      */
     @Test
     @OperateOnDeployment("ear-with-multiple-wars")
-    public void testWarsDontSeeEachOtherInEar() throws Exception {
-        final HttpClient httpClient = new DefaultHttpClient();
-        final String classInOtherWar = HelloWorldServlet.class.getName();
-        final String requestURL = managementClient.getWebUri() + "/"  + OTHER_WEB_APP_CONTEXT + ServletInOtherWar.URL_PATTERN +
-                "?" + ServletInOtherWar.CLASS_IN_OTHER_WAR_PARAMETER + "=" + classInOtherWar;
-        final HttpGet request = new HttpGet(requestURL);
-        final HttpResponse response = httpClient.execute(request);
-        final HttpEntity entity = response.getEntity();
-        Assert.assertNotNull("Response message from servlet was null", entity);
-        final String responseMessage = EntityUtils.toString(entity);
-        Assert.assertEquals("Unexpected echo message from servlet", ServletInOtherWar.SUCCESS_MESSAGE, responseMessage);
-
+    public void testWarsDontSeeEachOtherInEar(@ContainerResource ManagementClient managementClient) throws Exception {
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final String classInOtherWar = HelloWorldServlet.class.getName();
+            final String requestURL = managementClient.getWebUri() + "/" + OTHER_WEB_APP_CONTEXT + ServletInOtherWar.URL_PATTERN +
+                    "?" + ServletInOtherWar.CLASS_IN_OTHER_WAR_PARAMETER + "=" + classInOtherWar;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Unexpected echo message from servlet", ServletInOtherWar.SUCCESS_MESSAGE, responseMessage);
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/servlet/EjbInvokeClassloaderToStringServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/subdeployments/servlet/EjbInvokeClassloaderToStringServlet.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.servlet;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet invoking toString() method on class loader of class supplied as request parameter
+ */
+@WebServlet(urlPatterns = EjbInvokeClassloaderToStringServlet.URL_PATTERN)
+public class EjbInvokeClassloaderToStringServlet extends HttpServlet {
+
+    public static final String URL_PATTERN = "/invokeToStringOnClassloaderOfClass";
+
+    public static final String CLASS_NAME_PARAMETER = "className";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final String className = req.getParameter(CLASS_NAME_PARAMETER);
+        if (className == null) {
+            throw new ServletException(CLASS_NAME_PARAMETER + " parameter not set in request");
+        }
+        try {
+            // Invoke toString() method on className
+            Class<?> classInJar = Class
+                    .forName("org.jboss.as.test.integration.deployment.classloading.ear.subdeployments.ClassInJar");
+            Method invokeToStringOnClassloaderOfClassClassMethod;
+            invokeToStringOnClassloaderOfClassClassMethod = classInJar.getMethod("invokeToStringOnClassloaderOfClass", String.class);
+            resp.getOutputStream().print(invokeToStringOnClassloaderOfClassClassMethod.invoke(classInJar.newInstance(), className).toString());
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException |
+                SecurityException | IllegalArgumentException | InvocationTargetException ex) {
+            resp.getOutputStream().print(ex.toString());
+        }
+    }
+}


### PR DESCRIPTION
… first dependency parent ear

adds test for WFCORE-1479
replaces deprecated DefaultHttpClient with HttpClientBuilder
replaces hardcoded web context with injected

https://issues.jboss.org/browse/WFLY-6629

supersedes #8852