### PR TITLE
[WFLY-6390] Initial Elytron integration into the batch subsystem

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/AttributeParsers.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/AttributeParsers.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+/**
+ * Attribute parsing utilities.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class AttributeParsers {
+
+    /**
+     * An attribute parser for elements with a single {@code value} that don't allow any content within the element.
+     */
+    static final AttributeParser VALUE = new AttributeParser() {
+        @Override
+        public void parseElement(final AttributeDefinition attribute, final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+            operation.get(attribute.getName()).set(readValueAttribute(reader));
+            ParseUtils.requireNoContent(reader);
+        }
+
+        @Override
+        public boolean isParseAsElement() {
+            return true;
+        }
+    };
+
+    /**
+     * Reads a {@code name} attribute on an element.
+     *
+     * @param reader the reader used to read the attribute with
+     *
+     * @return the name attribute or {@code null} if the name attribute was not defined
+     *
+     * @throws XMLStreamException if an XML processing error occurs
+     */
+    static String readNameAttribute(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        return readRequiredAttributes(reader, EnumSet.of(Attribute.NAME)).get(Attribute.NAME);
+    }
+
+    /**
+     * Reads a {@code value} attribute on an element.
+     *
+     * @param reader the reader used to read the attribute with
+     *
+     * @return the value attribute or {@code null} if the value attribute was not defined
+     *
+     * @throws XMLStreamException if an XML processing error occurs
+     */
+    static String readValueAttribute(final XMLExtendedStreamReader reader) throws XMLStreamException {
+        return readRequiredAttributes(reader, EnumSet.of(Attribute.VALUE)).get(Attribute.VALUE);
+    }
+
+    /**
+     * Reads the required attributes from an XML configuration.
+     * <p>
+     * The reader must be on an element with attributes.
+     * </p>
+     *
+     * @param reader     the reader for the attributes
+     * @param attributes the required attributes
+     *
+     * @return a map of the required attributes with the key being the attribute and the value being the value of the
+     * attribute
+     *
+     * @throws XMLStreamException if an XML processing error occurs
+     */
+    static Map<Attribute, String> readRequiredAttributes(final XMLExtendedStreamReader reader, final Set<Attribute> attributes) throws XMLStreamException {
+        final int attributeCount = reader.getAttributeCount();
+        final Map<Attribute, String> result = new EnumMap<>(Attribute.class);
+        for (int i = 0; i < attributeCount; i++) {
+            final Attribute current = Attribute.forName(reader.getAttributeLocalName(i));
+            if (attributes.contains(current)) {
+                if (result.put(current, reader.getAttributeValue(i)) != null) {
+                    throw ParseUtils.duplicateAttribute(reader, current.getLocalName());
+                }
+            } else {
+                throw ParseUtils.unexpectedAttribute(reader, i, attributes.stream().map(Attribute::getLocalName).collect(Collectors.toSet()));
+            }
+        }
+        if (result.isEmpty()) {
+            throw ParseUtils.missingRequired(reader, attributes.stream().map(Attribute::getLocalName).collect(Collectors.toSet()));
+        }
+        return result;
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchConfiguration.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchConfiguration.java
@@ -18,6 +18,7 @@ package org.wildfly.extension.batch.jberet;
 
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.JobExecutor;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * A configuration for the {@link org.jberet.spi.BatchEnvironment} behavior.
@@ -47,4 +48,11 @@ public interface BatchConfiguration {
      * @return the default job executor
      */
     JobExecutor getDefaultJobExecutor();
+
+    /**
+     * Returns the security domain if defined.
+     *
+     * @return the security domain or {@code null} if not defined
+     */
+    SecurityDomain getSecurityDomain();
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchConfigurationService.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchConfigurationService.java
@@ -23,6 +23,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * A default batch configuration service.
@@ -33,6 +34,7 @@ class BatchConfigurationService implements BatchConfiguration, Service<BatchConf
 
     private final InjectedValue<JobRepository> jobRepositoryInjector = new InjectedValue<>();
     private final InjectedValue<JobExecutor> jobExecutorInjector = new InjectedValue<>();
+    private final InjectedValue<SecurityDomain> securityDomainInjector = new InjectedValue<>();
     private volatile boolean restartOnResume;
 
     @Override
@@ -55,6 +57,11 @@ class BatchConfigurationService implements BatchConfiguration, Service<BatchConf
     }
 
     @Override
+    public SecurityDomain getSecurityDomain() {
+        return securityDomainInjector.getOptionalValue();
+    }
+
+    @Override
     public void start(final StartContext context) throws StartException {
     }
 
@@ -73,5 +80,9 @@ class BatchConfigurationService implements BatchConfiguration, Service<BatchConf
 
     protected InjectedValue<JobExecutor> getJobExecutorInjector() {
         return jobExecutorInjector;
+    }
+
+    InjectedValue<SecurityDomain> getSecurityDomainInjector() {
+        return securityDomainInjector;
     }
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -91,6 +91,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition RESTART_JOBS_ON_RESUME = SimpleAttributeDefinitionBuilder.create("restart-jobs-on-resume", ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(true))
+            .setAttributeParser(AttributeParsers.VALUE)
             .setAttributeMarshaller(AttributeMarshallers.VALUE)
             .build();
 

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -50,6 +51,7 @@ import org.jboss.as.server.deployment.jbossallxml.JBossAllXmlParserRegisteringPr
 import org.jboss.as.threads.ThreadFactoryResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.extension.batch.jberet._private.Capabilities;
@@ -62,6 +64,7 @@ import org.wildfly.extension.batch.jberet.job.repository.InMemoryJobRepositoryDe
 import org.wildfly.extension.batch.jberet.job.repository.JdbcJobRepositoryDefinition;
 import org.wildfly.extension.batch.jberet.thread.pool.BatchThreadPoolResourceDefinition;
 import org.wildfly.extension.requestcontroller.RequestControllerExtension;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 public class BatchSubsystemDefinition extends SimpleResourceDefinition {
 
@@ -95,6 +98,12 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
             .setAttributeMarshaller(AttributeMarshallers.VALUE)
             .build();
 
+    static final SimpleAttributeDefinition SECURITY_DOMAIN = SimpleAttributeDefinitionBuilder.create("security-domain", ModelType.STRING, true)
+            .setAttributeMarshaller(AttributeMarshallers.NAMED)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setCapabilityReference(Capabilities.SECURITY_DOMAIN_CAPABILITY, Capabilities.BATCH_CONFIGURATION_CAPABILITY)
+            .build();
+
     private final boolean registerRuntimeOnly;
 
     BatchSubsystemDefinition(final boolean registerRuntimeOnly) {
@@ -125,9 +134,10 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL);
+        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, SECURITY_DOMAIN);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_JOB_REPOSITORY, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_THREAD_POOL, null, writeHandler);
+        resourceRegistration.registerReadWriteAttribute(SECURITY_DOMAIN, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(RESTART_JOBS_ON_RESUME, null, new AbstractWriteAttributeHandler<Boolean>() {
             @Override
             protected boolean applyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue, final HandbackHolder<Boolean> handbackHolder) throws OperationFailedException {
@@ -161,7 +171,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
         static final BatchSubsystemAdd INSTANCE = new BatchSubsystemAdd();
 
         private BatchSubsystemAdd() {
-            super(Collections.singleton(Capabilities.BATCH_CONFIGURATION_CAPABILITY), DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME);
+            super(Collections.singleton(Capabilities.BATCH_CONFIGURATION_CAPABILITY), DEFAULT_JOB_REPOSITORY, DEFAULT_THREAD_POOL, RESTART_JOBS_ON_RESUME, SECURITY_DOMAIN);
         }
 
         @Override
@@ -190,12 +200,13 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
 
             final ModelNode defaultJobRepository = DEFAULT_JOB_REPOSITORY.resolveModelAttribute(context, model);
             final ModelNode defaultThreadPool = DEFAULT_THREAD_POOL.resolveModelAttribute(context, model);
+            final ModelNode securityDomain = SECURITY_DOMAIN.resolveModelAttribute(context, model);
             final boolean restartOnResume = RESTART_JOBS_ON_RESUME.resolveModelAttribute(context, model).asBoolean();
 
             final ServiceTarget target = context.getServiceTarget();
             final BatchConfigurationService service = new BatchConfigurationService();
             service.setRestartOnResume(restartOnResume);
-            target.addService(context.getCapabilityServiceName(Capabilities.BATCH_CONFIGURATION_CAPABILITY.getName(), BatchConfiguration.class), service)
+            final ServiceBuilder<BatchConfiguration> serviceBuilder = target.addService(context.getCapabilityServiceName(Capabilities.BATCH_CONFIGURATION_CAPABILITY.getName(), BatchConfiguration.class), service)
                     .addDependency(
                             context.getCapabilityServiceName(Capabilities.JOB_REPOSITORY_CAPABILITY.getName(), defaultJobRepository.asString(), JobRepository.class),
                             JobRepository.class,
@@ -205,10 +216,18 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
                             context.getCapabilityServiceName(Capabilities.THREAD_POOL_CAPABILITY.getName(), defaultThreadPool.asString(), JobExecutor.class),
                             JobExecutor.class,
                             service.getJobExecutorInjector()
-                    )
-                    // Only start this service if there are deployments present, allow it to be stopped as deployments
-                    // are removed.
-                    .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                    );
+            if (securityDomain.isDefined()) {
+                serviceBuilder.addDependency(
+                        context.getCapabilityServiceName(Capabilities.SECURITY_DOMAIN_CAPABILITY, securityDomain.asString(), SecurityDomain.class),
+                        SecurityDomain.class,
+                        service.getSecurityDomainInjector()
+                );
+            }
+
+            // Only start this service if there are deployments present, allow it to be stopped as deployments
+            // are removed.
+            serviceBuilder.setInitialMode(ServiceController.Mode.ON_DEMAND)
                     .install();
         }
     }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
