### PR TITLE
WFLY-8003 Export javax.ws.rs.api services in RTS module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -37,7 +37,7 @@
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
-        <module name="javax.ws.rs.api"/>
+        <module name="javax.ws.rs.api" services="export"/>
         <module name="javax.servlet.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="javax.ejb.api"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8003
(caused by https://issues.jboss.org/browse/JBEAP-8341)