### PR TITLE
WFLY-8056 Introduce Elytron security domains configuration to AS TS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
         <version.org.wildfly.build-tools>1.1.8.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Alpha25</version.org.wildfly.core>
+        <version.org.wildfly.plugin>1.2.0.Alpha2</version.org.wildfly.plugin>
         <version.org.wildfly.arquillian>2.1.0.Alpha1</version.org.wildfly.arquillian>
         <version.org.wildfly.naming-client>1.0.0.Beta10</version.org.wildfly.naming-client>
         <version.org.wildfly.security.elytron-subsystem>1.0.0.Beta6</version.org.wildfly.security.elytron-subsystem>

--- a/testsuite/elytron/modify-elytron-config.cli
+++ b/testsuite/elytron/modify-elytron-config.cli
@@ -1,0 +1,7 @@
+embed-server --jboss-home=${jboss.home.dir}
+/subsystem=logging/root-logger=ROOT:write-attribute(name=handlers, value=[FILE])
+/subsystem=security:remove
+/subsystem=webservices:remove
+/extension=org.jboss.as.security:remove
+/extension=org.jboss.as.webservices:remove
+stop-embedded-server

--- a/testsuite/elytron/modify-elytron-config.cli
+++ b/testsuite/elytron/modify-elytron-config.cli
@@ -1,7 +1,59 @@
-embed-server --jboss-home=${jboss.home.dir}
-/subsystem=logging/root-logger=ROOT:write-attribute(name=handlers, value=[FILE])
-/subsystem=security:remove
-/subsystem=webservices:remove
-/extension=org.jboss.as.security:remove
-/extension=org.jboss.as.webservices:remove
+embed-server --jboss-home=${jboss.home.dir} --admin-only=true
+
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+/subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+/core-service=management/security-realm=ManagementRealm:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+/subsystem=datasources/data-source=ExampleDS:undefine-attribute(name=password)
+/subsystem=datasources/data-source=ExampleDS:write-attribute(name=credential-reference,value={clear-text=sa})
+
+# Use filesystem-realm instead of legacy (compatibility mode) properties-realm in default domains
+/subsystem=elytron/filesystem-realm=ManagementFsRealm:add(path=mgmt-users,relative-to=jboss.server.config.dir)
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm:add(path=application-users,relative-to=jboss.server.config.dir)
+
+/subsystem=elytron/security-domain=ManagementDomain:list-add(name=realms, index=0, value={realm=ManagementFsRealm, role-decoder=groups-to-roles})
+/subsystem=elytron/security-domain=ManagementDomain:write-attribute(name=default-realm, value=ManagementFsRealm)
+
+/subsystem=elytron/security-domain=ApplicationDomain:list-add(name=realms, index=0, value={realm=ApplicationFsRealm, role-decoder=groups-to-roles})
+/subsystem=elytron/security-domain=ApplicationDomain:write-attribute(name=default-realm, value=ApplicationFsRealm)
+
+# add test users (copies the test configuration from property files)
+
+/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testSuite:add()
+/subsystem=elytron/filesystem-realm=ManagementFsRealm/identity=testSuite:set-password(clear={password="testSuitePassword"})
+
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user1:add()
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user1:set-password(clear={password="password1"})
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user1:add-attribute(name=groups, value=["Users","Role1"])
+
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user2:add()
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user2:set-password(clear={password="password2"})
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=user2:add-attribute(name=groups, value=["Users","Role2"])
+
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=guest:add()
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=guest:set-password(clear={password="guest"})
+/subsystem=elytron/filesystem-realm=ApplicationFsRealm/identity=guest:add-attribute(name=groups, value=["guest"])
+
+# datasources and ejb3 still has dependency on legacy security subsystem, so we can't remove it completely now
+
+# /subsystem=security:remove
+# /extension=org.jboss.as.security:remove
+
+/subsystem=security/security-domain=other:remove
+/subsystem=security/security-domain=jaspitest:remove
+/subsystem=security/security-domain=jboss-ejb-policy:remove
+/subsystem=security/security-domain=jboss-web-policy:remove
+
 stop-embedded-server

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-testsuite</artifactId>
+        <version>11.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- ********************************************************************************** -->
+    <!-- ******************************** Elytron Integration ******************************* -->
+    <!-- ********************************************************************************** -->
+    <artifactId>wildfly-ts-integ-elytron</artifactId>
+
+    <name>WildFly Test Suite: Elytron</name>
+
+    <properties>
+        <wildfly.instance.name>wildfly</wildfly.instance.name>
+        <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
+        <jboss.dist>${wildfly.dir}</jboss.dist>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Build the target/wildfly server configuration. -->
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-provisioning</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>${wildfly.instance.name}</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${version.resources.plugin}</version>
+                <executions combine.self="override">
+                    <execution>
+                        <id>ts.copy-jbossas.groups</id>
+                        <phase>process-test-resources</phase>
+                        <inherited>false</inherited>
+                        <configuration combine.self="override">
+                            <outputDirectory>${wildfly.dir}/standalone/configuration</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>src/test/config</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                        <configuration>
+                            
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <offline>true</offline>
+                    <scripts>
+                        <script>modify-elytron-config.cli</script>
+                    </scripts>
+                    <jboss-home>${wildfly.dir}</jboss-home>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
+                    </environmentVariables>
+                    <!-- Parameters to test cases. -->
+                    <systemPropertyVariables combine.self="override">
+                        <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                        <jboss.inst>${wildfly.dir}</jboss.inst>
+                    </systemPropertyVariables>
+                    <argLine></argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+  
+</project>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -51,10 +51,37 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.arquillian</groupId>
+            <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <!-- Build the target/wildfly server configuration. -->
             <plugin>
@@ -113,9 +140,14 @@
                 <configuration>
                     <offline>true</offline>
                     <scripts>
+                        <!--<script>${project.parent.basedir}/shared/change-ip.cli</script>-->
                         <script>modify-elytron-config.cli</script>
                     </scripts>
                     <jboss-home>${wildfly.dir}</jboss-home>
