### PR TITLE
[WFLY-8159] avoid executing elytron testsuite profile in the parent integration module

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -42,6 +42,8 @@
 
         <ts.skipTests>${skipTests}</ts.skipTests>
         <enforcer.skip>true</enforcer.skip>
+
+        <ts.elytron.cli>../../shared/enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <profiles>
@@ -215,17 +217,19 @@
                 <property>
                     <name>elytron</name>
                 </property>
+                <file>
+                    <exists>${ts.elytron.cli}</exists>
+                </file>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>${version.exec.plugin}</version>
                         <executions>
                             <execution>
                                 <id>enable-elytron-cli</id>
-                                <phase>process-test-resources</phase>
+                                <phase>test-compile</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -237,7 +241,7 @@
                                         <argument>-mp</argument>
                                         <argument>${jboss.dist}/modules</argument>
                                         <argument>org.jboss.as.cli</argument>
-                                        <argument>--file=${project.parent.parent.basedir}/shared/enable-elytron.cli</argument>
+                                        <argument>--file=${ts.elytron.cli}</argument>
                                     </arguments>
                                     <environmentVariables>
                                         <JBOSS_HOME>${project.build.directory}/jbossas</JBOSS_HOME>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -32,6 +32,8 @@
         <!-- use the web build for tests -->
         <jboss.dist>${jbossas.project.dir}/${wildfly.web.build.output.dir}</jboss.dist>
         <jboss.home>${jboss.dist}</jboss.home>
+
+        <ts.elytron.cli>web-enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <dependencies>

--- a/testsuite/integration/web/web-enable-elytron.cli
+++ b/testsuite/integration/web/web-enable-elytron.cli
@@ -1,0 +1,16 @@
+embed-server --server-config=standalone.xml
+
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+
+## TODO use Elytron for management
+# /core-service=management/access=identity:add(security-domain=ManagementDomain)
+# /core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+# /core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+# /core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+# /core-service=management/security-realm=ManagementRealm:remove
+
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-server


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8159

This PR introduces fix for using `-Delytron` maven argument on `testsuite/integration` module. It also allows to configure custom *enable-elytron* scripts in child modules.