### PR TITLE
[WFLY-8102] Fix management address configuration for wildfly-ts-integ-xts tests

### DIFF
--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -24,7 +24,7 @@
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-xts.xml}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
-                <property name="managementAddress">${node1:127.0.0.1}</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort1:10090}</property>
             </configuration>
         </container>


### PR DESCRIPTION
"alternative-server" use 100 port offset, but doesn't change the managementAddress, this make tests fail with "Could not start container" in case that node0 is not binded to localhost

https://issues.jboss.org/browse/WFLY-8102 - Wrong management address used for graceful shutdown XTS tests