### PR TITLE
WFLY-7038 License files issues

### DIFF
--- a/feature-pack/src/license/licenses.xml
+++ b/feature-pack/src/license/licenses.xml
@@ -1423,14 +1423,12 @@
       <artifactId>javax.json</artifactId>
       <licenses>
         <license>
-          <name>Common Development and Distribution License</name>
-          <url>http://repository.jboss.org/licenses/cddl.txt</url>
-          <distribution>repo</distribution>
+          <name>Common Development and Distribution License version 1.1</name>
+          <url>http://repository.jboss.org/licenses/cddl-v1.1.txt</url>
         </license>
         <license>
           <name>GNU General Public License, Version 2 with the Classpath Exception</name>
           <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
-          <distribution>repo</distribution>
         </license>
       </licenses>
     </dependency>

--- a/feature-pack/src/main/resources/content/docs/licenses/licenses.xml
+++ b/feature-pack/src/main/resources/content/docs/licenses/licenses.xml
@@ -1423,14 +1423,12 @@
       <artifactId>javax.json</artifactId>
       <licenses>
         <license>
-          <name>Common Development and Distribution License</name>
-          <url>http://repository.jboss.org/licenses/cddl.txt</url>
-          <distribution>repo</distribution>
+          <name>Common Development and Distribution License version 1.1</name>
+          <url>http://repository.jboss.org/licenses/cddl-v1.1.txt</url>
         </license>
         <license>
           <name>GNU General Public License, Version 2 with the Classpath Exception</name>
           <url>http://repository.jboss.org/licenses/gpl-2.0-ce.txt</url>
-          <distribution>repo</distribution>
         </license>
       </licenses>
     </dependency>

--- a/feature-pack/src/main/resources/content/docs/licenses/licenses.xml
+++ b/feature-pack/src/main/resources/content/docs/licenses/licenses.xml
@@ -3115,6 +3115,39 @@
       </licenses>
     </dependency>
     <dependency>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-spec</artifactId>
+        <licenses>
+            <license>
+                <name>Apache Software License, Version 2.0</name>
+                <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+                <distribution>repo</distribution>
+            </license>
+        </licenses>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-impl</artifactId>
+        <licenses>
+            <license>
+                <name>Apache Software License, Version 2.0</name>
+                <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+                <distribution>repo</distribution>
+            </license>
+        </licenses>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-compat</artifactId>
+        <licenses>
+            <license>
+                <name>Apache Software License, Version 2.0</name>
+                <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+                <distribution>repo</distribution>
+            </license>
+        </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.transaction</groupId>
       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
       <licenses>


### PR DESCRIPTION
license for org.glassfish:javax.json should be CDDL 1.1 + GPL 2.0+CE
https://glassfish.java.net/public/CDDL+GPL_1_1.html

issue: https://issues.jboss.org/browse/WFLY-7038