### PR TITLE
[WFLY-8175] part 2: mvnw wrapper shouldn't deppend on .m2/wrapper

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -133,16 +133,16 @@ main() {
     #  Default goal if none specified.
     if [ -z "$MVN_GOAL" ]; then MVN_GOAL="install"; fi
 
-    # WFLY-8175 requires that we keep installing Maven under the tools directory
-    # the current project, at least when mvnw is invoked from build and integration-tests
-    # scripts
-    MVN_GOAL="-Dmaven.user.home=$DIRNAME/tools $MVN_GOAL"
-
     #  Export some stuff for maven.
     export MVN MAVEN_HOME MVN_OPTS MVN_GOAL
 
     # The default arguments.  `mvn -s ...` will override this.
     MVN_ARGS=${MVN_ARGS:-"$MVN_SETTINGS_XML_ARGS"};
+
+    # WFLY-8175 requires that we keep installing Maven under the tools directory
+    # the current project, at least when mvnw is invoked from build and integration-tests
+    # scripts
+    MVN_ARGS="-Dmaven.user.home=$DIRNAME/tools $MVN_ARGS"
 
     echo "$MVN $MVN_ARGS $MVN_GOAL $ADDIT_PARAMS"
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -159,13 +159,13 @@ main() {
     process_test_directives $MVN_GOAL
     MVN_GOAL=$CMD_LINE_PARAMS
 
+    # Export some stuff for maven.
+    export MVN MAVEN_HOME MVN_OPTS MVN_GOAL
+
     # WFLY-8175 requires that we keep installing Maven under the tools directory
     # the current project, at least when mvnw is invoked from build and integration-tests
     # scripts
-    MVN_GOAL="-Dmaven.user.home=$DIRNAME/tools $MVN_GOAL"
-
-    # Export some stuff for maven.
-    export MVN MAVEN_HOME MVN_OPTS MVN_GOAL
+    MVN_ARGS="-Dmaven.user.home=$DIRNAME/tools $MVN_ARGS"
 
     echo "$MVN $MVN_ARGS $MVN_GOAL"
 


### PR DESCRIPTION
location

https://issues.jboss.org/browse/WFLY-8175 this is the second round after reopening. The present PR adopts the solution proposed by @marekkopecky in https://issues.jboss.org/browse/JBEAP-8923?focusedCommentId=13372146&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13372146

Downstream: https://issues.jboss.org/browse/JBEAP-8923