### PR TITLE
[WFLY-7699] Fix registration of runtime operations for messaging resources

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CoreAddressDefinition.java
@@ -71,6 +71,11 @@ public class CoreAddressDefinition extends SimpleResourceDefinition {
     }
 
     @Override
+    public boolean isRuntime() {
+        return true;
+    }
+
+    @Override
     public void registerAttributes(ManagementResourceRegistration registry) {
         super.registerAttributes(registry);
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -190,8 +190,8 @@ public class MessagingExtension implements Extension {
         if (registerRuntimeOnly) {
             final ManagementResourceRegistration deployment = subsystemRegistration.registerDeploymentModel(new SimpleResourceDefinition(SUBSYSTEM_PATH, getResourceDescriptionResolver("deployed")));
             final ManagementResourceRegistration deployedServer = deployment.registerSubModel(new SimpleResourceDefinition(SERVER_PATH, getResourceDescriptionResolver(SERVER)));
-            deployedServer.registerSubModel(JMSQueueDefinition.DEPLOYMENT_INSTANCE);
-            deployedServer.registerSubModel(JMSTopicDefinition.DEPLOYMENT_INSTANCE);
+            deployedServer.registerSubModel(new JMSQueueDefinition(true, registerRuntimeOnly));
+            deployedServer.registerSubModel(new JMSTopicDefinition(true, registerRuntimeOnly));
             deployedServer.registerSubModel(PooledConnectionFactoryDefinition.DEPLOYMENT_INSTANCE);
         }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -47,9 +47,6 @@ import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinitio
 import org.wildfly.extension.messaging.activemq.ha.SharedStoreMasterDefinition;
 import org.wildfly.extension.messaging.activemq.ha.SharedStoreSlaveDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryDefinition;
-import org.wildfly.extension.messaging.activemq.jms.JMSQueueDefinition;
-import org.wildfly.extension.messaging.activemq.jms.JMSTopicDefinition;
 import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -421,19 +418,19 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(JMSQueueDefinition.INSTANCE)
+                                        builder(MessagingExtension.JMS_QUEUE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DESTINATION_ENTRIES,
                                                         CommonAttributes.SELECTOR,
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.LEGACY_ENTRIES))
                                 .addChild(
-                                        builder(JMSTopicDefinition.INSTANCE)
+                                        builder(MessagingExtension.JMS_TOPIC_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DESTINATION_ENTRIES,
                                                         CommonAttributes.LEGACY_ENTRIES))
                                 .addChild(
-                                        builder(ConnectionFactoryDefinition.INSTANCE)
+                                        builder(MessagingExtension.CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -251,7 +251,7 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(QueueDefinition.INSTANCE)
+                                        builder(MessagingExtension.QUEUE_PATH)
                                                 .addAttributes(
                                                         QueueDefinition.ADDRESS,
                                                         CommonAttributes.DURABLE,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -47,9 +47,6 @@ import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinitio
 import org.wildfly.extension.messaging.activemq.ha.SharedStoreMasterDefinition;
 import org.wildfly.extension.messaging.activemq.ha.SharedStoreSlaveDefinition;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
-import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryDefinition;
-import org.wildfly.extension.messaging.activemq.jms.JMSQueueDefinition;
-import org.wildfly.extension.messaging.activemq.jms.JMSTopicDefinition;
 import org.wildfly.extension.messaging.activemq.jms.PooledConnectionFactoryDefinition;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
@@ -432,19 +429,19 @@ public class MessagingSubsystemParser_1_1 implements XMLStreamConstants, XMLElem
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(JMSQueueDefinition.INSTANCE)
+                                        builder(MessagingExtension.JMS_QUEUE_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DESTINATION_ENTRIES,
                                                         CommonAttributes.SELECTOR,
                                                         CommonAttributes.DURABLE,
                                                         CommonAttributes.LEGACY_ENTRIES))
                                 .addChild(
-                                        builder(JMSTopicDefinition.INSTANCE)
+                                        builder(MessagingExtension.JMS_TOPIC_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.DESTINATION_ENTRIES,
                                                         CommonAttributes.LEGACY_ENTRIES))
                                 .addChild(
-                                        builder(ConnectionFactoryDefinition.INSTANCE)
+                                        builder(MessagingExtension.CONNECTION_FACTORY_PATH)
                                                 .addAttributes(
                                                         ConnectionFactoryAttributes.Common.ENTRIES,
                                                         // common

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -260,7 +260,7 @@ public class MessagingSubsystemParser_1_1 implements XMLStreamConstants, XMLElem
                                                         PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
                                                         PathDefinition.RELATIVE_TO))
                                 .addChild(
-                                        builder(QueueDefinition.INSTANCE)
+                                        builder(MessagingExtension.QUEUE_PATH)
                                                 .addAttributes(
                                                         QueueDefinition.ADDRESS,
                                                         CommonAttributes.DURABLE,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueDefinition.java
@@ -80,20 +80,21 @@ public class QueueDefinition extends PersistentResourceDefinition {
             CommonAttributes.SCHEDULED_COUNT, CommonAttributes.CONSUMER_COUNT
     };
 
-    static final QueueDefinition INSTANCE = new QueueDefinition(false, MessagingExtension.QUEUE_PATH);
+    private final boolean registerRuntimeOnly;
 
-    static final QueueDefinition RUNTIME_INSTANCE = new QueueDefinition(true,  MessagingExtension.RUNTIME_QUEUE_PATH);
-
-    private final boolean runtimeOnly;
-
-    private QueueDefinition(final boolean runtimeOnly,
-                            final PathElement path) {
+    QueueDefinition(final boolean registerRuntimeOnly,
+                    final PathElement path) {
         super(path,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.QUEUE),
-                runtimeOnly ? null : QueueAdd.INSTANCE,
-                runtimeOnly ? null : QueueRemove.INSTANCE,
-                runtimeOnly);
-        this.runtimeOnly = runtimeOnly;
+                path == MessagingExtension.RUNTIME_QUEUE_PATH ? null : QueueAdd.INSTANCE,
+                path == MessagingExtension.RUNTIME_QUEUE_PATH ? null : QueueRemove.INSTANCE,
+                path == MessagingExtension.RUNTIME_QUEUE_PATH);
+        this.registerRuntimeOnly = registerRuntimeOnly;
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return getPathElement() == MessagingExtension.RUNTIME_QUEUE_PATH;
     }
 
     @Override
@@ -102,7 +103,7 @@ public class QueueDefinition extends PersistentResourceDefinition {
 
         for (SimpleAttributeDefinition attr : ATTRIBUTES) {
             if (!attr.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME)) {
-                if (runtimeOnly) {
+                if (isRuntime()) {
                     AttributeDefinition readOnlyRuntimeAttr = create(attr)
                             .setStorageRuntime()
                             .build();
@@ -131,12 +132,14 @@ public class QueueDefinition extends PersistentResourceDefinition {
     public void registerOperations(ManagementResourceRegistration registry) {
         super.registerOperations(registry);
 
-        QueueControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+        if (registerRuntimeOnly) {
+            QueueControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+        }
     }
 
     @Override
     public List<AccessConstraintDefinition> getAccessConstraints() {
-        if (runtimeOnly) {
+        if (isRuntime()) {
             return Collections.emptyList();
         } else {
             return Arrays.asList(MessagingExtension.QUEUE_ACCESS_CONSTRAINT);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -32,6 +32,7 @@ import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -525,48 +526,6 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .addOptionalRequirements(JMX_CAPABILITY)
             .build();
 
-    private static PersistentResourceDefinition[] CHILDREN = {
-            // HA policy
-            LiveOnlyDefinition.INSTANCE,
-            ReplicationMasterDefinition.INSTANCE,
-            ReplicationSlaveDefinition.INSTANCE,
-            ReplicationColocatedDefinition.INSTANCE,
-            SharedStoreMasterDefinition.INSTANCE,
-            SharedStoreSlaveDefinition.INSTANCE,
-            SharedStoreColocatedDefinition.INSTANCE,
-
-            AddressSettingDefinition.INSTANCE,
-            SecuritySettingDefinition.INSTANCE,
-
-            // Connectors
-            HTTPConnectorDefinition.INSTANCE,
-            RemoteTransportDefinition.CONNECTOR_INSTANCE,
-            InVMTransportDefinition.CONNECTOR_INSTANCE,
-            GenericTransportDefinition.CONNECTOR_INSTANCE,
-
-            // Acceptors
-            HTTPAcceptorDefinition.INSTANCE,
-            RemoteTransportDefinition.ACCEPTOR_INSTANCE,
-            InVMTransportDefinition.ACCEPTOR_INSTANCE,
-            GenericTransportDefinition.ACCEPTOR_INSTANCE,
-
-            QueueDefinition.INSTANCE,
-            BroadcastGroupDefinition.INSTANCE,
-            DiscoveryGroupDefinition.INSTANCE,
-            BridgeDefinition.INSTANCE,
-            ClusterConnectionDefinition.INSTANCE,
-            DivertDefinition.INSTANCE,
-            ConnectorServiceDefinition.INSTANCE,
-            GroupingHandlerDefinition.INSTANCE,
-
-            // JMS resources
-            JMSQueueDefinition.INSTANCE,
-            JMSTopicDefinition.INSTANCE,
-            ConnectionFactoryDefinition.INSTANCE,
-            LegacyConnectionFactoryDefinition.INSTANCE,
-            PooledConnectionFactoryDefinition.INSTANCE
-    };
-
     private final boolean registerRuntimeOnly;
 
     ServerDefinition(boolean registerRuntimeOnly) {
@@ -607,18 +566,61 @@ public class ServerDefinition extends PersistentResourceDefinition {
 
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
-        return Arrays.asList(CHILDREN);
+        List<PersistentResourceDefinition> children = new ArrayList();
+        children.addAll(Arrays.asList(
+                // HA policy
+                LiveOnlyDefinition.INSTANCE,
+                ReplicationMasterDefinition.INSTANCE,
+                ReplicationSlaveDefinition.INSTANCE,
+                ReplicationColocatedDefinition.INSTANCE,
+                SharedStoreMasterDefinition.INSTANCE,
+                SharedStoreSlaveDefinition.INSTANCE,
+                SharedStoreColocatedDefinition.INSTANCE,
+
+                AddressSettingDefinition.INSTANCE,
+                SecuritySettingDefinition.INSTANCE,
+
+                // Connectors
+                HTTPConnectorDefinition.INSTANCE,
+                RemoteTransportDefinition.CONNECTOR_INSTANCE,
+                InVMTransportDefinition.CONNECTOR_INSTANCE,
+                GenericTransportDefinition.CONNECTOR_INSTANCE,
+
+                // Acceptors
+                HTTPAcceptorDefinition.INSTANCE,
+                RemoteTransportDefinition.ACCEPTOR_INSTANCE,
+                InVMTransportDefinition.ACCEPTOR_INSTANCE,
+                GenericTransportDefinition.ACCEPTOR_INSTANCE,
+
+                BroadcastGroupDefinition.INSTANCE,
+                DiscoveryGroupDefinition.INSTANCE,
+                BridgeDefinition.INSTANCE,
+                ClusterConnectionDefinition.INSTANCE,
+                DivertDefinition.INSTANCE,
+                ConnectorServiceDefinition.INSTANCE,
+                GroupingHandlerDefinition.INSTANCE,
+
+                // JMS resources
+                JMSQueueDefinition.INSTANCE,
+                JMSTopicDefinition.INSTANCE,
+                ConnectionFactoryDefinition.INSTANCE,
+                LegacyConnectionFactoryDefinition.INSTANCE,
+                PooledConnectionFactoryDefinition.INSTANCE));
+
+        children.add(new QueueDefinition(registerRuntimeOnly, MessagingExtension.QUEUE_PATH));
+
+        return children;
     }
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
 
-        // TODO WFLY-5285 get rid of redundant .setRuntimeOnly once WFCORE-959 is integrated
-        ManagementResourceRegistration runtimeQueue = resourceRegistration.registerSubModel(QueueDefinition.RUNTIME_INSTANCE);
-        runtimeQueue.setRuntimeOnly(true);
-        ManagementResourceRegistration coreAddress = resourceRegistration.registerSubModel(CoreAddressDefinition.INSTANCE);
-        coreAddress.setRuntimeOnly(true);
+        // runtime queues and core-address are only registered when it is ok to register runtime resource (ie they are not registered on HC).
+        if (registerRuntimeOnly) {
+            resourceRegistration.registerSubModel(new QueueDefinition(registerRuntimeOnly,  MessagingExtension.RUNTIME_QUEUE_PATH));
+            resourceRegistration.registerSubModel(CoreAddressDefinition.INSTANCE);
+        }
     }
 
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -567,6 +567,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
         List<PersistentResourceDefinition> children = new ArrayList();
+        // Static resources
         children.addAll(Arrays.asList(
                 // HA policy
                 LiveOnlyDefinition.INSTANCE,
@@ -601,13 +602,14 @@ public class ServerDefinition extends PersistentResourceDefinition {
                 GroupingHandlerDefinition.INSTANCE,
 
                 // JMS resources
-                JMSQueueDefinition.INSTANCE,
-                JMSTopicDefinition.INSTANCE,
-                ConnectionFactoryDefinition.INSTANCE,
                 LegacyConnectionFactoryDefinition.INSTANCE,
                 PooledConnectionFactoryDefinition.INSTANCE));
 
+        // Dynamic resources (depending on registerRuntimeOnly)
         children.add(new QueueDefinition(registerRuntimeOnly, MessagingExtension.QUEUE_PATH));
+        children.add(new JMSQueueDefinition(false, registerRuntimeOnly));
+        children.add(new JMSTopicDefinition(false, registerRuntimeOnly));
+        children.add(new ConnectionFactoryDefinition(registerRuntimeOnly));
 
         return children;
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryDefinition.java
@@ -58,8 +58,6 @@ public class ConnectionFactoryDefinition extends PersistentResourceDefinition {
 
     private final boolean registerRuntimeOnly;
 
-    public static final ConnectionFactoryDefinition INSTANCE = new ConnectionFactoryDefinition(false);
-
     public ConnectionFactoryDefinition(final boolean registerRuntimeOnly) {
         super(MessagingExtension.CONNECTION_FACTORY_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.CONNECTION_FACTORY),

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueConfigurationRuntimeHandler.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueConfigurationRuntimeHandler.java
@@ -47,7 +47,7 @@ public class JMSQueueConfigurationRuntimeHandler extends AbstractJMSRuntimeHandl
         if (destination.hasDefined(attributeName)) {
             context.getResult().set(destination.get(attributeName));
         } else if(includeDefault) {
-            for (AttributeDefinition attr : JMSQueueDefinition.DEPLOYMENT_INSTANCE.getAttributes()) {
+            for (AttributeDefinition attr : JMSQueueDefinition.DEPLOYMENT_ATTRIBUTES) {
                 if(attr.getName().equals(attributeName)) {
                     ModelNode resultNode = context.getResult();
                     ModelNode defaultValue = attr.getDefaultValue();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueDefinition.java
@@ -58,7 +58,7 @@ public class JMSQueueDefinition extends PersistentResourceDefinition {
     /**
      * Attributes for deployed JMS queue are stored in runtime
      */
-    private static AttributeDefinition[] DEPLOYMENT_ATTRIBUTES = {
+    static AttributeDefinition[] DEPLOYMENT_ATTRIBUTES = {
             new StringListAttributeDefinition.Builder(CommonAttributes.DESTINATION_ENTRIES)
                     .setStorageRuntime()
                     .build(),
@@ -103,18 +103,16 @@ public class JMSQueueDefinition extends PersistentResourceDefinition {
             CommonAttributes.CONSUMER_COUNT
     };
 
-    public static final JMSQueueDefinition INSTANCE = new JMSQueueDefinition(false);
-
-    public static final JMSQueueDefinition DEPLOYMENT_INSTANCE = new JMSQueueDefinition(true);
-
     private final boolean deployed;
+    private final boolean registerRuntimeOnly;
 
-    private JMSQueueDefinition(final boolean deployed) {
+    public JMSQueueDefinition(final boolean deployed, final boolean registerRuntimeOnly) {
         super(MessagingExtension.JMS_QUEUE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.JMS_QUEUE),
                 deployed ? null : JMSQueueAdd.INSTANCE,
                 deployed ? null : JMSQueueRemove.INSTANCE);
         this.deployed = deployed;
+        this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
     @Override
@@ -156,10 +154,11 @@ public class JMSQueueDefinition extends PersistentResourceDefinition {
     public void registerOperations(ManagementResourceRegistration registry) {
         super.registerOperations(registry);
 
-        JMSQueueControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
-
-        if (!deployed) {
-            JMSQueueUpdateJndiHandler.registerOperations(registry, getResourceDescriptionResolver());
+        if (registerRuntimeOnly) {
+            JMSQueueControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+            if (!deployed) {
+                JMSQueueUpdateJndiHandler.registerOperations(registry, getResourceDescriptionResolver());
+            }
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
@@ -108,17 +108,16 @@ public class JMSTopicDefinition extends PersistentResourceDefinition {
     };
 
     private final boolean deployed;
+    private final boolean registerRuntimeOnly;
 
-    public static final JMSTopicDefinition INSTANCE = new JMSTopicDefinition(false);
-
-    public static final JMSTopicDefinition DEPLOYMENT_INSTANCE = new JMSTopicDefinition(true);
-
-    private JMSTopicDefinition(final boolean deployed) {
+    public JMSTopicDefinition(final boolean deployed,
+                               final boolean registerRuntimeOnly) {
         super(MessagingExtension.JMS_TOPIC_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.JMS_TOPIC),
                 deployed ? null : JMSTopicAdd.INSTANCE,
                 deployed ? null : JMSTopicRemove.INSTANCE);
         this.deployed = deployed;
+        this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
     @Override
@@ -159,11 +158,13 @@ public class JMSTopicDefinition extends PersistentResourceDefinition {
     public void registerOperations(ManagementResourceRegistration registry) {
         super.registerOperations(registry);
 
-        if (!deployed) {
-            JMSTopicUpdateJndiHandler.registerOperations(registry, getResourceDescriptionResolver());
-        }
+        if (registerRuntimeOnly) {
+            JMSTopicControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
 
-        JMSTopicControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+            if (!deployed) {
+                JMSTopicUpdateJndiHandler.registerOperations(registry, getResourceDescriptionResolver());
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
* Remove INSTANCE and RUNTIME_INSTANCE QueueDefinitions and instantiate
them depending on the server's registerRuntimeOnly to ensure that their
runtime operations are only registered when registerRuntimeOnly is true
(i.e. on domain server and not on HC).
* same thing for connection-factory, jms-topic and jms-queue resources.

JIRA: https://issues.jboss.org/browse/WFLY-7699
