### PR TITLE
WFLY-7553 Upgrade Hibernate Search to version 5.5.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.2.4.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hibernate.search>5.5.4.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>5.5.5.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>8.2.4.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7553

Release Notes - Hibernate Search - Version 5.5.5.Final

** Bug
    * [HSEARCH-2314] - TokenStream contract violation during serialization of index on slave node in a JMS cluster
    * [HSEARCH-2351] - Documents lost after concurrent initialization of DirectoryProvider
    * [HSEARCH-2376] - Unable to sort string with non case sensitive order

** Task
    * [HSEARCH-2308] - Upgrade JGroups to version 3.6.10.Final
    * [HSEARCH-2309] - Getting started documentation points to an old version of Luke
    * [HSEARCH-2315] - Upgrade branch 5.5 to Hibernate ORM 5.0.10.Final
    * [HSEARCH-2377] - Upgrade branch 5.5 to Hibernate ORM 5.0.11.Final

 - https://hibernate.atlassian.net/secure/ReleaseNote.jspa?projectId=10061&version=24250