### PR TITLE
[WFLY-7808] Security subsystem, audit provider-module lacks "module"

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/AuditResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/AuditResourceDefinition.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -38,7 +39,6 @@ public class AuditResourceDefinition extends SimpleResourceDefinition {
 
     static final ListAttributeDefinition PROVIDER_MODULES = new LegacySupport.ProviderModulesAttributeDefinition(Constants.PROVIDER_MODULES, Constants.PROVIDER_MODULE);
     private static final OperationStepHandler LEGACY_ADD_HANDLER = new LegacySupport.LegacyModulesConverter(Constants.PROVIDER_MODULE, PROVIDER_MODULES);
-
 
     private AuditResourceDefinition() {
         super(SecurityExtension.PATH_AUDIT_CLASSIC,
@@ -74,5 +74,9 @@ public class AuditResourceDefinition extends SimpleResourceDefinition {
                }
     }
 
+    static void registerTransformers_1_3_0(ResourceTransformationDescriptionBuilder parentBuilder) {
+        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(SecurityExtension.PATH_AUDIT_CLASSIC);
+        MappingProviderModuleDefinition.registerTransformers_1_3_0(builder);
+    }
 
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/MappingModuleDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/MappingModuleDefinition.java
@@ -52,10 +52,12 @@ public class MappingModuleDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .build();
 
+    protected static final SimpleAttributeDefinition MODULE = LoginModuleResourceDefinition.MODULE;
+
     protected static final PropertiesAttributeDefinition MODULE_OPTIONS = new PropertiesAttributeDefinition.Builder(Constants.MODULE_OPTIONS, true)
             .setAllowExpression(true)
             .build();
-    private static final AttributeDefinition[] ATTRIBUTES = {CODE, TYPE, LoginModuleResourceDefinition.MODULE, MODULE_OPTIONS};
+    private static final AttributeDefinition[] ATTRIBUTES = {CODE, TYPE, MODULE, MODULE_OPTIONS};
 
 
     MappingModuleDefinition(String key) {

--- a/security/subsystem/src/main/java/org/jboss/as/security/MappingProviderModuleDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/MappingProviderModuleDefinition.java
@@ -25,12 +25,22 @@
 package org.jboss.as.security;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
 
 /**
+ * This class should better be called {@code AuditProviderModuleDefinition} rather than {@code MappingProviderModuleDefinition},
+ * because it hangs under {@code AuditResourceDefinition} rather than {@code MappingResourceDefinition}.
+ *
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
  */
 public class MappingProviderModuleDefinition extends MappingModuleDefinition {
-    private static final AttributeDefinition[] ATTRIBUTES = {CODE, MODULE_OPTIONS};
+    protected static final PathElement PATH_PROVIDER_MODULE = PathElement.pathElement(Constants.PROVIDER_MODULE);
+    private static final AttributeDefinition[] ATTRIBUTES = { CODE, MODULE, MODULE_OPTIONS };
 
     MappingProviderModuleDefinition(String key) {
         super(key);
@@ -40,4 +50,13 @@ public class MappingProviderModuleDefinition extends MappingModuleDefinition {
     public AttributeDefinition[] getAttributes() {
         return ATTRIBUTES;
     }
+
+    static void registerTransformers_1_3_0(ResourceTransformationDescriptionBuilder parentBuilder) {
+        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_PROVIDER_MODULE);
+        builder.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true,
+                        new ModelNode(ModuleName.PICKETBOX.getName())), MODULE)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, MODULE).end();
+    }
+
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
@@ -257,12 +257,12 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
         AuditInfo auditInfo = new AuditInfo(securityDomain);
         for (Property moduleProperty : node.asPropertyList()) {
             ModelNode module = moduleProperty.getValue();
-            String codeName = LoginModuleResourceDefinition.CODE.resolveModelAttribute(context, module).asString();
+            String codeName = MappingProviderModuleDefinition.CODE.resolveModelAttribute(context, module).asString();
             Map<String, Object> options = extractOptions(context, module);
             AuditProviderEntry entry = new AuditProviderEntry(codeName, options);
             auditInfo.add(entry);
 
-            ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
+            ModelNode moduleName = MappingProviderModuleDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 auditInfo.addJBossModuleName(moduleName.asString());
             } else {

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.security.logging.SecurityLogger;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.as.security.service.SecurityDomainService;
@@ -218,5 +219,9 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
+    static void registerTransformers_1_3_0(ResourceTransformationDescriptionBuilder parentBuilder) {
+        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(SecurityExtension.SECURITY_DOMAIN_PATH);
+        AuditResourceDefinition.registerTransformers_1_3_0(builder);
+    }
 
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -139,6 +139,9 @@ import org.jboss.msc.service.ServiceName;
         builder.rejectChildResource(PathElement.pathElement(Constants.ELYTRON_TRUST_STORE));
         builder.rejectChildResource(PathElement.pathElement(Constants.ELYTRON_KEY_MANAGER));
         builder.rejectChildResource(PathElement.pathElement(Constants.ELYTRON_TRUST_MANAGER));
+
+        SecurityDomainResourceDefinition.registerTransformers_1_3_0(builder);
+
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, ModelVersion.create(1, 3, 0));
     }
 }

