### PR TITLE
[WFLY-8247] Update append-to-file SQL statement

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/database/journal-sql.properties
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/database/journal-sql.properties
@@ -4,7 +4,7 @@ create-file-table=CREATE TABLE %s (ID BIGINT AUTO_INCREMENT, FILENAME VARCHAR(25
 insert-file=INSERT INTO %s (FILENAME, EXTENSION, DATA) VALUES (?,?,?)
 select-filenames-by-extension=SELECT FILENAME, ID FROM %s WHERE EXTENSION=?
 select-file-by-filename=SELECT ID, FILENAME, EXTENSION, DATA FROM %s WHERE fileName=?
-append-to-file=UPDATE %s SET DATA = CONCAT(DATA, ?) WHERE ID=?
+append-to-file=SELECT DATA FROM %s WHERE ID=? FOR UPDATE
 read-large-object=SELECT DATA FROM %s WHERE ID=?
 delete-file=DELETE FROM %s WHERE ID=?
 update-filename-by-id=UPDATE %s SET FILENAME=? WHERE ID=?
@@ -26,7 +26,6 @@ close-connection-on-shutdown=true
 # Derby SQL statements
 close-connection-on-shutdown.derby=false
 create-file-table.derby=CREATE TABLE %s (ID BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1), FILENAME VARCHAR(255), EXTENSION VARCHAR(10), DATA BLOB, PRIMARY KEY(ID))
-append-to-file.derby=UPDATE %s SET DATA = DATA || ? WHERE ID=?
 max-blob-size.derby=2147483647
 
 # PostgreSQL SQL statements


### PR DESCRIPTION
CONCAT() works only for character types not blob.

JIRA: https://issues.jboss.org/browse/WFLY-8247