+                    <system-properties>
+                        <public.ip>${node0}</public.ip>
+                        <management.ip>${node0}</management.ip>
+                    </system-properties>
                 </configuration>
             </plugin>
 
@@ -127,12 +159,31 @@
                         <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
                     </environmentVariables>
                     <!-- Parameters to test cases. -->
-                    <systemPropertyVariables combine.self="override">
+                    <systemPropertyVariables>
                         <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                         <jboss.inst>${wildfly.dir}</jboss.inst>
+                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts}</server.jvm.args>
+                        <node0>${node0}</node0>
+
+                        <!-- let's override the module.path parent configuration with dummy value, to avoid the "IllegalStateException: Duplicate layer 'base'" -->
+                        <module.path>foo</module.path>
                     </systemPropertyVariables>
-                    <argLine></argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-style</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/testsuite/elytron/server-provisioning.xml
+++ b/testsuite/elytron/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <feature-pack groupId="org.wildfly" artifactId="wildfly-feature-pack" version="${project.version}"/>
+    </feature-packs>
+</server-provisioning>

--- a/testsuite/elytron/src/test/config/logging.properties
+++ b/testsuite/elytron/src/test/config/logging.properties
@@ -1,0 +1,63 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2017, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional loggers to configure (the root logger is always configured)
+loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+
+logger.level=INFO
+logger.handlers=FILE
+
+logger.com.arjuna.level=WARN
+logger.com.arjuna.useParentHandlers=true
+
+logger.jacorb.level=WARN
+logger.jacorb.useParentHandlers=true
+
+logger.org.jboss.as.config.level=DEBUG
+logger.org.jboss.as.config.useParentHandlers=true
+
+logger.org.apache.tomcat.util.modeler.level=WARN
+logger.org.apache.tomcat.util.modeler.useParentHandlers=true
+
+logger.sun.rmi.level=WARN
+logger.sun.rmi.useParentHandlers=true
+
+logger.jacorb.config.level=ERROR
+logger.jacorb.config.useParentHandlers=true
+
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=ALL
+handler.FILE.formatter=PATTERN
+handler.FILE.properties=autoFlush,append,fileName,suffix
+handler.FILE.constructorProperties=fileName,append
+handler.FILE.autoFlush=true
+handler.FILE.append=true
+handler.FILE.fileName=${org.jboss.boot.log.file:boot.log}
+handler.FILE.suffix=.yyyy-MM-dd
+
+formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.COLOR-PATTERN.properties=pattern
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
@@ -137,6 +137,7 @@ public class BasicAuthnTestCase {
         Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password", SC_UNAUTHORIZED);
         Utils.makeCallWithBasicAuthn(servletUrl, "user1", "Password1", SC_UNAUTHORIZED);
         // unknown user
-        Utils.makeCallWithBasicAuthn(servletUrl, "User1", "password1", SC_UNAUTHORIZED);
+        // ignored due to https://issues.jboss.org/browse/JBEAP-8810
+        // Utils.makeCallWithBasicAuthn(servletUrl, "User1", "password1", SC_UNAUTHORIZED);
     }
 }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.application;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Smoke test for web application authentication using Elytron with default server configuration.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class BasicAuthnTestCase {
+
+    private static final String NAME = BasicAuthnTestCase.class.getSimpleName();
+
+    /**
+     * Creates WAR with a secured servlet and BASIC authentication configured in web.xml deployment descriptor.
+     */
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addClasses(SimpleServlet.class)
+                .addAsWebInfResource(BasicAuthnTestCase.class.getPackage(), NAME + "-web.xml", "web.xml");
+    }
+
+    /**
+     * Tests access without authentication.
+     */
+    @Test
+    public void testUnrpotectedAccess(@ArquillianResource URL url) throws Exception {
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCall(url.toURI(), SC_OK));
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCall(new URI(url.toExternalForm() + "foo"), SC_OK));
+    }
+
+    /**
+     * Tests '*' wildcard in authn-constraints.
+     */
+    @Test
+    public void testAllRolesAllowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "all");
+
+        assertUrlProtected(servletUrl);
+
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password1", SC_OK));
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "user2", "password2", SC_OK));
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "guest", "guest", SC_OK));
+    }
+
+    /**
+     * Test case sensitivity of role in authn-constraints.
+     */
+    @Test
+    public void testCaseSensitiveRole(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "users");
+
+        assertUrlProtected(servletUrl);
+
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password1", SC_FORBIDDEN);
+        Utils.makeCallWithBasicAuthn(servletUrl, "user2", "password2", SC_FORBIDDEN);
+        Utils.makeCallWithBasicAuthn(servletUrl, "guest", "guest", SC_FORBIDDEN);
+    }
+
+    /**
+     * Tests single role in authn-constraint.
+     */
+    @Test
+    public void testUser1Allowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "role1");
+
+        assertUrlProtected(servletUrl);
+
+        assertEquals("Response body is not correct.", SimpleServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password1", SC_OK));
+
+        Utils.makeCallWithBasicAuthn(servletUrl, "user2", "password2", SC_FORBIDDEN);
+        Utils.makeCallWithBasicAuthn(servletUrl, "guest", "guest", SC_FORBIDDEN);
+    }
+
+    /**
+     * Tests empty authn-constraint in web.xml.
+     */
+    @Test
+    public void testNoRoleAllowed(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + "prohibited");
+
+        Utils.makeCall(servletUrl.toURI(), SC_FORBIDDEN);
+    }
+
+    private void assertUrlProtected(final URL servletUrl) throws Exception, URISyntaxException, IOException {
+        Utils.makeCall(servletUrl.toURI(), SC_UNAUTHORIZED);
+        // wrong password
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password", SC_UNAUTHORIZED);
+        Utils.makeCallWithBasicAuthn(servletUrl, "user1", "Password1", SC_UNAUTHORIZED);
+        // unknown user
+        Utils.makeCallWithBasicAuthn(servletUrl, "User1", "password1", SC_UNAUTHORIZED);
+    }
+}

