### PR TITLE
Partial fix for WFLY-8087. Don't register a statistics resource on an…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -112,7 +112,9 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
 
     @Override
     protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-        DataSourceStatisticsService.registerStatisticsResources(resource);
+        if (context.getProcessType().isServer()) {
+            DataSourceStatisticsService.registerStatisticsResources(resource);
+        }
         super.populateModel(context, operation, resource);
 
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
@@ -59,7 +59,7 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
     public static final PooledConnectionFactoryAdd INSTANCE = new PooledConnectionFactoryAdd();
 
     @Override
-    protected void populateModel(ModelNode operation, Resource resource) throws OperationFailedException {
+    protected void populateModel(final OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         ModelNode model = resource.getModel();
 
         AlternativeAttributeCheckHandler.checkAlternatives(operation, Common.CONNECTORS.getName(), Common.DISCOVERY_GROUP.getName(), false);
@@ -68,8 +68,10 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
             attribute.validateAndSet(operation, model);
         }
 
-        // register the runtime statistics=pool child resource
-        PooledConnectionFactoryStatisticsService.registerStatisticsResources(resource);
+        if (context.getProcessType().isServer()) {
+            // register the runtime statistics=pool child resource
+            PooledConnectionFactoryStatisticsService.registerStatisticsResources(resource);
+        }
     }
 
     @Override


### PR DESCRIPTION
… HC.

There is still an issue related to this on the server, as the add handler doesn't know in Stage.MODEL if statistics are enabled (since the statistics-enabled attribute allows expressions) and it's invalid to add the resource in Stage.RUNTIME. So it guesses and adds the resource, and then the MRR is not present until the stats are enabled.

https://issues.jboss.org/browse/WFLY-8087