### PR TITLE
[WFLY-7330] Support http-acceptor for colocated backups.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.messaging.activemq;
 
 import static org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME;
+import static org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants.ACTIVEMQ_SERVER_NAME;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.FACTORY_CLASS;
@@ -342,10 +343,12 @@ public class TransportConfigOperationHandlers {
 
                 final String binding = HTTPConnectorDefinition.SOCKET_BINDING.resolveModelAttribute(context, config).asString();
                 bindings.add(binding);
+                // ARTEMIS-803 Artemis knows that is must not offset the HTTP port when it is used by colocated backups
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, HTTPConnectorDefinition.ENDPOINT.resolveModelAttribute(context, config).asString());
                 // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
                 parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
+                parameters.put(ACTIVEMQ_SERVER_NAME, configuration.getName());
                 connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName));
             }
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryService.java
@@ -319,6 +319,10 @@ public class LegacyConnectionFactoryService implements Service<ConnectionFactory
             String newKey = newEntry.getKey();
             Object value = newEntry.getValue();
             String legacyKey = PARAM_KEY_MAPPING.getOrDefault(newKey, newKey);
+            if (org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants.ACTIVEMQ_SERVER_NAME.equals(legacyKey)) {
+                // property specific to ActiveMQ that can not be mapped to HornetQ
+                continue;
+            }
             legacyParams.put(legacyKey, value);
         }
         return legacyParams;


### PR DESCRIPTION
Uses the TransportConstants.ACTIVEMQ_SERVER_NAME property during the
HTTP upgrade handshake to determine whether the request is for the main
ActiveMQ server or one of its colocated backups.

JIRA: https://issues.jboss.org/browse/WFLY-7330