### PR TITLE
WFLY-7728 - reduce memory usage of running server

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/validation/DoubleRangeValidatorBuilder.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/validation/DoubleRangeValidatorBuilder.java
@@ -98,7 +98,7 @@ public class DoubleRangeValidatorBuilder extends AbstractParameterValidatorBuild
         }
     }
 
-    private class DoubleRangeValidator extends ModelTypeValidator {
+    private static class DoubleRangeValidator extends ModelTypeValidator {
         private final Bound lowerBound;
         private final Bound upperBound;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
@@ -106,15 +106,15 @@ public class EJB3Extension implements Extension {
      */
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, EJB3Subsystem10Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, EJB3Subsystem11Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, EJB3Subsystem12Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_3, EJB3Subsystem13Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_4, EJB3Subsystem14Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_5, EJB3Subsystem15Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, EJB3Subsystem20Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_3_0, EJB3Subsystem30Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_4_0, EJB3Subsystem40Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_5_0, EJB3Subsystem50Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, EJB3Subsystem10Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, EJB3Subsystem11Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, EJB3Subsystem12Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_3, EJB3Subsystem13Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_4, EJB3Subsystem14Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_5, EJB3Subsystem15Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, EJB3Subsystem20Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_3_0, EJB3Subsystem30Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_4_0, EJB3Subsystem40Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_5_0, EJB3Subsystem50Parser::new);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem10Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem10Parser.java
@@ -41,9 +41,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
  */
 public class EJB3Subsystem10Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final EJB3Subsystem10Parser INSTANCE = new EJB3Subsystem10Parser();
-
-    private EJB3Subsystem10Parser() {
+    EJB3Subsystem10Parser() {
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem11Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem11Parser.java
@@ -62,9 +62,7 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
  */
 public class EJB3Subsystem11Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final EJB3Subsystem11Parser INSTANCE = new EJB3Subsystem11Parser();
-
-    private EJB3Subsystem11Parser() {
+    EJB3Subsystem11Parser() {
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -70,7 +70,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
  */
 public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final EJB3Subsystem12Parser INSTANCE = new EJB3Subsystem12Parser();
     protected static final PathAddress SUBSYSTEM_PATH = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME));
 
     protected EJB3Subsystem12Parser() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem13Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem13Parser.java
@@ -48,8 +48,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class EJB3Subsystem13Parser extends EJB3Subsystem12Parser {
 
-    public static final EJB3Subsystem13Parser INSTANCE = new EJB3Subsystem13Parser();
-
     protected EJB3Subsystem13Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem14Parser.java
@@ -40,8 +40,6 @@ import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
  */
 public class EJB3Subsystem14Parser extends EJB3Subsystem13Parser {
 
-    public static final EJB3Subsystem14Parser INSTANCE = new EJB3Subsystem14Parser();
-
     protected EJB3Subsystem14Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem15Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem15Parser.java
@@ -52,8 +52,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
  */
 public class EJB3Subsystem15Parser extends EJB3Subsystem14Parser {
 
-    public static final EJB3Subsystem15Parser INSTANCE = new EJB3Subsystem15Parser();
-
     protected EJB3Subsystem15Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
@@ -51,8 +51,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
  */
 public class EJB3Subsystem20Parser extends EJB3Subsystem14Parser {
 
-    public static final EJB3Subsystem20Parser INSTANCE = new EJB3Subsystem20Parser();
-
     protected EJB3Subsystem20Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem30Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem30Parser.java
@@ -58,8 +58,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
  */
 public class EJB3Subsystem30Parser extends EJB3Subsystem20Parser {
 
-    public static final EJB3Subsystem30Parser INSTANCE = new EJB3Subsystem30Parser();
-
     protected EJB3Subsystem30Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem40Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem40Parser.java
@@ -57,8 +57,6 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STRICT_MAX_BEAN_INS
  */
 public class EJB3Subsystem40Parser extends EJB3Subsystem30Parser {
 
-    public static final EJB3Subsystem40Parser INSTANCE = new EJB3Subsystem40Parser();
-
     protected EJB3Subsystem40Parser() {
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
@@ -55,9 +55,7 @@ import java.util.EnumSet;
  */
 public class EJB3Subsystem50Parser extends EJB3Subsystem40Parser {
 
-    public static final EJB3Subsystem50Parser INSTANCE = new EJB3Subsystem50Parser();
-
-    protected EJB3Subsystem50Parser() {
+    EJB3Subsystem50Parser() {
     }
 
     @Override

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemAdd.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemAdd.java
@@ -58,7 +58,7 @@ class JaxrsSubsystemAdd extends AbstractBoottimeAddStepHandler {
         context.addStep(new AbstractDeploymentChainStep() {
             public void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_JAXRS_ANNOTATIONS, new JaxrsAnnotationProcessor());
-                processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JAXRS_SPRING, new JaxrsSpringProcessor(serviceTarget));
+                processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JAXRS_SPRING, new JaxrsSpringProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JAXRS, new JaxrsDependencyProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_JAXRS_SCANNING, new JaxrsScanningProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_JAXRS_COMPONENT, new JaxrsComponentDeployer());

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
@@ -72,11 +72,9 @@ public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
     public static final String ENABLE_PROPERTY = "org.jboss.as.jaxrs.enableSpringIntegration";
     public static final String SERVICE_NAME = "resteasy-spring-integration-resource-root";
 
-    private final ServiceTarget serviceTarget;
     private VirtualFile resourceRoot;
 
-    public JaxrsSpringProcessor(ServiceTarget serviceTarget) {
-        this.serviceTarget = serviceTarget;
+    public JaxrsSpringProcessor() {
     }
 
     /**
@@ -85,8 +83,9 @@ public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
      * @return the Seam integration resource loader
      * @throws DeploymentUnitProcessingException
      *          for any error
+     * @param serviceTarget
      */
-    protected synchronized VirtualFile getResteasySpringVirtualFile() throws DeploymentUnitProcessingException {
+    protected synchronized VirtualFile getResteasySpringVirtualFile(ServiceTarget serviceTarget) throws DeploymentUnitProcessingException {
         if(resourceRoot != null) {
             return resourceRoot;
         }
@@ -195,7 +194,7 @@ public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
             if (found) {
                 try {
                     MountHandle mh = new MountHandle(null); // actual close is done by the MSC service above
-                    ResourceRoot resourceRoot = new ResourceRoot(getResteasySpringVirtualFile(), mh);
+                    ResourceRoot resourceRoot = new ResourceRoot(getResteasySpringVirtualFile(phaseContext.getServiceTarget()), mh);
                     ModuleRootMarker.mark(resourceRoot);
                     deploymentUnit.addToAttachmentList(Attachments.RESOURCE_ROOTS, resourceRoot);
                 } catch (Exception e) {

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging12SubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging12SubsystemParser.java
@@ -43,12 +43,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 public class Messaging12SubsystemParser extends MessagingSubsystemParser {
 
-    private static final Messaging12SubsystemParser INSTANCE = new Messaging12SubsystemParser();
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
-    }
-
     protected Messaging12SubsystemParser() {
     }
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging13SubsystemParser.java
@@ -64,12 +64,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class Messaging13SubsystemParser extends Messaging12SubsystemParser {
 
-    private static final Messaging13SubsystemParser INSTANCE = new Messaging13SubsystemParser();
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
-    }
-
     protected Messaging13SubsystemParser() {
     }
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
@@ -36,12 +36,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class Messaging14SubsystemParser extends Messaging13SubsystemParser {
 
-    private static final Messaging14SubsystemParser INSTANCE = new Messaging14SubsystemParser();
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
-    }
-
     protected Messaging14SubsystemParser() {
     }
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging20SubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging20SubsystemParser.java
@@ -54,12 +54,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class Messaging20SubsystemParser extends Messaging14SubsystemParser {
 
-    private static final Messaging20SubsystemParser INSTANCE = new Messaging20SubsystemParser();
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
-    }
-
     protected Messaging20SubsystemParser() {
     }
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging30SubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/Messaging30SubsystemParser.java
@@ -35,13 +35,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class Messaging30SubsystemParser extends Messaging20SubsystemParser {
 
-    private static final Messaging30SubsystemParser INSTANCE = new Messaging30SubsystemParser();
-
     protected Messaging30SubsystemParser() {
-    }
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
     }
 
     @Override

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -247,17 +247,17 @@ public class MessagingExtension extends AbstractLegacyExtension {
 
     @Override
     protected void initializeLegacyParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_0.getUriString(), MessagingSubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_1.getUriString(), MessagingSubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_2.getUriString(), Messaging12SubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_3.getUriString(), Messaging13SubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_4.getUriString(), Messaging14SubsystemParser.getInstance());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_0.getUriString(), MessagingSubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_1.getUriString(), MessagingSubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_2.getUriString(), Messaging12SubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_3.getUriString(), Messaging13SubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_4.getUriString(), Messaging14SubsystemParser::new);
         // the 1.5 schema is port forwarded from EAP 6.4.
         // The 1.4 schema was updated by mistake in EAP 6.4. The 1.4 parser in WildFly is updated to be able to parse these
         // elements. There are no other changes in the 1.5 schema apart from these elements so we use the 1.4 parser to parse
         // the 1.5 schema too.
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_5.getUriString(), Messaging14SubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_2_0.getUriString(), Messaging20SubsystemParser.getInstance());
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_3_0.getUriString(), Messaging30SubsystemParser.getInstance());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_5.getUriString(), Messaging14SubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_2_0.getUriString(), Messaging20SubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_3_0.getUriString(), Messaging30SubsystemParser::new);
     }
 }

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -91,11 +91,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>> {
 
-    private static final MessagingSubsystemParser INSTANCE = new MessagingSubsystemParser();
-
-    public static MessagingSubsystemParser getInstance() {
-        return INSTANCE;
-    }
 
     private static final EnumSet<Element> SIMPLE_ROOT_RESOURCE_ELEMENTS = EnumSet.noneOf(Element.class);
 

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
@@ -122,12 +122,12 @@ public class NamingExtension implements Extension {
      */
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, new NamingSubsystem10Parser(context.getProcessType() == ProcessType.APPLICATION_CLIENT));
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, NamingSubsystem11Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, NamingSubsystem12Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_3, NamingSubsystem13Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_4, NamingSubsystem14Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, NamingSubsystem20Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, () -> new NamingSubsystem10Parser(context.getProcessType() == ProcessType.APPLICATION_CLIENT));
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, NamingSubsystem11Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, NamingSubsystem12Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_3, NamingSubsystem13Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_4, NamingSubsystem14Parser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, NamingSubsystem20Parser::new);
     }
 
 

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem11Parser.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem11Parser.java
@@ -58,9 +58,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class NamingSubsystem11Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final NamingSubsystem11Parser INSTANCE = new NamingSubsystem11Parser();
-
-    private NamingSubsystem11Parser() {
+    NamingSubsystem11Parser() {
     }
 
     /**

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem12Parser.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem12Parser.java
@@ -58,9 +58,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class NamingSubsystem12Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final NamingSubsystem12Parser INSTANCE = new NamingSubsystem12Parser();
-
-    private NamingSubsystem12Parser() {
+    NamingSubsystem12Parser() {
     }
 
     /**

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem13Parser.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem13Parser.java
@@ -53,9 +53,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  */
 public class NamingSubsystem13Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final NamingSubsystem13Parser INSTANCE = new NamingSubsystem13Parser();
-
-    private NamingSubsystem13Parser() {
+    NamingSubsystem13Parser() {
     }
 
     /**

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem14Parser.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem14Parser.java
@@ -22,18 +22,6 @@
 
 package org.jboss.as.naming.subsystem;
 
-import java.util.EnumSet;
-import java.util.List;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.dmr.ModelNode;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.controller.parsing.ParseUtils.requireAttributes;
@@ -50,14 +38,28 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.LOOKUP;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.OBJECT_FACTORY;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.SIMPLE;
 
+import java.util.EnumSet;
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
 /**
  * @author Eduardo Martins
  */
 public class NamingSubsystem14Parser implements XMLElementReader<List<ModelNode>> {
 
-    public static final NamingSubsystem14Parser INSTANCE = new NamingSubsystem14Parser(NamingSubsystemNamespace.NAMING_1_4);
-
     private final NamingSubsystemNamespace validNamespace;
+
+    NamingSubsystem14Parser() {
+        this.validNamespace = NamingSubsystemNamespace.NAMING_1_4;
+    }
+
     NamingSubsystem14Parser(NamingSubsystemNamespace validNamespace) {
         this.validNamespace = validNamespace;
     }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem20Parser.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystem20Parser.java
@@ -25,11 +25,9 @@ package org.jboss.as.naming.subsystem;
 /**
  * @author Eduardo Martins
  */
-public class NamingSubsystem20Parser extends NamingSubsystem14Parser {
+class NamingSubsystem20Parser extends NamingSubsystem14Parser {
 
-    public static final NamingSubsystem20Parser INSTANCE = new NamingSubsystem20Parser();
-
-    private NamingSubsystem20Parser() {
+    NamingSubsystem20Parser() {
         super(NamingSubsystemNamespace.NAMING_2_0);
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/plugins/DefaultAuthenticationCacheFactory.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/plugins/DefaultAuthenticationCacheFactory.java
@@ -26,7 +26,6 @@ import java.security.Principal;
 import java.util.concurrent.ConcurrentMap;
 
 import org.jboss.as.security.lru.LRUCache;
-import org.jboss.as.security.lru.RemoveCallback;
 import org.jboss.security.authentication.JBossCachedAuthenticationManager.DomainInfo;
 
 /**
@@ -42,14 +41,10 @@ public class DefaultAuthenticationCacheFactory implements AuthenticationCacheFac
      * @return cache implementation
      */
     public ConcurrentMap<Principal, DomainInfo> getCache() {
-        ConcurrentMap<Principal, DomainInfo> map = new LRUCache<>(1000,  new RemoveCallback<Principal, DomainInfo>() {
-            @Override
-            public void afterRemove(Principal key, DomainInfo value) {
-                if (value != null) {
-                    value.logout();
-                }
+        return new LRUCache<>(1000, (key, value) -> {
+            if (value != null) {
+                value.logout();
             }
         });
-        return map;
     }
 }


### PR DESCRIPTION
jira https://issues.jboss.org/browse/WFLY-7728
related work in core https://github.com/wildfly/wildfly-core/pull/2005
WFLY-7728 - Don't store ServiceTarget but use one from DeploymentPhaseContext
WFLY-7728 - Remove inner class reference
WFLY-7728 - lazy create ejb3 subsystem parsers
WFLY-7728 - remove inner class reference
WFLY-7728 - Lazy load legacy messaging parsers
WFLY-7728 - Lazy load naming parsers 