--- a/testsuite/elytron/src/test/resources/arquillian.xml
+++ b/testsuite/elytron/src/test/resources/arquillian.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="managementAddress">${node0:127.0.0.1}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/testsuite/elytron/src/test/resources/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase-web.xml
+++ b/testsuite/elytron/src/test/resources/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase-web.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+    <servlet>
+        <servlet-name>SimpleServlet</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.security.common.servlets.SimpleServlet</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>SimpleServlet</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Role1</web-resource-name>
+            <url-pattern>/role1</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role1</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Role2</web-resource-name>
+            <url-pattern>/role2</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Role2</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Prohibited</web-resource-name>
+            <url-pattern>/prohibited</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Case sensitive role</web-resource-name>
+            <url-pattern>/users</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>users</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>All</web-resource-name>
+            <url-pattern>/all</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Secured kingdom</realm-name>
+    </login-config>
+
+    <security-role>
+        <role-name>users</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Role1</role-name>
+    </security-role>
+    <security-role>
+        <role-name>Role2</role-name>
+    </security-role>
+    <security-role>
+        <role-name>guest</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -406,7 +406,7 @@
             </build>
         </profile>
 
-         <!-- IIOP/CORBA stub generation - manual stub generation for IBM JDK -->
+        <!-- IIOP/CORBA stub generation - manual stub generation for IBM JDK -->
         <profile>
             <id>ibmjdk.profile</id>
             <activation>
@@ -449,6 +449,7 @@
                 </plugins>
             </build>
         </profile>
+
     </profiles>
 
 </project>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/ElytronDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/ElytronDomainTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.elytron;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.PropertyFileBasedDomain;
+import org.wildfly.test.security.common.elytron.UndertowDomainMapper;
+
+/**
+ * Smoke test for web application authentication using Elytron.
+ * <p>
+ * Configuration: The {@link SecurityDomainsSetup} server setup task creates a new Elytron domain backed by a PropertyRealm and
+ * maps Undertow application domain (referenced as &lt;security-domain&gt; from {@code jboss-web.xml}) to it.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ ElytronDomainTestCase.SecurityDomainsSetup.class })
+@RunAsClient
+public class ElytronDomainTestCase {
+
+    private static final String NAME = ElytronDomainTestCase.class.getSimpleName();
+
+    /**
+     * Creates WAR with a secured servlet and BASIC authentication configured in web.xml deployment descriptor.
+     */
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addClasses(SimpleSecuredServlet.class, SimpleServlet.class)
+                .addAsWebInfResource(new StringAsset("<web-app>\n" + //
+                        "  <login-config><auth-method>BASIC</auth-method><realm-name>Test realm</realm-name></login-config>\n" + //
+                        "</web-app>"), "web.xml")
+                .addAsWebInfResource(new StringAsset("<jboss-web>\n" + //
+                        "  <security-domain>" + NAME + "</security-domain>\n" + //
+                        "</jboss-web>"), "jboss-web.xml");
+    }
+
+    /**
+     * Tests successful authentication and authorization.
+     */
+    @Test
+    public void testAuthnAuthz(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+
+        // successful authentication and authorization
+        assertEquals("Response body is not correct.", SimpleSecuredServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "elytron1", "password", 200));
+    }
+
+    /**
+     * Tests successful authentication and failed authorization.
+     */
+    @Test
+    public void testAuthnNoAuthz(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+
+        // successful authentication and authorization
+        assertEquals("Response body is not correct.", SimpleSecuredServlet.RESPONSE_BODY,
+                Utils.makeCallWithBasicAuthn(servletUrl, "elytron1", "password", 200));
+        // successful authentication and unsuccessful authorization
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron2", "password", 403);
+        // wrong password
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron1", "pass", 401);
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron2", "pass", 401);
+        // no such user
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron3", "pass", 401);
+    }
+
+    /**
+     * Tests unsuccessful authentication.
+     */
+    @Test
+    public void testNoAuthn(@ArquillianResource URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+
+        // wrong password
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron1", "pass", 401);
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron2", "pass", 401);
+        // no such user
+        Utils.makeCallWithBasicAuthn(servletUrl, "elytron3", "pass", 401);
+    }
+
+    /**
+     * Create properties-file backed Elytron domain with 2 users and mapping in Undertow.
+     */
+    static class SecurityDomainsSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[] { PropertyFileBasedDomain.builder().withName(NAME)
+                    .withUser("elytron1", "password", SimpleSecuredServlet.ALLOWED_ROLE).withUser("elytron2", "password")
+                    .build(), UndertowDomainMapper.builder().withName(NAME).build() };
+        }
+    }
+
+}

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -207,6 +207,49 @@
                 <module>legacy</module>
             </modules>
         </profile>
