### PR TITLE
Add mixed domain host excludes for WF 10.0 and 10.1

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -92,4 +92,23 @@
         </server-group>
     </server-groups>
 
+    <host-excludes>
+        <host-exclude name="WildFly10.0">
+            <host-release id="WildFly10.0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.core-management"/>
+                <extension module="org.wildfly.extension.discovery"/>
+                <extension module="org.wildfly.extension.elytron"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly10.1">
+            <host-release id="WildFly10.1"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.core-management"/>
+                <extension module="org.wildfly.extension.discovery"/>
+                <extension module="org.wildfly.extension.elytron"/>
+            </excluded-extensions>
+        </host-exclude>
+    </host-excludes>
+
 </domain>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -86,4 +86,23 @@
         </server-group>
     </server-groups>
 
+    <host-excludes>
+        <host-exclude name="WildFly10.0">
+            <host-release id="WildFly10.0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.core-management"/>
+                <extension module="org.wildfly.extension.discovery"/>
+                <extension module="org.wildfly.extension.elytron"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly10.1">
+            <host-release id="WildFly10.1"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.core-management"/>
+                <extension module="org.wildfly.extension.discovery"/>
+                <extension module="org.wildfly.extension.elytron"/>
+            </excluded-extensions>
+        </host-exclude>
+    </host-excludes>
+
 </domain>


### PR DESCRIPTION
Upstream variant of https://github.com/jbossas/jboss-eap7/pull/1398, which is merged. WildFly and EAP need different configs in this area, as the expected "mixed domain" releases differ.