### PR TITLE
Revert "Merge pull request #9788 from jmesnil/WFLY-8345_upgrade_artemis_1.5.4.jbossorg-001"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.5.4.jbossorg-001</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.5.3.jbossorg-003</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.8.1</version.org.apache.avro>
         <version.org.apache.cxf>3.1.10</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
This reverts commit 8dcef4a0ec5917f951b6dd344f81b3590b5f4bb3, reversing
changes made to dbf633bb06aec28a1fed089c34a5fafd37bae6a2.

Artemis 1.5.4.jbossorg-001 does not contain the fix for https://issues.apache.org/jira/browse/ARTEMIS-930 that is present in 1.5.3.jbossorg-003 and can not be used without introducing a regression
