### PR TITLE
[jdk9] WFLY-3854 use posix parameter syntax to make launcher happy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6171,10 +6171,10 @@
             </activation>
             <properties>
                 <!-- [WFCORE-1431] remove SASL workaround -->
-                <modular.jdk.args>--add-exports java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
-                    --add-exports java.security.sasl/com.sun.security.sasl=ALL-UNNAMED
-                    --add-exports jdk.unsupported/sun.reflect=ALL-UNNAMED
-                    --add-exports jdk.unsupported/sun.misc=ALL-UNNAMED
+                <modular.jdk.args>--add-exports=java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
+                    --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
                 </modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>

--- a/pom.xml
+++ b/pom.xml
@@ -6180,6 +6180,8 @@
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>
                 <!-- There are lots of issues with checkstyle runtime on JDK9, it somewhat works but really slows down build, disabling it for now-->
                 <checkstyle.skip>true</checkstyle.skip>
+                <!-- we override javassit to version that works on JDK9 -->
+                <version.org.javassist>3.22.0-CR1</version.org.javassist>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6180,7 +6180,7 @@
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>
                 <!-- There are lots of issues with checkstyle runtime on JDK9, it somewhat works but really slows down build, disabling it for now-->
                 <checkstyle.skip>true</checkstyle.skip>
-                <!-- we override javassit to version that works on JDK9 -->
+                <!-- we override javassist to version that works on JDK9 -->
                 <version.org.javassist>3.22.0-CR1</version.org.javassist>
             </properties>
             <build>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1292,8 +1292,8 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <modular.jdk.testsuite.args>${modular.jdk.args} -XaddExports:java.base/sun.security.validator=ALL-UNNAMED
-                     -XaddExports:java.naming/com.sun.jndi.ldap=ALL-UNNAMED</modular.jdk.testsuite.args>
+                <modular.jdk.testsuite.args>${modular.jdk.args} --add-exports=java.base/sun.security.validator=ALL-UNNAMED
+                    --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED</modular.jdk.testsuite.args>
             </properties>
         </profile>
 


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/WFLY-3854

also use newer version of javaassit but only when running/testing on JDK9

this changes only affect build on jdk9
