### PR TITLE
[WFLY-7888] fix for TxTestUtil works with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessBmtBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessBmtBean.java
@@ -27,11 +27,13 @@ import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
+import javax.inject.Inject;
 import javax.naming.NamingException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
 import org.jboss.logging.Logger;
 
@@ -45,6 +47,9 @@ public class StatelessBmtBean {
 
     @Resource(name = "java:jboss/TransactionManager")
     private TransactionManager tm;
+
+    @Inject
+    private TransactionCheckerSingleton checker;
 
     public String testTransaction(int transactionCount, int timeoutCount)
             throws RemoteException, NamingException, SystemException {
@@ -71,8 +76,8 @@ public class StatelessBmtBean {
 
             txnToString = txn.toString();
 
-            TxTestUtil.enlistTestXAResource(tm.getTransaction());
-            TxTestUtil.enlistTestXAResource(tm.getTransaction());
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
 
             if(isTimeout) {
                 TxTestUtil.waitForTimeout(tm);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/timeout/StatelessTimeoutTestCase.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.ejb.transaction.bmt.timeout;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -29,16 +31,15 @@ import org.jboss.as.test.integration.transactions.TransactionTestLookupUtil;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import java.util.PropertyPermission;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -49,11 +50,6 @@ import javax.naming.NamingException;
  */
 @RunWith(Arquillian.class)
 public class StatelessTimeoutTestCase {
-
-    @BeforeClass
-    public static void beforeClass() {
-        DisableInvocationTestUtil.disable();
-    }
 
     @ArquillianResource
     private InitialContext initCtx;
@@ -67,7 +63,10 @@ public class StatelessTimeoutTestCase {
             .addPackage(StatelessTimeoutTestCase.class.getPackage())
             .addPackage(TxTestUtil.class.getPackage())
             .addClasses(TimeoutUtil.class)
-            .addAsManifestResource(new StringAsset("<beans></beans>"),  "beans.xml");
+            .addAsManifestResource(new StringAsset("<beans></beans>"),  "beans.xml")
+            // grant necessary permissions for -Dsecurity.manager
+            .addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("ts.timeout.factor", "read")), "META-INF/jboss-permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/ActivationPropertyTimeoutMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/ActivationPropertyTimeoutMDB.java
@@ -39,7 +39,7 @@ import org.jboss.as.test.integration.transactions.TxTestUtil;
 
 @MessageDriven(activationConfig = {
     @ActivationConfigProperty(propertyName = "destination", propertyValue = TransactionTimeoutQueueSetupTask.PROPERTY_TIMEOUT_JNDI_NAME),
-    @ActivationConfigProperty(propertyName = "transactionTimeout", propertyValue = "1"),
+    @ActivationConfigProperty(propertyName = "transactionTimeout", propertyValue = "1")
 })
 public class ActivationPropertyTimeoutMDB implements MessageListener {
     private static final Logger log = Logger.getLogger(ActivationPropertyTimeoutMDB.class);
@@ -72,7 +72,7 @@ public class ActivationPropertyTimeoutMDB implements MessageListener {
                     + " and bean does not know where to reply to");
             }
 
-            TxTestUtil.enlistTestXAResource(tm.getTransaction());
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
 
             try (
                 JMSContext context = factory.createContext()
@@ -82,7 +82,8 @@ public class ActivationPropertyTimeoutMDB implements MessageListener {
                     .send(replyTo, REPLY_PREFIX + ((TextMessage) message).getText());
             }
 
-            // would timeout txn when TransactionTimeout be cared
+            // would timeout txn - this timeout waiting has to be greater than 1 s
+            // (see transactionTimeout activation config property)
             TxTestUtil.waitForTimeout(tm);
         } catch (Exception e) {
             throw new RuntimeException("onMessage method execution failed", e);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/NoTimeoutMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/NoTimeoutMDB.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
 import javax.annotation.Resource;
 import javax.ejb.ActivationConfigProperty;
 import javax.ejb.MessageDriven;
+import javax.inject.Inject;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.JMSContext;
@@ -34,6 +35,7 @@ import javax.jms.TextMessage;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
 import org.jboss.logging.Logger;
 
@@ -50,6 +52,9 @@ public class NoTimeoutMDB implements MessageListener {
     @Resource(name = "java:jboss/TransactionManager")
     private TransactionManager tm;
 
+    @Inject
+    private TransactionCheckerSingleton checker;
+
     @Resource
     private TransactionSynchronizationRegistry synchroRegistry;
 
@@ -65,8 +70,8 @@ public class NoTimeoutMDB implements MessageListener {
                     + " and bean does not know where to reply to");
             }
 
-            TxTestUtil.enlistTestXAResource(tm.getTransaction());
-            TxTestUtil.addSynchronization(tm.getTransaction());
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
+            TxTestUtil.addSynchronization(tm.getTransaction(), checker);
 
             try (
                 JMSContext context = factory.createContext()

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/xa/SLSB1.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/xa/SLSB1.java
@@ -25,11 +25,13 @@ import javax.annotation.Resource;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
 
 /**
@@ -48,10 +50,13 @@ public class SLSB1 implements SLSB {
     @Resource
     private UserTransaction tx;
 
+    @Inject
+    private TransactionCheckerSingleton checker;
+
     @Override
     public void commit() throws Exception {
         tx.begin();
-        TxTestUtil.enlistTestXAResource(tm.getTransaction());
+        TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
         em.persist(new TestEntity());
         tx.commit();
     }
@@ -59,7 +64,7 @@ public class SLSB1 implements SLSB {
     @Override
     public void rollback() throws Exception {
         tx.begin();
-        TxTestUtil.enlistTestXAResource(tm.getTransaction());
+        TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
         em.persist(new TestEntity());
         tx.rollback();
     }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/IIOPTimeoutTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/IIOPTimeoutTestCase.java
@@ -22,7 +22,10 @@
 
 package org.jboss.as.test.iiop.transaction.timeout;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.rmi.RemoteException;
+import java.util.PropertyPermission;
 
 import javax.naming.NamingException;
 import javax.transaction.TransactionRolledbackException;
@@ -38,14 +41,12 @@ import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingletonRemote;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -64,11 +65,6 @@ public class IIOPTimeoutTestCase {
 
     private TransactionCheckerSingletonRemote checker;
 
-    @BeforeClass
-    public static void beforeClass() {
-        DisableInvocationTestUtil.disable();
-    }
-
     @Deployment(name = DEPLOYMENT_NAME)
     @TargetsContainer("iiop-client")
     public static Archive<?> deploy() {
@@ -78,7 +74,10 @@ public class IIOPTimeoutTestCase {
                 .addPackage(TxTestUtil.class.getPackage())
                 .addClasses(TimeoutUtil.class)
                 .addAsManifestResource(IIOPTimeoutTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("<beans></beans>"),  "beans.xml");
+                .addAsManifestResource(new StringAsset("<beans></beans>"),  "beans.xml")
+                // grant necessary permissions for -Dsecurity.manager
+                .addAsResource(createPermissionsXmlAsset(
+                    new PropertyPermission("ts.timeout.factor", "read")), "META-INF/jboss-permissions.xml");
     }
 
     @Before

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatefulBean.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatefulBean.java
@@ -75,8 +75,8 @@ public class StatefulBean implements SessionSynchronization {
         Transaction txn;
         txn = tm.getTransaction();
 
-        TxTestUtil.enlistTestXAResource(txn);
-        TxTestUtil.enlistTestXAResource(txn);
+        TxTestUtil.enlistTestXAResource(txn, checker);
+        TxTestUtil.enlistTestXAResource(txn, checker);
     }
 
     @TransactionTimeout(value = 1)
@@ -85,8 +85,8 @@ public class StatefulBean implements SessionSynchronization {
         Transaction txn;
         txn = tm.getTransaction();
 
-        TxTestUtil.enlistTestXAResource(txn);
-        TxTestUtil.enlistTestXAResource(txn);
+        TxTestUtil.enlistTestXAResource(txn, checker);
+        TxTestUtil.enlistTestXAResource(txn, checker);
 
         try {
             TxTestUtil.waitForTimeout(tm);

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatelessBean.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatelessBean.java
@@ -70,8 +70,8 @@ public class StatelessBean {
         Transaction txn;
         txn = tm.getTransaction();
 
-        TxTestUtil.enlistTestXAResource(txn);
-        TxTestUtil.enlistTestXAResource(txn);
+        TxTestUtil.enlistTestXAResource(txn, checker);
+        TxTestUtil.enlistTestXAResource(txn, checker);
     }
 
     @TransactionTimeout(value = 1)
@@ -80,8 +80,8 @@ public class StatelessBean {
         Transaction txn;
         txn = tm.getTransaction();
 
-        TxTestUtil.enlistTestXAResource(txn);
-        TxTestUtil.enlistTestXAResource(txn);
+        TxTestUtil.enlistTestXAResource(txn, checker);
+        TxTestUtil.enlistTestXAResource(txn, checker);
 
         try {
             TxTestUtil.waitForTimeout(tm);


### PR DESCRIPTION
Main point was not using CDI.current() as for such thing security
manager would need very special settings, see
https://github.com/wildfly/wildfly/pull/9591https://github.com/wildfly/wildfly/pull/9591

There is an additional fix for using adjust for MDB timeout tests as was changed by WFLY-8109.
There was an issue in test which does not wait long enough to receive a
message.

https://issues.jboss.org/browse/WFLY-7888