### PR TITLE
WFLY-8035 Enforce (via capability reference) that clustered caches require a transport.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
@@ -173,6 +173,8 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
         this.attributes.stream()
                 .filter(attribute -> attribute.hasCapabilityRequirements())
                 .forEach(attribute -> attribute.addCapabilityRequirements(context, model.get(attribute.getName())));
+
+        this.descriptor.getResourceCapabilityReferences().forEach((reference, resolver) -> reference.addCapabilityRequirements(context, null, resolver.apply(address)));
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
@@ -114,4 +114,16 @@ public class CapabilityReference implements CapabilityReferenceRecorder {
     public boolean isDynamicDependent() {
         return this.capability.getDefinition().isDynamicallyNamed();
     }
+
+    @Override
+    public int hashCode() {
+        return this.getBaseDependentName().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof CapabilityReferenceRecorder)) return false;
+        CapabilityReference reference = (CapabilityReference) object;
+        return this.capability.getDefinition().getName().equals(reference.capability.getDefinition().getName());
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
@@ -85,6 +85,8 @@ public class RemoveStepHandler extends AbstractRemoveStepHandler implements Regi
                         .filter(attribute -> attribute.hasCapabilityRequirements())
                         .forEach(attribute -> attribute.removeCapabilityRequirements(context, model.get(attribute.getName())));
 
+            this.descriptor.getResourceCapabilityReferences().forEach((reference, resolver) -> reference.removeCapabilityRequirements(context, null, resolver.apply(address)));
+
             // Remove any runtime child resources
             removeRuntimeChildren(context, PathAddress.EMPTY_ADDRESS);
         }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandlerDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandlerDescriptor.java
@@ -21,6 +21,12 @@
  */
 package org.jboss.as.clustering.controller;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 
 /**
@@ -34,4 +40,12 @@ public interface RemoveStepHandlerDescriptor extends OperationStepHandlerDescrip
      * @return a description resolver
      */
     ResourceDescriptionResolver getDescriptionResolver();
+
+    /**
+     * Returns a mapping of capability references to an ancestor resource.
+     * @return a tuple of capability references and requirement resolvers.
+     */
+    default Map<CapabilityReferenceRecorder, Function<PathAddress, String>> getResourceCapabilityReferences() {
+        return Collections.emptyMap();
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
@@ -33,11 +33,14 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jboss.as.clustering.function.Predicates;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -69,6 +72,7 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     private final Map<AttributeDefinition, AttributeTranslation> attributeTranslations = new TreeMap<>(ATTRIBUTE_COMPARATOR);
     private final List<OperationStepHandler> translators = new LinkedList<>();
     private final List<OperationStepHandler> runtimeResourceRegistrations = new LinkedList<>();
+    private final Map<CapabilityReferenceRecorder, Function<PathAddress, String>> resourceCapabilityReferences = new HashMap<>();
 
     public ResourceDescriptor(ResourceDescriptionResolver resolver) {
         this.resolver = resolver;
@@ -227,6 +231,16 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
 
     public ResourceDescriptor addRuntimeResourceRegistration(OperationStepHandler registration) {
         this.runtimeResourceRegistrations.add(registration);
+        return this;
+    }
+
+    @Override
+    public Map<CapabilityReferenceRecorder, Function<PathAddress, String>> getResourceCapabilityReferences() {
+        return this.resourceCapabilityReferences;
+    }
+
+    public ResourceDescriptor addResourceCapabilityReference(CapabilityReferenceRecorder reference, Function<PathAddress, String> resolver) {
+        this.resourceCapabilityReferences.put(reference, resolver);
         return this;
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/function/Consumers.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/function/Consumers.java
@@ -46,6 +46,10 @@ public class Consumers {
         };
     }
 
+    public static <T> Consumer<T> empty() {
+        return value -> {};
+    }
+
     private Consumers() {
         // Hide
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreResourceDefinition.java
@@ -27,11 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.SimpleAliasEntry;
-import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
@@ -44,7 +39,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.ReadResourceHandler;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.ResourceTransformationContext;
 import org.jboss.as.controller.transform.ResourceTransformer;
@@ -122,7 +116,16 @@ public class BinaryKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
     }
 
     BinaryKeyedJDBCStoreResourceDefinition(boolean allowRuntimeOnlyRegistration) {
-        super(PATH, new InfinispanResourceDescriptionResolver(PATH, pathElement("jdbc"), WILDCARD_PATH), allowRuntimeOnlyRegistration);
+        super(PATH, LEGACY_PATH, new InfinispanResourceDescriptionResolver(PATH, pathElement("jdbc"), WILDCARD_PATH), allowRuntimeOnlyRegistration, descriptor -> descriptor
+                .addExtraParameters(DeprecatedAttribute.class)
+                .addRequiredChildren(BinaryTableResourceDefinition.PATH)
+                // Translate deprecated TABLE attribute into separate add table operation
+                .addOperationTranslator(new TableAttributeTranslator(DeprecatedAttribute.TABLE, BinaryTableResourceDefinition.PATH))
+            , address -> new BinaryKeyedJDBCStoreBuilder(address.getParent()), registration -> {
+                registration.registerReadWriteAttribute(DeprecatedAttribute.TABLE.getDefinition(), LEGACY_READ_TABLE_HANDLER, LEGACY_WRITE_TABLE_HANDLER);
+
+                new BinaryTableResourceDefinition().register(registration);
+            });
     }
 
     static final OperationStepHandler LEGACY_READ_TABLE_HANDLER = new OperationStepHandler() {
@@ -148,31 +151,4 @@ public class BinaryKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
             }
         }
     };