@@ -34,8 +34,8 @@ import org.wildfly.extension.batch.jberet.deployment.BatchJobResourceDefinition;
 
 public class BatchSubsystemExtension implements Extension {
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 2;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     /**
@@ -48,7 +48,8 @@ public class BatchSubsystemExtension implements Extension {
 
     @Override
     public void initializeParsers(final ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(BatchSubsystemDefinition.NAME, Namespace.BATCH_1_0.getUriString(), new BatchSubsystemParser_1_0());
+        context.setSubsystemXmlMapping(BatchSubsystemDefinition.NAME, Namespace.BATCH_1_0.getUriString(), BatchSubsystemParser_1_0::new);
+        context.setSubsystemXmlMapping(BatchSubsystemDefinition.NAME, Namespace.BATCH_2_0.getUriString(), BatchSubsystemParser_2_0::new);
     }
 
     @Override

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtensionTransformerRegistration.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtensionTransformerRegistration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchSubsystemExtensionTransformerRegistration implements ExtensionTransformerRegistration {
+    private static final ModelVersion VERSION_1_1_0 = ModelVersion.create(1, 1, 0);
+
+    @Override
+    public String getSubsystemName() {
+        return BatchSubsystemDefinition.NAME;
+    }
+
+    @Override
+    public void registerTransformers(final SubsystemTransformerRegistration subsystemRegistration) {
+        final ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemRegistration.getCurrentSubsystemVersion());
+
+        chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), VERSION_1_1_0)
+                .getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, BatchSubsystemDefinition.SECURITY_DOMAIN)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, BatchSubsystemDefinition.SECURITY_DOMAIN)
+                .end();
+
+        chainedBuilder.buildAndRegister(subsystemRegistration, new ModelVersion[]{VERSION_1_1_0});
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_2_0.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_2_0.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet;
+
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class BatchSubsystemParser_2_0 extends BatchSubsystemParser_1_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>> {
+
+    public static final BatchSubsystemParser_2_0 INSTANCE = new BatchSubsystemParser_2_0();
+
+    public BatchSubsystemParser_2_0() {
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_2_0.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_2_0.java
@@ -16,6 +16,7 @@
 
 package org.wildfly.extension.batch.jberet;
 
+import java.util.Collections;
 import java.util.List;
 import javax.xml.stream.XMLStreamConstants;
 
@@ -30,5 +31,6 @@ class BatchSubsystemParser_2_0 extends BatchSubsystemParser_1_0 implements XMLSt
     public static final BatchSubsystemParser_2_0 INSTANCE = new BatchSubsystemParser_2_0();
 
     public BatchSubsystemParser_2_0() {
+        super(Collections.singletonMap(Element.SECURITY_DOMAIN, BatchSubsystemDefinition.SECURITY_DOMAIN));
     }
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
@@ -46,6 +46,7 @@ public class BatchSubsystemWriter implements XMLElementWriter<SubsystemMarshalli
         context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
         final ModelNode model = context.getModelNode();
         BatchSubsystemDefinition.DEFAULT_JOB_REPOSITORY.marshallAsElement(model, writer);
+        BatchSubsystemDefinition.SECURITY_DOMAIN.marshallAsElement(model, writer);
         BatchSubsystemDefinition.DEFAULT_THREAD_POOL.marshallAsElement(model, writer);
         BatchSubsystemDefinition.RESTART_JOBS_ON_RESUME.marshallAsElement(model, writer);
 

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/Element.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/Element.java
@@ -38,6 +38,7 @@ public enum Element {
     IN_MEMORY("in-memory"),
     NAMED("named"),
     RESTART_JOBS_ON_RESUME("restart-jobs-on-resume"),
+    SECURITY_DOMAIN("security-domain"),
     THREAD_FACTORY("thread-factory"),
     THREAD_POOL("thread-pool"),
     ;

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/Namespace.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/Namespace.java
@@ -33,12 +33,13 @@ enum Namespace {
     UNKNOWN(null),
 
     BATCH_1_0("urn:jboss:domain:batch-jberet:1.0"),
+    BATCH_2_0("urn:jboss:domain:batch-jberet:2.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = BATCH_1_0;
+    public static final Namespace CURRENT = BATCH_2_0;
 
     private final String name;
 

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
@@ -57,4 +57,9 @@ public class Capabilities {
      */
     public static final RuntimeCapability<Void> JOB_REPOSITORY_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.job.repository", true, JobRepository.class)
             .build();
+
+    /**
+     * The capability name for the Elytron security domain.
+     */
+    public static final String SECURITY_DOMAIN_CAPABILITY = "org.wildfly.security.security-domain";
 }

