### PR TITLE
WFLY-7538 fix SocketPermission for cases when node1 property is provided

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
@@ -58,7 +58,7 @@ public class WebSocketTestCase {
                                         TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort(),
                                         "connect,resolve"),
                                 // Needed for xnio's WorkerThread which binds to Xnio.ANY_INET_ADDRESS, see WFLY-7538
-                                new SocketPermission(TestSuiteEnvironment.getServerAddress() + ":0", "listen,resolve")),
+                                new SocketPermission("*:0", "listen,resolve")),
                         "permissions.xml");
     }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-7538

Additional fix for already merged PR #9506. The testcase was still failing when security manager was used and `node0` property was specified.