### PR TITLE
WFLY-7799 Failover targets should be chosen deterministically

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -159,6 +159,7 @@ public interface Constants {
     String REQUEST_QUEUE_SIZE = "request-queue-size";
     String CACHED_CONNECTIONS_PER_THREAD = "cached-connections-per-thread";
     String CONNECTION_IDLE_TIMEOUT = "connection-idle-timeout";
+    String DETERMINISTIC_FAILOVER = "deterministic-failover";
 
     String USE_SERVER_LOG = "use-server-log";
     String VALUE = "value";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowRootDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowRootDefinition.java
@@ -161,6 +161,8 @@ class UndertowRootDefinition extends PersistentResourceDefinition {
                     .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.SSL_CONTEXT)
                     .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(1)), Constants.MAX_RETRIES)
                     .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.MAX_RETRIES)
+                    .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), Constants.DETERMINISTIC_FAILOVER)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.DETERMINISTIC_FAILOVER)
                     .end();
 
         builder.addChildResource(UndertowExtension.PATH_HANDLERS)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_4_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_4_0.java
@@ -277,6 +277,7 @@ public class UndertowSubsystemParser_4_0 extends PersistentResourceXMLParser {
                                         ModClusterDefinition.ADVERTISE_PROTOCOL,
                                         ModClusterDefinition.ADVERTISE_PATH,
                                         ModClusterDefinition.ADVERTISE_FREQUENCY,
+                                        ModClusterDefinition.DETERMINISTIC_FAILOVER,
                                         ModClusterDefinition.HEALTH_CHECK_INTERVAL,
                                         ModClusterDefinition.BROKEN_NODE_TIMEOUT,
                                         ModClusterDefinition.WORKER,

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -107,6 +107,13 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .setRestartAllServices()
             .build();
 
+    public static final AttributeDefinition DETERMINISTIC_FAILOVER = new SimpleAttributeDefinitionBuilder(Constants.DETERMINISTIC_FAILOVER, ModelType.BOOLEAN)
+            .setRequired(false)
+            .setRestartAllServices()
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
     public static final AttributeDefinition HEALTH_CHECK_INTERVAL = new SimpleAttributeDefinitionBuilder(Constants.HEALTH_CHECK_INTERVAL, ModelType.INT)
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
@@ -260,7 +267,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .build();
 
     public static final Collection<AttributeDefinition> ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(MANAGEMENT_SOCKET_BINDING, ADVERTISE_SOCKET_BINDING, SECURITY_KEY, ADVERTISE_PROTOCOL,
-                ADVERTISE_PATH, ADVERTISE_FREQUENCY, HEALTH_CHECK_INTERVAL, BROKEN_NODE_TIMEOUT, WORKER, MAX_REQUEST_TIME, MANAGEMENT_ACCESS_PREDICATE,
+            ADVERTISE_PATH, ADVERTISE_FREQUENCY, DETERMINISTIC_FAILOVER, HEALTH_CHECK_INTERVAL, BROKEN_NODE_TIMEOUT, WORKER, MAX_REQUEST_TIME, MANAGEMENT_ACCESS_PREDICATE,
             CONNECTIONS_PER_THREAD, CACHED_CONNECTIONS_PER_THREAD, CONNECTION_IDLE_TIMEOUT, REQUEST_QUEUE_SIZE, SECURITY_REALM, SSL_CONTEXT, USE_ALIAS, ENABLE_HTTP2, MAX_AJP_PACKET_SIZE,
             HTTP2_MAX_HEADER_LIST_SIZE, HTTP2_MAX_FRAME_SIZE, HTTP2_MAX_CONCURRENT_STREAMS, HTTP2_INITIAL_WINDOW_SIZE, HTTP2_HEADER_TABLE_SIZE, HTTP2_ENABLE_PUSH, MAX_RETRIES));
     public static final ModClusterDefinition INSTANCE = new ModClusterDefinition();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
