### PR TITLE
[WFLY-8071] Use credential-reference for messaging core bridge

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -616,7 +616,7 @@ class ServerAdd extends AbstractAddStepHandler {
             String name = bridgeConfiguration.getName();
             InjectedValue<ExceptionSupplier<CredentialSource, Exception>> injector = amqService.getBridgeCredentialSourceSupplierInjector(name);
 
-            String[] modelFilter = {name};
+            String[] modelFilter = { CommonAttributes.BRIDGE, name };
 
             ModelNode filteredModelNode = model;
             if (modelFilter != null && modelFilter.length > 0) {


### PR DESCRIPTION
Fix the model filter used to resolve the credential-reference
attribute on the bridge resource.

JIRA: https://issues.jboss.org/browse/WFLY-8071