--- a/batch/extension-jberet/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/batch/extension-jberet/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.wildfly.extension.batch.jberet.BatchSubsystemExtensionTransformerRegistration

--- a/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
+++ b/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
@@ -32,6 +32,8 @@ batch.jberet.default-job-repository=The name of the default job repository.
 batch.jberet.default-thread-pool=The name of the default thread-pool.
 batch.jberet.restart-jobs-on-resume=If set to true when a resume operation has be invoked after a suspend operation any \
   jobs stopped during the suspend will be restarted. A value of false will leave the jobs in a stopped state.
+batch.jberet.security-domain=References the security domain for batch jobs. This can only be defined if the Elytron \
+  subsystem is available.
 
 # In-Memory job repository
 batch.jberet.in-memory-job-repository=A job repository that stores job information in memory.

--- a/batch/extension-jberet/src/main/resources/schema/wildfly-batch-jberet_2_0.xsd
+++ b/batch/extension-jberet/src/main/resources/schema/wildfly-batch-jberet_2_0.xsd
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:batch-jberet:2.0"
+           targetNamespace="urn:jboss:domain:batch-jberet:2.0"
+           xmlns:threads="urn:jboss:domain:threads:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="2.0">
+
+    <xs:import namespace="urn:jboss:domain:threads:1.1" schemaLocation="jboss-as-threads_1_1.xsd"/>
+
+    <!-- The batch subsystem root element -->
+    <xs:element name="subsystem" type="batch-subsystemType"/>
+
+    <xs:complexType name="batch-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the batch subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="default-job-repository" type="namedType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the default job-repository for the batch environment.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="default-thread-pool" type="namedType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the default thread-pool for the batch environment.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="restart-jobs-on-resume" type="booleanType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        If set to true when a resume operation has be invoked after a suspend operation any jobs stopped
+                        during the suspend will be restarted. A value of false will leave the jobs in a stopped state.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="job-repository" type="job-repositoryType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="thread-pool" type="thread-poolType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="thread-factory" type="threads:thread-factory" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="namedType">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanType">
+        <xs:attribute name="value" type="xs:boolean" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="job-repositoryType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The name of the job repository to use
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="in-memory" type="in-memoryType"/>
+            <xs:element name="jdbc" type="jdbcType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="in-memoryType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                        Used to describe an in-memory job repository.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                        Used to describe how the job repository should connect to a database.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="data-source" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="thread-poolType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no
+                upper bound.  When a task is submitted, if the number of running threads is less than the core size,
+                a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be
+                submitted to this type of executor, an out of memory condition may occur.
+
+                The "max-threads" attribute must be used to specify the thread pool size.  The nested
+                "keepalive-time" element may used to specify the amount of time that pool threads should
+                be kept running when idle; if not specified, threads will run until the executor is shut down.
+                The "thread-factory" element specifies the bean name of a specific thread factory to use to create worker
+                threads.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="threads:countType"/>
+            <xs:element name="keepalive-time" type="threads:time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="threads:ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+</xs:schema>

