### PR TITLE
[WFLY-8298] Not able to undefine initial-pool-size attribute of datas…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
@@ -145,6 +145,7 @@ public class Constants {
             .setXmlName(Pool.Tag.INITIAL_POOL_SIZE.getLocalName())
             .setAllowExpression(true)
             .setAllowNull(true)
+            .setDefaultValue(new ModelNode(Defaults.MIN_POOL_SIZE))
             .build();
 
     public static SimpleAttributeDefinition CAPACITY_INCREMENTER_CLASS = new SimpleAttributeDefinitionBuilder(CAPACITY_INCREMENTER_CLASS_NAME, ModelType.STRING, true)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -118,6 +118,7 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
                 "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
 
         rar.addAsLibrary(jar);
+
         return rar;
     }
 
@@ -140,7 +141,7 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
         Assert.assertNotNull(poolConfiguration);
         Assert.assertEquals(2, poolConfiguration.getMinSize());
         Assert.assertEquals(5, poolConfiguration.getMaxSize());
-        Assert.assertEquals(2, poolConfiguration.getInitialSize());
+        Assert.assertEquals(0, poolConfiguration.getInitialSize());
         Assert.assertEquals(30000, poolConfiguration.getBlockingTimeout());
         Assert.assertEquals(true, poolConfiguration.isFair());
         Assert.assertEquals(false, poolConfiguration.isStrictMin());


### PR DESCRIPTION
…ource

JIRA: https://issues.jboss.org/browse/WFLY-8298
downstream: https://github.com/jbossas/jboss-eap7/pull/1531