### PR TITLE
[WFLY-7937] ConfigValidator.java#L83 - serverRequiresSsl checked twic…

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/ConfigValidator.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/ConfigValidator.java
@@ -80,7 +80,7 @@ public class ConfigValidator {
                 if(attribute.equals(Constants.IOR_NONE)){
                     throw IIOPLogger.ROOT_LOGGER.inconsistentSupportedTransportConfig(attributeDefinition.getName());
                 }
-                if (serverRequiresSsl && serverRequiresSsl && attribute.equals(Constants.IOR_SUPPORTED)) {
+                if (serverRequiresSsl && attribute.equals(Constants.IOR_SUPPORTED)) {
                     throw IIOPLogger.ROOT_LOGGER.inconsistentRequiredTransportConfig(Constants.SECURITY_SERVER_REQUIRES_SSL, attributeDefinition.getName());
                 }
             } else {


### PR DESCRIPTION
…e on the same line, should be probably serverRequiresSsl && clientRequiresSsl
JIRA: https://issues.jboss.org/browse/WFLY-7937
downstream: https://github.com/jbossas/jboss-eap7/pull/1326