### PR TITLE
[WFLY-7636] Use Endpoint.builder() instead of getting the currently active Remoting endpoint in LazyConnectionContextSelector

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/service/LazyConnectionContextSelector.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/service/LazyConnectionContextSelector.java
@@ -85,7 +85,7 @@ public class LazyConnectionContextSelector implements ContextSelector<EJBClientC
             final AuthenticationContext context = AuthenticationContext.empty().with(MatchRule.ALL, mergedConfiguration);
 
             // open a connection
-            endpoint = Endpoint.getCurrent();
+            endpoint = Endpoint.builder().setEndpointName("endpoint").build();
             final IoFuture<Connection> futureConnection = endpoint.connect(uri, OptionMap.create(Options.SASL_POLICY_NOANONYMOUS, Boolean.FALSE, Options.SASL_POLICY_NOPLAINTEXT, Boolean.FALSE), context);
             connection = IoFutureHelper.get(futureConnection, 30L, TimeUnit.SECONDS);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7636