-
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(JDBCStoreResourceDefinition.Attribute.class)
-                .addAttributes(StoreResourceDefinition.Attribute.class)
-                .addExtraParameters(DeprecatedAttribute.class)
-                .addCapabilities(Capability.class)
-                .addRequiredChildren(BinaryTableResourceDefinition.PATH)
-                .addRequiredSingletonChildren(StoreWriteThroughResourceDefinition.PATH)
-                // Translate deprecated DATASOURCE attribute to DATA_SOURCE attribute
-                .addAttributeTranslation(JDBCStoreResourceDefinition.DeprecatedAttribute.DATASOURCE, JDBCStoreResourceDefinition.Attribute.DATA_SOURCE, JDBCStoreResourceDefinition.POOL_NAME_TO_JNDI_NAME_TRANSLATOR, JDBCStoreResourceDefinition.JNDI_NAME_TO_POOL_NAME_TRANSLATOR)
-                // Translate deprecated TABLE attribute into separate add table operation
-                .addOperationTranslator(new TableAttributeTranslator(DeprecatedAttribute.TABLE, BinaryTableResourceDefinition.PATH))
-                ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(address -> new BinaryKeyedJDBCStoreBuilder(address.getParent()));
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        registration.registerReadWriteAttribute(DeprecatedAttribute.TABLE.getDefinition(), LEGACY_READ_TABLE_HANDLER, LEGACY_WRITE_TABLE_HANDLER);
-
-        new BinaryTableResourceDefinition().register(registration);
-
-        super.register(registration);
-    }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -22,7 +22,10 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import java.util.function.Consumer;
+
 import org.jboss.as.clustering.controller.MetricHandler;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
 import org.jboss.as.controller.AttributeDefinition;
@@ -103,17 +106,14 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
         CacheResourceDefinition.buildTransformation(version, builder);
     }
 
