### PR TITLE
WFLY-7547 SSL certificate is generated at server boot

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -365,9 +365,9 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 87, value = "Duplicate default web module '%s' configured on server '%s', host '%s'")
     IllegalArgumentException duplicateDefaultWebModuleMapping(String defaultDeploymentName, String serverName, String hostName);
 
-    @LogMessage(level = WARN)
-    @Message(id = 88, value = "HTTP/2 will not be enabled as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 is not enabled. You may need to install JCE to enable strong ciphers to allow HTTP/2 to function.")
-    void noStrongCiphers();
+//    @LogMessage(level = WARN)
+//    @Message(id = 88, value = "HTTP/2 will not be enabled as TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 is not enabled. You may need to install JCE to enable strong ciphers to allow HTTP/2 to function.")
+//    void noStrongCiphers();
 
     @Message(id = 89, value = "Predicate %s was not valid, message was: %s")
     String predicateNotValid(String predicate, String error);


### PR DESCRIPTION
This removes the boot time check for strong ciphers for HTTP/2 as
Undertow 1.4.5.Final will do this check at connection time.

The connection time check is more flexible, as it can account for changes
in the SSLContext.