### PR TITLE
[WFLY-7221] Module slot for jms-bridge

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/CreateJMSBridgeSetupTask.java
@@ -69,6 +69,7 @@ public class CreateJMSBridgeSetupTask extends CreateQueueSetupTask {
         jmsBridgeAttributes.get("max-batch-size").set(1024);
         jmsBridgeAttributes.get("max-batch-time").set(100);
         jmsBridgeAttributes.get("add-messageID-in-header").set("true");
+        jmsBridgeAttributes.get("module").set("org.apache.activemq.artemis:main");
         jmsOperations.addJmsBridge(JMS_BRIDGE_NAME, jmsBridgeAttributes);
     }
 


### PR DESCRIPTION
In JMSBridgeTest, set module attribute to
org.apache.activemq.artemis:main to check that the module slot is taken
into account when loading the module that contains the classes required
for the JMS providers.

JIRA: https://issues.jboss.org/browse/WFLY-7721