-    ClusteredCacheResourceDefinition(PathElement path, PathManager pathManager, boolean allowRuntimeOnlyRegistration) {
-        super(path, pathManager, allowRuntimeOnlyRegistration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-
-        if (this.allowRuntimeOnlyRegistration) {
-            new MetricHandler<>(new ClusteredCacheMetricExecutor(), ClusteredCacheMetric.class).register(registration);
-        }
-
-        super.register(registration);
+    ClusteredCacheResourceDefinition(PathElement path, PathManager pathManager, boolean allowRuntimeOnlyRegistration, Consumer<ResourceDescriptor> descriptorConfigurator, ClusteredCacheServiceHandler handler, Consumer<ManagementResourceRegistration> registrationConfigurator) {
+        super(path, pathManager, allowRuntimeOnlyRegistration, descriptorConfigurator.andThen(descriptor -> descriptor
+                .addAttributes(Attribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+            ), handler, registrationConfigurator.andThen(registration -> {
+                if (allowRuntimeOnlyRegistration) {
+                    new MetricHandler<>(new ClusteredCacheMetricExecutor(), ClusteredCacheMetric.class).register(registration);
+                }
+            }));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
@@ -22,21 +22,16 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.SimpleAliasEntry;
-import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
+import org.jboss.as.clustering.function.Consumers;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelType;
 
@@ -83,22 +78,6 @@ public class CustomStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     CustomStoreResourceDefinition(boolean allowRuntimeOnlyRegistration) {
-        super(PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(Attribute.class)
-                .addAttributes(StoreResourceDefinition.Attribute.class)
-                .addRequiredSingletonChildren(StoreWriteThroughResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(address -> new CustomStoreBuilder(address.getParent()));
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+        super(PATH, LEGACY_PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration, descriptor -> descriptor.addAttributes(Attribute.class), address -> new CustomStoreBuilder(address.getParent()), Consumers.empty());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.validation.DoubleRangeValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.IntRangeValidatorBuilder;
@@ -36,7 +33,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
@@ -111,29 +107,6 @@ public class DistributedCacheResourceDefinition extends SharedStateCacheResource
     }
 
     DistributedCacheResourceDefinition(PathManager pathManager, boolean allowRuntimeOnlyRegistration) {
-        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(Attribute.class)
-                .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
-                .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
-                .addAttributes(CacheResourceDefinition.Attribute.class)
-                .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-                .addCapabilities(CacheResourceDefinition.Capability.class)
-                .addCapabilities(CacheResourceDefinition.CLUSTERING_CAPABILITIES.values())
-                .addRequiredChildren(EvictionResourceDefinition.PATH, ExpirationResourceDefinition.PATH, LockingResourceDefinition.PATH, TransactionResourceDefinition.PATH)
-                .addRequiredChildren(PartitionHandlingResourceDefinition.PATH, StateTransferResourceDefinition.PATH, BackupForResourceDefinition.PATH, BackupsResourceDefinition.PATH)
-                .addRequiredSingletonChildren(NoStoreResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new DistributedCacheServiceHandler();
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration, descriptor -> descriptor.addAttributes(Attribute.class), new DistributedCacheServiceHandler());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
@@ -22,12 +22,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.function.Consumers;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
@@ -50,27 +47,6 @@ public class InvalidationCacheResourceDefinition extends ClusteredCacheResourceD
     }
 
     InvalidationCacheResourceDefinition(PathManager pathManager, boolean allowRuntimeOnlyRegistration) {
-        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
-                .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
-                .addAttributes(CacheResourceDefinition.Attribute.class)
-                .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-                .addCapabilities(CacheResourceDefinition.Capability.class)
-                .addCapabilities(CacheResourceDefinition.CLUSTERING_CAPABILITIES.values())
-                .addRequiredChildren(EvictionResourceDefinition.PATH, ExpirationResourceDefinition.PATH, LockingResourceDefinition.PATH, TransactionResourceDefinition.PATH)
-                .addRequiredSingletonChildren(NoStoreResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new InvalidationCacheServiceHandler();
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration, Consumers.empty(), new InvalidationCacheServiceHandler(), Consumers.empty());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportBuilder.java
@@ -73,7 +73,7 @@ public class JGroupsTransportBuilder extends ComponentBuilder<TransportConfigura
     }
 
     @Override
-    public TransportConfiguration getValue() throws IllegalStateException, IllegalArgumentException {
+    public TransportConfiguration getValue() {
         ChannelFactory factory = this.factory.getValue();
         ProtocolStackConfiguration stack = factory.getProtocolStackConfiguration();
         org.wildfly.clustering.jgroups.spi.TransportConfiguration.Topology topology = stack.getTransport().getTopology();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
@@ -22,12 +22,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.function.Consumers;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
@@ -50,25 +47,6 @@ public class LocalCacheResourceDefinition extends CacheResourceDefinition {
     }
 
     LocalCacheResourceDefinition(PathManager pathManager, boolean allowRuntimeOnlyRegistration) {
-        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(CacheResourceDefinition.Attribute.class)
-                .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-                .addCapabilities(CacheResourceDefinition.Capability.class)
-                .addCapabilities(CacheResourceDefinition.CLUSTERING_CAPABILITIES.values())
-                .addRequiredChildren(EvictionResourceDefinition.PATH, ExpirationResourceDefinition.PATH, LockingResourceDefinition.PATH, TransactionResourceDefinition.PATH)
-                .addRequiredSingletonChildren(NoStoreResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new LocalCacheServiceHandler();
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration, Consumers.empty(), new LocalCacheServiceHandler(), Consumers.empty());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -28,14 +28,10 @@ import org.infinispan.commons.api.BasicCacheContainer;
 import org.jboss.as.clustering.controller.AttributeParsers;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.SimpleAliasEntry;
-import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
+import org.jboss.as.clustering.function.Consumers;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
@@ -46,7 +42,6 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -154,23 +149,9 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     RemoteStoreResourceDefinition(boolean allowRuntimeOnlyRegistration) {
-        super(PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+        super(PATH, LEGACY_PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration, descriptor -> descriptor
                 .addAttributes(Attribute.class)
-                .addAttributes(StoreResourceDefinition.Attribute.class)
                 .addCapabilities(Capability.class)
-                .addRequiredSingletonChildren(StoreWriteThroughResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(address -> new RemoteStoreBuilder(address.getParent()));
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+            , address -> new RemoteStoreBuilder(address.getParent()), Consumers.empty());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
@@ -22,12 +22,9 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.SimpleResourceRegistration;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.function.Consumers;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
@@ -50,28 +47,6 @@ public class ReplicatedCacheResourceDefinition extends SharedStateCacheResourceD
     }
 
     ReplicatedCacheResourceDefinition(PathManager pathManager, boolean allowRuntimeOnlyRegistration) {
-        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void register(ManagementResourceRegistration parentRegistration) {
-        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
-
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
-                .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
-                .addAttributes(CacheResourceDefinition.Attribute.class)
-                .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-                .addCapabilities(CacheResourceDefinition.Capability.class)
-                .addCapabilities(CacheResourceDefinition.CLUSTERING_CAPABILITIES.values())
-                .addRequiredChildren(EvictionResourceDefinition.PATH, ExpirationResourceDefinition.PATH, LockingResourceDefinition.PATH, TransactionResourceDefinition.PATH)
-                .addRequiredChildren(PartitionHandlingResourceDefinition.PATH, StateTransferResourceDefinition.PATH, BackupForResourceDefinition.PATH, BackupsResourceDefinition.PATH)
-                .addRequiredSingletonChildren(NoStoreResourceDefinition.PATH)
-                ;
-        ResourceServiceHandler handler = new ReplicatedCacheServiceHandler();
-        new SimpleResourceRegistration(descriptor, handler).register(registration);
-
-        super.register(registration);
+        super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration, Consumers.empty(), new ReplicatedCacheServiceHandler());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8035

Adds generic support for handling capability references to requirements provided by an ancestor resource (where the dynamic capability value is provided by some element of the path address, as opposed to an attribute value).