### PR TITLE
[WFLY-7879] JMS bridge not able to lookup remote destination

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -55,7 +55,7 @@
         <module name="org.picketbox"/>
         <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote
              WildFly server [AS7-6549] -->
-        <module name="org.wildfly.naming-client" optional="true"/>
+        <module name="org.wildfly.naming-client" optional="true"  services="import"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
         <module name="sun.jdk"/>
         <!-- supported protocols (in addition to the CORE protocol) -->


### PR DESCRIPTION
* add services="import" to org.wildfly.naming-client dependency so that
  the NamingProviderFactory implementations can be found and the JMS
  bridge can perform JNDI look up on a remote server.

JIRA: https://issues.jboss.org/browse/WFLY-7879