### PR TITLE
[WFLY-7548]: Servletcontext.getServerInfo() returns WildFly 2.2.0.Final - 1.4.0.Final instead of 10.1.0.Final

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/RSCodeResponder.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/RSCodeResponder.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.web.headers;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -48,5 +49,12 @@ public class RSCodeResponder {
         resp.setContentType("application/json");
         resp.getOutputStream().write((CONTENT).getBytes());
         return Response.status(Integer.parseInt(code)).build();
+    }
+
+    @GET
+    @Path("server/info")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String return204(@Context ServletContext servletContext) throws Exception{
+        return servletContext.getServerInfo();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/ResponseCodeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/ResponseCodeTestCase.java
@@ -103,6 +103,16 @@ public class ResponseCodeTestCase {
         doContentTypeChecks(response, 500);
     }
 
+     @Test
+    public void testServerInfo() throws Exception {
+        final HttpGet get = new HttpGet(url.toExternalForm() + "jaxrs/test/server/info");
+        final HttpResponse response = HTTP_CLIENT.execute(get);
+         final HttpEntity entity = response.getEntity();
+         Assert.assertNotNull("Null entity!", entity);
+         final String content = EntityUtils.toString(response.getEntity());
+         Assert.assertTrue("Wrong content! " + content, content.matches("WildFly Full .*\\(WildFly Core .*\\) - .*"));
+    }
+
     /**
      * @param execute
      * @param i

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -83,7 +83,6 @@ import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.suspend.ServerActivity;
 import org.jboss.as.server.suspend.ServerActivityCallback;
 import org.jboss.as.server.suspend.SuspendController;
-import org.jboss.as.version.Version;
 import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.ServletContextAttribute;
 import org.jboss.as.web.common.WebInjectionContainer;
@@ -193,6 +192,7 @@ import static io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic.AUTHENTICAT
 import static io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic.DENY;
 import static io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic.PERMIT;
 
+import org.jboss.as.server.ServerEnvironment;
 import org.jboss.security.authentication.JBossCachedAuthenticationManager;
 
 /**
@@ -244,6 +244,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
     private final InjectedValue<Host> host = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPointInjectedValue = new InjectedValue<>();
     private final InjectedValue<SuspendController> suspendControllerInjectedValue = new InjectedValue<>();
+    private final InjectedValue<ServerEnvironment> serverEnvironmentInjectedValue = new InjectedValue<>();
     private final Map<String, InjectedValue<Executor>> executorsByName = new HashMap<String, InjectedValue<Executor>>();
     private final WebSocketDeploymentInfo webSocketDeploymentInfo;
     private final File tempDir;
@@ -412,7 +413,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
                     deploymentInfo.addThreadSetupAction(threadSetupAction);
                 }
             }
-            deploymentInfo.setServerName("WildFly " + Version.AS_VERSION);
+            deploymentInfo.setServerName(serverEnvironmentInjectedValue.getValue().getProductConfig().getPrettyVersionString());
             if (undertowService.getValue().isStatisticsEnabled()) {
                 deploymentInfo.setMetricsCollector(new UndertowMetricsCollector());
             }
@@ -1451,6 +1452,10 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
 
     public InjectedValue<SuspendController> getSuspendControllerInjectedValue() {
         return suspendControllerInjectedValue;
+    }
+
+    public InjectedValue<ServerEnvironment> getServerEnvironmentInjectedValue() {
+        return serverEnvironmentInjectedValue;
     }
 
     public Injector<Function> getSecurityFunctionInjector() {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -101,6 +101,8 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.ServerEnvironmentService;
 
 public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
 
@@ -314,6 +316,7 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
                 .addDependency(UndertowService.SERVLET_CONTAINER.append(servletContainerName), ServletContainerService.class, undertowDeploymentInfoService.getContainer())
                 .addDependency(UndertowService.UNDERTOW, UndertowService.class, undertowDeploymentInfoService.getUndertowService())
                 .addDependency(hostServiceName, Host.class, undertowDeploymentInfoService.getHost())
+                .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, undertowDeploymentInfoService.getServerEnvironmentInjectedValue())
                 .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, undertowDeploymentInfoService.getSuspendControllerInjectedValue());
         if(securityDomain != null) {
             if (knownSecurityDomain.test(securityDomain)) {


### PR DESCRIPTION
Setting the productConfig pretty string as serverName.

Jira: https://issues.jboss.org/browse/WFLY-7548
JBEAP: https://issues.jboss.org/browse/JBEAP-8053