### PR TITLE
[WFLY-7671] Ensure usage of an in-memory database for batch JDBC repository tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/DeploymentDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/DeploymentDescriptorTestCase.java
@@ -139,7 +139,7 @@ public class DeploymentDescriptorTestCase extends AbstractBatchTestCase {
             ModelNode op = Operations.createAddOperation(address);
             op.get("driver-name").set("h2");
             op.get("jndi-name").set("java:jboss/datasources/batch");
-            op.get("connection-url").set("jdbc:h2:batch-test");
+            op.get("connection-url").set("jdbc:h2:mem:batch-test");
             operationBuilder.addStep(op);
 
             // Add a new JDBC job repository with the new data-source


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7671

The `mem` was missing from the JDBC URL resulting in file storage being used for the data source. Without a `clean` goal being executed the tests would fail.