### PR TITLE
WFLY-7958 Affinity methods do not need to be invoked within the context of a batch.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCache.java
@@ -57,16 +57,12 @@ public class DistributableCache<K, V extends Identifiable<K> & Contextual<Batch>
 
     @Override
     public Affinity getStrictAffinity() {
-        try (Batch batch = this.manager.getBatcher().createBatch()) {
-            return this.manager.getStrictAffinity();
-        }
+        return this.manager.getStrictAffinity();
     }
 
     @Override
     public Affinity getWeakAffinity(K id) {
-        try (Batch batch = this.manager.getBatcher().createBatch()) {
-            return this.manager.getWeakAffinity(id);
-        }
+        return this.manager.getWeakAffinity(id);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7958