### PR TITLE
[WFLY-4988]  Expand visibility of job XML files for WAR's and EJB's.

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -53,6 +53,7 @@ import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.extension.batch.jberet._private.Capabilities;
+import org.wildfly.extension.batch.jberet.deployment.BatchCleanupProcessor;
 import org.wildfly.extension.batch.jberet.deployment.BatchDependencyProcessor;
 import org.wildfly.extension.batch.jberet.deployment.BatchDeploymentDescriptorParser_1_0;
 import org.wildfly.extension.batch.jberet.deployment.BatchDeploymentResourceProcessor;
@@ -180,6 +181,8 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
                             Phase.POST_MODULE, Phase.POST_MODULE_BATCH_ENVIRONMENT, new BatchEnvironmentProcessor(rcPresent));
                     processorTarget.addDeploymentProcessor(NAME,
                             Phase.INSTALL, Phase.INSTALL_BATCH_RESOURCES, new BatchDeploymentResourceProcessor(NAME));
+                    processorTarget.addDeploymentProcessor(NAME,
+                            Phase.CLEANUP, Phase.CLEANUP_BATCH, new BatchCleanupProcessor());
 
                 }
             }, OperationContext.Stage.RUNTIME);

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchCleanupProcessor.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchCleanupProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+
+/**
+ * Cleans up attachments no longer required on {@linkplain DeploymentUnit deployment units}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchCleanupProcessor implements DeploymentUnitProcessor {
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        // Clean up job XML resolvers
+        phaseContext.getDeploymentUnit().removeAttachment(BatchEnvironmentProcessor.JOB_XML_RESOLVER);
+        // Clean jboss-all meta-data
+        phaseContext.getDeploymentUnit().removeAttachment(BatchDeploymentDescriptorParser_1_0.ATTACHMENT_KEY);
+    }
+
+    @Override
+    public void undeploy(final DeploymentUnit context) {
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentResourceProcessor.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentResourceProcessor.java
@@ -61,7 +61,7 @@ public class BatchDeploymentResourceProcessor implements DeploymentUnitProcessor
             final JobOperatorService jobOperatorService = new JobOperatorService();
 
             // Get all the job XML service
-            final WildFlyJobXmlResolver jobXmlResolver = deploymentUnit.getAttachment(WildFlyJobXmlResolver.JOB_XML_RESOLVER);
+            final WildFlyJobXmlResolver jobXmlResolver = deploymentUnit.getAttachment(BatchEnvironmentProcessor.JOB_XML_RESOLVER);
             // Process each job XML file
             for (String jobXml : jobXmlResolver.getJobXmlNames(moduleClassLoader)) {
                 try {

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.batch.deployment;
 
+import java.util.Collections;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.transaction.TransactionManager;
 
@@ -77,7 +78,8 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
             final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
 
             // Create the batch environment
-            final BatchEnvironmentService service = new BatchEnvironmentService(moduleClassLoader, WildFlyJobXmlResolver.of(moduleClassLoader, deploymentUnit), deploymentUnit.getName());
+            final WildFlyJobXmlResolver jobXmlResolver = WildFlyJobXmlResolver.of(moduleClassLoader, Collections.singletonList(deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT)));
+            final BatchEnvironmentService service = new BatchEnvironmentService(moduleClassLoader, jobXmlResolver, deploymentUnit.getName());
             // Set the value for the job-repository, this can't be a capability as the JDBC job repository cannot be constructed
             // until deployment time because the default JNDI data-source name is only known during DUP processing
             service.getJobRepositoryInjector().setValue(new ImmediateValue<>(JobRepositoryFactory.getInstance().getJobRepository(moduleDescription)));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.batch.common;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
@@ -45,12 +47,11 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
 import org.junit.Assert;
-
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -92,6 +93,35 @@ public abstract class AbstractBatchTestCase {
 
     protected static WebArchive addJobXml(final WebArchive deployment, final Asset asset, final String jobXml) {
         return deployment.addAsWebInfResource(asset, "classes/META-INF/batch-jobs/" + jobXml);
+    }
+
+    protected static WebArchive addJobXml(final WebArchive deployment, final String jobName) {
+        return deployment.addAsWebInfResource(createJobXml(jobName), "classes/META-INF/batch-jobs/" + jobName + ".xml");
+    }
+
+    protected static JavaArchive addJobXml(final JavaArchive deployment, final String jobName) {
+        return deployment.addAsResource(createJobXml(jobName), "META-INF/batch-jobs/" + jobName + ".xml");
+    }
+
+    static Asset createJobXml(final String jobName) {
+        final String xml = "<job id=\"" + jobName + "\" xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" version=\"1.0\">\n" +
+                "    <step id=\"step1\">\n" +
+                "        <chunk item-count=\"3\">\n" +
+                "            <reader ref=\"countingItemReader\">\n" +
+                "                <properties>\n" +
+                "                    <property name=\"reader.start\" value=\"#{jobParameters['reader.start']}\"/>\n" +
+                "                    <property name=\"reader.end\" value=\"#{jobParameters['reader.end']}\"/>\n" +
+                "                </properties>\n" +
+                "            </reader>\n" +
+                "            <writer ref=\"countingItemWriter\">\n" +
+                "                <properties>\n" +
+                "                    <property name=\"writer.sleep.time\" value=\"#{jobParameters['writer.sleep.time']}\"/>\n" +
+                "                </properties>\n" +
+                "            </writer>\n" +
+                "        </chunk>\n" +
+                "    </step>\n" +
+                "</job>";
+        return new StringAsset(xml);
     }
 
     public static class UrlBuilder {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobXmlVisibilityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobXmlVisibilityTestCase.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.batch.deployment;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
+import org.jboss.as.test.integration.batch.common.BatchExecutionService;
+import org.jboss.as.test.integration.batch.common.CountingItemReader;
+import org.jboss.as.test.integration.batch.common.CountingItemWriter;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+public class JobXmlVisibilityTestCase extends AbstractBatchTestCase {
+    private static final String EAR = "test-visibility.ear";
+    private static final String EAR_ISOLATED = "test-visibility-isolated.ear";
+    private static final String EAR_WITH_LIB = "test-with-lib.ear";
+    private static final String EAR_WITH_LIB_ISOLATED = "test-isolated-with-lib.ear";
+    private static final String WAR_WITH_LIB = "test-war-with-lib.war";
+
+    @ArquillianResource
+    // @OperateOnDeployment is required until WFARQ-13 is resolved, any deployment should suffice though
+    @OperateOnDeployment(EAR)
+    private ManagementClient managementClient;
+
+    @Deployment(name = EAR)
+    public static EnterpriseArchive visibleEarDeployment() {
+        return createEar(EAR, "visible");
+    }
+
+    @Deployment(name = EAR_ISOLATED)
+    public static EnterpriseArchive isolatedEarDeployment() {
+        return createEar(EAR_ISOLATED, "isolated")
+                .addAsManifestResource(new StringAsset(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<jboss-deployment-structure>\n" +
+                                "    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>\n" +
+                                "</jboss-deployment-structure>"
+                ), "jboss-deployment-structure.xml");
+    }
+
+    @Deployment(name = EAR_WITH_LIB)
+    public static EnterpriseArchive earWithLibDeployment() {
+        return createEar(EAR_WITH_LIB, "with-lib")
+                .addAsLibrary(createJar("lib-in-ear.jar"));
+    }
+
+    @Deployment(name = EAR_WITH_LIB_ISOLATED)
+    public static EnterpriseArchive isolatedEarWithLibDeployment() {
+        return createEar(EAR_WITH_LIB_ISOLATED, "isolated-with-lib")
+                .addAsLibrary(createJar("lib-in-ear.jar"))
+                .addAsManifestResource(new StringAsset(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<jboss-deployment-structure>\n" +
+                                "    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>\n" +
+                                "</jboss-deployment-structure>"
+                ), "jboss-deployment-structure.xml");
+    }
+
+    @Deployment(name = WAR_WITH_LIB)
+    public static WebArchive warWithLibDeployment() {
+        return createWar(WAR_WITH_LIB)
+                .addClasses(CountingItemReader.class, CountingItemWriter.class)
+                .addAsLibrary(createJar("lib-in-war.jar"));
+    }
+
+    /**
+     * Tests that all job XML files are visible from the WAR.
+     */
+    @Test
+    public void testJobXmlIsVisible() throws Exception {
+        validateJobNames(deploymentAddress(EAR, "war-in-ear-visible.war"), Arrays.asList("test-war.xml", "test-ejb.xml"));
+    }
+
+    /**
+     * Tests that the WAR can only see the job XML from the WAR and the EJB can only see the job XML from the EJB.
+     */
+    @Test
+    public void testJobXmlIsIsolated() throws Exception {
+        validateJobNames(deploymentAddress(EAR_ISOLATED, "war-in-ear-isolated.war"), Collections.singleton("test-war.xml"));
+
+        validateJobNames(deploymentAddress(EAR_ISOLATED, "ejb-in-ear-isolated.jar"), Collections.singleton("test-ejb.xml"));
+    }
+
+    /**
+     * Tests that the WAR can see the job XML from the WAR itself, the EJB and the EAR's global dependency. The EJB
+     * should be able to see the job XML from the EJB itself and the EAR's global dependency.
+     */
+    @Test
+    public void testJobXmlIsVisibleJar() throws Exception {
+        validateJobNames(deploymentAddress(EAR_WITH_LIB, "war-in-ear-with-lib.war"), Arrays.asList("test-war.xml", "test-ejb.xml", "test-jar.xml"));
+
+        validateJobNames(deploymentAddress(EAR_WITH_LIB, "ejb-in-ear-with-lib.jar"), Arrays.asList("test-ejb.xml", "test-jar.xml"));
+    }
+
+    /**
+     * Tests that the WAR can see the job XML from the WAR itself and the EAR's global dependency. The EJB
+     * should be able to see the job XML from the EJB itself and the EAR's global dependency.
+     */
+    @Test
+    public void testJobXmlIsIsolatedJar() throws Exception {
+        validateJobNames(deploymentAddress(EAR_WITH_LIB_ISOLATED, "war-in-ear-isolated-with-lib.war"), Arrays.asList("test-war.xml", "test-jar.xml"));
+
+        validateJobNames(deploymentAddress(EAR_WITH_LIB_ISOLATED, "ejb-in-ear-isolated-with-lib.jar"), Arrays.asList("test-ejb.xml", "test-jar.xml"));
+    }
+
+    /**
+     * Test that a WAR will see the job XML from a direct dependency.
+     */
+    @Test
+    public void testJobXmlInWar() throws Exception {
+        validateJobNames(deploymentAddress(WAR_WITH_LIB, null), Arrays.asList("test-war.xml", "test-jar.xml"));
+    }
+
+    private void validateJobNames(final ModelNode address, final Collection<String> expected) throws IOException {
+        Set<String> jobXmlNames = getJobNames(address);
+        Assert.assertEquals(expected.size(), jobXmlNames.size());
+        Assert.assertTrue("Expected the following job XML names: " + expected, jobXmlNames.containsAll(expected));
+    }
+
+    private Set<String> getJobNames(final ModelNode address) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(address, "job-xml-names");
+        final ModelNode result = executeOperation(op);
+        return result.asList()
+                .stream()
+                .map(ModelNode::asString)
+                .collect(Collectors.toSet());
+    }
+
+    @SuppressWarnings("Duplicates")
+    private ModelNode executeOperation(final ModelNode op) throws IOException {
+        final ModelControllerClient client = managementClient.getControllerClient();
+        final ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return Operations.readResult(result);
+        }
+        Assert.fail(Operations.getFailureDescription(result).asString());
+        // Should never be reached
+        return new ModelNode();
+    }
+
+    private static EnterpriseArchive createEar(final String name, final String suffix) {
+        return ShrinkWrap.create(EnterpriseArchive.class, name)
+                .addAsModule(createEjb("ejb-in-ear-" + suffix + ".jar"))
+                .addAsModule(createWar("war-in-ear-" + suffix + ".war"));
+    }
+
+    private static WebArchive createWar(final String name) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, name)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        addJobXml(war, "test-war");
+        return war;
+    }
+
+    private static JavaArchive createEjb(final String name) {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, name)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                // Add at least one EJB annotated class to make this an EJB JAR
+                .addClasses(CountingItemReader.class, CountingItemWriter.class, BatchExecutionService.class);
+        addJobXml(jar, "test-ejb");
+        return jar;
+    }
+
+    private static JavaArchive createJar(final String name) {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, name)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(AbstractBatchTestCase.class);
+        addJobXml(jar, "test-jar");
+        return jar;
+    }
+
+    private static ModelNode deploymentAddress(final String deploymentName, final String subDeploymentName) {
+        if (subDeploymentName == null) {
+            return Operations.createAddress(
+                    "deployment",
+                    deploymentName,
+                    "subsystem",
+                    "batch-jberet"
+            );
+        }
+        return Operations.createAddress(
+                "deployment",
+                deploymentName,
+                "subdeployment",
+                subDeploymentName,
+                "subsystem",
+                "batch-jberet"
+        );
+    }
+}


### PR DESCRIPTION
This allows sub-deployments visibility to each others job XML files as well as global EAR libraries.

I did sneak in one small fix to stop an NPE from being thrown on `/deployment=some.ear/subsystem=batch-jberet`.