### PR TITLE
WFLY-7924 adding reload-required flag...

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
@@ -98,6 +98,7 @@ public class Constants {
             .setMeasurementUnit(MeasurementUnit.MINUTES)
             .setAllowExpression(true)
             .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, true, true))
+            .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition BACKGROUNDVALIDATIONMILLIS = new SimpleAttributeDefinitionBuilder(BACKGROUNDVALIDATIONMILLIS_NAME, ModelType.LONG, true)
@@ -105,24 +106,28 @@ public class Constants {
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setValidator(new IntRangeValidator(1, true, true))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition BACKGROUNDVALIDATION = new SimpleAttributeDefinitionBuilder(BACKGROUNDVALIDATION_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Validation.Tag.BACKGROUND_VALIDATION.getLocalName())
             .setAllowExpression(true)
             //.setDefaultValue(new ModelNode(Defaults.BACKGROUND_VALIDATION))
+            .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition USE_FAST_FAIL = new SimpleAttributeDefinitionBuilder(USE_FAST_FAIL_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Validation.Tag.USE_FAST_FAIL.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.USE_FAST_FAIL))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     public static SimpleAttributeDefinition VALIDATE_ON_MATCH = new SimpleAttributeDefinitionBuilder(VALIDATEONMATCH_NAME, ModelType.BOOLEAN, true)
-                .setXmlName(Validation.Tag.VALIDATE_ON_MATCH.getLocalName())
-                .setAllowExpression(true)
-                .build();
+            .setXmlName(Validation.Tag.VALIDATE_ON_MATCH.getLocalName())
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
 
     public static final SimpleAttributeDefinition MAX_POOL_SIZE = new SimpleAttributeDefinitionBuilder(MAX_POOL_SIZE_NAME, ModelType.INT, true)
             .setXmlName(Pool.Tag.MAX_POOL_SIZE.getLocalName())
@@ -144,8 +149,8 @@ public class Constants {
 
     public static SimpleAttributeDefinition CAPACITY_INCREMENTER_CLASS = new SimpleAttributeDefinitionBuilder(CAPACITY_INCREMENTER_CLASS_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
-
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     public static PropertiesAttributeDefinition CAPACITY_INCREMENTER_PROPERTIES = new PropertiesAttributeDefinition.Builder(CAPACITY_INCREMENTER_PROPERTIES_NAME, true)
@@ -161,15 +166,16 @@ public class Constants {
                         writer.writeCharacters(property.asProperty().getValue().asString());
                         writer.writeEndElement();
                     }
-
                 }
 
             })
+            .setRestartAllServices()
             .build();
 
     public static SimpleAttributeDefinition CAPACITY_DECREMENTER_CLASS = new SimpleAttributeDefinitionBuilder(CAPACITY_DECREMENTER_CLASS_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     public static PropertiesAttributeDefinition CAPACITY_DECREMENTER_PROPERTIES = new PropertiesAttributeDefinition.Builder(CAPACITY_DECREMENTER_PROPERTIES_NAME, true)
@@ -185,10 +191,10 @@ public class Constants {
                         writer.writeCharacters(property.asProperty().getValue().asString());
                         writer.writeEndElement();
                     }
-
                 }
 
             })
+            .setRestartAllServices()
             .build();
 
 