--- a/batch/extension-jberet/src/main/resources/schema/wildfly-batch-jberet_2_0.xsd
+++ b/batch/extension-jberet/src/main/resources/schema/wildfly-batch-jberet_2_0.xsd
@@ -60,6 +60,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="security-domain" type="namedType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the name of the default security domain to use as a default for batch jobs.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="job-repository" type="job-repositoryType" minOccurs="1" maxOccurs="unbounded"/>
             <xs:element name="thread-pool" type="thread-poolType" minOccurs="1" maxOccurs="unbounded"/>
             <xs:element name="thread-factory" type="threads:thread-factory" minOccurs="0" maxOccurs="unbounded"/>

--- a/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
+++ b/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
@@ -27,7 +27,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.batch.jberet</extension-module>
-    <subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+    <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
         <default-job-repository name="in-memory"/>
         <default-thread-pool name="batch"/>
         <job-repository name="in-memory">

--- a/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
+++ b/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
@@ -29,6 +29,7 @@
     <extension-module>org.wildfly.extension.batch.jberet</extension-module>
     <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
         <default-job-repository name="in-memory"/>
+        <?ELYTRON?>
         <default-thread-pool name="batch"/>
         <job-repository name="in-memory">
             <in-memory/>
@@ -39,4 +40,9 @@
             <keepalive-time time="30" unit="seconds"/>
         </thread-pool>
     </subsystem>
