### PR TITLE
[WFLY-8166] Configure messaging subsystem in enable-elytron.cli script

### DIFF
--- a/testsuite/shared/enable-elytron.cli
+++ b/testsuite/shared/enable-elytron.cli
@@ -24,6 +24,8 @@ embed-server --server-config=standalone-full.xml
 /subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
 /subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
 /subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+/subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
+/subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
 
 /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
 /subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8166

This commit changes the default security provider to Elytron (Application domain) in messaging subsystem. It's used when the testsuite runs with Elytron profile enabled (`"-Delytron"`).