### PR TITLE
[WFLY-7559] Upgrade EJB client to 3.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.hal.release-stream>2.9.0.Alpha5</version.org.jboss.hal.release-stream>
-        <version.org.jboss.ejb-client>3.0.0.Beta2</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>3.0.0.Beta3</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.0.Alpha1</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>


### PR DESCRIPTION
This should hopefully resolve the intermittent testsuite failures that fail with "No EJB receiver available for handling...".

https://issues.jboss.org/browse/WFLY-7559