### PR TITLE
WFLY-7746 Resolve incompatibility between Infinispan 8.2.x and JBM2

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ExternalizerAdapter.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ExternalizerAdapter.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.infinispan.commons.marshall.Externalizer;
+
+/**
+ * Adapts an Infinispan {@link Externalizer} to a JBM2 {@link org.jboss.marshalling.Externalizer}.
+ * @author Paul Ferraro
+ */
+public class ExternalizerAdapter implements org.jboss.marshalling.Externalizer {
+    private static final long serialVersionUID = -8895560386441863197L;
+
+    private final Externalizer<Object> externalizer;
+
+    @SuppressWarnings("unchecked")
+    public ExternalizerAdapter(Externalizer<?> externalizer) {
+        this.externalizer = (Externalizer<Object>) externalizer;
+    }
+
+    @Override
+    public void writeExternal(Object subject, ObjectOutput output) throws IOException {
+        this.externalizer.writeObject(output, subject);
+    }
+
+    @Override
+    public Object createExternal(Class<?> subjectType, ObjectInput input) throws IOException, ClassNotFoundException {
+        return this.externalizer.readObject(input);
+    }
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/JBossMarshaller.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/JBossMarshaller.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan;
+
+import org.infinispan.commons.marshall.StreamingMarshaller;
+import org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller;
+import org.jboss.marshalling.ModularClassResolver;
+import org.jboss.marshalling.ObjectTable;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * JBM2-compatible {@link StreamingMarshaller}.
+ * @author Paul Ferraro
+ */
+public class JBossMarshaller extends AbstractJBossMarshaller {
+
+    public JBossMarshaller(ModuleLoader loader) {
+        super();
+        // Override the ClassExternalizerFactory configured by the superclass with an implementation that is compatible with JBM2.
+        this.baseCfg.setClassExternalizerFactory(new SerializeWithClassExternalizerFactory());
+        this.baseCfg.setClassResolver(ModularClassResolver.getInstance(loader));
+    }
+
+    // Infinispan's object table is not available until global component registry is built.
+    public void inject(ObjectTable table) {
+        this.baseCfg.setObjectTable(table);
+    }
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/SerializeWithClassExternalizerFactory.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/SerializeWithClassExternalizerFactory.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan;
+
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import org.infinispan.commons.marshall.Externalizer;
+import org.infinispan.commons.marshall.SerializeFunctionWith;
+import org.infinispan.commons.marshall.SerializeWith;
+import org.jboss.marshalling.AnnotationClassExternalizerFactory;
+import org.jboss.marshalling.ClassExternalizerFactory;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A JBM2-compatible version of {@link org.infinispan.commons.marshall.jboss.SerializeWithExtFactory}.
+ * @author Paul Ferraro
+ */
+public class SerializeWithClassExternalizerFactory implements ClassExternalizerFactory {
+
+    private final ClassExternalizerFactory defaultFactory = new AnnotationClassExternalizerFactory();
+
+    @Override
+    public org.jboss.marshalling.Externalizer getExternalizer(Class<?> type) {
+        SerializeWith annotation = type.getAnnotation(SerializeWith.class);
+        Class<? extends Externalizer<?>> externalizerClass = (annotation != null) ? annotation.value() : null;
+        if (externalizerClass == null) {
+            SerializeFunctionWith lambdaAnnotation = type.getAnnotation(SerializeFunctionWith.class);
+            if (lambdaAnnotation != null) {
+                externalizerClass = lambdaAnnotation.value();
+            }
+        }
+        return (externalizerClass != null) ? new ExternalizerAdapter(newInstance(externalizerClass)) : this.defaultFactory.getExternalizer(type);
+    }
+
+    private static <T> T newInstance(Class<? extends T> targetClass) {
+        try {
+            PrivilegedExceptionAction<T> constructor = () -> targetClass.newInstance();
+            return WildFlySecurityManager.doUnchecked(constructor);
+        } catch (PrivilegedActionException e) {
+            throw new IllegalArgumentException(targetClass.getName());
+        }
+    }
+}

--- a/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/ExternalizerAdapter.java
+++ b/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/ExternalizerAdapter.java
@@ -32,18 +32,16 @@ import org.wildfly.clustering.marshalling.Externalizer;
  * Adapts a {@link org.wildfly.clustering.marshalling.Externalizer} to a JBoss Marshalling {@link org.jboss.marshalling.Externalizer}.
  * @author Paul Ferraro
  */
-@SuppressWarnings("deprecation")
 public class ExternalizerAdapter implements org.jboss.marshalling.Externalizer {
     private static final long serialVersionUID = 1714120446322944436L;
 
-    @SuppressWarnings("rawtypes")
-    private final Externalizer externalizer;
-
-    public ExternalizerAdapter(Externalizer<?> externalizer) {
-        this.externalizer = externalizer;
-    }
+    private final Externalizer<Object> externalizer;
 
     @SuppressWarnings("unchecked")
+    public ExternalizerAdapter(Externalizer<?> externalizer) {
+        this.externalizer = (Externalizer<Object>) externalizer;
+    }
+
     @Override
     public void writeExternal(Object subject, ObjectOutput output) throws IOException {
         this.externalizer.writeObject(output, subject);
@@ -53,5 +51,4 @@ public class ExternalizerAdapter implements org.jboss.marshalling.Externalizer {
     public Object createExternal(Class<?> subjectType, ObjectInput input) throws IOException, ClassNotFoundException {
         return this.externalizer.readObject(input);
     }
-
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
@@ -36,7 +36,6 @@ import org.jboss.as.test.integration.web.sso.LogoutServlet;
 import org.jboss.as.test.integration.web.sso.SSOTestBase;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,7 +44,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("WFLY-7747")
 public class ClusteredSingleSignOnTestCase extends ClusterAbstractTestCase {
 
     private static Logger log = Logger.getLogger(ClusteredSingleSignOnTestCase.class);


### PR DESCRIPTION
The upgrade to JBoss Marshalling 2.0.0.Beta3 completely broke clustering. This PR fixes that.
https://issues.jboss.org/browse/WFLY-7746

WFLY-7747 Restore ClusteredSingleSignOnTestCase
https://issues.jboss.org/browse/WFLY-7747