### PR TITLE
WFLY-7769 WildFly artifacts have unnecessary transitive runtime dependency on org.wildfly.checkstyle:wildfly-checkstyle-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -827,6 +827,7 @@
         <dependency>
             <groupId>org.wildfly.checkstyle</groupId>
             <artifactId>wildfly-checkstyle-config</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7769