### PR TITLE
[WFLY-7858] Use the same order for the security-domain element in the produced configuration  file and the persisted configuration file as used in the schema.

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
@@ -46,9 +46,9 @@ public class BatchSubsystemWriter implements XMLElementWriter<SubsystemMarshalli
         context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
         final ModelNode model = context.getModelNode();
         BatchSubsystemDefinition.DEFAULT_JOB_REPOSITORY.marshallAsElement(model, writer);
-        BatchSubsystemDefinition.SECURITY_DOMAIN.marshallAsElement(model, writer);
         BatchSubsystemDefinition.DEFAULT_THREAD_POOL.marshallAsElement(model, writer);
         BatchSubsystemDefinition.RESTART_JOBS_ON_RESUME.marshallAsElement(model, writer);
+        BatchSubsystemDefinition.SECURITY_DOMAIN.marshallAsElement(model, writer);
 
         // Write the in-memory job repositories
         if (model.hasDefined(InMemoryJobRepositoryDefinition.NAME)) {

--- a/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
+++ b/batch/extension-jberet/src/main/resources/subsystem-templates/batch-jberet.xml
@@ -29,8 +29,8 @@
     <extension-module>org.wildfly.extension.batch.jberet</extension-module>
     <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
         <default-job-repository name="in-memory"/>
-        <?ELYTRON?>
         <default-thread-pool name="batch"/>
+        <?ELYTRON?>
         <job-repository name="in-memory">
             <in-memory/>
         </job-repository>

--- a/batch/extension-jberet/src/test/resources/security-domain-subsystem.xml
+++ b/batch/extension-jberet/src/test/resources/security-domain-subsystem.xml
@@ -16,9 +16,9 @@
 
 <subsystem xmlns="urn:jboss:domain:batch-jberet:2.0">
     <default-job-repository name="in-memory"/>
-    <security-domain name="ApplicationDomain"/>
     <default-thread-pool name="batch"/>
     <restart-jobs-on-resume value="false"/>
+    <security-domain name="ApplicationDomain"/>
     <job-repository name="in-memory">
         <in-memory/>
     </job-repository>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -98,6 +98,11 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     }
 
     @Test
+    public void testStandaloneElytron() throws Exception {
+        parseXml("standalone/configuration/standalone-elytron.xml");
+    }
+
+    @Test
     public void testStandaloneHA() throws Exception {
         parseXml("standalone/configuration/standalone-ha.xml");
     }


### PR DESCRIPTION
Ensures the persisted configuration file writes the elements in the same sequence the schema defines them. Also fixes the position in the default configurations.

The second commit just adds a test for the `standalone-elytron.xml` file. This can be squashed or removed. However it does seem like we should have it as we would have found this issue earlier if it was present.