### PR TITLE
[WFLY-8256] Change replication-master check-for-live-server default v…

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -44,6 +44,7 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.LIVE_ONL
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.PAGING_DIRECTORY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.QUEUE;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_COLOCATED;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_SLAVE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ROLE;
@@ -110,6 +111,7 @@ public class MessagingExtension implements Extension {
     public static final PathElement REPLICATION_SLAVE_PATH = pathElement(HA_POLICY, REPLICATION_SLAVE);
     public static final PathElement SHARED_STORE_MASTER_PATH = pathElement(HA_POLICY, SHARED_STORE_MASTER);
     public static final PathElement SHARED_STORE_SLAVE_PATH = pathElement(HA_POLICY, SHARED_STORE_SLAVE);
+    public static final PathElement REPLICATION_COLOCATED_PATH = pathElement(HA_POLICY, REPLICATION_COLOCATED);
     public static final PathElement CONFIGURATION_MASTER_PATH = pathElement(CONFIGURATION, MASTER);
     public static final PathElement CONFIGURATION_SLAVE_PATH = pathElement(CONFIGURATION, SLAVE);
     static final PathElement BINDINGS_DIRECTORY_PATH = pathElement(PATH, BINDINGS_DIRECTORY);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.transform.description.RejectAttributeChecker.DEFINED;
+import static org.jboss.as.controller.transform.description.RejectAttributeChecker.UNDEFINED;
 import static org.jboss.dmr.ModelType.INT;
 
 import java.util.Arrays;
@@ -41,6 +42,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
 
@@ -111,7 +113,15 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         server.getAttributeBuilder()
                     .setDiscard(DiscardAttributeChecker.ALWAYS, ServerDefinition.CREDENTIAL_REFERENCE)
                     .addRejectCheck(DEFINED, ServerDefinition.CREDENTIAL_REFERENCE);
-
+        ResourceTransformationDescriptionBuilder replicationMaster = server.addChildResource(MessagingExtension.REPLICATION_MASTER_PATH);
+        replicationMaster.getAttributeBuilder()
+                // reject if the attribute is undefined as its default value was changed from false to true in EAP 7.1.0
+                .addRejectCheck(UNDEFINED, HAAttributes.CHECK_FOR_LIVE_SERVER);
+        ResourceTransformationDescriptionBuilder replicationColocated = server.addChildResource(MessagingExtension.REPLICATION_COLOCATED_PATH);
+        ResourceTransformationDescriptionBuilder masterForReplicationColocated = replicationColocated.addChildResource(MessagingExtension.CONFIGURATION_MASTER_PATH);
+        masterForReplicationColocated.getAttributeBuilder()
+                // reject if the attribute is undefined as its default value was changed from false to true in EAP 7.1.0
+                .addRejectCheck(UNDEFINED, HAAttributes.CHECK_FOR_LIVE_SERVER);
         ResourceTransformationDescriptionBuilder bridge = server.addChildResource(MessagingExtension.BRIDGE_PATH);
         bridge.getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.ALWAYS, BridgeDefinition.CREDENTIAL_REFERENCE)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
@@ -73,9 +73,10 @@ public class HAAttributes {
             .setRestartAllServices()
             .build();
 
+    // WFLY-8256 change default value to true instead of Artemis's false
     public static SimpleAttributeDefinition CHECK_FOR_LIVE_SERVER = create(CommonAttributes.CHECK_FOR_LIVE_SERVER2, BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultCheckForLiveServer()))
-            .setAllowNull(true)
+            .setDefaultValue(new ModelNode(true))
+            .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
@@ -26,7 +26,6 @@ package org.wildfly.extension.messaging.activemq.ha;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONFIGURATION;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLICY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.MASTER;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_COLOCATED;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SLAVE;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_PORT_OFFSET;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRIES;
@@ -47,7 +46,6 @@ import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -59,8 +57,6 @@ import org.wildfly.extension.messaging.activemq.MessagingExtension;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
  */
 public class ReplicationColocatedDefinition extends PersistentResourceDefinition {
-
-    public static final PathElement PATH = PathElement.pathElement(HA_POLICY, REPLICATION_COLOCATED);
 
     public static Collection<AttributeDefinition> ATTRIBUTES =  Collections.unmodifiableList(Arrays.asList(
             REQUEST_BACKUP,
@@ -74,7 +70,7 @@ public class ReplicationColocatedDefinition extends PersistentResourceDefinition
     public static final ReplicationColocatedDefinition INSTANCE = new ReplicationColocatedDefinition();
 
     private ReplicationColocatedDefinition() {
-        super(PATH,
+        super(MessagingExtension.REPLICATION_COLOCATED_PATH,
                 MessagingExtension.getResourceDescriptionResolver(HA_POLICY),
                 createAddOperation(HA_POLICY, false, ATTRIBUTES),
                 ReloadRequiredRemoveStepHandler.INSTANCE);

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
@@ -14,6 +14,10 @@
                  large-messages-table="MY_LARGE_MESSAGES"
                  page-store-table="MY_PAGE_STORE" />
 
+        <replication-colocated>
+            <master />
+        </replication-colocated>
+
         <http-connector name="http"
                         socket-binding="http"
                         endpoint="http"
@@ -53,5 +57,8 @@
         <inbound-config
                 rebalance-connections="true" />
         </pooled-connection-factory>
+    </server>
+    <server name="other">
+        <replication-master />
     </server>
 </subsystem>


### PR DESCRIPTION
…alue

Change its default value to true so that it is not possible to have a
cluster with 2 nodes behaving as live servers at the same time (at the
cost of a 10s delay when servers are started and wait to check if there
is already a live server up).

This change applies for both replication-master and
replication-colocated/master HA policy

Add transformers to reject the attribute if it is undefined (new version
would default to true while legacy versions would default to false)

JIRA: https://issues.jboss.org/browse/WFLY-8256