### PR TITLE
[WFLY-7864] Missing dependency to JMS and EJB client BOM

### DIFF
--- a/client/ejb/pom.xml
+++ b/client/ejb/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
         </dependency>

--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -137,6 +137,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
         </dependency>


### PR DESCRIPTION
wildfly-naming-client now depends on org.wildfly.common:wildfly-common
to support expressions.

JIRA: https://issues.jboss.org/browse/WFLY-7864