### PR TITLE
WFLY-8333 Print info message with JGroups version during server startup

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -54,8 +54,8 @@ public interface JGroupsLogger extends BasicLogger {
      * Logs an informational message indicating the JGroups subsystem is being activated.
      */
     @LogMessage(level = INFO)
-    @Message(id = 1, value = "Activating JGroups subsystem.")
-    void activatingSubsystem();
+    @Message(id = 1, value = "Activating JGroups subsystem. JGroups version %s")
+    void activatingSubsystem(String version);
 
     @LogMessage(level = TRACE)
     @Message(id = 2, value = "Setting %s.%s=%d")

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemServiceHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemServiceHandler.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceTarget;
+import org.jgroups.Version;
 import org.wildfly.clustering.jgroups.spi.JGroupsRequirement;
 import org.wildfly.clustering.service.AliasServiceBuilder;
 import org.wildfly.clustering.service.ServiceNameProvider;
@@ -54,7 +55,7 @@ public class JGroupsSubsystemServiceHandler implements ResourceServiceHandler {
 
     @Override
     public void installServices(OperationContext context, ModelNode model) throws OperationFailedException {
-        ROOT_LOGGER.activatingSubsystem();
+        ROOT_LOGGER.activatingSubsystem(Version.printVersion());
 
         ServiceTarget target = context.getServiceTarget();
         PathAddress address = context.getCurrentAddress();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8333

``12:44:50,468 INFO  [org.jboss.as.clustering.jgroups] (ServerService Thread Pool -- 50) WFLYCLJG0001: Activating JGroups subsystem. JGroups version 3.6.13``