### PR TITLE
WFLY-7196 The outcome of xa_commit call on non exiting transaction is silently ignored

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionCommitTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionCommitTask.java
@@ -60,12 +60,10 @@ class XidTransactionCommitTask extends XidTransactionManagementTask {
             // check the recovery store - it's possible that the commit is coming in as part of recovery operation and the subordinate
             // tx may not yet be in memory, but might be in the recovery store
             final Transaction recoveredTransaction = tryRecoveryForImportedTransaction();
-            // still not found, so just return
+            // still not found
             if (recoveredTransaction == null) {
-                if (EjbLogger.EJB3_INVOCATION_LOGGER.isDebugEnabled()) {
-                    EjbLogger.EJB3_INVOCATION_LOGGER.debug("Not committing " + this.xidTransactionID + " as is was not found on the server");
-                }
-                return;
+                EjbLogger.EJB3_INVOCATION_LOGGER.error("Not committing " + this.xidTransactionID + " as is was not found on the server");
+                throw new XAException(XAException.XAER_NOTA);
             }
         }
         this.resumeTransaction(transaction);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionPrepareTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionPrepareTask.java
@@ -91,11 +91,10 @@ class XidTransactionPrepareTask extends XidTransactionManagementTask {
             // check the recovery store - it's possible that the "prepare" is coming in as part of recovery operation and the subordinate
             // tx may not yet be in memory, but might be in the recovery store
             final Transaction recoveredTransaction = tryRecoveryForImportedTransaction();
-            // still not found, so just return
+            // still not found
             if (recoveredTransaction == null) {
-                if (EjbLogger.EJB3_INVOCATION_LOGGER.isDebugEnabled()) {
-                    EjbLogger.EJB3_INVOCATION_LOGGER.debug("Not preparing " + this.xidTransactionID + " as is was not found on the server");
-                }
+                EjbLogger.EJB3_INVOCATION_LOGGER.error("Not preparing " + this.xidTransactionID + " as is was not found on the server");
+                throw new XAException(XAException.XAER_NOTA);
             }
             return XAResource.XA_OK;
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7196