### PR TITLE
[JBTM-2853][JBTM-2858][JBEAP-8890] fix for not working txn xts/rts bridging

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -72,6 +72,7 @@
         <module name="org.wildfly.extension.undertow" />
         <module name="io.undertow.core" />
         <module name="io.undertow.servlet"/>
+        <module name="org.wildfly.transaction.client"/>
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -42,6 +42,11 @@
         <module name="javax.xml.bind.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.jboss.jts"/>
+        <module name="org.wildfly.extension.rts" export="true">
+            <imports>
+                <include path="org/wildfly/extension/rts/jaxrs"/>
+            </imports>
+        </module>
         <module name="org.jboss.logging"/>
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -60,6 +60,7 @@
         <module name="org.jboss.resteasy.resteasy-jaxb-provider" services="export"/>
         <module name="org.hibernate.validator" services="export"/>
         <module name="org.jboss.narayana.rts"/>
+        <module name="org.wildfly.transaction.client"/>
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->
         <module name="javax.xml.rpc.api"/>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <version.org.jboss.ironjacamar>1.4.2.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.5.1.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Final</version.org.jboss.metadata>
-        <version.org.jboss.narayana>5.5.3.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.5.5.Final</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.6.CR2</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.0.7.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>

--- a/rts/src/main/java/org/wildfly/extension/rts/deployment/InboundBridgeDeploymentProcessor.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/deployment/InboundBridgeDeploymentProcessor.java
@@ -35,6 +35,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.narayana.rest.bridge.inbound.EJBExceptionMapper;
 import org.jboss.narayana.rest.bridge.inbound.InboundBridgeFilter;
 import org.jboss.narayana.rest.bridge.inbound.TransactionalExceptionMapper;
+import org.wildfly.extension.rts.jaxrs.ImportWildflyClientGlobalTransactionFilter;
 
 import javax.ejb.TransactionAttribute;
 import javax.transaction.Transactional;
@@ -54,6 +55,7 @@ public class InboundBridgeDeploymentProcessor implements DeploymentUnitProcessor
 
     private static final String[] PROVIDERS = new String[] {
             InboundBridgeFilter.class.getName(),
+            ImportWildflyClientGlobalTransactionFilter.class.getName(),
             TransactionalExceptionMapper.class.getName(),
             EJBExceptionMapper.class.getName()
     };

--- a/rts/src/main/java/org/wildfly/extension/rts/jaxrs/ImportWildflyClientGlobalTransactionFilter.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/jaxrs/ImportWildflyClientGlobalTransactionFilter.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.rts.jaxrs;
+
+import java.io.IOException;
+import javax.transaction.SystemException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.ext.Provider;
+import org.wildfly.extension.rts.logging.RTSLogger;
+import org.wildfly.transaction.client.LocalTransactionContext;
+
+
+/**
+ * Filter which is expected to be called after {@link InboundBridgeFilter} is processed.<br>
+ * Inbound bridge manages transactions on Narayana side and this filter causes the transaction
+ * from Narayana being imported by Wildfly transaction client.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+@Provider
+public class ImportWildflyClientGlobalTransactionFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        try {
+            // pull in any RTS transaction
+            LocalTransactionContext.getCurrent().importProviderTransaction();
+        } catch (SystemException se) {
+            throw RTSLogger.ROOT_LOGGER.failueOnImportingGlobalTransactionFromWildflyClient(se);
+        }
+    }
+
+}

--- a/rts/src/main/java/org/wildfly/extension/rts/logging/RTSLogger.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/logging/RTSLogger.java
@@ -22,8 +22,11 @@
 
 package org.wildfly.extension.rts.logging;
 
+import javax.transaction.SystemException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
@@ -36,4 +39,6 @@ public interface RTSLogger extends BasicLogger {
 
     RTSLogger ROOT_LOGGER = Logger.getMessageLogger(RTSLogger.class, "org.wildfly.extension.rts");
 
+    @Message(id = 1, value = "Can't import global transaction to wildfly transaction client.")
+    IllegalStateException failueOnImportingGlobalTransactionFromWildflyClient(@Cause SystemException se);
 }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/invocation/AbstractInvocationHandler.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/invocation/AbstractInvocationHandler.java
@@ -44,6 +44,8 @@ import org.jboss.wsf.spi.deployment.Endpoint;
 import org.jboss.wsf.spi.deployment.EndpointState;
 import org.jboss.wsf.spi.invocation.Invocation;
 import org.jboss.wsf.spi.security.SecurityDomainContext;
+import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.LocalTransactionContext;
 
 /**
  * Invocation abstraction for all endpoint types
@@ -149,6 +151,9 @@ abstract class AbstractInvocationHandler extends org.jboss.ws.common.invocation.
         context.setParameters(wsInvocation.getArgs());
         context.putPrivateData(Component.class, component);
         context.putPrivateData(ComponentView.class, componentView);
+        // pull in any XTS transaction
+        LocalTransactionContext.getCurrent().importProviderTransaction();
+        context.setTransaction(ContextTransactionManager.getInstance().getTransaction());
         if (forceTargetBean) {
             context.putPrivateData(ManagedReference.class, reference);
         }


### PR DESCRIPTION
Adding XTS WS handler and RTS rest provider which hook after transaction is imported by TXN bridge to Narayana. This hooks then cause that the transaction from Narayana is pulled by wildfly transaction client to its  global context. Wildfly transaction client is then capable to work with the transaction and used it for example for EJB interceptor processing.

https://issues.jboss.org/browse/JBTM-2858
https://issues.jboss.org/browse/JBTM-2853
https://issues.jboss.org/browse/JBEAP-8890

eap7x: https://github.com/jbossas/jboss-eap7/pull/1485