### PR TITLE
[WFLY-7836] Upgrade wildfly-arquillian from 2.0.0.Final to 2.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.build-tools>1.1.8.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Alpha16</version.org.wildfly.core>
-        <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>2.0.2.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.naming-client>1.0.0.Beta6</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-subsystem>1.0.0.Alpha17</version.org.wildfly.security.elytron-subsystem>
         <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-7836

Changes are minimal between [2.0.0.Final and 2.0.2.Final](https://github.com/wildfly/wildfly-arquillian/compare/2.0.0.Final...wildfly:2.0.2.Final). Mostly notably are the last few commits which help out the clustering tests.