### PR TITLE
[WFLY-7810] Artemis hangs during failback

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -139,11 +139,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
                             if (endpoint == null) {
                                 return true;
                             } else {
-                                if (acceptorName.equals(endpoint)) {
-                                    return !remotingService.isPaused();
-                                } else {
-                                    return false;
-                                }
+                                return acceptorName.equals(endpoint);
                             }
                         } else {
                             return false;


### PR DESCRIPTION
Revert call to remotingService.isPaused() that is causing a 10s pause
for every connection attempt.

JIRA: https://issues.jboss.org/browse/WFLY-7810