### PR TITLE
[WFLY-8348] Removing  ambiguousness on method enlistTestXAResource

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -44,10 +44,6 @@ public final class TxTestUtil {
         // no instance here
     }
 
-    public static TestXAResource enlistTestXAResource(Transaction txn, TransactionCheckerSingletonRemote checker) {
-        return enlistTestXAResource(txn, checker);
-    }
-
     public static TestXAResource enlistTestXAResource(Transaction txn, TransactionCheckerSingleton checker) {
         TestXAResource xaResource = new TestXAResource(checker);
         try {


### PR DESCRIPTION
Removing ambiguousness method `TxTestUtil#enlistTestXAResource` introduced by fix of WFLY-7205.

https://issues.jboss.org/browse/WFLY-8348

eap7: https://github.com/jbossas/jboss-eap7/pull/1486