@@ -196,6 +202,7 @@ public class Constants {
             .setDefaultValue(new ModelNode(Defaults.PREFILL))
             .setAllowExpression(true)
             .setXmlName(Pool.Tag.PREFILL.getLocalName())
+            .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition POOL_FAIR = new SimpleAttributeDefinitionBuilder(POOL_FAIR_NAME, ModelType.BOOLEAN, true)
@@ -217,6 +224,7 @@ public class Constants {
             .setAllowExpression(true)
             .setAllowedValues(Stream.of(FlushStrategy.values()).map(FlushStrategy::toString).filter(Objects::nonNull).toArray(String[]::new))
             .setValidator(new EnumValidator<FlushStrategy>(FlushStrategy.class, true, true))
+            .setRestartAllServices()
             .build();
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.core.api.connectionmanager.pool.PoolConfiguration;
+import org.jboss.jca.core.api.management.ConnectionFactory;
 import org.jboss.jca.core.api.management.Connector;
 import org.jboss.jca.core.api.management.DataSource;
 import org.jboss.jca.core.api.management.ManagementRepository;
@@ -96,7 +97,7 @@ public class PoolConfigurationRWHandler {
                                                final ModelNode currentValue, final HandbackHolder<List<PoolConfiguration>> handbackHolder) throws OperationFailedException {
 
             final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-            final String jndiName = address.getLastElement().getValue();
+            final String poolName = address.getLastElement().getValue();
 
             final ServiceController<?> managementRepoService = context.getServiceRegistry(false).getService(
                     ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE);
@@ -104,7 +105,7 @@ public class PoolConfigurationRWHandler {
             if (managementRepoService != null) {
                 try {
                     final ManagementRepository repository = (ManagementRepository) managementRepoService.getValue();
-                    poolConfigs = getMatchingPoolConfigs(jndiName, repository);
+                    poolConfigs = getMatchingPoolConfigs(poolName, repository);
                     updatePoolConfigs(poolConfigs, parameterName, newValue);
                     handbackHolder.setHandback(poolConfigs);
                 } catch (Exception e) {
@@ -164,14 +165,13 @@ public class PoolConfigurationRWHandler {
             super();
         }
 
-        protected List<PoolConfiguration> getMatchingPoolConfigs(String jndiName, ManagementRepository repository) {
+        protected List<PoolConfiguration> getMatchingPoolConfigs(String poolName, ManagementRepository repository) {
             ArrayList<PoolConfiguration> result = new ArrayList<PoolConfiguration>(repository.getDataSources().size());
             if (repository.getDataSources() != null) {
                 for (DataSource ds : repository.getDataSources()) {
-                    if (jndiName.equalsIgnoreCase(ds.getJndiName())) {
+                    if (poolName.equalsIgnoreCase(ds.getPool().getName())) {
                         result.add(ds.getPoolConfiguration());
                     }
-
                 }
             }
             result.trimToSize();
@@ -188,17 +188,19 @@ public class PoolConfigurationRWHandler {
             super();
         }
 
-        protected List<PoolConfiguration> getMatchingPoolConfigs(String jndiName, ManagementRepository repository) {
+        protected List<PoolConfiguration> getMatchingPoolConfigs(String poolName, ManagementRepository repository) {
             ArrayList<PoolConfiguration> result = new ArrayList<PoolConfiguration>(repository.getConnectors().size());
             if (repository.getConnectors() != null) {
                 for (Connector conn : repository.getConnectors()) {
-                    if (jndiName.equalsIgnoreCase(conn.getUniqueId())) {
-                        if (conn.getConnectionFactories() == null || conn.getConnectionFactories().get(0) == null)
-                            continue;
+                    if (conn.getConnectionFactories() == null || conn.getConnectionFactories().get(0) == null
+                            || conn.getConnectionFactories().get(0).getPool() == null)
+                        continue;
+
+                    ConnectionFactory connectionFactory = conn.getConnectionFactories().get(0);
+                    if (poolName.equals(connectionFactory.getPool().getName())) {
                         PoolConfiguration pc = conn.getConnectionFactories().get(0).getPoolConfiguration();
                         result.add(pc);
                     }
-
                 }
             }
             result.trimToSize();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
@@ -152,6 +152,9 @@ public class PoolConfigurationRWHandler {
                 if (VALIDATE_ON_MATCH.getName().equals(parameterName)) {
                     pc.setValidateOnMatch(newValue.asBoolean());
                 }
+                if (POOL_FAIR.getName().equals(parameterName)) {
+                    pc.setFair(newValue.asBoolean());
+                }
             }
         }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -263,12 +263,14 @@ public class Constants {
     static SimpleAttributeDefinition CONNECTION_URL = new SimpleAttributeDefinitionBuilder(CONNECTION_URL_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
             .setXmlName(DataSource.Tag.CONNECTION_URL.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition DRIVER_CLASS = new SimpleAttributeDefinitionBuilder(DATASOURCE_DRIVER_CLASS_NAME, ModelType.STRING)
             .setAllowNull(true)
             .setAllowExpression(true)
             .setXmlName(DataSource.Tag.DRIVER_CLASS.getLocalName())
+            .setRestartAllServices()
             .build();
 
 
@@ -276,6 +278,7 @@ public class Constants {
             .setXmlName(DataSource.Tag.DATASOURCE_CLASS.getLocalName())
             .setAllowExpression(true)
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition JNDI_NAME = new SimpleAttributeDefinitionBuilder(JNDINAME_NAME, ModelType.STRING, false)
@@ -303,23 +306,27 @@ public class Constants {
                     validateParameter(parameterName, value.resolve());
                 }
             })
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition DATASOURCE_DRIVER = new SimpleAttributeDefinitionBuilder(DATASOURCE_DRIVER_NAME, ModelType.STRING, false)
             .setXmlName(DataSource.Tag.DRIVER.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition NEW_CONNECTION_SQL = new SimpleAttributeDefinitionBuilder(NEW_CONNECTION_SQL_NAME, ModelType.STRING, true)
             .setAllowExpression(true)
             .setXmlName(DataSource.Tag.NEW_CONNECTION_SQL.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition URL_DELIMITER = new SimpleAttributeDefinitionBuilder(URL_DELIMITER_NAME, ModelType.STRING, true)
             .setXmlName(DataSource.Tag.URL_DELIMITER.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
@@ -327,17 +334,20 @@ public class Constants {
             .setAllowExpression(true)
             .setAllowNull(true)
             .setXmlName(XaDataSource.Tag.URL_PROPERTY.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition URL_SELECTOR_STRATEGY_CLASS_NAME = new SimpleAttributeDefinitionBuilder(URL_SELECTOR_STRATEGY_CLASS_NAME_NAME, ModelType.STRING, true)
             .setXmlName(DataSource.Tag.URL_SELECTOR_STRATEGY_CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition USE_JAVA_CONTEXT = new SimpleAttributeDefinitionBuilder(USE_JAVA_CONTEXT_NAME, ModelType.BOOLEAN, true)
             .setXmlName(DataSource.Attribute.USE_JAVA_CONTEXT.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.USE_JAVA_CONTEXT))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ENABLED = new SimpleAttributeDefinitionBuilder(ENABLED_NAME, ModelType.BOOLEAN)
@@ -346,6 +356,7 @@ public class Constants {
             .setDefaultValue(new ModelNode(Defaults.ENABLED))
             .setAllowNull(true)
             .setDeprecated(ModelVersion.create(3), false)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition CONNECTABLE = new SimpleAttributeDefinitionBuilder(CONNECTABLE_NAME, ModelType.BOOLEAN)
@@ -353,6 +364,7 @@ public class Constants {
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(Defaults.CONNECTABLE))
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ENLISTMENT_TRACE = new SimpleAttributeDefinitionBuilder(ENLISTMENT_TRACE_NAME, ModelType.BOOLEAN)
@@ -367,6 +379,7 @@ public class Constants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreConcurrentLinkedDequeManagedConnectionPool.class.getName()))
             .setXmlName(DataSource.Attribute.MCP.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition TRACKING = new SimpleAttributeDefinitionBuilder(TRACKING_NAME, ModelType.BOOLEAN)
@@ -374,17 +387,20 @@ public class Constants {
             .setDefaultValue(new ModelNode(false))
             .setAllowExpression(true)
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition JTA = new SimpleAttributeDefinitionBuilder(JTA_NAME, ModelType.BOOLEAN, true)
             .setXmlName(DataSource.Attribute.JTA.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.JTA))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static final PropertiesAttributeDefinition CONNECTION_PROPERTIES = new PropertiesAttributeDefinition.Builder(CONNECTION_PROPERTIES_NAME, true)
             .setXmlName(DataSource.Tag.CONNECTION_PROPERTY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition CONNECTION_PROPERTY_VALUE = new SimpleAttributeDefinitionBuilder(CONNECTION_PROPERTY_VALUE_NAME, ModelType.STRING, true)
@@ -398,6 +414,7 @@ public class Constants {
             .addAlternatives(SECURITY_DOMAIN_NAME, AUTHENTICATION_CONTEXT_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(DS_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     public static SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(PASSWORD_NAME, ModelType.STRING)
@@ -408,6 +425,7 @@ public class Constants {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(DS_SECURITY_DEF)
             .addAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
+            .setRestartAllServices()
             .build();
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
@@ -425,6 +443,7 @@ public class Constants {
             .addAlternatives(USERNAME_NAME, AUTHENTICATION_CONTEXT_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(DS_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     public static SimpleAttributeDefinition ELYTRON_ENABLED = new SimpleAttributeDefinitionBuilder(ELYTRON_ENABLED_NAME, ModelType.BOOLEAN, true)
@@ -432,6 +451,7 @@ public class Constants {
             .setDefaultValue(new ModelNode(ELYTRON_MANAGED_SECURITY))
             .setAllowExpression(true)
             .addAccessConstraint(DS_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
     public static SimpleAttributeDefinition AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(AUTHENTICATION_CONTEXT_NAME, ModelType.STRING, true)
             .setXmlName(Security.Tag.AUTHENTICATION_CONTEXT.getLocalName())
@@ -440,11 +460,13 @@ public class Constants {
             .addAlternatives(SECURITY_DOMAIN_NAME, USERNAME_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_CLIENT_REF)
             .addAccessConstraint(DS_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition PREPARED_STATEMENTS_CACHE_SIZE = new SimpleAttributeDefinitionBuilder(PREPAREDSTATEMENTSCACHESIZE_NAME, ModelType.LONG, true)
             .setAllowExpression(true)
             .setXmlName(Statement.Tag.PREPARED_STATEMENT_CACHE_SIZE.getLocalName())
+            .setRestartAllServices()
             .build();
 
 
@@ -452,6 +474,7 @@ public class Constants {
             .setXmlName(Statement.Tag.SHARE_PREPARED_STATEMENTS.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.SHARE_PREPARED_STATEMENTS))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
@@ -459,17 +482,20 @@ public class Constants {
             .setAllowExpression(true)
             .setXmlName(Statement.Tag.TRACK_STATEMENTS.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.TRACK_STATEMENTS.name()))
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ALLOCATION_RETRY = new SimpleAttributeDefinitionBuilder(ALLOCATION_RETRY_NAME, ModelType.INT, true)
             .setXmlName(TimeOut.Tag.ALLOCATION_RETRY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition ALLOCATION_RETRY_WAIT_MILLIS = new SimpleAttributeDefinitionBuilder(ALLOCATION_RETRY_WAIT_MILLIS_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.ALLOCATION_RETRY_WAIT_MILLIS.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
@@ -477,61 +503,72 @@ public class Constants {
             .setXmlName(DsPool.Tag.ALLOW_MULTIPLE_USERS.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.ALLOW_MULTIPLE_USERS))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition CONNECTION_LISTENER_CLASS = new SimpleAttributeDefinitionBuilder(CONNECTION_LISTENER_CLASS_NAME, ModelType.STRING)
             .setAllowExpression(true)
             .setAllowNull(true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
+            .setRestartAllServices()
             .build();
     static PropertiesAttributeDefinition CONNECTION_LISTENER_PROPERTIES = new PropertiesAttributeDefinition.Builder(CONNECTION_LISTENER_PROPERTY_NAME, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Tag.CONFIG_PROPERTY.getLocalName())
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition QUERY_TIMEOUT = new SimpleAttributeDefinitionBuilder(QUERYTIMEOUT_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.QUERY_TIMEOUT.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition USE_TRY_LOCK = new SimpleAttributeDefinitionBuilder(USETRYLOCK_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.USE_TRY_LOCK.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition SET_TX_QUERY_TIMEOUT = new SimpleAttributeDefinitionBuilder(SETTXQUERYTIMEOUT_NAME, ModelType.BOOLEAN, true)
             .setXmlName(TimeOut.Tag.SET_TX_QUERY_TIMEOUT.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.SET_TX_QUERY_TIMEOUT))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition TRANSACTION_ISOLATION = new SimpleAttributeDefinitionBuilder(TRANSACTION_ISOLATION_NAME, ModelType.STRING, true)
             .setXmlName(DataSource.Tag.TRANSACTION_ISOLATION.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition CHECK_VALID_CONNECTION_SQL = new SimpleAttributeDefinitionBuilder(CHECKVALIDCONNECTIONSQL_NAME, ModelType.STRING, true)
             .setXmlName(Validation.Tag.CHECK_VALID_CONNECTION_SQL.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition EXCEPTION_SORTER_CLASSNAME = new SimpleAttributeDefinitionBuilder(EXCEPTIONSORTERCLASSNAME_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition EXCEPTION_SORTER_PROPERTIES = new PropertiesAttributeDefinition.Builder(EXCEPTIONSORTER_PROPERTIES_NAME, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Tag.CONFIG_PROPERTY.getLocalName())
             .setAllowExpression(true)
             .setRequires(EXCEPTIONSORTERCLASSNAME_NAME)
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition STALE_CONNECTION_CHECKER_CLASSNAME = new SimpleAttributeDefinitionBuilder(STALECONNECTIONCHECKERCLASSNAME_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition STALE_CONNECTION_CHECKER_PROPERTIES = new PropertiesAttributeDefinition.Builder(STALECONNECTIONCHECKER_PROPERTIES_NAME, true)
@@ -539,11 +576,13 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setRequires(STALECONNECTIONCHECKERCLASSNAME_NAME)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition VALID_CONNECTION_CHECKER_CLASSNAME = new SimpleAttributeDefinitionBuilder(VALID_CONNECTION_CHECKER_CLASSNAME_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition VALID_CONNECTION_CHECKER_PROPERTIES = new PropertiesAttributeDefinition.Builder(VALIDCONNECTIONCHECKER_PROPERTIES_NAME, true)
@@ -551,67 +590,79 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setRequires(VALID_CONNECTION_CHECKER_CLASSNAME_NAME)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition VALIDATE_ON_MATCH = new SimpleAttributeDefinitionBuilder(VALIDATEONMATCH_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Validation.Tag.VALIDATE_ON_MATCH.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition SPY = new SimpleAttributeDefinitionBuilder(SPY_NAME, ModelType.BOOLEAN, true)
             .setXmlName(DataSource.Attribute.SPY.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.SPY))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition USE_CCM = new SimpleAttributeDefinitionBuilder(USE_CCM_NAME, ModelType.BOOLEAN, true)
             .setXmlName(DataSource.Attribute.USE_CCM.getLocalName())
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(Defaults.USE_CCM))
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition XA_DATASOURCE_CLASS = new SimpleAttributeDefinitionBuilder(XADATASOURCECLASS_NAME, ModelType.STRING, true)
             .setXmlName(XaDataSource.Tag.XA_DATASOURCE_CLASS.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition INTERLEAVING = new SimpleAttributeDefinitionBuilder(INTERLEAVING_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.INTERLEAVING.getLocalName())
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(Defaults.INTERLEAVING))
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition NO_TX_SEPARATE_POOL = new SimpleAttributeDefinitionBuilder(NOTXSEPARATEPOOL_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.NO_TX_SEPARATE_POOLS.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.NO_TX_SEPARATE_POOL))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition PAD_XID = new SimpleAttributeDefinitionBuilder(PAD_XID_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.PAD_XID.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.PAD_XID))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition SAME_RM_OVERRIDE = new SimpleAttributeDefinitionBuilder(SAME_RM_OVERRIDE_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.IS_SAME_RM_OVERRIDE.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition WRAP_XA_RESOURCE = new SimpleAttributeDefinitionBuilder(WRAP_XA_RESOURCE_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.WRAP_XA_RESOURCE.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.WRAP_XA_RESOURCE))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition XA_RESOURCE_TIMEOUT = new SimpleAttributeDefinitionBuilder(XA_RESOURCE_TIMEOUT_NAME, ModelType.INT, true)
             .setXmlName(TimeOut.Tag.XA_RESOURCE_TIMEOUT.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition REAUTH_PLUGIN_CLASSNAME = new SimpleAttributeDefinitionBuilder(REAUTHPLUGIN_CLASSNAME_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition REAUTHPLUGIN_PROPERTIES = new PropertiesAttributeDefinition.Builder(REAUTHPLUGIN_PROPERTIES_NAME, true)
@@ -619,12 +670,14 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setRequires(REAUTHPLUGIN_CLASSNAME_NAME)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition STATISTICS_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.STATISTICS_ENABLED, ModelType.BOOLEAN)
             .setDefaultValue(new ModelNode(false))
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
@@ -676,6 +729,7 @@ public class Constants {
             .setAllowExpression(true)
             .addAlternatives(RECOVERY_SECURITY_DOMAIN_NAME, RECOVERY_AUTHENTICATION_CONTEXT_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_PASSWORD = new SimpleAttributeDefinitionBuilder(RECOVERY_PASSWORD_NAME, ModelType.STRING)
@@ -684,6 +738,7 @@ public class Constants {
             .setAllowNull(true)
             .setRequires(RECOVERY_USERNAME_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(RECOVERY_SECURITY_DOMAIN_NAME, ModelType.STRING)
@@ -691,12 +746,14 @@ public class Constants {
             .setAllowExpression(true)
             .setAllowNull(true)
             .addAlternatives(RECOVERY_USERNAME_NAME, RECOVERY_AUTHENTICATION_CONTEXT_NAME)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_ELYTRON_ENABLED = new SimpleAttributeDefinitionBuilder(RECOVERY_ELYTRON_ENABLED_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Security.Tag.ELYTRON_ENABLED.getLocalName())
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(ELYTRON_MANAGED_SECURITY))
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(RECOVERY_AUTHENTICATION_CONTEXT_NAME, ModelType.STRING, true)
@@ -704,6 +761,7 @@ public class Constants {
             .setAllowExpression(true)
             .setRequires(RECOVERY_ELYTRON_ENABLED_NAME)
             .addAlternatives(RECOVERY_SECURITY_DOMAIN_NAME, RECOVERY_USERNAME_NAME)
+            .setRestartAllServices()
             .build();
 
     static final ObjectTypeAttributeDefinition RECOVERY_CREDENTIAL_REFERENCE =
@@ -713,22 +771,26 @@ public class Constants {
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(DS_SECURITY_DEF)
                     .addAlternatives(RECOVERY_PASSWORD_NAME)
+                    .setRestartAllServices()
                     .build();
 
     static SimpleAttributeDefinition RECOVER_PLUGIN_CLASSNAME = new SimpleAttributeDefinitionBuilder(RECOVER_PLUGIN_CLASSNAME_NAME, ModelType.STRING, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition RECOVER_PLUGIN_PROPERTIES = new PropertiesAttributeDefinition.Builder(RECOVER_PLUGIN_PROPERTIES_NAME, true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Tag.CONFIG_PROPERTY.getLocalName())
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition NO_RECOVERY = new SimpleAttributeDefinitionBuilder(NO_RECOVERY_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Recovery.Attribute.NO_RECOVERY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
     static final SimpleAttributeDefinition[] XA_DATASOURCE_ATTRIBUTE = new SimpleAttributeDefinition[]{
             Constants.XA_DATASOURCE_CLASS, JNDI_NAME, DATASOURCE_DRIVER,
@@ -773,6 +835,7 @@ public class Constants {
     static final PropertiesAttributeDefinition XADATASOURCE_PROPERTIES = new PropertiesAttributeDefinition.Builder(XADATASOURCEPROPERTIES_NAME, false)
             .setXmlName(XaDataSource.Tag.XA_DATASOURCE_PROPERTY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition XADATASOURCE_PROPERTY_VALUE = new SimpleAttributeDefinitionBuilder(XADATASOURCEPROPERTIES_VALUE_NAME, ModelType.STRING, true)
@@ -784,6 +847,7 @@ public class Constants {
             .setXmlName(Driver.Attribute.NAME.getLocalName())
             .setAllowNull(false)
                     //.setResourceOnly()
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition DRIVER_MODULE_NAME = new SimpleAttributeDefinitionBuilder(DRIVER_MODULE_NAME_NAME, ModelType.STRING)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
@@ -26,6 +26,7 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.CONNE
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 
+import org.jboss.as.connector.subsystems.common.pool.PoolConfigurationRWHandler;
 import org.jboss.as.connector.subsystems.common.pool.PoolOperations;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
@@ -43,6 +44,7 @@ import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
+
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -59,7 +61,7 @@ public class ConnectionDefinitionResourceDefinition extends SimpleResourceDefini
     private static final OperationDefinition FLUSH_ALL_DEFINITION = new SimpleOperationDefinitionBuilder(Constants.FLUSH_ALL_CONNECTION_IN_POOL, RESOLVER)
             .withFlag(Flag.RUNTIME_ONLY)
             .build();
-    static final SimpleOperationDefinition DUMP_QUEUED_THREADS = new SimpleOperationDefinitionBuilder("dump-queued-threads-in-pool", RESOLVER)
+    private static final SimpleOperationDefinition DUMP_QUEUED_THREADS = new SimpleOperationDefinitionBuilder("dump-queued-threads-in-pool", RESOLVER)
             .setRuntimeOnly().build();
 
     private static final OperationDefinition FLUSH_INVALID_DEFINITION = new SimpleOperationDefinitionBuilder(Constants.FLUSH_INVALID_CONNECTION_IN_POOL, RESOLVER)
@@ -88,9 +90,10 @@ public class ConnectionDefinitionResourceDefinition extends SimpleResourceDefini
             if (readOnly) {
                 resourceRegistration.registerReadOnlyAttribute(attribute, null);
             } else {
-                if (attribute.equals(ENLISTMENT_TRACE)) {
+                if (PoolConfigurationRWHandler.ATTRIBUTES.contains(attribute.getName())) {
+                    resourceRegistration.registerReadWriteAttribute(attribute, null, PoolConfigurationRWHandler.RaPoolConfigurationWriteHandler.INSTANCE);
+                } else if (attribute.equals(ENLISTMENT_TRACE)) {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new EnlistmentTraceAttributeWriteHandler());
-
                 } else {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new ReloadRequiredWriteAttributeHandler(attribute));
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -212,21 +212,25 @@ public class Constants {
     static final SimpleAttributeDefinition CLASS_NAME = new SimpleAttributeDefinitionBuilder(CLASS_NAME_NAME, ModelType.STRING, false)
             .setXmlName(ConnectionDefinition.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition JNDINAME = new SimpleAttributeDefinitionBuilder(JNDINAME_NAME, ModelType.STRING, true)
             .setXmlName(ConnectionDefinition.Attribute.JNDI_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition CONFIG_PROPERTIES = new SimpleAttributeDefinitionBuilder(CONFIG_PROPERTIES_NAME, ModelType.STRING, true)
             .setXmlName(ConnectionDefinition.Tag.CONFIG_PROPERTY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition CONFIG_PROPERTY_VALUE = new SimpleAttributeDefinitionBuilder(CONFIG_PROPERTY_VALUE_NAME, ModelType.STRING, true)
             .setXmlName(ConnectionDefinition.Tag.CONFIG_PROPERTY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition ARCHIVE = SimpleAttributeDefinitionBuilder.create(ARCHIVE_NAME, ModelType.STRING)
@@ -245,7 +249,9 @@ public class Constants {
                     }
                 }
             })
-            .setAlternatives(MODULE_NAME).build();
+            .setAlternatives(MODULE_NAME)
+            .setRestartAllServices()
+            .build();
 
     static final SimpleAttributeDefinition MODULE = SimpleAttributeDefinitionBuilder.create(MODULE_NAME, ModelType.STRING)
             .setXmlName(AS7ResourceAdapterTags.MODULE.getLocalName())
@@ -273,30 +279,36 @@ public class Constants {
                     }
                 }
             })
-            .setAlternatives(ARCHIVE_NAME).build();
+            .setAlternatives(ARCHIVE_NAME)
+            .setRestartAllServices()
+            .build();
 
     static final SimpleAttributeDefinition BOOTSTRAP_CONTEXT = new SimpleAttributeDefinitionBuilder(BOOTSTRAPCONTEXT_NAME, ModelType.STRING, true)
             .setXmlName(Activation.Tag.BOOTSTRAP_CONTEXT.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition TRANSACTION_SUPPORT = new SimpleAttributeDefinitionBuilder(TRANSACTIONSUPPORT_NAME, ModelType.STRING, true)
             .setXmlName(Activation.Tag.TRANSACTION_SUPPORT.getLocalName())
             .setAllowExpression(true)
             .setValidator(new EnumValidator<TransactionSupportEnum>(TransactionSupportEnum.class, true, true))
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition STATISTICS_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.STATISTICS_ENABLED, ModelType.BOOLEAN)
-                .setDefaultValue(new ModelNode(false))
-                .setAllowNull(true)
-                .setAllowExpression(true)
-                .build();
+            .setDefaultValue(new ModelNode(false))
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
 
     static final SimpleAttributeDefinition WM_SECURITY = new SimpleAttributeDefinitionBuilder(WM_SECURITY_NAME, ModelType.BOOLEAN)
             .setAllowExpression(true)
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(false))
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition WM_SECURITY_MAPPING_REQUIRED = new SimpleAttributeDefinitionBuilder(WM_SECURITY_MAPPING_REQUIRED_NAME, ModelType.BOOLEAN)
@@ -304,6 +316,7 @@ public class Constants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(false))
             .setXmlName(WorkManagerSecurity.Tag.MAPPING_REQUIRED.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition WM_SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(WM_SECURITY_DOMAIN_NAME, ModelType.STRING, true)
@@ -311,6 +324,7 @@ public class Constants {
             .setDefaultValue(new ModelNode("other"))
             .setXmlName(WorkManagerSecurity.Tag.DOMAIN.getLocalName())
             .setAlternatives(WM_ELYTRON_SECURITY_DOMAIN_NAME)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition WM_ELYTRON_SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(WM_ELYTRON_SECURITY_DOMAIN_NAME, ModelType.STRING, true)
@@ -318,12 +332,14 @@ public class Constants {
             .setXmlName(WorkManagerSecurity.Tag.ELYTRON_SECURITY_DOMAIN.getLocalName())
             .setAlternatives(WM_SECURITY_DOMAIN_NAME)
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.ELYTRON_SECURITY_DOMAIN_REF)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition WM_SECURITY_DEFAULT_PRINCIPAL = new SimpleAttributeDefinitionBuilder(WM_SECURITY_DEFAULT_PRINCIPAL_NAME, ModelType.STRING)
             .setAllowExpression(true)
             .setAllowNull(true)
             .setXmlName(WorkManagerSecurity.Tag.DEFAULT_PRINCIPAL.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static final StringListAttributeDefinition WM_SECURITY_DEFAULT_GROUPS = (new StringListAttributeDefinition.Builder(WM_SECURITY_DEFAULT_GROUPS_NAME))
@@ -331,6 +347,7 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setElementValidator(new StringLengthValidator(1, false, true))
+            .setRestartAllServices()
             .build();
     static final SimpleAttributeDefinition WM_SECURITY_DEFAULT_GROUP = new SimpleAttributeDefinitionBuilder(WM_SECURITY_DEFAULT_GROUP_NAME, ModelType.STRING, true)
             .setXmlName(WorkManagerSecurity.Tag.GROUP.getLocalName())
@@ -353,11 +370,13 @@ public class Constants {
     static final ObjectTypeAttributeDefinition WM_SECURITY_MAPPING_GROUP = ObjectTypeAttributeDefinition.Builder.of(WM_SECURITY_MAPPING_GROUP_NAME, WM_SECURITY_MAPPING_FROM, WM_SECURITY_MAPPING_TO).build();
     static final ObjectListAttributeDefinition WM_SECURITY_MAPPING_GROUPS = ObjectListAttributeDefinition.Builder.of(WM_SECURITY_MAPPING_GROUPS_NAME, WM_SECURITY_MAPPING_GROUP)
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
 
     static final ObjectTypeAttributeDefinition WM_SECURITY_MAPPING_USER = ObjectTypeAttributeDefinition.Builder.of(WM_SECURITY_MAPPING_USER_NAME, WM_SECURITY_MAPPING_FROM, WM_SECURITY_MAPPING_TO).build();
     static final ObjectListAttributeDefinition WM_SECURITY_MAPPING_USERS = ObjectListAttributeDefinition.Builder.of(WM_SECURITY_MAPPING_USERS_NAME, WM_SECURITY_MAPPING_USER)
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
 
     static final StringListAttributeDefinition BEANVALIDATION_GROUPS = (new StringListAttributeDefinition.Builder(BEANVALIDATIONGROUPS_NAME))
@@ -365,6 +384,7 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setElementValidator(new StringLengthValidator(1, false, true))
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition BEANVALIDATIONGROUP = new SimpleAttributeDefinitionBuilder(BEANVALIDATIONGROUPS_NAME, ModelType.STRING, true)
@@ -376,12 +396,14 @@ public class Constants {
             .setXmlName(DataSource.Attribute.USE_JAVA_CONTEXT.getLocalName())
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(Defaults.USE_JAVA_CONTEXT))
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ENABLED = new SimpleAttributeDefinitionBuilder(ENABLED_NAME, ModelType.BOOLEAN, true)
             .setXmlName(DataSource.Attribute.ENABLED.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.ENABLED))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition CONNECTABLE = new SimpleAttributeDefinitionBuilder(CONNECTABLE_NAME, ModelType.BOOLEAN)
@@ -389,11 +411,13 @@ public class Constants {
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(Defaults.CONNECTABLE))
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
     static SimpleAttributeDefinition TRACKING = new SimpleAttributeDefinitionBuilder(TRACKING_NAME, ModelType.BOOLEAN)
             .setXmlName(DataSource.Attribute.TRACKING.getLocalName())
             .setAllowExpression(true)
             .setAllowNull(true)
+            .setRestartAllServices()
             .build();
     static SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(SECURITY_DOMAIN_NAME, ModelType.STRING, true)
             .setXmlName(Security.Tag.SECURITY_DOMAIN.getLocalName())
@@ -402,6 +426,7 @@ public class Constants {
                     AUTHENTICATION_CONTEXT_AND_APPLICATION_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
     static final SimpleAttributeDefinition SECURITY_DOMAIN_AND_APPLICATION = new SimpleAttributeDefinitionBuilder(SECURITY_DOMAIN_AND_APPLICATION_NAME, ModelType.STRING, true)
             .setXmlName(Security.Tag.SECURITY_DOMAIN_AND_APPLICATION.getLocalName())
@@ -410,6 +435,7 @@ public class Constants {
                     AUTHENTICATION_CONTEXT_AND_APPLICATION_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ELYTRON_ENABLED = new SimpleAttributeDefinitionBuilder(ELYTRON_ENABLED_NAME, ModelType.BOOLEAN, true)
@@ -417,6 +443,7 @@ public class Constants {
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(ELYTRON_MANAGED_SECURITY))
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
     static SimpleAttributeDefinition AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(AUTHENTICATION_CONTEXT_NAME, ModelType.STRING, true)
             .setXmlName(Security.Tag.AUTHENTICATION_CONTEXT.getLocalName())
@@ -426,6 +453,7 @@ public class Constants {
                     AUTHENTICATION_CONTEXT_AND_APPLICATION_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_CLIENT_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
     static final SimpleAttributeDefinition AUTHENTICATION_CONTEXT_AND_APPLICATION = new SimpleAttributeDefinitionBuilder(AUTHENTICATION_CONTEXT_AND_APPLICATION_NAME, ModelType.STRING, true)
             .setXmlName(Security.Tag.AUTHENTICATION_CONTEXT_AND_APPLICATION.getLocalName())
@@ -435,6 +463,7 @@ public class Constants {
                     AUTHENTICATION_CONTEXT_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_CLIENT_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition APPLICATION = new SimpleAttributeDefinitionBuilder(APPLICATION_NAME, ModelType.BOOLEAN)
@@ -447,17 +476,20 @@ public class Constants {
                     AUTHENTICATION_CONTEXT_AND_APPLICATION_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
 
     static SimpleAttributeDefinition ALLOCATION_RETRY = new SimpleAttributeDefinitionBuilder(ALLOCATION_RETRY_NAME, ModelType.INT, true)
             .setXmlName(TimeOut.Tag.ALLOCATION_RETRY.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ALLOCATION_RETRY_WAIT_MILLIS = new SimpleAttributeDefinitionBuilder(ALLOCATION_RETRY_WAIT_MILLIS_NAME, ModelType.LONG, true)
             .setXmlName(TimeOut.Tag.ALLOCATION_RETRY_WAIT_MILLIS.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition USETRYLOCK = new SimpleAttributeDefinitionBuilder(USETRYLOCK_NAME, ModelType.LONG, true)
@@ -469,6 +501,7 @@ public class Constants {
             .setXmlName(DataSource.Attribute.USE_CCM.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.USE_CCM))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition SHARABLE = new SimpleAttributeDefinitionBuilder(SHARABLE_NAME, ModelType.BOOLEAN)
@@ -476,6 +509,7 @@ public class Constants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(Defaults.SHARABLE))
             .setXmlName(ConnectionDefinition.Attribute.SHARABLE.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition ENLISTMENT = new SimpleAttributeDefinitionBuilder(ENLISTMENT_NAME, ModelType.BOOLEAN)
@@ -483,6 +517,7 @@ public class Constants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode(Defaults.ENLISTMENT))
             .setXmlName(ConnectionDefinition.Attribute.ENLISTMENT.getLocalName())
+            .setRestartAllServices()
             .build();
 
 
@@ -497,6 +532,7 @@ public class Constants {
             .setAllowExpression(true)
             .setAllowNull(true)
             .setXmlName(ConnectionDefinition.Attribute.MCP.getLocalName())
+            .setRestartAllServices()
             .build();
 
 
@@ -504,18 +540,21 @@ public class Constants {
             .setXmlName(XaPool.Tag.INTERLEAVING.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.INTERLEAVING))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition NOTXSEPARATEPOOL = new SimpleAttributeDefinitionBuilder(NOTXSEPARATEPOOL_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.NO_TX_SEPARATE_POOLS.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.NO_TX_SEPARATE_POOL))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition PAD_XID = new SimpleAttributeDefinitionBuilder(PAD_XID_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.PAD_XID.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.PAD_XID))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
 
@@ -523,17 +562,20 @@ public class Constants {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setXmlName(XaPool.Tag.IS_SAME_RM_OVERRIDE.getLocalName())
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition WRAP_XA_RESOURCE = new SimpleAttributeDefinitionBuilder(WRAP_XA_RESOURCE_NAME, ModelType.BOOLEAN, true)
             .setXmlName(XaPool.Tag.WRAP_XA_RESOURCE.getLocalName())
             .setDefaultValue(new ModelNode(Defaults.WRAP_XA_RESOURCE))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition XA_RESOURCE_TIMEOUT = new SimpleAttributeDefinitionBuilder(XA_RESOURCE_TIMEOUT_NAME, ModelType.INT, true)
             .setXmlName(TimeOut.Tag.XA_RESOURCE_TIMEOUT.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_USERNAME = new SimpleAttributeDefinitionBuilder(RECOVERY_USERNAME_NAME, ModelType.STRING, true)
@@ -543,6 +585,7 @@ public class Constants {
             .setMeasurementUnit(MeasurementUnit.NONE)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_PASSWORD = new SimpleAttributeDefinitionBuilder(RECOVERY_PASSWORD_NAME, ModelType.STRING, true)
@@ -553,6 +596,7 @@ public class Constants {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
             .addAlternatives(RECOVERY_CREDENTIAL_REFERENCE_NAME)
+            .setRestartAllServices()
             .build();
 
     static ObjectTypeAttributeDefinition RECOVERY_CREDENTIAL_REFERENCE =
@@ -572,6 +616,7 @@ public class Constants {
             .setAlternatives(RECOVERY_AUTHENTICATION_CONTEXT_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_ELYTRON_ENABLED = new SimpleAttributeDefinitionBuilder(RECOVERY_ELYTRON_ENABLED_NAME, ModelType.BOOLEAN, true)
@@ -580,6 +625,7 @@ public class Constants {
             .setMeasurementUnit(MeasurementUnit.NONE)
             .setDefaultValue(new ModelNode(ELYTRON_MANAGED_SECURITY))
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERY_AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(RECOVERY_AUTHENTICATION_CONTEXT_NAME, ModelType.STRING, true)
@@ -589,23 +635,26 @@ public class Constants {
             .setAlternatives(RECOVERY_SECURITY_DOMAIN_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_CLIENT_REF)
             .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition NO_RECOVERY = new SimpleAttributeDefinitionBuilder(NO_RECOVERY_NAME, ModelType.BOOLEAN, true)
             .setXmlName(Recovery.Attribute.NO_RECOVERY.getLocalName())
             .setDefaultValue(new ModelNode(false))
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static SimpleAttributeDefinition RECOVERLUGIN_CLASSNAME = new SimpleAttributeDefinitionBuilder(RECOVERLUGIN_CLASSNAME_NAME, ModelType.STRING, true)
-
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Attribute.CLASS_NAME.getLocalName())
             .setAllowExpression(true)
+            .setRestartAllServices()
             .build();
 
     static PropertiesAttributeDefinition RECOVERLUGIN_PROPERTIES = new PropertiesAttributeDefinition.Builder(RECOVERLUGIN_PROPERTIES_NAME, true)
             .setAllowExpression(true)
             .setXmlName(org.jboss.jca.common.api.metadata.common.Extension.Tag.CONFIG_PROPERTY.getLocalName())
+            .setRestartAllServices()
             .build();
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -606,6 +606,7 @@ public class Constants {
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)
                     .addAlternatives(RECOVERY_PASSWORD_NAME)
+                    .setRestartAllServices()
                     .build();
 
     static SimpleAttributeDefinition RECOVERY_SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(RECOVERY_SECURITY_DOMAIN_NAME, ModelType.STRING, true)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
@@ -1,0 +1,216 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.jca.poolattributes;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import javax.annotation.Resource;
+import javax.sql.DataSource;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.connector.subsystems.common.pool.Constants;
+import org.jboss.as.connector.subsystems.datasources.WildFlyDataSource;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.jca.JcaMgmtBase;
+import org.jboss.as.test.integration.jca.JcaMgmtServerSetupTask;
+import org.jboss.as.test.integration.jca.JcaTestsUtil;
+import org.jboss.as.test.integration.jca.datasource.Datasource;
+import org.jboss.as.test.integration.jca.datasource.DatasourceNonCcmTestCase;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.jca.adapters.jdbc.WrapperDataSource;
+import org.jboss.jca.core.api.connectionmanager.pool.PoolConfiguration;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Checks that pool attributes can be set and do (not) require a reload.
+ *
+ * @author <a href="mailto:thofman@redhat.com">Tomas Hofman</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(DatasourcePoolAttributesTestCase.DatasourceServerSetupTask.class)
+public class DatasourcePoolAttributesTestCase extends JcaMgmtBase {
+
+    private static final String DS_NAME = "DS";
+    private static final ModelNode DS_ADDRESS = new ModelNode().add(SUBSYSTEM, "datasources")
+            .add("data-source", DS_NAME);
+
+    static {
+        DS_ADDRESS.protect();
+    }
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "deployment.jar");
+
+        jar.addClasses(
+                DatasourceNonCcmTestCase.class,
+                Datasource.class,
+                WildFlyDataSource.class,
+                WrapperDataSource.class,
+                JcaMgmtServerSetupTask.class,
+                DatasourcePoolAttributesTestCase.class,
+                AbstractMgmtServerSetupTask.class,
+                AbstractMgmtTestBase.class,
+                JcaMgmtBase.class,
+                ContainerResourceMgmtTestBase.class,
+                MgmtOperationException.class,
+                ManagementOperations.class,
+                JcaTestsUtil.class,
+                ServerReload.class);
+
+        jar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api," +
+                "org.jboss.as.connector," +
+                "org.jboss.as.controller," +
+                "org.jboss.dmr," +
+                "org.jboss.as.cli," +
+                "org.jboss.staxmapper," +
+                "org.jboss.ironjacamar.api," +
+                "org.jboss.ironjacamar.impl," +
+                "org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
+
+        return jar;
+    }
+
+    @Resource(mappedName = "java:jboss/datasources/" + DS_NAME)
+    private DataSource datasource;
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @ArquillianResource
+    private static ContainerController container;
+
+    @Override
+    protected ModelControllerClient getModelControllerClient() {
+        return managementClient.getControllerClient();
+    }
+
+    /**
+     * Checks that attributes not requiring reload can be set.
+     */
+    @Test
+    public void testModifyNonReloadAttributes() throws Exception {
+        WrapperDataSource wrapperDataSource = JcaTestsUtil.extractWrapperDatasource((WildFlyDataSource) datasource);
+        PoolConfiguration poolConfiguration = JcaTestsUtil.exctractPoolConfiguration(wrapperDataSource);
+
+        // check initial values
+        Assert.assertNotNull(poolConfiguration);
+        Assert.assertEquals(0, poolConfiguration.getMinSize());
+        Assert.assertEquals(20, poolConfiguration.getMaxSize());
+        Assert.assertEquals(0, poolConfiguration.getInitialSize());
+        Assert.assertEquals(30000, poolConfiguration.getBlockingTimeout());
+        Assert.assertEquals(true, poolConfiguration.isFair());
+        Assert.assertEquals(false, poolConfiguration.isStrictMin());
+
+        // modify values
+        writeAttribute(DS_ADDRESS, Constants.MIN_POOL_SIZE.getName(), "4");
+        writeAttribute(DS_ADDRESS, Constants.MAX_POOL_SIZE.getName(), "10");
+        writeAttribute(DS_ADDRESS, Constants.INITIAL_POOL_SIZE.getName(), "6");
+        writeAttribute(DS_ADDRESS, Constants.BLOCKING_TIMEOUT_WAIT_MILLIS.getName(), "10000");
+        writeAttribute(DS_ADDRESS, Constants.POOL_FAIR.getName(), "false");
+        writeAttribute(DS_ADDRESS, Constants.POOL_USE_STRICT_MIN.getName(), "true");
+
+        // check that server is not in reload-required state
+        ModelNode serverState = readAttribute(new ModelNode(), "server-state");
+        Assert.assertEquals("running", serverState.asString());
+
+        // check that runtime was updated
+        Assert.assertEquals(4, poolConfiguration.getMinSize());
+        Assert.assertEquals(10, poolConfiguration.getMaxSize());
+        Assert.assertEquals(6, poolConfiguration.getInitialSize());
+        Assert.assertEquals(10000, poolConfiguration.getBlockingTimeout());
+        Assert.assertEquals(false, poolConfiguration.isFair());
+        Assert.assertEquals(true, poolConfiguration.isStrictMin());
+    }
+
+    static class DatasourceServerSetupTask extends JcaMgmtServerSetupTask {
+
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            setupDs(managementClient, DS_NAME, true);
+            reload();
+        }
+
+        private void setupDs(ManagementClient managementClient, String dsName, boolean jta) throws Exception {
+            Datasource ds = Datasource.Builder(dsName).build();
+            ModelNode address = new ModelNode();
+            address.add("subsystem", "datasources");
+            address.add("data-source", dsName);
+
+            ModelNode operation = new ModelNode();
+            operation.get(OP).set(ADD);
+            operation.get(OP_ADDR).set(address);
+            operation.get("jndi-name").set(ds.getJndiName());
+            operation.get("use-java-context").set("true");
+            operation.get("driver-name").set(ds.getDriverName());
+            operation.get("enabled").set("true");
+            operation.get("user-name").set(ds.getUserName());
+            operation.get("password").set(ds.getPassword());
+            operation.get("jta").set(jta);
+            operation.get("use-ccm").set("true");
+            operation.get("connection-url").set(ds.getConnectionUrl());
+            managementClient.getControllerClient().execute(operation);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            removeDs(managementClient, DS_NAME);
+            reload();
+        }
+
+        private void removeDs(ManagementClient managementClient, String dsName) throws Exception {
+            ModelNode address = new ModelNode();
+            address.add("subsystem", "datasources");
+            address.add("data-source", dsName);
+            ModelNode operation = new ModelNode();
+            operation.get(OP).set(REMOVE);
+            operation.get(OP_ADDR).set(address);
+            managementClient.getControllerClient().execute(operation);
+        }
+
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.jca.poolattributes;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.List;
+
+import javax.annotation.Resource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.connector.subsystems.common.pool.Constants;
+import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
+import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.jca.JcaMgmtBase;
+import org.jboss.as.test.integration.jca.JcaMgmtServerSetupTask;
+import org.jboss.as.test.integration.jca.JcaTestsUtil;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactoryImpl;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionImpl;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyLocalTransaction;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionMetaData;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyResourceAdapter;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyXAResource;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.FileUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.jca.core.api.connectionmanager.pool.PoolConfiguration;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Checks that pool attributes can be set and do not require a reload.
+ *
+ * @author <a href="mailto:thofman@redhat.com">Tomas Hofman</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(ResourceAdapterPoolAttributesTestCase.ResourceAdapterCapacityPoliciesServerSetupTask.class)
+public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
+    private static final String RA_NAME = "pool-attributes-test.rar";
+    private static final ModelNode RA_ADDRESS = new ModelNode().add(SUBSYSTEM, "resource-adapters")
+            .add("resource-adapter", RA_NAME);
+    private static final ModelNode CONNECTION_ADDRESS = RA_ADDRESS.clone().add("connection-definitions", "Lazy");
+
+    static {
+        RA_ADDRESS.protect();
+        CONNECTION_ADDRESS.protect();
+    }
+
+    @Deployment
+    public static Archive<?> createResourceAdapter() {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RA_NAME);
+        rar.addAsManifestResource(LazyResourceAdapter.class.getPackage(), "ra-notx.xml", "ra.xml");
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "pool-attributes-test.jar");
+        jar.addClass(LazyResourceAdapter.class)
+                .addClass(LazyManagedConnectionFactory.class)
+                .addClass(LazyManagedConnection.class)
+                .addClass(LazyConnection.class)
+                .addClass(LazyConnectionImpl.class)
+                .addClass(LazyXAResource.class)
+                .addClass(LazyLocalTransaction.class)
+                .addClass(LazyManagedConnectionMetaData.class)
+                .addClass(LazyConnectionFactory.class)
+                .addClass(LazyConnectionFactoryImpl.class);
+
+        jar.addClasses(
+                ResourceAdapterPoolAttributesTestCase.class,
+                AbstractMgmtServerSetupTask.class, JcaMgmtServerSetupTask.class,
+                AbstractMgmtTestBase.class,
+                JcaMgmtBase.class,
+                ContainerResourceMgmtTestBase.class,
+                MgmtOperationException.class,
+                ManagementOperations.class,
+                JcaTestsUtil.class);
+
+        rar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector," +
+                "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper," +
+                "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
+
+        rar.addAsLibrary(jar);
+        return rar;
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Override
+    protected ModelControllerClient getModelControllerClient() {
+        return managementClient.getControllerClient();
+    }
+
+    @Test
+    public void testModifyPoolAttributes() throws Exception {
+        PoolConfiguration poolConfiguration = JcaTestsUtil.exctractPoolConfiguration(lcf);
+
+        // check initial values
+        Assert.assertNotNull(poolConfiguration);
+        Assert.assertEquals(2, poolConfiguration.getMinSize());
+        Assert.assertEquals(5, poolConfiguration.getMaxSize());
+        Assert.assertEquals(2, poolConfiguration.getInitialSize());
+        Assert.assertEquals(30000, poolConfiguration.getBlockingTimeout());
+        Assert.assertEquals(true, poolConfiguration.isFair());
+        Assert.assertEquals(false, poolConfiguration.isStrictMin());
+
+        // modify values
+        writeAttribute(CONNECTION_ADDRESS, Constants.MIN_POOL_SIZE.getName(), "4");
+        writeAttribute(CONNECTION_ADDRESS, Constants.MAX_POOL_SIZE.getName(), "10");
+        writeAttribute(CONNECTION_ADDRESS, Constants.INITIAL_POOL_SIZE.getName(), "6");
+        writeAttribute(CONNECTION_ADDRESS, Constants.BLOCKING_TIMEOUT_WAIT_MILLIS.getName(), "10000");
+        writeAttribute(CONNECTION_ADDRESS, Constants.POOL_FAIR.getName(), "false");
+        writeAttribute(CONNECTION_ADDRESS, Constants.POOL_USE_STRICT_MIN.getName(), "true");
+
+        // check that server is not in reload-required state
+        ModelNode serverState = readAttribute(new ModelNode(), "server-state");
+        Assert.assertEquals("running", serverState.asString());
+
+        // check that runtime was updated
+        Assert.assertEquals(4, poolConfiguration.getMinSize());
+        Assert.assertEquals(10, poolConfiguration.getMaxSize());
+        Assert.assertEquals(6, poolConfiguration.getInitialSize());
+        Assert.assertEquals(10000, poolConfiguration.getBlockingTimeout());
+        Assert.assertEquals(false, poolConfiguration.isFair());
+        Assert.assertEquals(true, poolConfiguration.isStrictMin());
+    }
+
+    static class ResourceAdapterCapacityPoliciesServerSetupTask extends JcaMgmtServerSetupTask {
+
+        @Override
+        public void doSetup(final ManagementClient managementClient) throws Exception {
+            String xml = FileUtils.readFile(ResourceAdapterPoolAttributesTestCase.class, "ra-def.xml");
+            List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_1.getUriString(), new ResourceAdapterSubsystemParser());
+            executeOperation(operationListToCompositeOperation(operations));
+            reload();
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            remove(RA_ADDRESS);
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ra-def.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ra-def.xml
@@ -1,0 +1,42 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat Middleware LLC, and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~
+  -->
+
+<subsystem xmlns="urn:jboss:domain:resource-adapters:1.1">
+    <resource-adapters>
+        <resource-adapter statistics-enabled="true">
+            <archive>pool-attributes-test.rar</archive>
+            <transaction-support>NoTransaction</transaction-support>
+            <connection-definitions>
+                <connection-definition
+                        class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"
+                        jndi-name="java:/eis/Lazy"
+                        pool-name="Lazy">
+                    <pool>
+                        <min-pool-size>2</min-pool-size>
+                        <max-pool-size>5</max-pool-size>
+                    </pool>
+                </connection-definition>
+            </connection-definitions>
+        </resource-adapter>
+    </resource-adapters>
+</subsystem>


### PR DESCRIPTION
...in datasource & resource-adapter attributes and admin-object add step handler

* added ```.setRestartAllServices()``` to attributes in datasource and resource-adapter subsystems that use ReloadRequiredWriteAttributeHandler
* added ```context.reloadRequired();``` to AdminObjectAdd, because reload is necessary for the newly added AdminObject to appear in JNDI tree

Wildfly Issue: https://issues.jboss.org/browse/WFLY-7924
EAP7 Issue: https://issues.jboss.org/browse/JBEAP-6854