### PR TITLE
[WFLY-8174] add server name to capability names

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -71,11 +71,16 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        //super.recordCapabilitiesAndRequirements(context, operation, resource);
+        String broadcastGroupName = context.getCurrentAddressValue();
+        String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        String compositeName = serverName + "." + broadcastGroupName;
+
+        context.registerCapability(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.fromBaseCapability(compositeName));
 
         ModelNode model = resource.getModel();
         if (CommonAttributes.JGROUPS_CHANNEL.resolveModelAttribute(context, model).isDefined() && !BroadcastGroupDefinition.JGROUPS_STACK.resolveModelAttribute(context, model).isDefined()) {
-            context.registerAdditionalCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), context.getCurrentAddressValue()), BroadcastGroupDefinition.JGROUPS_STACK.getName());
+            context.registerAdditionalCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), compositeName), BroadcastGroupDefinition.JGROUPS_STACK.getName());
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupRemove.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupRemove.java
@@ -45,11 +45,17 @@ public class BroadcastGroupRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        //super.recordCapabilitiesAndRequirements(context, operation, resource);
+
+        String broadcastGroupName = context.getCurrentAddressValue();
+        String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        String compositeName = serverName + "." + broadcastGroupName;
+
+        context.deregisterCapability(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getDynamicName(compositeName));
 
         ModelNode model = resource.getModel();
         if (CommonAttributes.JGROUPS_CHANNEL.resolveModelAttribute(context, model).isDefined() && !BroadcastGroupDefinition.JGROUPS_STACK.resolveModelAttribute(context, model).isDefined()) {
-            context.deregisterCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), context.getCurrentAddressValue()));
+            context.deregisterCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(BroadcastGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), compositeName));
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -66,11 +66,16 @@ public class DiscoveryGroupAdd extends AbstractAddStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        //super.recordCapabilitiesAndRequirements(context, operation, resource);
+        String discoveryGroupName = context.getCurrentAddressValue();
+        String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        String compositeName = serverName + "." + discoveryGroupName;
+
+        context.registerCapability(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.fromBaseCapability(compositeName));
 
         ModelNode model = resource.getModel();
         if (CommonAttributes.JGROUPS_CHANNEL.resolveModelAttribute(context, model).isDefined() && !DiscoveryGroupDefinition.JGROUPS_STACK.resolveModelAttribute(context, model).isDefined()) {
-            context.registerAdditionalCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), context.getCurrentAddressValue()), DiscoveryGroupDefinition.JGROUPS_STACK.getName());
+            context.registerAdditionalCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), compositeName), DiscoveryGroupDefinition.JGROUPS_STACK.getName());
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupRemove.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupRemove.java
@@ -45,11 +45,16 @@ public class DiscoveryGroupRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
-        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        //super.recordCapabilitiesAndRequirements(context, operation, resource);
+        String discoveryGroupName = context.getCurrentAddressValue();
+        String serverName = context.getCurrentAddress().getParent().getLastElement().getValue();
+        String compositeName = serverName + "." + discoveryGroupName;
+
+        context.deregisterCapability(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getDynamicName(compositeName));
 
         ModelNode model = resource.getModel();
         if (CommonAttributes.JGROUPS_CHANNEL.resolveModelAttribute(context, model).isDefined() && !DiscoveryGroupDefinition.JGROUPS_STACK.resolveModelAttribute(context, model).isDefined()) {
-            context.deregisterCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), context.getCurrentAddressValue()));
+            context.deregisterCapabilityRequirement(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), RuntimeCapability.buildDynamicCapabilityName(DiscoveryGroupDefinition.CHANNEL_FACTORY_CAPABILITY.getName(), compositeName));
         }
     }
 


### PR DESCRIPTION
add the name of the ActiveMQ server to both broadcast-group and
discovery-group capabilities so that broadcast-groups with the same name
but belonging to 2 different ActiveMQ server can properly register their
capabilities.

Do not call the super method from recordCapabilitiesAndRequirements as
its implemention will only append the value of the context's current
address while these 2 resources needs to include the name of their
parent (the server name) as well.

JIRA: https://issues.jboss.org/browse/WFLY-8174