### PR TITLE
WFLY-7874 Configuring SSLContext in mod_cluster filter fails with "Ca…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AbstractHandlerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AbstractHandlerDefinition.java
@@ -49,9 +49,6 @@ public abstract class AbstractHandlerDefinition extends PersistentResourceDefini
             new SensitivityClassification(UndertowExtension.SUBSYSTEM_NAME, "undertow-filter", false, false, false)
     ).wrapAsList();
 
-
-    protected final String name;
-
     protected AbstractHandlerDefinition(final String name, AbstractAddStepHandler addHandler, AbstractRemoveStepHandler removeHandler) {
         this(name, Constants.HANDLER, addHandler, removeHandler);
     }
@@ -60,17 +57,17 @@ public abstract class AbstractHandlerDefinition extends PersistentResourceDefini
         this(name, Constants.HANDLER);
     }
 
-
     protected AbstractHandlerDefinition(final String name, String prefix, AbstractAddStepHandler addHandler, AbstractRemoveStepHandler removeHandler) {
         super(PathElement.pathElement(name), UndertowExtension.getResolver(prefix, name), addHandler, removeHandler);
-        this.name = name;
     }
 
     protected AbstractHandlerDefinition(final String name, String prefix) {
         super(PathElement.pathElement(name), UndertowExtension.getResolver(prefix, name));
-        this.name = name;
     }
 
+    protected AbstractHandlerDefinition(final Parameters parameters) {
+        super(parameters);
+    }
 
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
@@ -96,11 +93,6 @@ public abstract class AbstractHandlerDefinition extends PersistentResourceDefini
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public String getXmlElementName() {
-        return this.name;
     }
 
     protected static class DefaultHandlerRemove extends AbstractRemoveStepHandler {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Handler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Handler.java
@@ -35,8 +35,6 @@ import org.jboss.dmr.ModelNode;
 public interface Handler {
     Collection<AttributeDefinition> getAttributes();
 
-    String getXmlElementName();
-
     Class<? extends HttpHandler> getHandlerClass();
 
     HttpHandler createHttpHandler(final Predicate predicate, final ModelNode model, final HttpHandler next);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/Filter.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/Filter.java
@@ -58,11 +58,6 @@ abstract class Filter extends AbstractHandlerDefinition {
 
     }
 
-    @Override
-    public String getXmlElementName() {
-        return name;
-    }
-
     public HttpHandler createHttpHandler(final Predicate predicate, final ModelNode model, HttpHandler next) {
         List<AttributeDefinition> attributes = new ArrayList<>(getAttributes());
         HttpHandler handler = createHandler(getHandlerClass(), model, attributes, next);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
@@ -1,6 +1,6 @@
 package org.wildfly.extension.undertow.filters;
 
-import static org.wildfly.extension.undertow.filters.ModClusterDefinition.SSL_CONTEXT_CAPABILITY;
+import static org.wildfly.extension.undertow.filters.ModClusterDefinition.SSL_CONTEXT_CAPABILITY_NAME;
 import io.undertow.Handlers;
 import io.undertow.UndertowOptions;
 import io.undertow.client.UndertowClient;
@@ -278,7 +278,7 @@ public class ModClusterService extends FilterService {
         serviceBuilder.addDependency(IOServices.WORKER.append(ModClusterDefinition.WORKER.resolveModelAttribute(operationContext, model).asString()), XnioWorker.class, service.workerInjectedValue);
 
         if (sslContext.isDefined()) {
-            serviceBuilder.addDependency(operationContext.getCapabilityServiceName(SSL_CONTEXT_CAPABILITY, sslContext.asString(), SSLContext.class), SSLContext.class, service.sslContext);
+            serviceBuilder.addDependency(operationContext.getCapabilityServiceName(SSL_CONTEXT_CAPABILITY_NAME, sslContext.asString(), SSLContext.class), SSLContext.class, service.sslContext);
         }
         if(securityRealm.isDefined()) {
             SecurityRealm.ServiceUtil.addDependency(serviceBuilder, service.securityRealm, securityRealm.asString(), false);


### PR DESCRIPTION
…pability 'org.wildfly.undertow.mod_cluster_filter.modcluster' is unknown in context 'global'."

Jira
https://issues.jboss.org/browse/WFLY-7874