### PR TITLE
[WFLY-7300] Follow up to fix legacy batch subsystem boot handler

### DIFF
--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
@@ -178,7 +178,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model)
+        protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model)
                 throws OperationFailedException {
             // Check if the request-controller subsystem exists
             final boolean rcPresent = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS).hasChild(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RequestControllerExtension.SUBSYSTEM_NAME));


### PR DESCRIPTION
This is a follow up for https://github.com/wildfly/wildfly/pull/9264. With the change to the `AbstractBoottimeAddStepHandler` the `performRuntime(OperationContext, ModelNode, ModelNode)` is never invoked which failures when deploying batch application to the legacy subsystem.