### PR TITLE
WFLY-7711 Make AbstractSubsystemBaseTest#testSchemaOfSubsystemTemplat…

### DIFF
--- a/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
+++ b/batch/extension-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
@@ -66,6 +66,12 @@ public class JBeretSubsystemParsingTestCase extends AbstractBatchTestCase {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testMinimalSubsystem() throws Exception {
         standardSubsystemTest("/minimal-subsystem.xml");
     }

--- a/batch/extension/src/test/java/org/wildfly/extension/batch/BatchSubsystemParsingTestCase.java
+++ b/batch/extension/src/test/java/org/wildfly/extension/batch/BatchSubsystemParsingTestCase.java
@@ -53,6 +53,12 @@ public class BatchSubsystemParsingTestCase extends AbstractBatchTestCase {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testMinimalSubsystem() throws Exception {
         standardSubsystemTest("/minimal-subsystem.xml");
     }

--- a/bean-validation/src/test/java/org/wildfly/extension/beanvalidation/BeanValidationSubsystemTestCase.java
+++ b/bean-validation/src/test/java/org/wildfly/extension/beanvalidation/BeanValidationSubsystemTestCase.java
@@ -25,6 +25,7 @@ package org.wildfly.extension.beanvalidation;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 /**
  * Bean Validation subsystem tests.
@@ -52,5 +53,11 @@ public class BeanValidationSubsystemTestCase extends AbstractSubsystemBaseTest {
         return new String[] {
                 "/subsystem-templates/bean-validation.xml"
         };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 }

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -71,6 +71,12 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testFullConfig() throws Exception {
         standardSubsystemTest("datasources-full.xml");
     }

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -71,6 +71,12 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.withCapabilities(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName());

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
@@ -80,6 +80,12 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected Properties getResolvedProperties() {
         Properties properties = new Properties();

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -73,6 +73,12 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void test15() throws Exception {
         standardSubsystemTest("subsystem15.xml", false);
     }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -73,6 +73,12 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testTransformerEAP620() throws Exception {
         ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_2_0;
         testTransformation(ModelVersion.create(1, 2, 1), controller,

--- a/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
+++ b/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
@@ -85,6 +85,12 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testParseEmptySubsystem() throws Exception {
         // parse the subsystem xml into operations.
         String subsystemXml =

--- a/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsSubsystemTestCase.java
+++ b/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsSubsystemTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.jaxrs;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -49,6 +50,12 @@ public class JaxrsSubsystemTestCase extends AbstractSubsystemBaseTest {
         return new String[]{
                 "/subsystem-templates/jaxrs.xml"
         };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 
     //no point in testing 1.0.0 (current) --> 1.0.0 (all previous) for transformers

--- a/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrSubsystemTestCase.java
+++ b/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrSubsystemTestCase.java
@@ -72,6 +72,13 @@ public class JdrSubsystemTestCase extends AbstractSubsystemBaseTest {
                 "/subsystem-templates/jdr.xml"
         };
     }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     //todo not sure how much sense does it make to test this as model version is exactly the same as in current version
     /*@Test
     public void testTransformersEAP620() throws Exception {

--- a/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
+++ b/jpa/subsystem/src/test/java/org/jboss/as/jpa/subsystem/JPA11SubsystemTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.jpa.subsystem;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -52,4 +53,9 @@ public class JPA11SubsystemTestCase extends AbstractSubsystemBaseTest {
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
 }

--- a/jsf/subsystem/src/test/java/org/jboss/as/jsf/subsystem/JSFSubsystemTestCase.java
+++ b/jsf/subsystem/src/test/java/org/jboss/as/jsf/subsystem/JSFSubsystemTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.jsf.subsystem;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 import java.io.IOException;
 
@@ -49,5 +50,11 @@ public class JSFSubsystemTestCase extends AbstractSubsystemBaseTest {
         return new String[] {
                 "/subsystem-templates/jsf.xml"
         };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 }

--- a/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
+++ b/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -59,4 +60,9 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
 }

--- a/legacy/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/legacy/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -69,6 +69,12 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected String getSubsystemXml(String configId) throws IOException {
         return readResource(configId);

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem30TestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem30TestCase.java
@@ -85,6 +85,12 @@ public class MessagingSubsystem30TestCase extends AbstractLegacySubsystemBaseTes
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected Properties getResolvedProperties() {
         Properties properties = new Properties();

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem20TestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem20TestCase.java
@@ -73,6 +73,12 @@ public class MailSubsystem20TestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testExpressions() throws Exception {
         standardSubsystemTest("subsystem_1_1_expressions.xml", false);
     }

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
@@ -85,6 +85,12 @@ public class MessagingActiveMQSubsystem_1_1_TestCase extends AbstractSubsystemBa
         return properties;
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     /////////////////////////////////////////
     //  Tests for HA Policy Configuration  //
     /////////////////////////////////////////

--- a/naming/src/test/java/org/jboss/as/naming/subsystem/NamingSubsystemTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/subsystem/NamingSubsystemTestCase.java
@@ -62,6 +62,12 @@ public class NamingSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testOnlyExternalContextAllowsCache() throws Exception {
         KernelServices services = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .build();

--- a/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/FederationSubsystem_2_0_UnitTestCase.java
+++ b/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/FederationSubsystem_2_0_UnitTestCase.java
@@ -62,6 +62,12 @@ public class FederationSubsystem_2_0_UnitTestCase extends AbstractSubsystemBaseT
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testRuntime() throws Exception {
         System.setProperty("jboss.server.data.dir", System.getProperty("java.io.tmpdir"));
         System.setProperty("jboss.home.dir", System.getProperty("java.io.tmpdir"));

--- a/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/IDMSubsystem_2_0_UnitTestCase.java
+++ b/picketlink/src/test/java/org/wildfly/extension/picketlink/subsystem/IDMSubsystem_2_0_UnitTestCase.java
@@ -65,6 +65,12 @@ public class IDMSubsystem_2_0_UnitTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testRuntime() throws Exception {
         System.setProperty("jboss.server.data.dir", System.getProperty("java.io.tmpdir"));
         System.setProperty("jboss.home.dir", System.getProperty("java.io.tmpdir"));

--- a/rts/src/test/java/org/wildfly/extension/rts/RTSSubsystemTestCase.java
+++ b/rts/src/test/java/org/wildfly/extension/rts/RTSSubsystemTestCase.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.rts;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
@@ -49,5 +50,11 @@ public class RTSSubsystemTestCase extends AbstractSubsystemBaseTest {
         return new String[] {
                 "/subsystem-templates/rts.xml"
         };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 }

--- a/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
+++ b/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.junit.Test;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -57,5 +58,11 @@ public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
         return new String[]{
                 "/subsystem-templates/sar.xml"
         };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 }

--- a/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv30UnitTestCase.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/SecurityDomainModelv30UnitTestCase.java
@@ -98,6 +98,12 @@ public class SecurityDomainModelv30UnitTestCase extends AbstractSubsystemBaseTes
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testTransformersEAP64() throws Exception {
         testTransformers(ModelTestControllerVersion.EAP_6_4_0);
     }

--- a/transactions/src/test/java/org/jboss/as/txn/subsystem/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/subsystem/TransactionSubsystemTestCase.java
@@ -77,6 +77,12 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected void compareXml(String configId, String original, String marshalled) throws Exception {
         String transformed = ModelTestUtils.normalizeXML(

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
@@ -100,6 +100,12 @@ public class UndertowSubsystemTestCase extends AbstractUndertowSubsystemTestCase
         return properties;
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     @Override
     protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
         return super.standardSubsystemTest(configId, false);

--- a/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemParserTestCase.java
+++ b/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemParserTestCase.java
@@ -73,6 +73,12 @@ public class WebservicesSubsystemParserTestCase extends AbstractSubsystemBaseTes
         };
     }
 
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
     protected AdditionalInitialization createAdditionalInitialization() {
         return new AdditionalInitialization() {
             @Override

--- a/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/subsystem/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -64,6 +64,12 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testSubsystem10() throws Exception {
         standardSubsystemTest("subsystem_1_0.xml", false);
     }

--- a/xts/src/test/java/org/jboss/as/xts/XTSSubsystemTestCase.java
+++ b/xts/src/test/java/org/jboss/as/xts/XTSSubsystemTestCase.java
@@ -63,6 +63,12 @@ public class XTSSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Test
     public void testBootEAP620() throws Exception {
         testBoot1_1_0(ModelTestControllerVersion.EAP_6_2_0);
     }


### PR DESCRIPTION
…es opt-in as opposed to flooding reports with @Ignored tests (WFCORE-1677)

https://issues.jboss.org/browse/WFLY-7711

WildFly part of https://issues.jboss.org/browse/WFCORE-1677 which needed needed wildfly/wildfly-core#1938 (now merged in core and here).