### PR TITLE
WFLY-6357 Don't block topology change event thread. 

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import org.infinispan.commons.CacheException;
 import org.infinispan.notifications.cachelistener.event.Event;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -88,7 +87,7 @@ public interface ClusteringServerLogger extends BasicLogger {
 
     @LogMessage(level = WARN)
     @Message(id = 10, value = "Failed to purge %s/%s registry of old registry entries for: %s")
-    void registryPurgeFailed(@Cause CacheException e, String containerName, String cacheName, Collection<Node> nodes);
+    void registryPurgeFailed(@Cause Throwable e, String containerName, String cacheName, Collection<Node> nodes);
 
     @LogMessage(level = WARN)
     @Message(id = 11, value = "Failed to notify %s/%s registry listener of %s(%s) event")
@@ -104,4 +103,8 @@ public interface ClusteringServerLogger extends BasicLogger {
 
     @Message(id = 14, value = "Specified quorum %d must be greater than zero")
     IllegalArgumentException invalidQuorum(int quorum);
+
+    @LogMessage(level = WARN)
+    @Message(id = 15, value = "Failed to restore local %s/%s registry entry following network partititon merge")
+    void failedToRestoreLocalRegistryEntry(@Cause Throwable cause, String containerName, String cacheName);
 }


### PR DESCRIPTION
This causes replication timeouts waiting for initial state xfr to complete.

https://issues.jboss.org/browse/WFLY-6357