### PR TITLE
WFLY-8025 Alternatives attribute "domain" doesn't exist in modcluster…

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterConfigResourceDefinition.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterConfigResourceDefinition.java
@@ -261,7 +261,6 @@ class ModClusterConfigResourceDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition LOAD_BALANCING_GROUP = SimpleAttributeDefinitionBuilder.create(CommonAttributes.LOAD_BALANCING_GROUP, ModelType.STRING, true)
             .setAllowExpression(true)
             .setRestartAllServices()
-            .addAlternatives(CommonAttributes.DOMAIN)
             .build();
 
     static final SimpleAttributeDefinition SIMPLE_LOAD_PROVIDER = SimpleAttributeDefinitionBuilder.create(CommonAttributes.SIMPLE_LOAD_PROVIDER_FACTOR, ModelType.INT, true)


### PR DESCRIPTION
… subsystem

https://issues.jboss.org/browse/WFLY-8025