### PR TITLE
WFLY-8139 Add smoke tests for Undertow SSL listener backed by Elytron SSL context

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslNeedClientAuthTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslNeedClientAuthTestCase.java
@@ -1,0 +1,195 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.ssl;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.jboss.as.test.integration.security.common.SSLTruststoreUtil.HTTPS_PORT;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.SocketException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import javax.net.ssl.SSLHandshakeException;
+import org.apache.http.client.HttpClient;
+import org.codehaus.plexus.util.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.Path;
+import org.wildfly.test.security.common.elytron.SimpleKeyManagers;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.SimpleTrustManagers;
+import org.wildfly.test.security.common.elytron.UndertowSslContext;
+
+/**
+ * Smoke test for two way SSL authentication using Elytron server-ssl-context with need-client-auth=true
+ * added to default server configuration.
+ *
+ * @author Ondrej Kotek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ UndertowTwoWaySslNeedClientAuthTestCase.ElytronSslContextInUndertowSetupTask.class })
+@RunAsClient
+public class UndertowTwoWaySslNeedClientAuthTestCase {
+
+    private static final String NAME = UndertowTwoWaySslNeedClientAuthTestCase.class.getSimpleName();
+    private static final File WORK_DIR = new File("target" + File.separatorChar +  NAME);
+    private static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_KEYSTORE);
+    private static final File SERVER_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_TRUSTSTORE);
+    private static final File CLIENT_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_KEYSTORE);
+    private static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_TRUSTSTORE);
+    private static final File UNTRUSTED_STORE_FILE = new File(WORK_DIR, SecurityTestConstants.UNTRUSTED_KEYSTORE);
+    private static final String PASSWORD = SecurityTestConstants.KEYSTORE_PASSWORD;
+
+    private static URL securedRootUrl;
+
+    // just to make server setup task work
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war")
+                .add(new StringAsset("index page"), "index.html");
+    }
+
+    @BeforeClass
+    public static void setSecuredRootUrl() throws Exception {
+        try {
+            securedRootUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT, "");
+        } catch (MalformedURLException ex) {
+            throw new IllegalStateException("Unable to create HTTPS URL to server root", ex);
+        }
+    }
+
+    @Test
+    public void testSendingTrustedClientCertificate() {
+        HttpClient client = SSLTruststoreUtil
+                .getHttpClientWithSSL(CLIENT_KEYSTORE_FILE, PASSWORD, CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertConnectionToServer(client, SC_OK);
+    }
+
+    @Test
+    public void testSendingNonTrustedClientCertificateFails() {
+        HttpClient client = SSLTruststoreUtil
+                .getHttpClientWithSSL(UNTRUSTED_STORE_FILE, PASSWORD, CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertSslHandshakeFails(client);
+    }
+
+    @Test
+    public void testSendingNoClientCertificateFails() {
+        HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertSslHandshakeFails(client);
+    }
+
+    private void assertConnectionToServer(HttpClient client, int expectedStatusCode) {
+        try {
+            Utils.makeCallWithHttpClient(securedRootUrl, client, expectedStatusCode);
+        } catch (IOException | URISyntaxException ex) {
+            throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+        }
+    }
+
+    private void assertSslHandshakeFails(HttpClient client) {
+        try {
+            Utils.makeCallWithHttpClient(securedRootUrl, client, SC_OK);
+        } catch (SSLHandshakeException | SocketException e) {
+            // expected
+            return;
+        } catch (IOException | URISyntaxException ex) {
+            throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+        }
+        fail("SSL handshake should fail");
+    }
+
+    /**
+     * Creates Elytron server-ssl-context and key/trust stores.
+     */
+    static class ElytronSslContextInUndertowSetupTask extends AbstractElytronSetupTask {
+
+        @Override
+        protected void setup(final ModelControllerClient modelControllerClient) throws Exception {
+            keyMaterialSetup(WORK_DIR);
+            super.setup(modelControllerClient);
+        }
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[] {
+                SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                        .withPath(Path.builder().withPath(SERVER_KEYSTORE_FILE.getPath()).build())
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_TRUSTSTORE)
+                        .withPath(Path.builder().withPath(SERVER_TRUSTSTORE_FILE.getPath()).build())
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleKeyManagers.builder().withName(NAME)
+                        .withKeyStore(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleTrustManagers.builder().withName(NAME)
+                        .withKeyStore(NAME + SecurityTestConstants.SERVER_TRUSTSTORE)
+                        .build(),
+                SimpleServerSslContext.builder().withName(NAME)
+                        .withKeyManagers(NAME)
+                        .withTrustManagers(NAME)
+                        .withNeedClientAuth(true)
+                        .build(),
+                UndertowSslContext.builder().withName(NAME).build()
+            };
+        }
+
+        @Override
+        protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+            super.tearDown(modelControllerClient);
+            FileUtils.deleteDirectory(WORK_DIR);
+        }
+
+        protected static void keyMaterialSetup(File workDir) throws Exception {
+            FileUtils.deleteDirectory(workDir);
+            workDir.mkdirs();
+            Assert.assertTrue(workDir.exists());
+            Assert.assertTrue(workDir.isDirectory());
+            CoreUtils.createKeyMaterial(workDir);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslTestCase.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.ssl;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.jboss.as.test.integration.security.common.SSLTruststoreUtil.HTTPS_PORT;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import org.apache.http.client.HttpClient;
+import org.codehaus.plexus.util.FileUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.Path;
+import org.wildfly.test.security.common.elytron.SimpleKeyManagers;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.SimpleTrustManagers;
+import org.wildfly.test.security.common.elytron.UndertowSslContext;
+
+/**
+ * Smoke test for two way SSL authentication using Elytron server-ssl-context added to default server configuration.
+ *
+ * @author Ondrej Kotek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ UndertowTwoWaySslTestCase.ElytronSslContextInUndertowSetupTask.class })
+@RunAsClient
+public class UndertowTwoWaySslTestCase {
+
+    private static final String NAME = UndertowTwoWaySslTestCase.class.getSimpleName();
+    private static final File WORK_DIR = new File("target" + File.separatorChar +  NAME);
+    private static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_KEYSTORE);
+    private static final File SERVER_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.SERVER_TRUSTSTORE);
+    private static final File CLIENT_KEYSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_KEYSTORE);
+    private static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR, SecurityTestConstants.CLIENT_TRUSTSTORE);
+    private static final File UNTRUSTED_STORE_FILE = new File(WORK_DIR, SecurityTestConstants.UNTRUSTED_KEYSTORE);
+    private static final String PASSWORD = SecurityTestConstants.KEYSTORE_PASSWORD;
+
+    private static URL securedRootUrl;
+
+    // just to make server setup task work
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war")
+                .add(new StringAsset("index page"), "index.html");
+    }
+
+    @BeforeClass
+    public static void setSecuredRootUrl() throws Exception {
+        try {
+            securedRootUrl = new URL("https", TestSuiteEnvironment.getServerAddress(), HTTPS_PORT, "");
+        } catch (MalformedURLException ex) {
+            throw new IllegalStateException("Unable to create HTTPS URL to server root", ex);
+        }
+    }
+
+    @Test
+    public void testSendingTrustedClientCertificate() {
+        HttpClient client = SSLTruststoreUtil
+                .getHttpClientWithSSL(CLIENT_KEYSTORE_FILE, PASSWORD, CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertConnectionToServer(client, SC_OK);
+    }
+
+    @Test
+    public void testSendingNonTrustedClientCertificate() {
+        HttpClient client = SSLTruststoreUtil
+                .getHttpClientWithSSL(UNTRUSTED_STORE_FILE, PASSWORD, CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertConnectionToServer(client, SC_OK);
+    }
+
+    @Test
+    public void testSendingNoClientCertificate() {
+        HttpClient client = SSLTruststoreUtil.getHttpClientWithSSL(CLIENT_TRUSTSTORE_FILE, PASSWORD);
+        assertConnectionToServer(client, SC_OK);
+    }
+
+    private void assertConnectionToServer(HttpClient client, int expectedStatusCode) {
+        try {
+            Utils.makeCallWithHttpClient(securedRootUrl, client, expectedStatusCode);
+        } catch (IOException | URISyntaxException ex) {
+            throw new IllegalStateException("Unable to request server root over HTTPS", ex);
+        }
+    }
+
+    /**
+     * Creates Elytron server-ssl-context and key/trust stores.
+     */
+    static class ElytronSslContextInUndertowSetupTask extends AbstractElytronSetupTask {
+
+        @Override
+        protected void setup(final ModelControllerClient modelControllerClient) throws Exception {
+            keyMaterialSetup(WORK_DIR);
+            super.setup(modelControllerClient);
+        }
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[] {
+                SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                        .withPath(Path.builder().withPath(SERVER_KEYSTORE_FILE.getPath()).build())
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleKeyStore.builder().withName(NAME + SecurityTestConstants.SERVER_TRUSTSTORE)
+                        .withPath(Path.builder().withPath(SERVER_TRUSTSTORE_FILE.getPath()).build())
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleKeyManagers.builder().withName(NAME)
+                        .withKeyStore(NAME + SecurityTestConstants.SERVER_KEYSTORE)
+                        .withCredentialReference(CredentialReference.builder().withClearText(PASSWORD).build())
+                        .build(),
+                SimpleTrustManagers.builder().withName(NAME)
+                        .withKeyStore(NAME + SecurityTestConstants.SERVER_TRUSTSTORE)
+                        .build(),
+                SimpleServerSslContext.builder().withName(NAME).withKeyManagers(NAME).withTrustManagers(NAME).build(),
+                UndertowSslContext.builder().withName(NAME).build()
+            };
+        }
+
+        @Override
+        protected void tearDown(ModelControllerClient modelControllerClient) throws Exception {
+            super.tearDown(modelControllerClient);
+            FileUtils.deleteDirectory(WORK_DIR);
+        }
+
+        protected static void keyMaterialSetup(File workDir) throws Exception {
+            FileUtils.deleteDirectory(workDir);
+            workDir.mkdirs();
+            Assert.assertTrue(workDir.exists());
+            Assert.assertTrue(workDir.isDirectory());
+            CoreUtils.createKeyMaterial(workDir);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowSslContext.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowSslContext.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+
+/**
+ * Updates Undertow https-listener of the defaul-server to use given (Elytron server-ssl-context) SSL context
+ * instead of SSL context from legacy security-realm.
+ *
+ * @author Ondrej Kotek
+ */
+public class UndertowSslContext  extends AbstractConfigurableElement {
+
+    private UndertowSslContext(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void create(CLIWrapper cli) throws Exception {
+        cli.sendLine("/subsystem=undertow/server=default-server/https-listener=https"
+                + ":undefine-attribute(name=security-realm)");
+        cli.sendLine(String.format("/subsystem=undertow/server=default-server/https-listener=https"
+                + ":write-attribute(name=ssl-context,value=%s)", name));
+    }
+
+    @Override
+    public void remove(CLIWrapper cli) throws Exception {
+        cli.sendLine("/subsystem=undertow/server=default-server/https-listener=https"
+                + ":undefine-attribute(name=ssl-context)");
+        cli.sendLine("/subsystem=undertow/server=default-server/https-listener=https"
+                + ":write-attribute(name=security-realm,value=ApplicationRealm)");
+    }
+
+    /**
+     * Creates builder to build {@link UndertowSslContext}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link UndertowSslContext}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+
+        private Builder() {
+        }
+
+        public UndertowSslContext build() {
+            return new UndertowSslContext(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8139