### PR TITLE
[WFLY-6565-reopened]: Add and remove operation of jaxrs subsystem under deployment are useless and should not be available.

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
@@ -38,7 +38,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinition;
@@ -46,7 +45,6 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
@@ -64,14 +62,7 @@ import org.wildfly.extension.undertow.deployment.UndertowDeploymentService;
  */
 public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
 
-    public static final JaxrsDeploymentDefinition DEPLOYMENT_INSTANCE = new JaxrsDeploymentDefinition(true);
-    public static final JaxrsDeploymentDefinition SUBSYSTEM_INSTANCE = new JaxrsDeploymentDefinition(false);
-    private static final SimpleOperationDefinition ADD_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, JaxrsExtension.getResolver())
-                .setEntryType( OperationEntry.EntryType.PRIVATE)
-                .build();
-    private static final SimpleOperationDefinition REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.REMOVE, JaxrsExtension.getResolver())
-                .setEntryType( OperationEntry.EntryType.PRIVATE)
-                .build();
+    public static final JaxrsDeploymentDefinition INSTANCE = new JaxrsDeploymentDefinition();
 
     public static final String SHOW_RESOURCES = "show-resources";
     public static final AttributeDefinition CLASSNAME
@@ -85,23 +76,17 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
     public static final ObjectTypeAttributeDefinition JAXRS_RESOURCE
             = new ObjectTypeAttributeDefinition.Builder("jaxrs-resource", CLASSNAME, PATH, METHODS).setStorageRuntime().build();
 
-    private final boolean showResources;
-    private JaxrsDeploymentDefinition(boolean showResources) {
+    private JaxrsDeploymentDefinition() {
          super(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver());
-         this.showResources = showResources;
     }
 
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
-        resourceRegistration.registerOperationHandler(ADD_DEFINITION, JaxrsSubsystemAdd.INSTANCE);
-        resourceRegistration.registerOperationHandler(REMOVE_DEFINITION, ReloadRequiredRemoveStepHandler.INSTANCE);
-        if(showResources) {
-            resourceRegistration.registerOperationHandler(ShowJaxrsResourcesHandler.DEFINITION, new ShowJaxrsResourcesHandler());
-        }
+        resourceRegistration.registerOperationHandler(ShowJaxrsResourcesHandler.DEFINITION, new ShowJaxrsResourcesHandler());
     }
 
-    static class ShowJaxrsResourcesHandler implements OperationStepHandler {
+    private static class ShowJaxrsResourcesHandler implements OperationStepHandler {
         public static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(SHOW_RESOURCES,
                 JaxrsExtension.getResolver("deployment"))
                 .setReadOnly()

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsExtension.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsExtension.java
@@ -87,9 +87,9 @@ public class JaxrsExtension implements Extension {
     public void initialize(final ExtensionContext context) {
         JAXRS_LOGGER.debug("Activating JAX-RS Extension");
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
-        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(JaxrsDeploymentDefinition.SUBSYSTEM_INSTANCE);
+        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(JaxrsSubsystemDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
-        ManagementResourceRegistration jaxrsResReg = subsystem.registerDeploymentModel(JaxrsDeploymentDefinition.DEPLOYMENT_INSTANCE);
+        ManagementResourceRegistration jaxrsResReg = subsystem.registerDeploymentModel(JaxrsDeploymentDefinition.INSTANCE);
         jaxrsResReg.registerSubModel(DeploymentRestResourcesDefintion.INSTANCE);
         subsystem.registerXMLElementWriter(parser);
     }

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemDefinition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.jaxrs;
+
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class JaxrsSubsystemDefinition extends SimpleResourceDefinition {
+
+    public static final JaxrsSubsystemDefinition INSTANCE = new JaxrsSubsystemDefinition();
+
+    private JaxrsSubsystemDefinition() {
+         super(new Parameters(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver())
+                 .setAddHandler(JaxrsSubsystemAdd.INSTANCE)
+                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/JaxrsRuntimeNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/JaxrsRuntimeNameTestCase.java
@@ -61,6 +61,7 @@ import static org.jboss.as.jaxrs.DeploymentRestResourcesDefintion.REST_RESOURCE_
 import static org.jboss.as.jaxrs.DeploymentRestResourcesDefintion.SUB_RESOURCE_LOCATORS;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.CoreMatchers;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.jaxrs.JaxrsDeploymentDefinition;
 import org.jboss.as.jaxrs.JaxrsExtension;
@@ -136,6 +137,8 @@ public class JaxrsRuntimeNameTestCase extends AbstractRuntimeTestCase {
 
     @Test
     public void testReadRestResource() throws Exception {
+        ModelNode removeResource =  Util.createRemoveOperation(PathAddress.pathAddress(DEPLOYMENT, DEPLOYMENT_NAME).append(SUBSYSTEM, JaxrsExtension.SUBSYSTEM_NAME));
+        assertThat(Operations.getFailureDescription(controllerClient.execute(removeResource)).asString(), CoreMatchers.containsString("WFLYCTL0031"));
         ModelNode readResource =  Util.createOperation(READ_RESOURCE_OPERATION, PathAddress.pathAddress(DEPLOYMENT, DEPLOYMENT_NAME)
                 .append(SUBSYSTEM, JaxrsExtension.SUBSYSTEM_NAME)
                 .append(REST_RESOURCE_NAME, HelloResource.class.getCanonicalName()));


### PR DESCRIPTION
Removing those handlers that are not used.

Jira: https://issues.jboss.org/browse/WFLY-6565
JBEAP:  https://issues.jboss.org/browse/JBEAP-4374