### PR TITLE
[WFLY-7857] Fix http-acceptor service names

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorRemove.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorRemove.java
@@ -22,13 +22,9 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.LEGACY;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -41,19 +37,19 @@ public class HTTPAcceptorRemove extends AbstractRemoveStepHandler {
     static final HTTPAcceptorRemove INSTANCE = new HTTPAcceptorRemove();
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final String name = context.getCurrentAddressValue();
-        context.removeService(HTTPUpgradeService.UPGRADE_SERVICE_NAME.append(name));
+        final String acceptorName = context.getCurrentAddressValue();
+        final String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        context.removeService(MessagingServices.getHttpUpgradeServiceName(serverName, acceptorName));
 
         boolean upgradeLegacy = HTTPAcceptorDefinition.UPGRADE_LEGACY.resolveModelAttribute(context, model).asBoolean();
         if (upgradeLegacy) {
-            context.removeService(HTTPUpgradeService.UPGRADE_SERVICE_NAME.append(name, LEGACY));
+            context.removeService(MessagingServices.getLegacyHttpUpgradeServiceName(serverName, acceptorName));
         }
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        String activeMQServerName = address.getElement(address.size() - 2).getValue();
-        String acceptorName = address.getLastElement().getValue();
-        HTTPAcceptorAdd.INSTANCE.launchServices(context, activeMQServerName, acceptorName, model);
+        final String acceptorName = context.getCurrentAddressValue();
+        final String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        HTTPAcceptorAdd.INSTANCE.launchServices(context, serverName, acceptorName, model);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -31,7 +31,6 @@ import static org.hornetq.core.remoting.impl.netty.NettyConnector.HORNETQ_REMOTI
 import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_ACCEPT;
 import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_KEY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CORE;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.LEGACY;
 
 import java.io.IOException;
 import java.util.Map;
@@ -51,7 +50,6 @@ import org.jboss.as.remoting.HttpListenerRegistryService;
 import org.jboss.as.remoting.SimpleHttpUpgradeHandshake;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
@@ -70,9 +68,6 @@ import org.xnio.netty.transport.WrappingXnioSocketChannel;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
  */
 public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
-
-    public static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
-    public static final ServiceName UPGRADE_SERVICE_NAME = MessagingServices.JBOSS_MESSAGING_ACTIVEMQ.append("http-upgrade-service");
 
     private final String activeMQServerName;
     private final String acceptorName;
@@ -97,8 +92,8 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
 
         final HTTPUpgradeService service = new HTTPUpgradeService(activeMQServerName, acceptorName, httpListenerName);
 
-        serviceTarget.addService(UPGRADE_SERVICE_NAME.append(acceptorName), service)
-                .addDependency(HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
+        serviceTarget.addService(MessagingServices.getHttpUpgradeServiceName(activeMQServerName, acceptorName), service)
+                .addDependency(MessagingServices.HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
                 .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.listenerRegistry)
                 .addDependency(ActiveMQActivationService.getServiceName(MessagingServices.getActiveMQServiceName(activeMQServerName)))
                 .setInitialMode(ServiceController.Mode.PASSIVE)
@@ -240,8 +235,8 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
 
             final LegacyHttpUpgradeService service = new LegacyHttpUpgradeService(activeMQServerName, acceptorName, httpListenerName);
 
-            serviceTarget.addService(UPGRADE_SERVICE_NAME.append(acceptorName, LEGACY), service)
-                    .addDependency(HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
+            serviceTarget.addService(MessagingServices.getLegacyHttpUpgradeServiceName(activeMQServerName, acceptorName), service)
+                    .addDependency(MessagingServices.HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
                     .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.listenerRegistry)
                     .addDependency(ActiveMQActivationService.getServiceName(MessagingServices.getActiveMQServiceName(activeMQServerName)))
                     .setInitialMode(ServiceController.Mode.PASSIVE)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -37,6 +37,7 @@ public class MessagingServices {
      * The service name is "jboss.messaging-activemq"
      */
     static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
+    static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
 
    public static ServiceName getActiveMQServiceName(PathAddress pathAddress) {
          // We need to figure out what ActiveMQ this operation is targeting.
@@ -72,7 +73,15 @@ public class MessagingServices {
        return serverServiceName.append(CommonAttributes.QUEUE);
    }
 
-   public static ServiceName getJMSBridgeServiceName(String bridgeName) {
+    static ServiceName getHttpUpgradeServiceName(String activemqServerName, String acceptorName) {
+        return getActiveMQServiceName(activemqServerName).append("http-upgrade-service", acceptorName);
+    }
+
+    static ServiceName getLegacyHttpUpgradeServiceName(String activemqServerName, String acceptorName) {
+        return getActiveMQServiceName(activemqServerName).append(CommonAttributes.LEGACY, "http-upgrade-service", acceptorName);
+    }
+
+    public static ServiceName getJMSBridgeServiceName(String bridgeName) {
        return JBOSS_MESSAGING_ACTIVEMQ.append(JMS_BRIDGE).append(bridgeName);
    }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -302,7 +302,7 @@ class ServerAdd extends AbstractAddStepHandler {
                 if (model.hasDefined(HTTP_ACCEPTOR)) {
                     for (final Property property : model.get(HTTP_ACCEPTOR).asPropertyList()) {
                         String httpListener = HTTPAcceptorDefinition.HTTP_LISTENER.resolveModelAttribute(context, property.getValue()).asString();
-                        serviceBuilder.addDependency(HTTPUpgradeService.HTTP_UPGRADE_REGISTRY.append(httpListener));
+                        serviceBuilder.addDependency(MessagingServices.HTTP_UPGRADE_REGISTRY.append(httpListener));
                     }
                 }
 


### PR DESCRIPTION
Use server name in the messagin's http-acceptor ServiceName to uniquely
identify the services for http-acceptor with the same name belonging to
two different server resources.

JIRA: https://issues.jboss.org/browse/WFLY-7857