### PR TITLE
WFLY-7684 WFLY-7692 add validators and default values for listener http2-* attributes tp2-* attributes.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -27,11 +27,15 @@ import java.util.Collection;
 import java.util.List;
 
 import io.undertow.UndertowOptions;
+import io.undertow.protocols.ajp.AjpClientRequestClientStreamSinkChannel;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.io.OptionAttributeDefinition;
 
@@ -46,7 +50,14 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .build();
-    public static final OptionAttributeDefinition MAX_AJP_PACKET_SIZE = OptionAttributeDefinition.builder("max-ajp-packet-size", UndertowOptions.MAX_AJP_PACKET_SIZE).setMeasurementUnit(MeasurementUnit.BYTES).setAllowNull(true).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_AJP_PACKET_SIZE = OptionAttributeDefinition
+            .builder("max-ajp-packet-size", UndertowOptions.MAX_AJP_PACKET_SIZE)
+            .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(AjpClientRequestClientStreamSinkChannel.DEFAULT_MAX_DATA_SIZE))
+            .setValidator(new IntRangeValidator(1))
+            .build();
 
     private AjpListenerResourceDefinition() {
         super(UndertowExtension.AJP_LISTENER_PATH);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
@@ -23,10 +23,13 @@
 package org.wildfly.extension.undertow;
 
 import io.undertow.UndertowOptions;
+import io.undertow.protocols.http2.Http2Channel;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -76,6 +79,8 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(UndertowOptions.HTTP2_SETTINGS_HEADER_TABLE_SIZE_DEFAULT))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     protected static final OptionAttributeDefinition HTTP2_INITIAL_WINDOW_SIZE = OptionAttributeDefinition.builder("http2-initial-window-size", UndertowOptions.HTTP2_SETTINGS_INITIAL_WINDOW_SIZE)
@@ -83,12 +88,15 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(Http2Channel.DEFAULT_INITIAL_WINDOW_SIZE))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     protected static final OptionAttributeDefinition HTTP2_MAX_CONCURRENT_STREAMS = OptionAttributeDefinition.builder("http2-max-concurrent-streams", UndertowOptions.HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS)
             .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     protected static final OptionAttributeDefinition HTTP2_MAX_FRAME_SIZE = OptionAttributeDefinition.builder("http2-max-frame-size", UndertowOptions.HTTP2_SETTINGS_MAX_FRAME_SIZE)
@@ -96,6 +104,8 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(Http2Channel.DEFAULT_MAX_FRAME_SIZE))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     protected static final OptionAttributeDefinition HTTP2_MAX_HEADER_LIST_SIZE = OptionAttributeDefinition.builder("http2-max-header-list-size", UndertowOptions.HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE)
@@ -103,6 +113,7 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     protected static final OptionAttributeDefinition REQUIRE_HOST_HTTP11 = OptionAttributeDefinition.builder("require-host-http11", UndertowOptions.REQUIRE_HOST_HTTP11)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.undertow.filters;
 
 import io.undertow.UndertowOptions;
 import io.undertow.predicate.Predicate;
+import io.undertow.protocols.http2.Http2Channel;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.handlers.proxy.ProxyHandler;
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -39,6 +40,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -237,6 +239,8 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(UndertowOptions.HTTP2_SETTINGS_HEADER_TABLE_SIZE_DEFAULT))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     public static final OptionAttributeDefinition HTTP2_INITIAL_WINDOW_SIZE = OptionAttributeDefinition.builder("http2-initial-window-size", UndertowOptions.HTTP2_SETTINGS_INITIAL_WINDOW_SIZE)
@@ -244,12 +248,15 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(Http2Channel.DEFAULT_INITIAL_WINDOW_SIZE))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     public static final OptionAttributeDefinition HTTP2_MAX_CONCURRENT_STREAMS = OptionAttributeDefinition.builder("http2-max-concurrent-streams", UndertowOptions.HTTP2_SETTINGS_MAX_CONCURRENT_STREAMS)
             .setRequired(false)
             .setRestartAllServices()
             .setAllowExpression(true)
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     public static final OptionAttributeDefinition HTTP2_MAX_FRAME_SIZE = OptionAttributeDefinition.builder("http2-max-frame-size", UndertowOptions.HTTP2_SETTINGS_MAX_FRAME_SIZE)
@@ -257,6 +264,8 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setDefaultValue(new ModelNode(Http2Channel.DEFAULT_MAX_FRAME_SIZE))
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     public static final OptionAttributeDefinition HTTP2_MAX_HEADER_LIST_SIZE = OptionAttributeDefinition.builder("http2-max-header-list-size", UndertowOptions.HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE)
@@ -264,6 +273,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
             .setRestartAllServices()
             .setAllowExpression(true)
             .setMeasurementUnit(MeasurementUnit.BYTES)
+            .setValidator(new IntRangeValidator(1))
             .build();
 
     public static final AttributeDefinition MAX_RETRIES = new SimpleAttributeDefinitionBuilder(Constants.MAX_RETRIES, ModelType.INT)


### PR DESCRIPTION
add validators and default values for listener http2-* attributes.
https://issues.jboss.org/browse/WFLY-8169 for validators
https://issues.jboss.org/browse/WFLY-7692 for default values

http2-header-table-size default value 4096
http2-initial-window-size default value 65535
http2-max-concurrent-streams undefined for unlimited size
http2-max-frame-size default value 16384
http2-max-header-list-size undefined for unlimited size

max-ajp-packet-size default value 8192

downstream issues: https://issues.jboss.org/browse/JBEAP-7050 and https://issues.jboss.org/browse/JBEAP-7061
downstream PR: https://github.com/jbossas/jboss-eap7/pull/1468