--- a/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv30.xml
+++ b/security/subsystem/src/test/resources/org/jboss/as/security/securitysubsystemv30.xml
@@ -132,6 +132,11 @@
         <security-domain name="jboss-empty-jsse" >
             <jsse server-alias="silent.planet" />
         </security-domain>
+        <security-domain name="domain-with-custom-audit-provider" >
+            <audit>
+                <provider-module code="org.myorg.security.MyCustomLogAuditProvider" module="org.myorg.security" />
+            </audit>
+        </security-domain>
     </security-domains>
     <vault code="somevault">
         <vault-option name="xyz" value="zxc"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModule.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModule.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.security.auditing;
+
+import org.jboss.logging.Logger;
+import org.jboss.security.audit.AbstractAuditProvider;
+import org.jboss.security.audit.AuditEvent;
+
+/**
+ * A simple {@link org.jboss.security.audit.AuditProvider} implementation that just logs on the INFO level.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class CustomAuditProviderModule extends AbstractAuditProvider {
+
+    private static final Logger log = Logger.getLogger(CustomAuditProviderModule.class);
+
+    public void audit(AuditEvent auditEvent) {
+        Exception e = auditEvent.getUnderlyingException();
+        if (e != null) {
+            log.info(auditEvent, e);
+        } else {
+            log.info(auditEvent);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModuleTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModuleTest.java
@@ -1,0 +1,318 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.auditing;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.security.Constants.CODE;
+import static org.jboss.as.security.Constants.FLAG;
+import static org.jboss.as.security.Constants.LOGIN_MODULE;
+import static org.jboss.as.security.Constants.MODULE;
+import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.security.Constants;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.as.test.integration.security.loginmodules.common.CustomLoginModule1;
+import org.jboss.as.test.integration.security.loginmodules.common.CustomLoginModule2;
+import org.jboss.as.test.integration.web.security.SecuredServlet;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import io.undertow.util.FlexBase64;
+
+/**
+ * Tests whether the loading of an audit provider module from a non-default JBoss module works properly.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(CustomAuditProviderModuleTest.CustomAuditProviderModuleSecurityDomainSetup.class)
+@Category(CommonCriteria.class)
+public class CustomAuditProviderModuleTest {
+
+    /**
+     * Creates two JBoss modules that host {@link CustomLoginModule1} and {@link CustomLoginModule2} respectively and then
+     * creates a security domain that uses them in a chain.
+     */
+    static class CustomAuditProviderModuleSecurityDomainSetup extends AbstractSecurityDomainSetup {
+
+        private static final Logger log = Logger.getLogger(CustomAuditProviderModuleSecurityDomainSetup.class);
+
+        private static final String SECURITY_DOMAIN_NAME = "custom-audit-module-" + RANDOM_EXECUTION_ID;
+
+        private final TestModule auditProviderJBossModule;
+
+        private final TestModule loginJBossModule;
+
+        public CustomAuditProviderModuleSecurityDomainSetup() {
+
+            final Class<?> providerModuleClass = CustomAuditProviderModule.class;
+            auditProviderJBossModule = new TestModule(providerModuleClass.getName()+ RANDOM_EXECUTION_ID, "org.picketbox", "javax.api",
+                    "org.jboss.logging");
+            JavaArchive auditJar = auditProviderJBossModule.addResource(providerModuleClass.getSimpleName() + ".jar");
+            auditJar.addClass(providerModuleClass);
+
+            Class<?> loginModuleClass = CustomLoginModule1.class;
+            loginJBossModule = new TestModule(loginModuleClass.getName()+ RANDOM_EXECUTION_ID, "org.picketbox", "javax.api", "org.jboss.logging");
+            JavaArchive loginJar = loginJBossModule.addResource(loginModuleClass.getSimpleName() + ".jar");
+            loginJar.addClass(loginModuleClass);
+        }
+
+        @Override
+        protected String getSecurityDomainName() {
+            return SECURITY_DOMAIN_NAME;
+        }
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws IOException {
+
+            auditProviderJBossModule.create(true);
+            loginJBossModule.create(true);
+
+            log.debug("start of the domain creation");
+
+            final ModelNode compositeOp = new ModelNode();
+            compositeOp.get(OP).set(COMPOSITE);
+            compositeOp.get(OP_ADDR).setEmptyList();
+
+            ModelNode steps = compositeOp.get(STEPS);
+            PathAddress address = PathAddress.pathAddress().append(SUBSYSTEM, "security").append(SECURITY_DOMAIN,
+                    getSecurityDomainName());
+
+            steps.add(Util.createAddOperation(address));
+            PathAddress authAddress = address.append(Constants.AUTHENTICATION, Constants.CLASSIC);
+            steps.add(Util.createAddOperation(authAddress));
+
+            final Class<?> loginModuleClass = CustomLoginModule1.class;
+            ModelNode loginModule1 = Util
+                    .createAddOperation(authAddress.append(LOGIN_MODULE, loginModuleClass.getSimpleName()));
+            loginModule1.get(CODE).set(loginModuleClass.getName());
+            loginModule1.get(MODULE).set(loginJBossModule.getName());
+            loginModule1.get(FLAG).set("required");
+            loginModule1.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            steps.add(loginModule1);
+
+
+            PathAddress auditAddress = address.append(Constants.AUDIT, Constants.CLASSIC);
+            steps.add(Util.createAddOperation(auditAddress));
+
+            final Class<?> auditProviderClass = CustomAuditProviderModule.class;
+            ModelNode auditProvider = Util
+                    .createAddOperation(auditAddress.append(Constants.PROVIDER_MODULE, auditProviderClass.getSimpleName()));
+            auditProvider.get(CODE).set(auditProviderClass.getName());
+            auditProvider.get(MODULE).set(auditProviderJBossModule.getName());
+            auditProvider.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            steps.add(auditProvider);
+
+
+            ModelNode addAuditLogOp = Util.createAddOperation(PathAddress.pathAddress().append(SUBSYSTEM, "logging")
+                    .append("periodic-rotating-file-handler", AUDIT_HANDLER_NAME));
+            addAuditLogOp.get("level").set("TRACE");
+            addAuditLogOp.get("append").set("true");
+            addAuditLogOp.get("suffix").set(".yyyy-MM-dd");
+            ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(AUDIT_LOG_FILE_NAME);
+            addAuditLogOp.get("file").set(file);
+            addAuditLogOp.get("formatter").set("%-5p %c %s%E%n");
+            steps.add(addAuditLogOp);
+
+            ModelNode addAuditLoggerOp = Util.createAddOperation(PathAddress.pathAddress().append(SUBSYSTEM, "logging")
+                    .append("logger", CustomAuditProviderModule.class.getName()));
+            addAuditLoggerOp.get("level").set("TRACE");
+            addAuditLoggerOp.get("handlers").add(AUDIT_HANDLER_NAME);
+            steps.add(addAuditLoggerOp);
+            applyUpdates(managementClient.getControllerClient(), Arrays.asList(compositeOp));
+
+            log.debug("end of the domain creation");
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) {
+            super.tearDown(managementClient, containerId);
+
+            auditProviderJBossModule.remove();
+            loginJBossModule.remove();
+
+        }
+
+    }
+
+    private static final Charset UTF_8 = Charset.forName("utf-8");
+    private static String RANDOM_EXECUTION_ID = String.valueOf(UUID.randomUUID().toString().replace("-", ""));
+    private static final String AUDIT_HANDLER_NAME;
+    private static final String AUDIT_LOG_FILE_NAME;
+    private static Path AUDIT_LOG_PATH;
+
+    static {
+        /*
+         * Let's make both the audit handler name and the audit log file specific for this class and execution so that we do not
+         * interfere with other test classes or multiple subsequent executions of this class against the same container
+         */
+        AUDIT_HANDLER_NAME = "audit-" + CustomAuditProviderModuleTest.class.getSimpleName() + "-" + RANDOM_EXECUTION_ID;
+        AUDIT_LOG_FILE_NAME = AUDIT_HANDLER_NAME + ".log";
+        AUDIT_LOG_PATH = new File(System.getProperty("jboss.home", null),
+                "standalone" + File.separator + "log" + File.separator + AUDIT_LOG_FILE_NAME).toPath();
+    }
+
+    private static void assertAuditLog(BufferedReader reader, String regex) throws Exception {
+
+        Pattern successPattern = Pattern.compile(regex);
+
+        // we'll be actively waiting for a given INTERVAL for the record to appear
+        final long deadline = 5000 + System.currentTimeMillis();
+        String line;
+        while (true) {
+            // some new lines were added -> go trough those and check whether our record is present
+            while (null != (line = reader.readLine())) {
+                if (successPattern.matcher(line).find()) {
+                    return;
+                }
+            }
+            // record not written to log yet -> continue checking if the time has not yet expired
+            if (System.currentTimeMillis() > deadline) {
+                // time expired
+                throw new AssertionError(
+                        "Login record has not been written into audit log! (time expired). Checked regex=" + regex);
+            }
+        }
+
+    }
+
+    @Deployment
+    public static WebArchive deployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, CustomAuditProviderModuleTest.class.getSimpleName() + ".war");
+        war.addClass(SecuredServlet.class);
+        war.addAsWebInfResource(new StringAsset("<jboss-web>" + //
+                "<security-domain>" + CustomAuditProviderModuleSecurityDomainSetup.SECURITY_DOMAIN_NAME + "</security-domain>" //
+                + "<disable-audit>false</disable-audit>" //
+                + "</jboss-web>"), "jboss-web.xml");
+        war.addAsWebInfResource(new StringAsset("<web-app>" //
+                + " <login-config>" //
+                + " <auth-method>BASIC</auth-method>" //
+                + " </login-config>" //
+                + " </web-app>"), "web.xml");
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    private void assertResponse(String user, String password, int expectedStatusCode) throws Exception {
+
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+
+            HttpGet request = new HttpGet(url.toExternalForm() + "secured/");
+
+            if (password != null) {
+                request.addHeader(HttpHeaders.AUTHORIZATION,
+                        "Basic " + FlexBase64.encodeString((user + ":" + password).getBytes("utf-8"), false));
+            }
+
+            HttpResponse response = httpclient.execute(request);
+            HttpEntity entity = response.getEntity();
+            StatusLine statusLine = response.getStatusLine();
+            assertEquals(expectedStatusCode, statusLine.getStatusCode());
+            if (statusLine.getStatusCode() == 200) {
+                String body = EntityUtils.toString(entity, "utf-8");
+                assertEquals("GOOD", body);
+            } else {
+                EntityUtils.consume(entity);
+            }
+        }
+    }
+
+    @Test
+    public void testBaduser1() throws Exception {
+        /*
+         * baduser1 can authenticate, because we use the correct password, but he does not have the "gooduser" role required by
+         * SecuredServlet and the server thus return 403 rather than 401
+         */
+        assertResponse(CustomLoginModule1.BADUSER1_USERNAME, CustomLoginModule1.BADUSER1_PASSWORD, 403);
+
+        try (BufferedReader r = Files.newBufferedReader(AUDIT_LOG_PATH, UTF_8)) {
+            assertAuditLog(r, Pattern.quote("INFO  " + CustomAuditProviderModule.class.getName() + " [Success]principal="
+                    + CustomLoginModule1.BADUSER1_USERNAME + ";"));
+        }
+    }
+
+    @Test
+    public void testGooduser1() throws Exception {
+        assertResponse(CustomLoginModule1.GOODUSER1_USERNAME, CustomLoginModule1.GOODUSER1_PASSWORD, 200);
+        try (BufferedReader r = Files.newBufferedReader(AUDIT_LOG_PATH, UTF_8)) {
+            assertAuditLog(r, Pattern.quote("INFO  " + CustomAuditProviderModule.class.getName() + " [Success]principal="
+                    + CustomLoginModule1.GOODUSER1_USERNAME + ";"));
+        }
+    }
+
+    @Test
+    public void testGooduser1WithBadPassword() throws Exception {
+        assertResponse(CustomLoginModule1.GOODUSER1_USERNAME, "bogus", 401);
+        try (BufferedReader r = Files.newBufferedReader(AUDIT_LOG_PATH, UTF_8)) {
+            assertAuditLog(r, Pattern.quote("INFO  " + CustomAuditProviderModule.class.getName() + " [Failure]"));
+        }
+    }
+
+}


### PR DESCRIPTION
attribute

https://issues.jboss.org/browse/WFLY-7808

Related downstream issues:
* https://issues.jboss.org/browse/JBEAP-8089
* https://issues.jboss.org/browse/JBEAP-8090
* https://bugzilla.redhat.com/show_bug.cgi?id=1392436