### PR TITLE
Remove no longer applicable test paths now that WFCORE-1716 is integr…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/full/JMXFilterTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/full/JMXFilterTestCase.java
@@ -86,13 +86,11 @@ public class JMXFilterTestCase {
         Assert.assertTrue(names.contains(new ObjectName("jboss:name=test-sar-1234567890,type=jmx-sar")));
 
         names = connection.queryNames(new ObjectName("*:subsystem=jsr77,*"), null);
-        Assert.assertTrue(names.toString(), names.size() == 2 || names.size() == 4); // once WFCORE-1716 is in place it should be 4, but we need 2 to pass until that's fixed
+        Assert.assertTrue(names.toString(), names.size() == 4);
         Assert.assertTrue(names.contains(new ObjectName("jboss.as.expr:subsystem=jsr77")));
         Assert.assertTrue(names.contains(new ObjectName("jboss.as:subsystem=jsr77")));
-        if (names.size() > 2) {
-            Assert.assertTrue(names.contains(new ObjectName("jboss.as.expr:extension=org.jboss.as.jsr77,subsystem=jsr77")));
-            Assert.assertTrue(names.contains(new ObjectName("jboss.as:extension=org.jboss.as.jsr77,subsystem=jsr77")));
-        }
+        Assert.assertTrue(names.contains(new ObjectName("jboss.as.expr:extension=org.jboss.as.jsr77,subsystem=jsr77")));
+        Assert.assertTrue(names.contains(new ObjectName("jboss.as:extension=org.jboss.as.jsr77,subsystem=jsr77")));
 
         names = connection.queryNames(new ObjectName("*:j2eeType=J2EEServer,*"), null);
         Assert.assertEquals(1, names.size());


### PR DESCRIPTION
…ated in full WildFly

This test had code paths to support behavior both before and after WFCORE-1716 was fixed. This allowed the fix to be tested in full before merging into core. The dual code paths are no longer needed.