### PR TITLE
[WFLY-8314] adding elytron subsystem to examples standalone xmls

### DIFF
--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -29,6 +29,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -27,6 +27,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
@@ -26,6 +26,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem supplement="jts-example">transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
@@ -29,6 +29,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem supplement="picketlink">security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -28,6 +28,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -27,6 +27,7 @@
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>


### PR DESCRIPTION
configs standalone*.xml  under exampels directory which defines http subsystem starts with erros in log
it's because http subsystem http-invoker depends on elytron capabilities.
this adding elytron subsystem to those configs for clean startup happens.

https://issues.jboss.org/browse/WFLY-8314
https://github.com/jbossas/jboss-eap7/pull/1467