### PR TITLE
[WFLY-7536] RemotingLoginModuleUseNewClientCertTestCase fails on IBM jdk

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleUseNewClientCertTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleUseNewClientCertTestCase.java
@@ -417,7 +417,7 @@ public class RemotingLoginModuleUseNewClientCertTestCase {
             v3CertGen.setIssuerDN(dn);
             v3CertGen.setSubjectDN(dn);
             v3CertGen.setPublicKey(keyPair.getPublic());
-            v3CertGen.setSignatureAlgorithm("MD5withRSA");
+            v3CertGen.setSignatureAlgorithm("SHA256withRSA");
             final SecureRandom sr = new SecureRandom();
             v3CertGen.setSerialNumber(BigInteger.ONE);
             X509Certificate certificate = v3CertGen.generate(keyPair.getPrivate(), sr);


### PR DESCRIPTION
Replace MD5withRSA, which is included in jdk.tls.disabledAlgorithms in
java.security
`jdk.tls.disabledAlgorithms=SSLv3, RC4, MD5withRSA, DH keySize < 768`

Upstream issue: https://issues.jboss.org/browse/WFLY-7536