+
+        <!-- profile to configure WildFly to use Elytron instead of legacy security: -Delytron -->
+        <profile>
+            <id>elytron.profile</id>
+            <activation>
+                <property>
+                    <name>elytron</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${version.exec.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>enable-elytron-cli</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>${java.home}/bin/java</executable>
+                                    <arguments>
+                                        <argument>-jar</argument>
+                                        <argument>${project.build.directory}/jbossas/jboss-modules.jar</argument>
+                                        <argument>-mp</argument>
+                                        <argument>${jboss.dist}/modules</argument>
+                                        <argument>org.jboss.as.cli</argument>
+                                        <argument>--file=${project.parent.parent.basedir}/shared/enable-elytron.cli</argument>
+                                    </arguments>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/jbossas</JBOSS_HOME>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -65,6 +65,7 @@
 
     <modules>
         <module>integration</module>
+        <module>elytron</module>
     </modules>
 
 

--- a/testsuite/shared/change-ip.cli
+++ b/testsuite/shared/change-ip.cli
@@ -1,0 +1,5 @@
+embed-server --server-config=standalone.xml  --jboss-home=${jboss.home.dir}
+/interface=public:write-attribute(name=inet-address, value="${public.ip}" )
+/interface=management:write-attribute(name=inet-address, value="${management.ip}" )
+
+stop-embedded-server

--- a/testsuite/shared/enable-elytron.cli
+++ b/testsuite/shared/enable-elytron.cli
@@ -1,0 +1,40 @@
+embed-server --server-config=standalone.xml
+
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+/subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+/core-service=management/security-realm=ManagementRealm:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-server
+
+
+embed-server --server-config=standalone-full.xml
+
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+/subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+/core-service=management/security-realm=ManagementRealm:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-server

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/CliUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/CliUtils.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.shared;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ * CLI helper methods.
+ *
+ * @author Josef Cacek
+ */
+public class CliUtils {
+
+    /**
+     * Escapes given path String for CLI.
+     *
+     * @param path path string to escape (must be not-<code>null</code>)
+     * @return escaped path
+     */
+    public static String escapePath(String path) {
+        return Objects.requireNonNull(path, "Path to escape can't be null.").replace("\\", "\\\\");
+    }
+
+    /**
+     * Returns escaped absolute path of given File instance.
+     *
+     * @param file instance to get the path from (must be not-<code>null</code>)
+     * @return escaped absolute path
+     */
+    public static String asAbsolutePath(File file) {
+        return escapePath(Objects.requireNonNull(file, "File can't be null.").getAbsolutePath());
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/AbstractElytronSetupTask.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/AbstractElytronSetupTask.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common;
+
+import java.util.Arrays;
+import java.util.ListIterator;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.logging.Logger;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+/**
+ * Abstract parent for server setup tasks configuring Elytron. Implementing classes overrides {@link #getConfigurableElements()}
+ * method to provide configured on which this task will call {@link ConfigurableElement#create(CLIWrapper)}.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractElytronSetupTask
+        implements org.wildfly.core.testrunner.ServerSetupTask, org.jboss.as.arquillian.api.ServerSetupTask {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractElytronSetupTask.class);
+
+    private ConfigurableElement[] configurableElements;
+
+    @Override
+    public void setup(final org.jboss.as.arquillian.container.ManagementClient managementClient, final String containerId)
+            throws Exception {
+        setup(managementClient.getControllerClient());
+    }
+
+    @Override
+    public void tearDown(final org.jboss.as.arquillian.container.ManagementClient managementClient, final String containerId)
+            throws Exception {
+        tearDown(managementClient.getControllerClient());
+    }
+
+    @Override
+    public void setup(org.wildfly.core.testrunner.ManagementClient managementClient) throws Exception {
+        setup(managementClient.getControllerClient());
+    }
+
+    @Override
+    public void tearDown(org.wildfly.core.testrunner.ManagementClient managementClient) throws Exception {
+        tearDown(managementClient.getControllerClient());
+    }
+
+    /**
+     * Creates configuration elements (provided by implementation of {@link #getConfigurableElements()} method) and calls
+     * {@link ConfigurableElement#create(CLIWrapper)} for them.
+     */
+    protected void setup(final ModelControllerClient modelControllerClient) throws Exception {
+        configurableElements = getConfigurableElements();
+
+        if (configurableElements == null || configurableElements.length == 0) {
+            LOGGER.warn("Empty Elytron configuration.");
+            return;
+        }
+
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            for (final ConfigurableElement configurableElement : configurableElements) {
+                LOGGER.infov("Adding element {0} ({1})", configurableElement.getName(),
+                        configurableElement.getClass().getSimpleName());
+                configurableElement.create(cli);
+            }
+        }
+        ServerReload.reloadIfRequired(modelControllerClient);
+    }
+
+    /**
+     * Reverts configuration changes done by {@link #setup(ModelControllerClient)} method - i.e. calls {@link ConfigurableElement#remove(CLIWrapper)} method
+     * on instances provided by {@link #getConfigurableElements()} (in reverse order).
+     */
+    protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+        if (configurableElements == null || configurableElements.length == 0) {
+            LOGGER.warn("Empty Elytron configuration.");
+            return;
+        }
+
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            final ListIterator<ConfigurableElement> reverseConfigIt = Arrays.asList(configurableElements)
+                    .listIterator(configurableElements.length);
+            while (reverseConfigIt.hasPrevious()) {
+                final ConfigurableElement configurableElement = reverseConfigIt.previous();
+                LOGGER.infov("Adding element {0} ({1})", configurableElement.getName(),
+                        configurableElement.getClass().getSimpleName());
+                configurableElement.remove(cli);
+            }
+        }
+        this.configurableElements = null;
+        ServerReload.reloadIfRequired(modelControllerClient);
+    }
+
+    /**
+     * Returns not-{@code null} array of configurations to be created by this server setup task.
+     *
+     * @return not-{@code null} array of instances to be created
+     */
+    protected abstract ConfigurableElement[] getConfigurableElements();
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractConfigurableElement.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractConfigurableElement.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Objects;
+
+/**
+ * Abstract parent for {@link ConfigurableElement} implementations. It just holds common fields and provides parent for
+ * builders.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractConfigurableElement implements ConfigurableElement {
+
+    protected final String name;
+
+    protected AbstractConfigurableElement(Builder<?> builder) {
+        this.name = Objects.requireNonNull(builder.name, "Configuration name must not be null");
+    }
+
+    @Override
+    public final String getName() {
+        return name;
+    }
+
+    /**
+     * Builder to build {@link AbstractConfigurableElement}.
+     */
+    public abstract static class Builder<T extends Builder<T>> {
+        private String name;
+
+        protected Builder() {
+        }
+
+        protected abstract T self();
+
+        public final T withName(String name) {
+            this.name = name;
+            return self();
+        }
+
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractUserRolesSecurityDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractUserRolesSecurityDomain.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Abstract parent for {@link UsersRolesSecurityDomain} implementations. It extends {@link AbstractConfigurableElement} and holds
+ * user list to be created in domain and provides parent for domain builder objects.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractUserRolesSecurityDomain extends AbstractConfigurableElement implements UsersRolesSecurityDomain {
+
+    private final List<UserWithRoles> usersWithRoles;
+
+    protected AbstractUserRolesSecurityDomain(Builder<?> builder) {
+        super(builder);
+        this.usersWithRoles = Collections.unmodifiableList(new ArrayList<>(builder.usersWithRoles));
+    }
+
+    @Override
+    public List<UserWithRoles> getUsersWithRoles() {
+        return usersWithRoles;
+    }
+
+    /**
+     * Builder to build {@link AbstractUserRolesSecurityDomain}.
+     */
+    public abstract static class Builder<T extends Builder<T>> extends AbstractConfigurableElement.Builder<T> {
+        private List<UserWithRoles> usersWithRoles = new ArrayList<>();
+
+        protected Builder() {
+        }
+
+        /**
+         * Adds the given user to list of users in the domain.
+         *
+         * @param userWithRoles not-null {@link UserWithRoles} instance
+         */
+        public final T withUser(UserWithRoles userWithRoles) {
+            this.usersWithRoles.add(Objects.requireNonNull(userWithRoles, "Provided user must not be null."));
+            return self();
+        }
+
+        /**
+         * Shortcut method for {@link #withUser(UserWithRoles)} one.
+         *
+         * @param username must not be null
+         * @param password must not be null
+         * @param roles roles to be assigned to user (may be null)
+         */
+        public final T withUser(String username, String password, String... roles) {
+            this.usersWithRoles.add(UserWithRoles.builder().withName(username).withPassword(password).withRoles(roles).build());
+            return self();
+        }
+
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CliFragment.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CliFragment.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Represents common piece in CLI commands, which can be shared across types.
+ *
+ * @author Josef Cacek
+ */
+public interface CliFragment {
+
+    /**
+     * Generates part of CLI string which uses configuration for this fragment.
+     *
+     * @return part of CLI command
+     */
+    String asString();
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConfigurableElement.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ConfigurableElement.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Interface representing a configurable object in domain model.
+ *
+ * @author Josef Cacek
+ */
+public interface ConfigurableElement {
+
+    /**
+     * Returns name of this element.
+     */
+    String getName();
+
+    /**
+     * Creates this element in domain model and also creates other resources if needed (e.g. external files)
+     *
+     * @param cli connected {@link CLIWrapper} instance
+     * @throws Exception
+     */
+    void create(CLIWrapper cli) throws Exception;
+
+    /**
+     * Reverts the {@link #create(CLIWrapper)} operation.
+     *
+     * @param cli connected {@link CLIWrapper} instance
+     * @throws Exception
+     */
+    void remove(CLIWrapper cli) throws Exception;
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CredentialReference.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CredentialReference.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Helper class for adding "credential-reference" attributes into CLI commands.
+ *
+ * @author Josef Cacek
+ */
+public class CredentialReference implements CliFragment {
+
+    public static final CredentialReference EMPTY = CredentialReference.builder().build();
+
+    private final String store;
+    private final String alias;
+    private final String clearText;
+
+    private CredentialReference(Builder builder) {
+        this.store = builder.store;
+        this.alias = builder.alias;
+        this.clearText = builder.clearText;
+    }
+
+    @Override
+    public String asString() {
+        StringBuilder sb = new StringBuilder();
+        if (isNotBlank(alias) || isNotBlank(clearText) || isNotBlank(store)) {
+            sb.append("credential-reference={ ");
+            if (isNotBlank(alias)) {
+                sb.append(String.format("alias=\"%s\", ", alias));
+            }
+            if (isNotBlank(store)) {
+                sb.append(String.format("store=\"%s\", ", store));
+            }
+            if (isNotBlank(clearText)) {
+                sb.append(String.format("clear-text=\"%s\"", clearText));
+            }
+            sb.append("}, ");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Creates builder to build {@link CredentialReference}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link CredentialReference}.
+     */
+    public static final class Builder {
+        private String store;
+        private String alias;
+        private String clearText;
+
+        private Builder() {
+        }
+
+        public Builder withStore(String store) {
+            this.store = store;
+            return this;
+        }
+
+        public Builder withAlias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        public Builder withClearText(String clearText) {
+            this.clearText = clearText;
+            return this;
+        }
+
+        public CredentialReference build() {
+            return new CredentialReference(this);
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KeyManagers.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KeyManagers.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron key-managers.
+ *
+ * @author Josef Cacek
+ */
+public interface KeyManagers extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KeyStore.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KeyStore.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron key-stores.
+ *
+ * @author Josef Cacek
+ */
+public interface KeyStore extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/Path.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/Path.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.jboss.as.test.shared.CliUtils.escapePath;
+
+/**
+ * Helper class for adding "path" and "relative-to" attributes into CLI commands.
+ *
+ * @author Josef Cacek
+ */
+public class Path implements CliFragment {
+
+    public static final Path EMPTY = Path.builder().build();
+
+    private final String path;
+    private final String relativeTo;
+
+    private Path(Builder builder) {
+        this.path = builder.path;
+        this.relativeTo = builder.relativeTo;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getRelativeTo() {
+        return relativeTo;
+    }
+
+    /**
+     * Generates part of CLI string in form "[path=..., [relative-to=..., ]"
+     */
+    @Override
+    public String asString() {
+        StringBuilder sb = new StringBuilder();
+        if (isNotBlank(path)) {
+            sb.append(String.format("path=\"%s\", ", escapePath(path)));
+            if (isNotBlank(relativeTo)) {
+                sb.append(String.format("relative-to=\"%s\"", relativeTo));
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Creates builder to build {@link Path}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link Path}.
+     */
+    public static final class Builder {
+        private String path;
+        private String relativeTo;
+
+        private Builder() {
+        }
+
+        public Builder withPath(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder withRelativeTo(String relativeTo) {
+            this.relativeTo = relativeTo;
+            return this;
+        }
+
+        public Path build() {
+            return new Path(this);
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileBasedDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/PropertyFileBasedDomain.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.jboss.as.test.shared.CliUtils.asAbsolutePath;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.logging.Logger;
+import org.wildfly.security.auth.permission.LoginPermission;
+
+/**
+ * Elytron Security domain implementation which uses {@code properties-realm} to hold the users.
+ * <p>
+ * For this given domain are created also following Elytron resources (with the same name as the domain):
+ * </p>
+ * <ul>
+ * <li>properties-realm</li>
+ * <li>simple-role-decoder</li>
+ * <li>constant-permission-mapper</li>
+ * </ul>
+ *
+ * @author Josef Cacek
+ */
+public class PropertyFileBasedDomain extends AbstractUserRolesSecurityDomain {
+
+    private static final Logger LOGGER = Logger.getLogger(PropertyFileBasedDomain.class);
+
+    private File tempFolder;
+
+    private PropertyFileBasedDomain(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        tempFolder = createTemporaryFolder("ely-" + getName());
+        final Properties usersProperties = new Properties();
+        final Properties rolesProperties = new Properties();
+        for (UserWithRoles user : getUsersWithRoles()) {
+            usersProperties.setProperty(user.getName(), user.getPassword());
+            rolesProperties.setProperty(user.getName(), String.join(",", user.getRoles()));
+        }
+        File usersFile = writeProperties(usersProperties, "users.properties");
+        File rolesFile = writeProperties(rolesProperties, "roles.properties");
+
+        // /subsystem=elytron/properties-realm=test:add(users-properties={path=/tmp/users.properties, plain-text=true},
+        // groups-properties={path=/tmp/groups.properties})
+        cli.sendLine(String.format(
+                "/subsystem=elytron/properties-realm=%s:add(users-properties={path=\"%s\", plain-text=true}, groups-properties={path=\"%s\"})",
+                name, asAbsolutePath(usersFile), asAbsolutePath(rolesFile)));
+
+        // /subsystem=elytron/simple-role-decoder=test:add(attribute=groups)
+        cli.sendLine(String.format("/subsystem=elytron/simple-role-decoder=%s:add(attribute=groups)", name));
+
+        // /subsystem=elytron/constant-permission-mapper=test:add(permissions=[{class-name="org.wildfly.security.auth.permission.LoginPermission"}])
+        cli.sendLine(String.format("/subsystem=elytron/constant-permission-mapper=%s:add(permissions=[{class-name=\"%s\"}])",
+                name, LoginPermission.class.getName()));
+
+        // /subsystem=elytron/security-domain=test:add(default-realm=test, permission-mapper=test, realms=[{role-decoder=test,
+        // realm=test}]
+        cli.sendLine(String.format(
+                "/subsystem=elytron/security-domain=%s:add(default-realm=%1$s, permission-mapper=%1$s, realms=[{role-decoder=%1$s, realm=%1$s}]",
+                name));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()", name));
+        cli.sendLine(String.format("/subsystem=elytron/constant-permission-mapper=%s:remove()", name));
+        cli.sendLine(String.format("/subsystem=elytron/simple-role-decoder=%s:remove()", name));
+        cli.sendLine(String.format("/subsystem=elytron/properties-realm=%s:remove()", name));
+
+        FileUtils.deleteQuietly(tempFolder);
+    }
+
+    /**
+     * Creates builder to build {@link PropertyFileBasedDomain}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractUserRolesSecurityDomain.Builder<Builder> {
+        private Builder() {
+            // empty
+        }
+
+        public PropertyFileBasedDomain build() {
+            return new PropertyFileBasedDomain(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+    }
+
+    private File writeProperties(Properties properties, String fileName) throws IOException {
+        File result = new File(tempFolder, fileName);
+        LOGGER.debugv("Creating property file {0}", result);
+        try (FileOutputStream fos = new FileOutputStream(result)) {
+            // comment $REALM_NAME is just a workaround for https://issues.jboss.org/browse/WFLY-7104
+            properties.store(fos, "$REALM_NAME=" + name + "$");
+        }
+        return result;
+    }
+
+    /**
+     * Creates a temporary folder name with given name prefix.
+     *
+     * @param prefix folder name prefix
+     * @return created folder
+     */
+    private static File createTemporaryFolder(String prefix) throws IOException {
+        File file = File.createTempFile(prefix, "", null);
+        LOGGER.debugv("Creating temporary folder {0}", file);
+        file.delete();
+        file.mkdir();
+        return file;
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityDomain.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron Security domain and resources related to it (e.g. realms, mappers, external resources).
+ * <p>
+ * The Security domains represented by this interface should be based on scenario point of view and should provide a simple
+ * quick way to be configured. (They should provide reasonable defaults for values.)
+ * </p>
+ *
+ * @author Josef Cacek
+ */
+public interface SecurityDomain extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityDomainMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SecurityDomainMapper.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron KeyStore configuration.
+ *
+ * @author Josef Cacek
+ */
+public interface SecurityDomainMapper extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ServerSslContext.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ServerSslContext.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron server-ssl-context.
+ *
+ * @author Josef Cacek
+ */
+public interface ServerSslContext extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyManagers.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyManagers.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+import java.util.Objects;
+
+import javax.net.ssl.KeyManagerFactory;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Elytron key-managers configuration implementation.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleKeyManagers extends AbstractConfigurableElement implements KeyManagers {
+
+    private final String keyStore;
+    private final CredentialReference credentialReference;
+
+    private SimpleKeyManagers(Builder builder) {
+        super(builder);
+        this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
+        this.credentialReference = defaultIfNull(builder.credentialReference, CredentialReference.EMPTY);
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        // /subsystem=elytron/key-managers=httpsKM:add(key-store=httpsKS,algorithm="SunX509",credential-reference={clear-text=secret})
+
+        cli.sendLine(String.format("/subsystem=elytron/key-managers=%s:add(key-store=\"%s\",algorithm=\"%s\", %s)", name,
+                keyStore, KeyManagerFactory.getDefaultAlgorithm(), credentialReference.asString()));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/key-managers=%s:remove()", name));
+    }
+
+    /**
+     * Creates builder to build {@link SimpleKeyManagers}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link SimpleKeyManagers}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String keyStore;
+        private CredentialReference credentialReference;
+
+        private Builder() {
+        }
+
+        public Builder withKeyStore(String keyStore) {
+            this.keyStore = keyStore;
+            return this;
+        }
+
+        public Builder withCredentialReference(CredentialReference credentialReference) {
+            this.credentialReference = credentialReference;
+            return this;
+        }
+
+        public SimpleKeyManagers build() {
+            return new SimpleKeyManagers(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyStore.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleKeyStore.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Elytron key-store configuration implementation.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleKeyStore extends AbstractConfigurableElement implements KeyStore {
+
+    private final Path path;
+    private final CredentialReference credentialReference;
+    private final String type;
+
+    private SimpleKeyStore(Builder builder) {
+        super(builder);
+        this.path = defaultIfNull(builder.path, Path.EMPTY);
+        this.credentialReference = defaultIfNull(builder.credentialReference, CredentialReference.EMPTY);
+        this.type = defaultIfNull(builder.type, "JKS");
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        // /subsystem=elytron/key-store=httpsKS:add(path=keystore.jks,relative-to=jboss.server.config.dir,credential-reference={clear-text=secret},type=JKS)
+
+        cli.sendLine(String.format("/subsystem=elytron/key-store=%s:add(%s%stype=\"%s\")", name, path.asString(),
+                credentialReference.asString(), type));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/key-store=%s:remove()", name));
+    }
+
+    /**
+     * Creates builder to build {@link SimpleKeyStore}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link SimpleKeyStore}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Path path;
+        private CredentialReference credentialReference;
+        private String type;
+
+        private Builder() {
+        }
+
+        public Builder withPath(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder withCredentialReference(CredentialReference credentialReference) {
+            this.credentialReference = credentialReference;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public SimpleKeyStore build() {
+            return new SimpleKeyStore(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleServerSslContext.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleServerSslContext.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Elytron server-ssl-context configuration implementation.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleServerSslContext extends AbstractConfigurableElement implements ServerSslContext {
+
+    private final String keyManagers;
+    private final String trustManagers;
+    private final String[] protocols;
+    private final boolean needClientAuth;
+
+    private SimpleServerSslContext(Builder builder) {
+        super(builder);
+        this.keyManagers = builder.keyManagers;
+        this.trustManagers = builder.trustManagers;
+        this.protocols = builder.protocols;
+        this.needClientAuth = builder.needClientAuth;
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        // /subsystem=elytron/server-ssl-context=twoWaySSC:add(key-managers=twoWayKM,protocols=["TLSv1.2"],trust-managers=twoWayTM,need-client-auth=true)
+        StringBuilder sb = new StringBuilder("/subsystem=elytron/server-ssl-context=").append(name).append(":add(");
+        if (StringUtils.isNotBlank(keyManagers)) {
+            sb.append("key-managers=\"").append(keyManagers).append("\", ");
+        }
+        if (protocols != null) {
+            sb.append("protocols=[")
+                    .append(Arrays.stream(protocols).map(s -> "\"" + s + "\"").collect(Collectors.joining(", "))).append("], ");
+        }
+        if (StringUtils.isNotBlank(trustManagers)) {
+            sb.append("trust-managers=\"").append(trustManagers).append("\", ");
+        }
+        sb.append("need-client-auth=").append(needClientAuth).append(")");
+        cli.sendLine(sb.toString());
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/server-ssl-context=%s:remove()", name));
+    }
+
+    /**
+     * Creates builder to build {@link SimpleServerSslContext}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link SimpleServerSslContext}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String keyManagers;
+        private String trustManagers;
+        private String[] protocols;
+        private boolean needClientAuth;
+
+        private Builder() {
+        }
+
+        public Builder withKeyManagers(String keyManagers) {
+            this.keyManagers = keyManagers;
+            return this;
+        }
+
+        public Builder withTrustManagers(String trustManagers) {
+            this.trustManagers = trustManagers;
+            return this;
+        }
+
+        public Builder withProtocols(String... protocols) {
+            this.protocols = protocols;
+            return this;
+        }
+
+        public Builder withNeedClientAuth(boolean needClientAuth) {
+            this.needClientAuth = needClientAuth;
+            return this;
+        }
+
+        public SimpleServerSslContext build() {
+            return new SimpleServerSslContext(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleTrustManagers.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/SimpleTrustManagers.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Objects;
+
+import javax.net.ssl.KeyManagerFactory;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Elytron trust-managers configuration implementation.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleTrustManagers extends AbstractConfigurableElement implements TrustManagers {
+
+    private final String keyStore;
+
+    private SimpleTrustManagers(Builder builder) {
+        super(builder);
+        this.keyStore = Objects.requireNonNull(builder.keyStore, "Key-store name has to be provided");
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        // /subsystem=elytron/trust-managers=twoWayTM:add(key-store=twoWayTS,algorithm="SunX509")
+
+        cli.sendLine(String.format("/subsystem=elytron/trust-managers=%s:add(key-store=\"%s\",algorithm=\"%s\")", name,
+                keyStore, KeyManagerFactory.getDefaultAlgorithm()));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine(String.format("/subsystem=elytron/trust-managers=%s:remove()", name));
+    }
+
+    /**
+     * Creates builder to build {@link SimpleTrustManagers}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link SimpleTrustManagers}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String keyStore;
+
+        private Builder() {
+        }
+
+        public Builder withKeyStore(String keyStore) {
+            this.keyStore = keyStore;
+            return this;
+        }
+
+        public SimpleTrustManagers build() {
+            return new SimpleTrustManagers(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/TrustManagers.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/TrustManagers.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+/**
+ * Interface representing Elytron trust-managers.
+ *
+ * @author Josef Cacek
+ */
+public interface TrustManagers extends ConfigurableElement {
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Creates Undertow mapping to Elytron security domain. The Undertow-to-Elytron mapping goes from Undertow
+ * {@code applicationDomain} configuration to Elytron's {@code http-authentication-factory} (which uses a
+ * {@code http-server-mechanism-factor}). The {@code http-authentication-factory} then references Elytron security domain to be
+ * used.
+ * <p>
+ * Configuration of this undertow mapping may contain set of application domains names (referenced as {@code security-domain}s
+ * in {@code jboss-web.xml}) to be mapped to given security domain name. If applicationDomains is not configured for the mapper
+ * (i.e. it's empty), then just one mapping is created with applicationDomain name the same as Elytron security domain name. If
+ * the applicationDomains attribute is not empty, then just the provided names are mapped (i.e. the Elytron domain name is not
+ * used automatically in such case).
+ * </p>
+ *
+ * @author Josef Cacek
+ */
+public class UndertowDomainMapper  extends AbstractConfigurableElement implements SecurityDomainMapper {
+
+    private final Set<String> applicationDomains;
+
+    private UndertowDomainMapper(Builder builder) {
+        super(builder);
+        this.applicationDomains = new HashSet<>(builder.applicationDomains);
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        // /subsystem=elytron/provider-http-server-mechanism-factory=test:add()
+        cli.sendLine(String.format("/subsystem=elytron/provider-http-server-mechanism-factory=%s:add()", name));
+
+        // /subsystem=elytron/http-authentication-factory=test:add(security-domain=test,
+        // http-server-mechanism-factory=test,
+        // mechanism-configurations=[
+        // {mechanism-name=DIGEST,mechanism-realm-configurations=[{realm-name=test}]},
+        // {mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=test}]},
+        // {mechanism-name=FORM]}])
+
+        cli.sendLine(String
+                .format("/subsystem=elytron/http-authentication-factory=%1$s:add(security-domain=%1$s, http-server-mechanism-factory=%1$s,"
+                        + "  mechanism-configurations=["
+                        + "    {mechanism-name=DIGEST,mechanism-realm-configurations=[{realm-name=%1$s}]},"
+                        + "    {mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=%1$s}]},"
+                        + "    {mechanism-name=FORM]}])", name));
+
+        if (applicationDomains.isEmpty()) {
+            // /subsystem=undertow/application-security-domain=test:add(http-authentication-factory=test)
+            cli.sendLine(String.format(
+                    "/subsystem=undertow/application-security-domain=%1$s:add(http-authentication-factory=%1$s)", name));
+        } else {
+            for (String appDomain : applicationDomains) {
+                // /subsystem=undertow/application-security-domain=appdomain:add(http-authentication-factory=test)
+                cli.sendLine(
+                        String.format("/subsystem=undertow/application-security-domain=%s:add(http-authentication-factory=%s)",
+                                appDomain, name));
+            }
+        }
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        if (applicationDomains.isEmpty()) {
+            cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", name));
+        } else {
+            for (String appDomain : applicationDomains) {
+                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", appDomain));
+            }
+        }
+        cli.sendLine(String.format("/subsystem=elytron/http-authentication-factory=%s:remove()", name));
+        cli.sendLine(String.format("/subsystem=elytron/provider-http-server-mechanism-factory=%s:remove()", name));
+    }
+
+    /**
+     * Creates builder to build {@link UndertowDomainMapper}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link UndertowDomainMapper}. The name attribute is used for security domain name.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Set<String> applicationDomains = new HashSet<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Adds given application domains to the configuration.
+         */
+        public Builder withApplicationDomains(String... applicationDomains) {
+            if (applicationDomains != null) {
+                for (String domain : applicationDomains) {
+                    this.applicationDomains.add(domain);
+                }
+            }
+            return this;
+        }
+
+        public UndertowDomainMapper build() {
+            return new UndertowDomainMapper(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UserWithRoles.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UserWithRoles.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Object which holds user configuration (password, roles).
+ *
+ * @author Josef Cacek
+ */
+public class UserWithRoles {
+
+    private final String name;
+    private final String password;
+    private final Set<String> roles;
+
+    private UserWithRoles(Builder builder) {
+        this.name = Objects.requireNonNull(builder.name, "Username must be not-null");
+        this.password = builder.password != null ? builder.password : builder.name;
+        this.roles = new HashSet<>(builder.roles);
+    }
+
+    /**
+     * Returns username.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns password as plain text.
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * Set of roles to be assigned to the user.
+     */
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    /**
+     * Creates builder to build {@link UserWithRoles}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link UserWithRoles}.
+     */
+    public static final class Builder {
+        private String name;
+        private String password;
+        private final Set<String> roles = new HashSet<>();
+
+        private Builder() {
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        /**
+         * Add given roles to the builder. It doesn't replace existing roles, but it adds given roles to them.
+         */
+        public Builder withRoles(Set<String> roles) {
+            if (roles != null) {
+                this.roles.addAll(roles);
+            }
+            return this;
+        }
+
+        /**
+         * Add given roles to the builder. It doesn't replace existing roles, but it adds given roles to them.
+         */
+        public Builder withRoles(String... roles) {
+            if (roles != null) {
+                this.roles.addAll(Arrays.asList(roles));
+            }
+            return this;
+        }
+
+        /**
+         * Clears set of already added roles.
+         */
+        public Builder clearRoles() {
+            this.roles.clear();
+            return this;
+        }
+
+        /**
+         * Builds UserWithRoles instance.
+         *
+         * @return
+         */
+        public UserWithRoles build() {
+            return new UserWithRoles(this);
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UsersRolesSecurityDomain.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UsersRolesSecurityDomain.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.List;
+
+/**
+ * This interface represent Elytron Security Domain with predefined list of users and their roles. It provides ability to tests
+ * to come up with own user population for the tested scenario.
+ * <p>
+ * <b>Implementation notes:</b> If the Elytron security realm can be preconfigured with user list (e.g. domain implementation is
+ * creating a property file with users), then the domain created around such a realm should implement this interface.
+ * </p>
+ *
+ * @author Josef Cacek
+ */
+public interface UsersRolesSecurityDomain extends SecurityDomain {
+
+    /**
+     * Returns predefined (not {@code null}) list of users and their attributes to be created in the domain (realm in fact).
+     */
+    List<UserWithRoles> getUsersWithRoles();
+}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8056

This PR introduces new elytron testsuite module and support for Elytron testing into the integration testsuite modules.

The sample Elytron integration test the `ElytronDomainTestCase` in the `testsuite/integration/basic`.