### PR TITLE
[WFLY-8109] Improve timeouts in AS TS

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -29,6 +29,7 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
     </properties>
 
     <dependencies>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
@@ -90,7 +90,7 @@ public class MDBTestCase {
     @ArquillianResource
     private ManagementClient managementClient;
 
-    private static final int TIMEOUT = TimeoutUtil.adjust(2000);
+    private static final int TIMEOUT = TimeoutUtil.adjust(5000);
 
     static class JmsQueueSetup implements ServerSetupTask {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @ServerSetup(PassivationTestCaseSetup.class)
 public class PassivationTestCase {
-    private static final long PASSIVATION_WAIT = TimeoutUtil.adjust(1000);
+    private static final long PASSIVATION_WAIT = TimeoutUtil.adjust(5000);
 
     @ArquillianResource
     private InitialContext ctx;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/JspCompilerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/jsp/JspCompilerTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -62,6 +63,6 @@ public class JspCompilerTestCase {
 
     @Test
     public void test(@ArquillianResource URL url) throws Exception {
-        HttpRequest.get(url + "index.jsp", 10, TimeUnit.SECONDS);
+        HttpRequest.get(url + "index.jsp", TimeoutUtil.adjust(15), TimeUnit.SECONDS);
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -29,7 +29,6 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.junit.Assert;
 
 /**
@@ -39,7 +38,7 @@ import org.junit.Assert;
  * @author Ondra Chaloupka <ochaloup@redhat.com>
  */
 public final class TxTestUtil {
-    private static final int timeoutWaitTime_ms = TimeoutUtil.adjust(2500);
+    private static final int timeoutWaitTime_ms = 2500;
 
     private TxTestUtil() {
         // no instance here


### PR DESCRIPTION
Improve timeouts in AS TS
* JMSMessageDrivenBeanTestCase should use TimeoutUtil for timeout
* increase timeout in PassivationTestCase
* JspCompilerTestCase should use TimeoutUtil for timeout
* increase timeout in MDBTestCase
* increase the default forked process timeout for basic module to hour, same timeout is used in clustering module, see https://github.com/wildfly/wildfly/blob/master/testsuite/integration/clustering/pom.xml#L24

This stabilizes TS on slower machines.

Jira: https://issues.jboss.org/browse/WFLY-8109
Downstream jira: https://issues.jboss.org/browse/JBEAP-8966
Downstream PR: https://github.com/jbossas/jboss-eap7/pull/1373