### PR TITLE
[WFLY-8246] Static cluster with http-connector

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
@@ -61,9 +61,14 @@ public class HTTPConnectorDefinition extends AbstractTransportDefinition {
             .setAllowExpression(false) // references another resource
             .build();
 
+    public static final SimpleAttributeDefinition SERVER_NAME = create("server-name", ModelType.STRING)
+            .setRequired(false)
+            .setAllowExpression(false)
+            .build();
+
     static final HTTPConnectorDefinition INSTANCE = new HTTPConnectorDefinition();
 
     public HTTPConnectorDefinition() {
-        super(false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING, ENDPOINT, PARAMS);
+        super(false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING, ENDPOINT, SERVER_NAME, PARAMS);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -293,6 +293,7 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                 .addAttributes(
                                                         HTTPConnectorDefinition.SOCKET_BINDING,
                                                         HTTPConnectorDefinition.ENDPOINT,
+                                                        HTTPConnectorDefinition.SERVER_NAME,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
                                         builder(RemoteTransportDefinition.CONNECTOR_INSTANCE)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -116,7 +116,9 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         bridge.getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.ALWAYS, BridgeDefinition.CREDENTIAL_REFERENCE)
                 .addRejectCheck(DEFINED, BridgeDefinition.CREDENTIAL_REFERENCE);
-
+        ResourceTransformationDescriptionBuilder httpConnector = server.addChildResource(HTTPConnectorDefinition.INSTANCE);
+        // reject server-name introduced in management version 2.0.0 if it is defined
+        rejectDefinedAttributeWithDefaultValue(httpConnector, HTTPConnectorDefinition.SERVER_NAME);
         // reject producer-window-size introduced in management version 2.0.0 if it is defined and different from the default value.
         rejectDefinedAttributeWithDefaultValue(bridge, BridgeDefinition.PRODUCER_WINDOW_SIZE);
         ResourceTransformationDescriptionBuilder jmsBridge = server.addChildResource(MessagingExtension.JMS_BRIDGE_PATH);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -348,7 +348,11 @@ public class TransportConfigOperationHandlers {
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, HTTPConnectorDefinition.ENDPOINT.resolveModelAttribute(context, config).asString());
                 // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
                 parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
-                parameters.put(ACTIVEMQ_SERVER_NAME, configuration.getName());
+                ModelNode serverNameModelNode = HTTPConnectorDefinition.SERVER_NAME.resolveModelAttribute(context, config);
+                // use the name of this server if the server-name attribute is undefined
+                String serverName = serverNameModelNode.isDefined() ? serverNameModelNode.asString() : configuration.getName();
+                parameters.put(ACTIVEMQ_SERVER_NAME, serverName);
+
                 connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName));
             }
         }

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -185,6 +185,7 @@ connector-service=A connector service allows to integrate external components wi
 connector.add.params=A set of key-value pairs understood by the connector factory-class and used to configure it.
 connector.add=Operation adding a connector
 connector.endpoint=The http-acceptor that serves as the endpoint of this http-connector.
+connector.server-name=The name of the ActiveMQ Artemis server that will be connected to on the remote server. If undefined, the name of the parent ActiveMQ Artemis server will be used (suitable if the http-connector is used to connect to the parent server)
 connector.factory-class=Class name of the factory class that can instantiate the connector.
 connector.params=A key-value pair understood by the connector factory-class and used to configure it.
 connector.remove=Operation removing a connector

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
@@ -286,6 +286,7 @@
                     <xs:attribute name="name" type="xs:string" use="required" />
                     <xs:attribute name="socket-binding" type="xs:string" use="required" />
                     <xs:attribute name="endpoint" type="xs:string" use="required" />
+                    <xs:attribute name="server-name" type="xs:string" use="optional" />
                 </xs:complexType>
             </xs:element>
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -160,6 +161,9 @@ public class MessagingActiveMQSubsystem_1_1_TestCase extends AbstractSubsystemBa
                                 ServerDefinition.JOURNAL_LARGE_MESSAGES_TABLE,
                                 ServerDefinition.JOURNAL_PAGE_STORE_TABLE,
                                 ServerDefinition.JOURNAL_DATABASE))
+                .addFailedAttribute(subsystemAddress.append(SERVER_PATH, PathElement.pathElement(CommonAttributes.HTTP_CONNECTOR)),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(
+                                HTTPConnectorDefinition.SERVER_NAME))
                 .addFailedAttribute(subsystemAddress.append(SERVER_PATH, BRIDGE_PATH),
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 BridgeDefinition.PRODUCER_WINDOW_SIZE))

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
@@ -134,7 +134,8 @@
 
         <http-connector name="http"
                         socket-binding="http"
-                        endpoint="http">
+                        endpoint="http"
+                        server-name="=foo">
             <param name="batch-delay" value="${batch.delay:50}"/>
         </http-connector>
         <remote-connector name="netty"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
@@ -14,6 +14,13 @@
                  large-messages-table="MY_LARGE_MESSAGES"
                  page-store-table="MY_PAGE_STORE" />
 
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http"
+                        server-name="=foo">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+
         <cluster-connection name="cc1"
                             address="${address:cc1-address}"
                             connector-name="netty"


### PR DESCRIPTION
add server-name attribute to the http-connector resources so that the
connector can connect to the correct ActiveMQ Artemis server on a remote
app server (as the app server can embed multiple Artemis server with the
same acceptor names, the Artemis server name is required to identifed
the correct one).
If this attribute is undefined, the http-connector will use the name of
its parent Artemis server (making it suitable for http-connector used to
connect to the server itself).

JIRA: https://issues.jboss.org/browse/WFLY-8246