+    <supplement name="elytron">
+        <replacement placeholder="ELYTRON">
+            <security-domain name="ApplicationDomain"/>
+        </replacement>
+    </supplement>
 </config>

--- a/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
+++ b/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
@@ -80,9 +80,9 @@ public class JBeretSubsystemParsingTestCase extends AbstractBatchTestCase {
         standardSubsystemTest("/jdbc-default-subsystem.xml");
     }
 
-    @Override
-    protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities("org.wildfly.data-source.ExampleDS");
+    @Test
+    public void testSecurityDomainSubsystem() throws Exception {
+        standardSubsystemTest("/security-domain-subsystem.xml");
     }
 
     @Test
@@ -116,5 +116,10 @@ public class JBeretSubsystemParsingTestCase extends AbstractBatchTestCase {
             // Run the standard subsystem test, but don't compare the XML as it should never match
             standardSubsystemTest(configId, false);
         }
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.data-source.ExampleDS", "org.wildfly.security.security-domain.ApplicationDomain");
     }
 }

--- a/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemTransformerTestCase.java
+++ b/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemTransformerTestCase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.batch.jberet;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SubsystemTransformerTestCase extends AbstractBatchTestCase {
+    public SubsystemTransformerTestCase() {
+        super(BatchSubsystemDefinition.NAME, new BatchSubsystemExtension());
+    }
+
+    @Override
+    protected void standardSubsystemTest(final String configId) throws Exception {
+        // do nothing as this is not a subsystem parsing test
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("/security-domain-subsystem.xml");
+    }
+
+    @Test
+    public void testTransformersEAP700() throws Exception {
+        final KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXmlResource("/default-subsystem_1_0.xml");
+        final ModelVersion legacyVersion = ModelVersion.create(1, 1, 0);
+
+
+        final ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_0_0;
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, legacyVersion)
+                .addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-batch-jberet:" + controllerVersion.getMavenGavVersion())
+                .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-threads:" + controllerVersion.getCoreVersion());
+        final KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        final KernelServices legacyServices = mainServices.getLegacyServices(legacyVersion);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkSubsystemModelTransformation(mainServices, legacyVersion, null, false);
+    }
+
+    @Test
+    public void testFailedTransformersEAP700() throws Exception {
+        // Add the default capabilities so that a composite operation is not required
+        final AdditionalInitialization additionalInitialization = AdditionalInitialization.withCapabilities(
+                "org.wildfly.security.security-domain.ApplicationDomain",
+                "org.wildfly.batch.job.repository.in-memory",
+                "org.wildfly.batch.thread.pool.batch");
+        // An old version of the subsystem had a type on the job repository and therefore requires a different capability
+        // name.
+        final AdditionalInitialization legacyAdditionalInitialization = AdditionalInitialization.withCapabilities(
+                "org.wildfy.batch.job.repository.in-memory",
+                "org.wildfly.batch.thread.pool.batch");
+        final KernelServicesBuilder builder = createKernelServicesBuilder(additionalInitialization);
+        final ModelVersion legacyVersion = ModelVersion.create(1, 1, 0);
+
+
+        final ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_0_0;
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(legacyAdditionalInitialization, controllerVersion, legacyVersion)
+                .addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-batch-jberet:" + controllerVersion.getMavenGavVersion())
+                .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-threads:" + controllerVersion.getCoreVersion());
+
+
+        final KernelServices mainServices = builder.build();
+        final KernelServices legacyServices = mainServices.getLegacyServices(legacyVersion);
+
+        Assert.assertNotNull(legacyServices);
+        Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        final List<ModelNode> ops = builder.parseXmlResource("/default-subsystem.xml");
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, legacyVersion, ops,
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(PathAddress.pathAddress(BatchSubsystemDefinition.SUBSYSTEM_PATH),
+                                new FailedOperationTransformationConfig.NewAttributesConfig(BatchSubsystemDefinition.SECURITY_DOMAIN))
+        );
+    }
+}

