### PR TITLE
[WFLY-8302][SECURITY-921] Negotiation only reads kerberos for MechType 1.2.840.113554.1.2.2 if it is the first mechanism in the list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.resteasy>3.0.21.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
-        <version.org.jboss.security.jboss-negotiation>3.0.3.Final</version.org.jboss.security.jboss-negotiation>
+        <version.org.jboss.security.jboss-negotiation>3.0.4.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/SPNEGOLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/SPNEGOLoginModuleTestCase.java
@@ -362,7 +362,7 @@ public class SPNEGOLoginModuleTestCase {
         final URI uri = getServletURI(webAppURL, SimpleSecuredServlet.SERVLET_PATH);
         final String[] mechTypes = new String[]{OID_KERBEROS_V5_LEGACY, OID_KERBEROS_V5};
         final byte[] kerberosToken = createNewKerberosTicketForHttp(uri);
-        assertSpnegoWorkflow(uri, mechTypes, kerberosToken, kerberosToken, true, true);
+        assertSpnegoWorkflow(uri, mechTypes, kerberosToken, kerberosToken, false, true);
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8302
SECURITY: https://issues.jboss.org/browse/SECURITY-921

These are only test cases. The actual fix is in:
https://issues.jboss.org/browse/SECURITY-921

Downstream (EAP 6.4): https://bugzilla.redhat.com/show_bug.cgi?id=1331176
Downstream (EAP 7.0): https://issues.jboss.org/browse/JBEAP-4394
Downstream (EAP 7.1): https://issues.jboss.org/browse/JBEAP-9334

Donwstream PR (EAP 6.4): https://github.com/jbossas/jboss-eap/pull/2939
Downstream PR (EAP 7.0): https://github.com/jbossas/jboss-eap7/pull/1452
Downstream PR (EAP 7.1): https://github.com/jbossas/jboss-eap7/pull/1453