### PR TITLE
[WFLY-8311] JMS Bridge can not load ActiveMQRegistry

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -33,6 +33,7 @@
         <artifact name="${org.apache.activemq:artemis-jdbc-store}"/>
         <artifact name="${org.apache.activemq:artemis-jms-client}"/>
         <artifact name="${org.apache.activemq:artemis-jms-server}"/>
+        <artifact name="${org.apache.activemq:artemis-service-extensions}"/>
     </resources>
 
     <dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -29,7 +29,6 @@
 
     <resources>
         <artifact name="${org.apache.activemq:artemis-ra}"/>
-        <artifact name="${org.apache.activemq:artemis-service-extensions}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
move org.apache.activemq:artemis-service-extensions artifact from
org.apache.activemq.artemis.ra to org.apache.activemq.artemis so that
ActiveMQRegistry can be loaded by both JMS Bridges and Artemis RA.

JIRA: https://issues.jboss.org/browse/WFLY-8311