### PR TITLE
WFLY-7695 Block distributed session manager stop until all sessions are closed.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManager.java
@@ -31,7 +31,9 @@ import io.undertow.server.session.SessionManagerStatistics;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.locks.StampedLock;
 
 import org.wildfly.clustering.ee.Batch;
 import org.wildfly.clustering.ee.Batcher;
@@ -50,6 +52,10 @@ public class DistributableSessionManager implements UndertowSessionManager {
     private final SessionListeners listeners;
     private final SessionManager<LocalSessionContext, Batch> manager;
     private final RecordableSessionManagerStatistics statistics;
+    private final StampedLock lifecycleLock = new StampedLock();
+
+    // Guarded by this
+    private OptionalLong lifecycleStamp = OptionalLong.empty();
 
     public DistributableSessionManager(String deploymentName, SessionManager<LocalSessionContext, Batch> manager, SessionListeners listeners, RecordableSessionManagerStatistics statistics) {
         this.deploymentName = deploymentName;
@@ -69,7 +75,8 @@ public class DistributableSessionManager implements UndertowSessionManager {
     }
 
     @Override
-    public void start() {
+    public synchronized void start() {
+        this.lifecycleStamp.ifPresent(stamp -> this.lifecycleLock.unlock(stamp));
         this.manager.start();
         if (this.statistics != null) {
             this.statistics.reset();
@@ -77,8 +84,23 @@ public class DistributableSessionManager implements UndertowSessionManager {
     }
 
     @Override
-    public void stop() {
-        this.manager.stop();
+    public synchronized void stop() {
+        if (!this.lifecycleStamp.isPresent()) {
+            try {
+                this.lifecycleStamp = OptionalLong.of(this.lifecycleLock.writeLockInterruptibly());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            this.manager.stop();
+        }
+    }
+
+    private Runnable getSessionCloseTask() {
+        long stamp = this.lifecycleLock.tryReadLock();
+        if (stamp == 0) {
+            throw UndertowClusteringLogger.ROOT_LOGGER.sessionManagerStopped();
+        }
+        return () -> this.lifecycleLock.unlock(stamp);
     }
 
     @Override
@@ -87,31 +109,43 @@ public class DistributableSessionManager implements UndertowSessionManager {
             throw UndertowMessages.MESSAGES.couldNotFindSessionCookieConfig();
         }
 
-        Batcher<Batch> batcher = this.manager.getBatcher();
-        // Batch will be closed by Session.close();
-        @SuppressWarnings("resource")
-        Batch batch = batcher.createBatch();
-        try {
-            String requestedSessionId = config.findSessionId(exchange);
-            String id = (requestedSessionId == null) ? this.manager.createIdentifier() : requestedSessionId;
-            Session<LocalSessionContext> session = this.manager.createSession(id);
-            if (session == null) {
-                throw UndertowClusteringLogger.ROOT_LOGGER.sessionAlreadyExists(id);
-            }
-            if (requestedSessionId == null) {
-                config.setSessionId(exchange, id);
-            }
+        String requestedId = config.findSessionId(exchange);
+        String id = (requestedId == null) ? this.manager.createIdentifier() : requestedId;
 
-            io.undertow.server.session.Session adapter = new DistributableSession(this, session, config, batcher.suspendBatch());
-            this.listeners.sessionCreated(adapter, exchange);
-            if (this.statistics != null) {
-                this.statistics.record(adapter);
+        Runnable closeTask = this.getSessionCloseTask();
+        boolean close = true;
+        try {
+            Batcher<Batch> batcher = this.manager.getBatcher();
+            // Batch will be closed by Session.close();
+            Batch batch = batcher.createBatch();
+            try {
+                Session<LocalSessionContext> session = this.manager.createSession(id);
+                if (session == null) {
+                    throw UndertowClusteringLogger.ROOT_LOGGER.sessionAlreadyExists(id);
+                }
+                if (requestedId == null) {
+                    config.setSessionId(exchange, id);
+                }
+
+                io.undertow.server.session.Session result = new DistributableSession(this, session, config, batcher.suspendBatch(), closeTask);
+                this.listeners.sessionCreated(result, exchange);
+                if (this.statistics != null) {
+                    this.statistics.record(result);
+                }
+                close = false;
+                return result;
+            } catch (RuntimeException | Error e) {
+                batch.discard();
+                throw e;
+            } finally {
+                if (close) {
+                    batch.close();
+                }
             }
-            return adapter;
-        } catch (RuntimeException | Error e) {
-            batch.discard();
-            batch.close();
-            throw e;
+        } finally {
+            if (close) {
+                closeTask.run();
+            }
         }
     }
 
@@ -121,34 +155,44 @@ public class DistributableSessionManager implements UndertowSessionManager {
             throw UndertowMessages.MESSAGES.couldNotFindSessionCookieConfig();
         }
 
-        Batcher<Batch> batcher = this.manager.getBatcher();
-        @SuppressWarnings("resource")
-        Batch batch = batcher.createBatch();
+        String id = config.findSessionId(exchange);
+        if (id == null) {
+            return null;
+        }
+
+        // If requested id contains invalid characters, then session cannot exist and would otherwise cause session lookup to fail
         try {
-            String id = config.findSessionId(exchange);
-            if (id == null) {
-                batch.close();
-                return null;
-            }
+            Base64.getUrlDecoder().decode(id);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
 
-            // If requested id contains invalid characters, then session cannot exist and would otherwise cause session lookup to fail
+        Runnable closeTask = this.getSessionCloseTask();
+        boolean close = true;
+        try {
+            Batcher<Batch> batcher = this.manager.getBatcher();
+            Batch batch = batcher.createBatch();
             try {
-                Base64.getUrlDecoder().decode(id);
-            } catch (IllegalArgumentException e) {
-                batch.close();
-                return null;
-            }
+                Session<LocalSessionContext> session = this.manager.findSession(id);
+                if (session == null) {
+                    return null;
+                }
 
-            Session<LocalSessionContext> session = this.manager.findSession(id);
-            if (session == null) {
-                batch.close();
-                return null;
+                io.undertow.server.session.Session result = new DistributableSession(this, session, config, batcher.suspendBatch(), closeTask);
+                close = false;
+                return result;
+            } catch (RuntimeException | Error e) {
+                batch.discard();
+                throw e;
+            } finally {
+                if (close) {
+                    batch.close();
+                }
             }
-            return new DistributableSession(this, session, config, batcher.suspendBatch());
-        } catch (RuntimeException | Error e) {
-            batch.discard();
-            batch.close();
-            throw e;
+        } finally {
+            if (close) {
+                closeTask.run();
+            }
         }
     }
 

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerConfiguration.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerConfiguration.java
@@ -17,27 +17,25 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.clustering.web.undertow.logging;
+package org.wildfly.clustering.web.undertow.session;
 
-import org.jboss.logging.BasicLogger;
-import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.Message;
-import org.jboss.logging.annotations.MessageLogger;
+import java.util.concurrent.locks.StampedLock;
 
-@MessageLogger(projectCode = "WFLYCLWEBUT", length = 4)
-public interface UndertowClusteringLogger extends BasicLogger {
+import org.wildfly.clustering.ee.Batch;
+import org.wildfly.clustering.web.session.SessionManager;
 
-    UndertowClusteringLogger ROOT_LOGGER = Logger.getMessageLogger(UndertowClusteringLogger.class, "org.wildfly.clustering.web.undertow");
+import io.undertow.server.session.SessionListeners;
 
-    @Message(id = 1, value = "Session %s is invalid")
-    IllegalStateException sessionIsInvalid(String sessionId);
-
-    @Message(id = 2, value = "Session %s already exists")
-    IllegalStateException sessionAlreadyExists(String sessionId);
-
-    @Message(id = 3, value = "Session manager was stopped")
-    IllegalStateException sessionManagerStopped();
+/**
+ * @author Paul Ferraro
+ */
+public interface DistributableSessionManagerConfiguration {
+    String getDeploymentName();
+    SessionManager<LocalSessionContext, Batch> getSessionManager();
+    SessionListeners getSessionListeners();
+    RecordableSessionManagerStatistics getStatistics();
+    StampedLock getLifecycleLock();
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerTestCase.java
@@ -58,7 +58,8 @@ public class DistributableSessionManagerTestCase {
     private final SessionListener listener = mock(SessionListener.class);
     private final SessionListeners listeners = new SessionListeners();
     private final RecordableSessionManagerStatistics statistics = mock(RecordableSessionManagerStatistics.class);
-    private DistributableSessionManager adapter = new DistributableSessionManager(this.deploymentName, this.manager, this.listeners, this.statistics);
+
+    private final DistributableSessionManager adapter = new DistributableSessionManager(this.deploymentName, this.manager, this.listeners, this.statistics);
 
     @Before
     public void init() {
@@ -213,39 +214,26 @@ public class DistributableSessionManagerTestCase {
     public void getSessionNoSessionId() {
         HttpServerExchange exchange = new HttpServerExchange(null);
         SessionConfig config = mock(SessionConfig.class);
-        Batcher<Batch> batcher = mock(Batcher.class);
-        Batch batch = mock(Batch.class);
 
-        when(this.manager.getBatcher()).thenReturn(batcher);
-        when(batcher.createBatch()).thenReturn(batch);
         when(config.findSessionId(exchange)).thenReturn(null);
 
         io.undertow.server.session.Session sessionAdapter = this.adapter.getSession(exchange, config);
 
         assertNull(sessionAdapter);
-
-        verify(batch).close();
-        verify(batcher, never()).suspendBatch();
     }
 
     @Test
     public void getSessionInvalidCharacters() {
         HttpServerExchange exchange = new HttpServerExchange(null);
-        Batcher<Batch> batcher = mock(Batcher.class);
-        Batch batch = mock(Batch.class);
         SessionConfig config = mock(SessionConfig.class);
         String sessionId = "session+";
 
         when(config.findSessionId(exchange)).thenReturn(sessionId);
-        when(this.manager.getBatcher()).thenReturn(batcher);
-        when(batcher.createBatch()).thenReturn(batch);
 
         io.undertow.server.session.Session sessionAdapter = this.adapter.getSession(exchange, config);
 
         assertNull(sessionAdapter);
 
-        verify(batch).close();
-        verify(batcher, never()).suspendBatch();
         verify(this.manager, never()).findSession(sessionId);
     }
 

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
@@ -68,8 +68,9 @@ public class DistributableSessionTestCase {
     private final SessionConfig config = mock(SessionConfig.class);
     private final Session<LocalSessionContext> session = mock(Session.class);
     private final Batch batch = mock(Batch.class);
+    private final Runnable closeTask = mock(Runnable.class);
 
-    private final io.undertow.server.session.Session adapter = new DistributableSession(this.manager, this.session, this.config, this.batch);
+    private final io.undertow.server.session.Session adapter = new DistributableSession(this.manager, this.session, this.config, this.batch, this.closeTask);
 
     @Test
     public void getId() {
@@ -98,8 +99,9 @@ public class DistributableSessionTestCase {
         verify(this.session).close();
         verify(this.batch).close();
         verify(context).close();
+        verify(this.closeTask).run();
 
-        reset(this.batch, this.session, context);
+        reset(this.batch, this.session, context, this.closeTask);
 
         when(this.session.isValid()).thenReturn(false);
 
@@ -108,6 +110,7 @@ public class DistributableSessionTestCase {
         verify(this.session, never()).close();
         verify(this.batch, never()).close();
         verify(context, never()).close();
+        verify(this.closeTask, never()).run();
     }
 
     @Test
@@ -553,7 +556,6 @@ public class DistributableSessionTestCase {
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         when(this.session.getId()).thenReturn(sessionId);
         when(this.manager.getSessionManager()).thenReturn(manager);
-        when(this.manager.getSessionManager()).thenReturn(manager);
         when(manager.getBatcher()).thenReturn(batcher);
         when(batcher.resumeBatch(this.batch)).thenReturn(context);
 
@@ -564,6 +566,7 @@ public class DistributableSessionTestCase {
         verify(listener).sessionDestroyed(this.adapter, exchange, SessionDestroyedReason.INVALIDATED);
         verify(this.batch).close();
         verify(context).close();
+        verify(this.closeTask).run();
     }
 
     @Test

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
@@ -175,7 +175,7 @@ public class DistributableTestCase extends ClusterAbstractTestCase {
     public void testGracefulServeOnUndeploy(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1)
             throws Exception {
-        this.abstractGracefulServe(baseURL1, true);
+        this.testGracefulServe(baseURL1, new RedeployLifecycle());
     }
 
     /**
@@ -185,10 +185,10 @@ public class DistributableTestCase extends ClusterAbstractTestCase {
     public void testGracefulServeOnShutdown(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1)
             throws Exception {
-        this.abstractGracefulServe(baseURL1, false);
+        this.testGracefulServe(baseURL1, new RestartLifecycle());
     }
 
-    private void abstractGracefulServe(URL baseURL, boolean undeployOnly) throws URISyntaxException, IOException, InterruptedException {
+    private void testGracefulServe(URL baseURL, Lifecycle lifecycle) throws URISyntaxException, IOException, InterruptedException {
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             URI uri = SimpleServlet.createURI(baseURL);
@@ -209,13 +209,7 @@ public class DistributableTestCase extends ClusterAbstractTestCase {
             // Make sure long request has started
             Thread.sleep(1000);
 
-            if (undeployOnly) {
-                // Undeploy the app only.
-                undeploy(DEPLOYMENT_1);
-            } else {
-                // Shutdown server.
-                stop(CONTAINER_1);
-            }
+            lifecycle.stop(NODE_1);
 
             // Get result of long request
             // This request should succeed since it initiated before server shutdown
@@ -230,17 +224,6 @@ public class DistributableTestCase extends ClusterAbstractTestCase {
             } catch (ExecutionException e) {
                 e.printStackTrace(System.err);
                 Assert.fail(e.getCause().getMessage());
-            }
-
-            if (undeployOnly) {
-                // If we are only undeploying, then subsequent requests should return 404.
-                response = client.execute(new HttpGet(uri));
-                try {
-                    Assert.assertEquals("If we are only undeploying, then subsequent requests should return 404.",
-                            HttpServletResponse.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
-                } finally {
-                    HttpClientUtils.closeQuietly(response);
-                }
             }
         }
     }


### PR DESCRIPTION
Undertow doesn't close a session until after the corresponding response was flushed, which happens outside the request controller, hence the need for additional tracking.  Additionally, the request controller used by Undertow is associated with a deployment, and a session manager can span deployments.

https://issues.jboss.org/browse/WFLY-7695