### PR TITLE
[WFLY-7516 WFLY-813] Upgrade Netty to 4.1.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.groovy-all>2.4.7</version.groovy-all>
         <version.httpunit>1.7</version.httpunit>
-        <version.io.netty>4.0.35.Final</version.io.netty>
+        <version.io.netty>4.1.5.Final</version.io.netty>
         <version.io.undertow.jastow>2.0.1.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
@@ -167,7 +167,7 @@
         <version.org.jboss.narayana>5.5.1.Final</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.6.CR1</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.0.7.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.resteasy>3.0.20.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.3.Final</version.org.jboss.security.jboss-negotiation>
@@ -5499,6 +5499,12 @@
                 <groupId>org.jboss.xnio.netty</groupId>
                 <artifactId>netty-xnio-transport</artifactId>
                 <version>${version.org.jboss.xnio.netty.netty-xnio-transport}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
and netty-xnio-transport to 0.1.2.Final

JIRA: https://issues.jboss.org/browse/WFLY-7516
JIRA: https://issues.jboss.org/browse/WFLY-8113

__Do not merge this PR until an Artemis version with https://issues.apache.org/jira/browse/ARTEMIS-963 is also integrated__