--- a/batch/extension-jberet/src/test/resources/default-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/default-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+<subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
     <default-job-repository name="in-memory"/>
     <default-thread-pool name="batch"/>
     <restart-jobs-on-resume value="false"/>

--- a/batch/extension-jberet/src/test/resources/default-subsystem_1_0.xml
+++ b/batch/extension-jberet/src/test/resources/default-subsystem_1_0.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+    <default-job-repository name="in-memory"/>
+    <default-thread-pool name="batch"/>
+    <restart-jobs-on-resume value="false"/>
+    <job-repository name="in-memory">
+        <in-memory/>
+    </job-repository>
+
+    <thread-pool name="batch">
+        <max-threads count="10"/>
+        <keepalive-time time="100" unit="milliseconds"/>
+        <thread-factory name="batch"/>
+    </thread-pool>
+
+    <thread-factory name="batch" group-name="batch" priority="5" thread-name-pattern="%i-%g"/>
+</subsystem>

--- a/batch/extension-jberet/src/test/resources/jdbc-default-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/jdbc-default-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+<subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
     <default-job-repository name="jdbc"/>
     <default-thread-pool name="batch"/>
     <job-repository name="jdbc">

--- a/batch/extension-jberet/src/test/resources/jdbc-default-subsystem_1_0.xml
+++ b/batch/extension-jberet/src/test/resources/jdbc-default-subsystem_1_0.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+    <default-job-repository name="jdbc"/>
+    <default-thread-pool name="batch"/>
+    <job-repository name="jdbc">
+        <jdbc data-source="ExampleDS"/>
+    </job-repository>
+
+    <thread-pool name="batch">
+        <max-threads count="10"/>
+        <keepalive-time time="100" unit="milliseconds"/>
+        <thread-factory name="batch"/>
+    </thread-pool>
+
+    <thread-factory name="batch" group-name="batch" priority="5" thread-name-pattern="%i-%g"/>
+</subsystem>

--- a/batch/extension-jberet/src/test/resources/minimal-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/minimal-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+<subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
     <default-job-repository name="in-memory"/>
     <default-thread-pool name="batch"/>
     <job-repository name="in-memory">

--- a/batch/extension-jberet/src/test/resources/multi-thread-factory-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/multi-thread-factory-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+<subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
     <default-job-repository name="in-memory"/>
     <default-thread-pool name="batch"/>
     <job-repository name="in-memory">

--- a/batch/extension-jberet/src/test/resources/multi-thread-factory-subsystem_1_0.xml
+++ b/batch/extension-jberet/src/test/resources/multi-thread-factory-subsystem_1_0.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:batch-jberet:1.0">
+    <default-job-repository name="in-memory"/>
+    <default-thread-pool name="batch"/>
+    <job-repository name="in-memory">
+        <in-memory/>
+    </job-repository>
+
+    <thread-pool name="batch">
+        <max-threads count="10"/>
+        <keepalive-time time="100" unit="milliseconds"/>
+        <thread-factory name="batch"/>
+    </thread-pool>
+
+    <thread-factory name="batch" group-name="batch" priority="5" thread-name-pattern="%i-%g"/>
+    <thread-factory name="batch-new" group-name="batch" priority="5" thread-name-pattern="%i-%g"/>
+</subsystem>

