### PR TITLE
WFLY-8237 Upgrade to xalan 2.7.1.jbossorg-4 and include fix for cve-2014-0107 + JBEAP-5364/XALANJ-2591

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
         <version.org.apache.ws.security>2.1.8</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
-        <version.org.apache.xalan>2.7.1.jbossorg-2</version.org.apache.xalan>
+        <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bouncycastle>1.56</version.org.bouncycastle>
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.8</version.org.codehaus.jettison>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8237
https://issues.jboss.org/browse/JBEAP-6902 was the original product issue but the product side already has the cve-2014-0107 fix applied, so I think we will close JBEAP-6902.