@@ -64,6 +64,7 @@ public class ModClusterService extends FilterService {
     private final int requestQueueSize;
     private final boolean useAlias;
     private final int maxRetries;
+    private final boolean deterministicFailover;
 
     private ModCluster modCluster;
     private MCMPConfig config;
@@ -84,6 +85,7 @@ public class ModClusterService extends FilterService {
                       int requestQueueSize,
                       boolean useAlias,
                       int maxRetries,
+                      boolean deterministicFailover,
                       OptionMap clientOptions) {
         super(ModClusterDefinition.INSTANCE, model);
         this.healthCheckInterval = healthCheckInterval;
@@ -100,6 +102,7 @@ public class ModClusterService extends FilterService {
         this.requestQueueSize = requestQueueSize;
         this.useAlias = useAlias;
         this.maxRetries = maxRetries;
+        this.deterministicFailover = deterministicFailover;
         this.clientOptions = clientOptions;
     }
 
@@ -129,9 +132,9 @@ public class ModClusterService extends FilterService {
             XnioSsl xnioSsl = new UndertowXnioSsl(worker.getXnio(), combined, sslContext);
             modClusterBuilder = ModCluster.builder(worker, UndertowClient.getInstance(), xnioSsl);
         }
-        modClusterBuilder.setMaxRetries(maxRetries);
-        modClusterBuilder.setClientOptions(clientOptions);
-        modClusterBuilder.setHealthCheckInterval(healthCheckInterval)
+        modCluster = modClusterBuilder
+                .setClientOptions(clientOptions)
+                .setHealthCheckInterval(healthCheckInterval)
                 .setMaxRequestTime(maxRequestTime)
                 .setCacheConnections(cachedConnections)
                 .setQueueNewRequests(requestQueueSize > 0)
@@ -139,9 +142,9 @@ public class ModClusterService extends FilterService {
                 .setRemoveBrokenNodes(removeBrokenNodes)
                 .setTtl(connectionIdleTimeout)
                 .setMaxConnections(connectionsPerThread)
-                .setUseAlias(useAlias);
-
-        modCluster = modClusterBuilder
+                .setUseAlias(useAlias)
+                .setMaxRetries(maxRetries)
+                .setDeterministicFailover(deterministicFailover)
                 .build();
 
         MCMPConfig.Builder builder = MCMPConfig.builder();
@@ -257,6 +260,7 @@ public class ModClusterService extends FilterService {
                 ModClusterDefinition.REQUEST_QUEUE_SIZE.resolveModelAttribute(operationContext, model).asInt(),
                 ModClusterDefinition.USE_ALIAS.resolveModelAttribute(operationContext, model).asBoolean(),
                 ModClusterDefinition.MAX_RETRIES.resolveModelAttribute(operationContext, model).asInt(),
+                ModClusterDefinition.DETERMINISTIC_FAILOVER.resolveModelAttribute(operationContext, model).asBoolean(),
                 builder.getMap());
         ServiceBuilder<FilterService> serviceBuilder = serviceTarget.addService(UndertowService.FILTER.append(name), service);
         serviceBuilder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(ModClusterDefinition.MANAGEMENT_SOCKET_BINDING.resolveModelAttribute(operationContext, model).asString()), SocketBinding.class, service.managementSocketBinding);

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -400,6 +400,7 @@ undertow.handler.mod-cluster.security-key=The security key that is used for the 
 undertow.handler.mod-cluster.advertise-protocol=The protocol that is in use.
 undertow.handler.mod-cluster.advertise-path=The path that mod-cluster is registered under.
 undertow.handler.mod-cluster.advertise-frequency=The frequency (in milliseconds) that mod-cluster advertises itself on the network
+undertow.handler.mod-cluster.deterministic-failover=Configures whether a node upon failover is chosen deterministically from session ID.
 undertow.handler.mod-cluster.health-check-interval=The frequency of health check pings to backend nodes
 undertow.handler.mod-cluster.broken-node-timeout=The amount of time that must elapse before a broken node is removed from the table
 undertow.handler.mod-cluster.max-request-time=The max amount of time that a request to a backend node can take before it is killed

--- a/undertow/src/main/resources/schema/wildfly-undertow_4_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_4_0.xsd
@@ -587,6 +587,13 @@
         <xs:attribute name="advertise-protocol" type="xs:string" use="optional"/>
         <xs:attribute name="advertise-path" type="xs:string" use="optional"/>
         <xs:attribute name="advertise-frequency" type="xs:int" use="optional"/>
+        <xs:attribute name="deterministic-failover" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Configures whether a node upon failover is chosen deterministically from session ID.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="health-check-interval" type="xs:int" use="optional"/>
         <xs:attribute name="broken-node-timeout" type="xs:int" use="optional"/>
         <xs:attribute name="worker" type="xs:string" use="optional" />


### PR DESCRIPTION
Requires core upgrade 3.0.0.Alpha16 with undertow 1.4.8.Final.

https://issues.jboss.org/browse/WFLY-7799