### PR TITLE
Rollback WildFlyDataSource#getJndiName() exposure.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/WildFlyDataSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/WildFlyDataSource.java
@@ -104,10 +104,6 @@ public class WildFlyDataSource implements DataSource, Serializable {
         return delegate.getParentLogger();
     }
 
-    public String getJndiName() {
-        return jndiName;
-    }
-
     private void writeObject(java.io.ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeObject(jndiName);


### PR DESCRIPTION
This was originally exposed as a hack in order to implement WFLY-6599.
https://issues.jboss.org/browse/WFLY-6599
However, the refactoring for WFLY-7882 made this obsolete.
https://issues.jboss.org/browse/WFLY-7882