--- a/batch/extension-jberet/src/test/resources/security-domain-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/security-domain-subsystem.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
+    <default-job-repository name="in-memory"/>
+    <security-domain name="ApplicationDomain"/>
+    <default-thread-pool name="batch"/>
+    <restart-jobs-on-resume value="false"/>
+    <job-repository name="in-memory">
+        <in-memory/>
+    </job-repository>
+
+    <thread-pool name="batch">
+        <max-threads count="10"/>
+        <keepalive-time time="100" unit="milliseconds"/>
+        <thread-factory name="batch"/>
+    </thread-pool>
+
+    <thread-factory name="batch" group-name="batch" priority="5" thread-name-pattern="%i-%g"/>
+</subsystem>

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/DefaultConfigurationService.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/DefaultConfigurationService.java
@@ -24,6 +24,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.batch.jberet.BatchConfiguration;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -46,6 +47,12 @@ class DefaultConfigurationService implements BatchConfiguration, Service<BatchCo
     @Override
     public JobExecutor getDefaultJobExecutor() {
         return jobExecutorInjector.getValue();
+    }
+
+    @Override
+    public SecurityDomain getSecurityDomain() {
+        // No security domain will be used for the legacy subsystem
+        return null;
     }
 
     @Override

--- a/feature-pack/src/main/resources/configuration/domain/subsystems-elytron.xml
+++ b/feature-pack/src/main/resources/configuration/domain/subsystems-elytron.xml
@@ -4,7 +4,7 @@
    <subsystems name="default">
       <!-- Each subsystem to be included relative to the src/main/resources directory -->
       <subsystem>logging.xml</subsystem>
-      <subsystem>batch-jberet.xml</subsystem>
+      <subsystem supplement="elytron">batch-jberet.xml</subsystem>
       <subsystem>bean-validation.xml</subsystem>
       <subsystem>datasources.xml</subsystem>
       <subsystem>ee.xml</subsystem>
@@ -35,7 +35,7 @@
    <subsystems name="ha">
       <!-- Each subsystem to be included relative to the src/main/resources directory -->
       <subsystem>logging.xml</subsystem>
-      <subsystem>batch-jberet.xml</subsystem>
+      <subsystem supplement="elytron">batch-jberet.xml</subsystem>
       <subsystem>bean-validation.xml</subsystem>
       <subsystem>datasources.xml</subsystem>
       <subsystem>ee.xml</subsystem>
@@ -69,7 +69,7 @@
    <subsystems name="full">
       <!-- Each subsystem to be included relative to the src/main/resources directory -->
       <subsystem>logging.xml</subsystem>
-      <subsystem>batch-jberet.xml</subsystem>
+      <subsystem supplement="elytron">batch-jberet.xml</subsystem>
       <subsystem>bean-validation.xml</subsystem>
       <subsystem>datasources.xml</subsystem>
       <subsystem supplement="full">ee.xml</subsystem>
@@ -103,7 +103,7 @@
    <subsystems name="full-ha">
       <!-- Each subsystem to be included relative to the src/main/resources directory -->
       <subsystem>logging.xml</subsystem>
-      <subsystem>batch-jberet.xml</subsystem>
+      <subsystem supplement="elytron">batch-jberet.xml</subsystem>
       <subsystem>bean-validation.xml</subsystem>
       <subsystem>datasources.xml</subsystem>
       <subsystem supplement="full">ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-elytron.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-elytron.xml
@@ -3,7 +3,7 @@
 <config>
    <subsystems>
       <subsystem>logging.xml</subsystem>
-      <subsystem>batch-jberet.xml</subsystem>
+      <subsystem supplement="elytron">batch-jberet.xml</subsystem>
       <subsystem>bean-validation.xml</subsystem>
       <subsystem>datasources.xml</subsystem>
       <subsystem>deployment-scanner.xml</subsystem>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-6390

This is the initial Elytron integration into the batch subsystem. @darranl or @dmlloyd should review or appoint someone to review this.

There are currently two missing pieces which may require a change in JBeret.

1. Caching the user that started the job is not currently supported. The use case for this is when the server is suspended batch jobs are stopped. On resume, by default, these stopped jobs are restarted. With the current behavior these jobs will be restarted with the management user or in most cases anonymously as the default domain is the `ApplicationDomain` which uses the `ApplicationRealm`.
2. A batch permission for read, start, stop, restart and abandon are not yet created. This is easily workable with the `start`, `stop` and `restart` management operations however a change in JBeret may be needed to support this in deployments.