### PR TITLE
[WFLY-8257] ignore tests failing in Elytron AS TS profile

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/JarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/JarOverlayTestBase.java
@@ -32,10 +32,12 @@ import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 
 /**
  * @author baranowb
@@ -48,6 +50,11 @@ public class JarOverlayTestBase {
 
     @ArquillianResource
     protected Deployer deployer;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     public static Archive<?> createOverlayedArchive(final boolean resourcePresent, final String deploymentOverlayedArchive){
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, deploymentOverlayedArchive);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestCase.java
@@ -26,10 +26,12 @@ import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +42,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class DefaultContextServiceTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static WebArchive getDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedExecutorServiceTestCase.java
@@ -26,10 +26,12 @@ import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +42,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class DefaultManagedExecutorServiceTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static WebArchive getDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedScheduledExecutorServiceTestCase.java
@@ -27,10 +27,12 @@ import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +43,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class DefaultManagedScheduledExecutorServiceTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static WebArchive getDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
@@ -26,10 +26,12 @@ import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +42,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class DefaultManagedThreadFactoryTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static WebArchive getDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -46,6 +46,7 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -58,6 +59,7 @@ import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -96,6 +98,11 @@ public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestB
                 jmsAdminOperations.close();
             }
         }
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     @Before

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AbstractAuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AbstractAuthenticationTestCase.java
@@ -55,11 +55,13 @@ import org.jboss.as.test.integration.ejb.security.base.WhoAmIBean;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -69,10 +71,15 @@ import org.junit.Test;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-abstract class AbstractAuthenticationTestCase {
+public abstract class AbstractAuthenticationTestCase {
 
     private static final String SERVER_HOST_PORT = TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort();
     private static final String WAR_URL = "http://" + SERVER_HOST_PORT + "/ejb3security/";
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     /*
      * Authentication Scenarios

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
@@ -37,11 +37,13 @@ import org.jboss.as.test.integration.ejb.security.authorization.AnnOnlyCheckSLSB
 import org.jboss.as.test.integration.ejb.security.authorization.ParentAnnOnlyCheck;
 import org.jboss.as.test.integration.ejb.security.authorization.SimpleAuthorizationRemote;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -60,6 +62,10 @@ public abstract class AnnSBTest {
     @ContainerResource
     private ManagementClient managementClient;
 
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     public static Archive<JavaArchive> testAppDeployment(final Logger LOG, final String MODULE, final Class SB_TO_TEST) {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE + ".jar")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -43,6 +43,7 @@ import org.jboss.as.test.integration.ejb.security.runasprincipal.transitive.Sing
 import org.jboss.as.test.integration.ejb.security.runasprincipal.transitive.StatelessSingletonUseBean;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
@@ -51,6 +52,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -72,6 +74,11 @@ public class RunAsPrincipalTestCase  {
     @ArquillianResource
     public Deployer deployer;
 
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
+
     @Deployment(name = STARTUP_SINGLETON_DEPLOYMENT, managed = false, testable = false)
     public static Archive<?> runAsStartupTransitiveDeployment() {
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
@@ -92,6 +99,12 @@ public class RunAsPrincipalTestCase  {
 
     @Deployment
     public static Archive<?> runAsDeployment() {
+        //XXX This is hack related to Elytron profile assumption in beforeClass() method.
+        // Arquillian does deploy before executing @BeforeClass annotated methods. So let's create a dummy deployment
+        if (! AssumeTestGroupUtil.CONDITION_SKIP_ELYTRON_PROFILE.get()) {
+            return ShrinkWrap.create(WebArchive.class).addAsWebResource(new StringAsset(""), "index.html");
+        }
+
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war")
                 .addPackage(WhoAmI.class.getPackage())

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsDefaultAllowedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsDefaultAllowedTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -42,6 +43,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -107,6 +109,11 @@ public class MissingMethodPermissionsDefaultAllowedTestCase {
 
     }
 
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static Archive createDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ejb.security.missingmethodpermission;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -33,6 +34,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,6 +62,11 @@ public class MissingMethodPermissionsTestCase {
     private static final String MODULE_THREE_NAME = "missing-method-permissions-test-ejb-jar-three";
 
     private LoginContext loginContext;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static Archive createDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
@@ -30,9 +30,11 @@ import javax.ejb.EJBAccessException;
 import javax.naming.InitialContext;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.security.client.SecurityClient;
 import org.jboss.security.client.SecurityClientFactory;
 import org.jboss.shrinkwrap.api.Archive;
@@ -52,6 +54,11 @@ import org.junit.runner.RunWith;
 @Category(CommonCriteria.class)
 public class SingletonSecurityTestCase {
     private static final Logger log = Logger.getLogger(SingletonSecurityTestCase.class.getName());
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static Archive<?> deploy() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.ChildFirstClassLoaderBuilder;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -53,6 +54,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -102,6 +104,11 @@ public class ClientCompatibilityUnitTestCase {
                     .append(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT)
                     .append(ModelDescriptionConstants.MANAGEMENT_INTERFACE, ModelDescriptionConstants.NATIVE_INTERFACE).toModelNode();
         }
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     // Arquillian requires a deployment to trigger @ServerSetup handling

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
@@ -17,6 +17,7 @@ import org.jboss.as.test.integration.management.deploy.runtime.ejb.singleton.tim
 import org.jboss.as.test.integration.management.deploy.runtime.ejb.singleton.timer.PointlessInterface;
 import org.jboss.as.test.integration.management.util.ModelUtil;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,6 +47,11 @@ public class TimerEJBRuntimeNameTestCase extends AbstractRuntimeTestCase {
     private static final String SUB_DEPLOYMENT_MODULE_NAME = "ejb";
     private static final String SUB_DEPLOYMENT_NAME = SUB_DEPLOYMENT_MODULE_NAME + ".jar";
     private static ModelControllerClient controllerClient = TestSuiteEnvironment.getModelControllerClient();
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
@@ -45,6 +45,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,6 +61,11 @@ public class SecurityTestCase {
 
     @ContainerResource
     private ManagementClient managementClient;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Test
     public void testFailedAuthenticationBadUserPass() throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -12,10 +12,13 @@ import org.wildfly.naming.java.permission.JndiPermission;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import org.jboss.remoting3.security.RemotingPermission;
 import static org.junit.Assert.assertEquals;
@@ -38,6 +41,11 @@ public class MultipleClientRemoteJndiTestCase {
 
     private static final Package thisPackage = MultipleClientRemoteJndiTestCase.class.getPackage();
 
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment(name="one")
     public static WebArchive deploymentOne() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -14,11 +14,13 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.java.permission.JndiPermission;
@@ -36,6 +38,10 @@ public class NestedRemoteContextTestCase {
 
     private static final Package thisPackage = NestedRemoteContextTestCase.class.getPackage();
 
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static EnterpriseArchive deploymentTwo() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
@@ -50,12 +50,14 @@ import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServ
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -130,6 +132,11 @@ public class SecurityAuditingTestCase extends AnnSBTest {
             executeOperations(updates);
 
         }
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     @Deployment

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
@@ -31,6 +31,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -70,6 +71,11 @@ public class CLISecurityTestCase {
         public synchronized void shutdown() {
             this.quit();
         }
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,6 +58,11 @@ public class DMRSecurityTestCase {
 
     private static File originalTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth");
     private static File renamedTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth.renamed");
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     /**
      * Workaround to disable silent login on localhost.

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
@@ -31,8 +31,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,6 +47,11 @@ public class DefaultContextServiceServletTestCase {
 
     @ArquillianResource
     private URL url;
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment
     public static WebArchive deployment() {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
@@ -39,10 +39,12 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -71,6 +73,11 @@ public class FormAuthUnitTestCase {
     private URL baseURLNoAuth;
 
     DefaultHttpClient httpclient = new DefaultHttpClient();
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @Deployment(name="form-auth.war", testable = false)
     public static WebArchive deployment() {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -1,0 +1,49 @@
+package org.jboss.as.test.shared.util;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.function.Supplier;
+
+import org.junit.Assume;
+
+/**
+ * Helper methods which help to skip tests for feature which is not yet fully working. Put the call of the method directly into
+ * the failing test method, or if you want to skip whole test class, then put the method call into method annotated with
+ * {@link org.junit.BeforeClass}.
+ *
+ * @author Josef Cacek
+ */
+public class AssumeTestGroupUtil {
+
+    public static final Supplier<Boolean> CONDITION_SKIP_ELYTRON_PROFILE = () -> (System.getProperty("elytron") == null
+            || Boolean.getBoolean("wildfly.tmp.enable.elytron.profile.tests"));
+
+    /**
+     * Assume for invocation-related test failures. It skips test in case the system property
+     * {@codewildfly.tmp.enable.invocation.tests} hasn't value {@code 'true'}.
+     */
+    public static void assumeInvocationTestsEnabled() {
+        assumeCondition("Failing Invocation tests are disabled",
+                () -> Boolean.getBoolean("wildfly.tmp.enable.invocation.tests"));
+    }
+
+    /**
+     * Assume for test failures when running with Elytron profile enabled. It skips test in case the {@code '-Delytron'} Maven
+     * argument is used (for Elytron profile activation) and system property {@code wildfly.tmp.enable.elytron.profile.tests}
+     * hasn't value {@code 'true'}.
+     */
+    public static void assumeElytronProfileTestsEnabled() {
+        assumeCondition("Tests failing in Elytron profile are disabled", CONDITION_SKIP_ELYTRON_PROFILE);
+    }
+
+    private static void assumeCondition(final String message, final Supplier<Boolean> assumeTrueCondition) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                Assume.assumeTrue(message, assumeTrueCondition.get());
+                return null;
+            }
+        });
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/DisableInvocationTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/DisableInvocationTestUtil.java
@@ -1,21 +1,10 @@
 package org.jboss.as.test.shared.util;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
-import org.junit.Assume;
-
 /**
  * @author Kabir Khan
  */
 public class DisableInvocationTestUtil {
     public static void disable() {
-        final boolean enableInvocationTests = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-            @Override
-            public Boolean run() {
-                return Boolean.getBoolean("wildfly.tmp.enable.invocation.tests");
-            }
-        });
-        Assume.assumeTrue(enableInvocationTests);
+        AssumeTestGroupUtil.assumeInvocationTestsEnabled();
     }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8257

Ignore tests failing when executed under elytron profile in the similar way as the invocation tests are skipped.