### PR TITLE
WFLY-8335 - User should be informed when switching between JDBC and journal store in transactions subsystem

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
@@ -114,23 +114,32 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
 
     @Test
     public void testJdbcObjectStore() throws IOException, MgmtOperationException {
-
         try {
             String objectStoreType = readObjectStoreType();
             assertEquals("default", objectStoreType);
-
             // add data source
             createDataSource();
-
             cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/ObjectStoreTestDS)");
             cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
-            final CLIOpResult ret = cli.readAllAsOpResult();
-            assertEquals("restart-required", ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
 
+            CLIOpResult ret = cli.readAllAsOpResult();
+            assertEquals("restart-required", ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
             cli.sendLine("reload");
 
             objectStoreType = readObjectStoreType();
             assertEquals("jdbc", objectStoreType);
+
+            // set journal store
+            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=false)");
+            cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=true)");
+
+            ret = cli.readAllAsOpResult();
+            assertEquals("restart-required", ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
+            cli.sendLine("reload");
+
+            objectStoreType = readObjectStoreType();
+            assertEquals("journal", objectStoreType);
+
 
         } finally {
             try {

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -184,6 +184,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     public static final SimpleAttributeDefinition USE_JOURNAL_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_JOURNAL_STORE, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode().set(false))
+            .setAlternatives(CommonAttributes.USE_JDBC_STORE)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAllowExpression(false).build();
     public static final SimpleAttributeDefinition JOURNAL_STORE_ENABLE_ASYNC_IO = new SimpleAttributeDefinitionBuilder(CommonAttributes.JOURNAL_STORE_ENABLE_ASYNC_IO, ModelType.BOOLEAN, true)
@@ -195,6 +196,8 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     public static final SimpleAttributeDefinition USE_JDBC_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_JDBC_STORE, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode(false))
+            .setAlternatives(CommonAttributes.USE_JOURNAL_STORE)
+            .setRequires(CommonAttributes.JDBC_STORE_DATASOURCE)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAllowExpression(false).build();
     public static final SimpleAttributeDefinition JDBC_STORE_DATASOURCE = new SimpleAttributeDefinitionBuilder(CommonAttributes.JDBC_STORE_DATASOURCE, ModelType.STRING, true)


### PR DESCRIPTION
Issue: [JBEAP-6449](https://issues.jboss.org/browse/JBEAP-6449)
Upstream Issue: [WFLY-8335](https://issues.jboss.org/browse/WFLY-8335)

This PR superseeds [PR 9772](https://github.com/wildfly/wildfly/pull/9772).

Following tips from @claudio4j I've used the setAlternatives to enforce the proper behavior / validation. Below is the new CLI behavior:

```
[standalone@localhost:9990 /] /subsystem=transactions:write-attribute(name=use-journal-store, value=true)
{
    "outcome" => "success",
    "response-headers" => {
        "operation-requires-restart" => true,
        "process-state" => "restart-required"
    }
}
[standalone@localhost:9990 /] /subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)
{
    "outcome" => "failed",
    "failure-description" => "WFLYTX0032: jdbc-store-datasource must be defined if use-jdbc-store is 'true'.",
    "rolled-back" => true,
    "response-headers" => {"process-state" => "restart-required"}
}
[standalone@localhost:9990 /] /subsystem=transactions:write-attribute(name=jdbc-st, value=true)
jdbc-state-store-drop-table  jdbc-state-store-table-prefix  jdbc-store-datasource  
[standalone@localhost:9990 /] /subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/ExampleDS)
{
    "outcome" => "success",
    "response-headers" => {
        "operation-requires-restart" => true,
        "process-state" => "restart-required"
    }
}
[standalone@localhost:9990 /] /subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)
{
    "outcome" => "failed",
    "failure-description" => "WFLYCTL0105: use-journal-store is invalid in combination with use-jdbc-store",
    "rolled-back" => true,
    "response-headers" => {"process-state" => "restart-required"}
}

```
@tomjenkinson I think this answer your requirements of having the a warning if the jdbc-store is not defined.

@rhusar no longer any need for i18n 

I hope this PR is "ready to go", but of course, any feedbacks for enhacement are welcomed.

PS: I meant to update PR 9772 rather than close it, but a bad push on my part closed it. Sorry about that.