### PR TITLE
[WFLY-7597] Make Artemis SQLProvider.Factory configurable

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -47,7 +47,6 @@ import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
-import org.apache.activemq.artemis.jdbc.store.sql.GenericSQLProvider;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.services.path.AbsolutePathService;
 import org.jboss.as.controller.services.path.PathManager;
@@ -303,8 +302,6 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
             if (ds != null) {
                 DatabaseStorageConfiguration dbConfiguration = (DatabaseStorageConfiguration) configuration.getStoreConfiguration();
                 dbConfiguration.setDataSource(ds);
-                // FIXME: make this configurable
-                dbConfiguration.setSqlProvider(new GenericSQLProvider.Factory());
                 configuration.setStoreConfiguration(dbConfiguration);
                 ROOT_LOGGER.infof("use JDBC store for Artemis server, bindingsTable:%s",
                         dbConfiguration.getBindingsTableName());


### PR DESCRIPTION
* do not set the SQL provider factory to the GenericSQLProvider.Factory
  when Artemis server is started. The factory can be configured by using
  the journal-sql-provider-factory attribute (during the runtime stage
  of the server's :add operation).

JIRA: https://issues.jboss.org/browse/WFLY-7597