### PR TITLE
WFLY-8342 Web sessions and SFSBs cannot be configured with string-keyed-jdbc-store

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/KeyMapper.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/KeyMapper.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,35 +22,18 @@
 
 package org.wildfly.clustering.ejb.infinispan;
 
-import java.util.ServiceLoader;
-
 import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
-import org.junit.Test;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderFactoryProvider;
-import org.wildfly.clustering.marshalling.Externalizer;
-import org.wildfly.clustering.spi.CacheAliasBuilderProvider;
-import org.wildfly.clustering.spi.DistributedCacheBuilderProvider;
-import org.wildfly.clustering.spi.LocalCacheBuilderProvider;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.DynamicKeyFormatMapper;
 
 /**
- * Validates loading of services.
- *
+ * {@link TwoWayKey2StringMapper} for EJB cache keys.
  * @author Paul Ferraro
  */
-public class ServiceLoaderTestCase {
+@MetaInfServices(TwoWayKey2StringMapper.class)
+public class KeyMapper extends DynamicKeyFormatMapper {
 
-    private static <T> void load(Class<T> targetClass) {
-        System.out.println(targetClass.getName() + ":");
-        ServiceLoader.load(targetClass, ServiceLoaderTestCase.class.getClassLoader()).forEach(object -> System.out.println("\t" + object.getClass().getName()));
-    }
-
-    @Test
-    public void load() {
-        load(Externalizer.class);
-        load(BeanManagerFactoryBuilderFactoryProvider.class);
-        load(DistributedCacheBuilderProvider.class);
-        load(LocalCacheBuilderProvider.class);
-        load(CacheAliasBuilderProvider.class);
-        load(TwoWayKey2StringMapper.class);
+    public KeyMapper() {
+        super(KeyMapper.class.getClassLoader());
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
@@ -24,24 +24,25 @@ package org.wildfly.clustering.ejb.infinispan;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Base64;
 
 import org.jboss.ejb.client.BasicSessionID;
 import org.jboss.ejb.client.SessionID;
 import org.jboss.ejb.client.UUIDSessionID;
 import org.jboss.ejb.client.UnknownSessionID;
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.SimpleKeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.marshalling.spi.IndexExternalizer;
 
 /**
  * @author Paul Ferraro
  */
-public class SessionIDExternalizer<T extends SessionID> implements Externalizer<T> {
+public class SessionIDExternalizer<T extends SessionID> extends SimpleKeyFormat<T> implements Externalizer<T> {
 
-    private final Class<T> targetClass;
-
+    @SuppressWarnings("unchecked")
     public SessionIDExternalizer(Class<T> targetClass) {
-        this.targetClass = targetClass;
+        super(targetClass, value -> (T) SessionID.createSessionID(Base64.getDecoder().decode(value)), id -> Base64.getEncoder().encodeToString(id.getEncodedForm()));
     }
 
     @Override
@@ -57,11 +58,6 @@ public class SessionIDExternalizer<T extends SessionID> implements Externalizer<
         byte[] encoded = new byte[IndexExternalizer.UNSIGNED_BYTE.readData(input)];
         input.readFully(encoded);
         return (T) SessionID.createSessionID(encoded);
-    }
-
-    @Override
-    public Class<T> getTargetClass() {
-        return this.targetClass;
     }
 
     @MetaInfServices(Externalizer.class)

--- a/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/KeyMapperTestCase.java
+++ b/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/KeyMapperTestCase.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.jboss.ejb.client.SessionID;
+import org.jboss.ejb.client.UUIDSessionID;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.ejb.infinispan.bean.InfinispanBeanKey;
+import org.wildfly.clustering.ejb.infinispan.group.InfinispanBeanGroupKey;
+
+/**
+ * @author Paul Ferraro
+ */
+public class KeyMapperTestCase {
+    @Test
+    public void test() {
+        TwoWayKey2StringMapper mapper = new KeyMapper();
+        Assert.assertTrue(mapper.isSupportedType(InfinispanBeanKey.class));
+        Assert.assertTrue(mapper.isSupportedType(InfinispanBeanGroupKey.class));
+
+        Set<String> formatted = new HashSet<>();
+
+        SessionID id = new UUIDSessionID(UUID.randomUUID());
+        BeanKey<SessionID> beanKey = new InfinispanBeanKey<>(id);
+
+        String formattedBeanKey = mapper.getStringMapping(beanKey);
+        Assert.assertEquals(beanKey, mapper.getKeyMapping(formattedBeanKey));
+        Assert.assertTrue(formatted.add(formattedBeanKey));
+
+        BeanGroupKey<SessionID> beanGroupKey = new InfinispanBeanGroupKey<>(id);
+
+        String formattedBeanGroupKey = mapper.getStringMapping(beanGroupKey);
+        Assert.assertEquals(beanGroupKey, mapper.getKeyMapping(formattedBeanGroupKey));
+        Assert.assertTrue(formatted.add(formattedBeanGroupKey));
+    }
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreBuilder.java
@@ -26,10 +26,7 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcBinaryStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcBinaryStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
@@ -43,8 +40,6 @@ public class BinaryKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcBinaryStor
     private final InjectedValue<TableManipulationConfiguration> table = new InjectedValue<>();
     private final PathAddress cacheAddress;
 
-    private volatile JdbcBinaryStoreConfigurationBuilder builder;
-
     BinaryKeyedJDBCStoreBuilder(PathAddress cacheAddress) {
         super(JdbcBinaryStoreConfigurationBuilder.class, cacheAddress);
         this.cacheAddress = cacheAddress;
@@ -56,14 +51,8 @@ public class BinaryKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcBinaryStor
     }
 
     @Override
-    public PersistenceConfiguration getValue() {
-        this.builder.table().read(this.table.getValue());
-        return super.getValue();
-    }
-
-    @Override
-    JdbcBinaryStoreConfigurationBuilder createStore(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.builder = super.createStore(context, model);
-        return this.builder;
+    public void accept(JdbcBinaryStoreConfigurationBuilder builder) {
+        builder.table().read(this.table.getValue());
+        super.accept(builder);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
@@ -78,6 +78,6 @@ public class CustomStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     CustomStoreResourceDefinition(boolean allowRuntimeOnlyRegistration) {
-        super(PATH, LEGACY_PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration, descriptor -> descriptor.addAttributes(Attribute.class), address -> new CustomStoreBuilder(address.getParent()), Consumers.empty());
+        super(PATH, LEGACY_PATH, new InfinispanResourceDescriptionResolver(PATH, WILDCARD_PATH), allowRuntimeOnlyRegistration, descriptor -> descriptor.addAttributes(Attribute.class), address -> new CustomStoreBuilder<>(address.getParent()), Consumers.empty());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreBuilder.java
@@ -26,10 +26,7 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcMixedStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcMixedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
@@ -43,8 +40,6 @@ public class MixedKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcMixedStoreC
     private final InjectedValue<TableManipulationConfiguration> stringTable = new InjectedValue<>();
 
     private final PathAddress cacheAddress;
-
-    private volatile JdbcMixedStoreConfigurationBuilder builder;
 
     MixedKeyedJDBCStoreBuilder(PathAddress cacheAddress) {
         super(JdbcMixedStoreConfigurationBuilder.class, cacheAddress);
@@ -60,15 +55,9 @@ public class MixedKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcMixedStoreC
     }
 
     @Override
-    public PersistenceConfiguration getValue() {
-        this.builder.binaryTable().read(this.binaryTable.getValue());
-        this.builder.stringTable().read(this.stringTable.getValue());
-        return super.getValue();
-    }
-
-    @Override
-    JdbcMixedStoreConfigurationBuilder createStore(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.builder = super.createStore(context, model);
-        return this.builder;
+    public void accept(JdbcMixedStoreConfigurationBuilder builder) {
+        builder.binaryTable().read(this.binaryTable.getValue());
+        builder.stringTable().read(this.stringTable.getValue());
+        super.accept(builder);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreBuilder.java
@@ -22,14 +22,25 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+
 import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.InjectedValueDependency;
+import org.wildfly.clustering.service.ValueDependency;
 
 /**
  * @author Paul Ferraro
@@ -39,6 +50,8 @@ public class StringKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcStringBase
     private final InjectedValue<TableManipulationConfiguration> table = new InjectedValue<>();
     private final PathAddress cacheAddress;
 
+    private volatile ValueDependency<Module> module;
+
     StringKeyedJDBCStoreBuilder(PathAddress cacheAddress) {
         super(JdbcStringBasedStoreConfigurationBuilder.class, cacheAddress);
         this.cacheAddress = cacheAddress;
@@ -46,12 +59,22 @@ public class StringKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcStringBase
 
     @Override
     public ServiceBuilder<PersistenceConfiguration> build(ServiceTarget target) {
-        return super.build(target).addDependency(CacheComponent.STRING_TABLE.getServiceName(this.cacheAddress), TableManipulationConfiguration.class, this.table);
+        return this.module.register(super.build(target))
+                .addDependency(CacheComponent.STRING_TABLE.getServiceName(this.cacheAddress), TableManipulationConfiguration.class, this.table)
+                ;
+    }
+
+    @Override
+    public Builder<PersistenceConfiguration> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        this.module = new InjectedValueDependency<>(CacheContainerComponent.MODULE.getServiceName(context.getCurrentAddress().getParent().getParent()), Module.class);
+        return super.configure(context, model);
     }
 
     @Override
     public void accept(JdbcStringBasedStoreConfigurationBuilder builder) {
         builder.table().read(this.table.getValue());
+        StreamSupport.stream(ServiceLoader.load(TwoWayKey2StringMapper.class, this.module.getValue().getClassLoader()).spliterator(), false).findFirst()
+                .ifPresent(impl -> builder.key2StringMapper(impl.getClass()));
         super.accept(builder);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreBuilder.java
@@ -26,10 +26,7 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfiguration;
 import org.infinispan.persistence.jdbc.configuration.JdbcStringBasedStoreConfigurationBuilder;
 import org.infinispan.persistence.jdbc.configuration.TableManipulationConfiguration;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
@@ -40,12 +37,9 @@ import org.jboss.msc.value.InjectedValue;
 public class StringKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcStringBasedStoreConfiguration, JdbcStringBasedStoreConfigurationBuilder> {
 
     private final InjectedValue<TableManipulationConfiguration> table = new InjectedValue<>();
-
     private final PathAddress cacheAddress;
 
-    private volatile JdbcStringBasedStoreConfigurationBuilder builder;
-
-    public StringKeyedJDBCStoreBuilder(PathAddress cacheAddress) {
+    StringKeyedJDBCStoreBuilder(PathAddress cacheAddress) {
         super(JdbcStringBasedStoreConfigurationBuilder.class, cacheAddress);
         this.cacheAddress = cacheAddress;
     }
@@ -56,14 +50,8 @@ public class StringKeyedJDBCStoreBuilder extends JDBCStoreBuilder<JdbcStringBase
     }
 
     @Override
-    public PersistenceConfiguration getValue() {
-        this.builder.table().read(this.table.getValue());
-        return super.getValue();
-    }
-
-    @Override
-    JdbcStringBasedStoreConfigurationBuilder createStore(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.builder = super.createStore(context, model);
-        return this.builder;
+    public void accept(JdbcStringBasedStoreConfigurationBuilder builder) {
+        builder.table().read(this.table.getValue());
+        super.accept(builder);
     }
 }

--- a/clustering/infinispan/spi/pom.xml
+++ b/clustering/infinispan/spi/pom.xml
@@ -54,5 +54,15 @@
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/BinaryKeyFormat.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/BinaryKeyFormat.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+
+import org.wildfly.common.function.ExceptionBiConsumer;
+import org.wildfly.common.function.ExceptionFunction;
+
+/**
+ * {@link KeyFormat} implementation for binary keys.
+ * @author Paul Ferraro
+ */
+public class BinaryKeyFormat<K> implements KeyFormat<K> {
+
+    private final Class<K> targetClass;
+    private final ExceptionFunction<DataInput, K, IOException> reader;
+    private final ExceptionBiConsumer<DataOutput, K, IOException> writer;
+
+    public BinaryKeyFormat(Class<K> targetClass, ExceptionFunction<DataInput, K, IOException> reader, ExceptionBiConsumer<DataOutput, K, IOException> writer) {
+        this.targetClass = targetClass;
+        this.reader = reader;
+        this.writer = writer;
+    }
+
+    @Override
+    public Class<K> getTargetClass() {
+        return this.targetClass;
+    }
+
+    @Override
+    public K parse(String value) {
+        try (DataInputStream input = new DataInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(value)))) {
+            return this.reader.apply(input);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public String format(K key) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(bytes)) {
+            this.writer.accept(output, key);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return Base64.getEncoder().encodeToString(bytes.toByteArray());
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/DelimitedKeyFormat.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/DelimitedKeyFormat.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * {@link KeyFormat} for keys with multiple string fields.
+ * @author Paul Ferraro
+ */
+public class DelimitedKeyFormat<K> extends SimpleKeyFormat<K> {
+
+    public DelimitedKeyFormat(Class<K> targetClass, String delimiter, Function<String[], K> parser, Function<K, String[]> formatter) {
+        super(targetClass, value -> parser.apply(value.split(Pattern.quote(delimiter))), key -> String.join(delimiter, formatter.apply(key)));
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/DynamicKeyFormatMapper.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/DynamicKeyFormatMapper.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+
+/**
+ * {@link TwoWayKey2StringMapper} implementation that based on a set of dynamically loaded {@link KeyFomat} instances.
+ * @author Paul Ferraro
+ */
+public class DynamicKeyFormatMapper extends IndexedKeyFormatMapper {
+
+    public DynamicKeyFormatMapper(ClassLoader loader) {
+        super(load(loader));
+    }
+
+    private static List<KeyFormat<?>> load(ClassLoader loader) {
+        List<KeyFormat<?>> keyFormats = new LinkedList<>();
+        // Add key formats for common key types
+        keyFormats.add(new SimpleKeyFormat<>(String.class, Function.identity()));
+        keyFormats.add(new SimpleKeyFormat<>(Byte.class, Byte::valueOf));
+        keyFormats.add(new SimpleKeyFormat<>(Short.class, Short::valueOf));
+        keyFormats.add(new SimpleKeyFormat<>(Integer.class, Integer::valueOf));
+        keyFormats.add(new SimpleKeyFormat<>(Long.class, Long::valueOf));
+        keyFormats.add(new SimpleKeyFormat<>(UUID.class, UUID::fromString));
+        StreamSupport.stream(ServiceLoader.load(KeyFormat.class, loader).spliterator(), false).forEach(keyFormat -> keyFormats.add(keyFormat));
+        return keyFormats;
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/IndexedKeyFormatMapper.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/IndexedKeyFormatMapper.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+
+/**
+ * {@link TwoWayKey2StringMapper} implementation that maps multiple {@link KeyFormat} instances.
+ * Key is mapped to an padded hexadecimal index + the formatted key.
+ * @author Paul Ferraro
+ */
+public class IndexedKeyFormatMapper implements TwoWayKey2StringMapper {
+    private static final int HEX_RADIX = 16;
+
+    private final Map<Class<?>, Integer> indexes = new IdentityHashMap<>();
+    private final List<? extends KeyFormat<Object>> keyFormats;
+    private final int padding;
+
+    @SuppressWarnings("unchecked")
+    public IndexedKeyFormatMapper(Collection<? extends KeyFormat<?>> keyFormats) {
+        this.keyFormats = keyFormats.stream().map(format -> (KeyFormat<Object>) format).collect(Collectors.toList());
+        for (int i = 0; i < this.keyFormats.size(); ++i) {
+            this.indexes.put(this.keyFormats.get(i).getTargetClass(), i);
+        }
+        // Determine number of characters to reserve for index
+        this.padding = (int) (Math.log(this.keyFormats.size() - 1) / Math.log(HEX_RADIX)) + 1;
+    }
+
+    @Override
+    public boolean isSupportedType(Class<?> keyType) {
+        return this.indexes.containsKey(keyType);
+    }
+
+    @Override
+    public String getStringMapping(Object key) {
+        Integer index = this.indexes.get(key.getClass());
+        if (index == null) {
+            throw new IllegalArgumentException(key.getClass().getName());
+        }
+        KeyFormat<Object> keyFormat = this.keyFormats.get(index);
+        return String.format("%0" + this.padding + "X%s", index, keyFormat.format(key));
+    }
+
+    @Override
+    public Object getKeyMapping(String value) {
+        int index = Integer.parseUnsignedInt(value.substring(0, this.padding), HEX_RADIX);
+        KeyFormat<Object> keyFormat = this.keyFormats.get(index);
+        return keyFormat.parse(value.substring(this.padding));
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/KeyFormat.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/KeyFormat.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+/**
+ * Formats a cache key to a string representation and back again.
+ * @author Paul Ferraro
+ */
+public interface KeyFormat<K> {
+    /**
+     * The implementation class of the target key of this format.
+     * @return an implementation class
+     */
+    Class<K> getTargetClass();
+
+    /**
+     * Parses the key from the specified string.
+     * @param value a string representation of the key
+     * @return the parsed key
+     */
+    K parse(String value);
+
+    /**
+     * Formats the specified key to a string representation.
+     * @param key a key to format
+     * @return a string representation of the specified key.
+     */
+    String format(K key);
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormat.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormat.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.util.function.Function;
+
+/**
+ * {@link KeyFormat} for keys with a simple string representation.
+ * @author Paul Ferraro
+ */
+public class SimpleKeyFormat<K> implements KeyFormat<K> {
+
+    private final Class<K> targetClass;
+    private final Function<String, K> parser;
+    private final Function<K, String> formatter;
+
+    public SimpleKeyFormat(Class<K> targetClass, Function<String, K> parser) {
+        this(targetClass, parser, Object::toString);
+    }
+
+    public SimpleKeyFormat(Class<K> targetClass, Function<String, K> parser, Function<K, String> formatter) {
+        this.targetClass = targetClass;
+        this.parser = parser;
+        this.formatter = formatter;
+    }
+
+    @Override
+    public Class<K> getTargetClass() {
+        return this.targetClass;
+    }
+
+    @Override
+    public K parse(String value) {
+        return this.parser.apply(value);
+    }
+
+    @Override
+    public String format(K key) {
+        return this.formatter.apply(key);
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatMapper.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatMapper.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+
+/**
+ * Simple {@link TwoWayKey2StringMapper} based on a single {@link KeyFormat}.
+ * @author Paul Ferraro
+ */
+public class SimpleKeyFormatMapper implements TwoWayKey2StringMapper {
+
+    private final KeyFormat<Object> format;
+
+    @SuppressWarnings("unchecked")
+    public SimpleKeyFormatMapper(KeyFormat<?> format) {
+        this.format = (KeyFormat<Object>) format;
+    }
+
+    @Override
+    public boolean isSupportedType(Class<?> keyType) {
+        return this.format.getTargetClass().equals(keyType);
+    }
+
+    @Override
+    public String getStringMapping(Object key) {
+        return this.format.format(key);
+    }
+
+    @Override
+    public Object getKeyMapping(String value) {
+        return this.format.parse(value);
+    }
+}

--- a/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/OrdinalKeyFormatMapperTestCase.java
+++ b/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/OrdinalKeyFormatMapperTestCase.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Paul Ferraro
+ */
+public class OrdinalKeyFormatMapperTestCase {
+
+    enum Type {
+        TYPE00 {},
+        TYPE01 {},
+        TYPE02 {},
+        TYPE03 {},
+        TYPE04 {},
+        TYPE05 {},
+        TYPE06 {},
+        TYPE07 {},
+        TYPE08 {},
+        TYPE09 {},
+        TYPE10 {},
+        TYPE11 {},
+        TYPE12 {},
+        TYPE13 {},
+        TYPE14 {},
+        TYPE15 {},
+        TYPE16 {},
+        TYPE17 {},
+    }
+
+    @Test
+    public void testSinglePadding() {
+        TwoWayKey2StringMapper mapper = new IndexedKeyFormatMapper(createPersistenceList(16));
+
+        Assert.assertTrue(mapper.isSupportedType(Type.TYPE00.getClass()));
+        Assert.assertTrue(mapper.isSupportedType(Type.TYPE15.getClass()));
+        Assert.assertFalse(mapper.isSupportedType(Type.TYPE16.getClass()));
+        Assert.assertFalse(mapper.isSupportedType(Type.TYPE17.getClass()));
+
+        String result = mapper.getStringMapping(Type.TYPE00);
+        Assert.assertSame(Type.TYPE00, mapper.getKeyMapping(result));
+        Assert.assertEquals("0TYPE00", result);
+
+        result = mapper.getStringMapping(Type.TYPE15);
+        Assert.assertSame(Type.TYPE15, mapper.getKeyMapping(result));
+        Assert.assertEquals("FTYPE15", result);
+    }
+
+    @Test
+    public void testDoublePadding() {
+        TwoWayKey2StringMapper mapper = new IndexedKeyFormatMapper(createPersistenceList(17));
+
+        Assert.assertTrue(mapper.isSupportedType(Type.TYPE00.getClass()));
+        Assert.assertTrue(mapper.isSupportedType(Type.TYPE15.getClass()));
+        Assert.assertTrue(mapper.isSupportedType(Type.TYPE16.getClass()));
+        Assert.assertFalse(mapper.isSupportedType(Type.TYPE17.getClass()));
+
+        String result = mapper.getStringMapping(Type.TYPE00);
+        Assert.assertSame(Type.TYPE00, mapper.getKeyMapping(result));
+        Assert.assertEquals("00TYPE00", result);
+
+        result = mapper.getStringMapping(Type.TYPE15);
+        Assert.assertSame(Type.TYPE15, mapper.getKeyMapping(result));
+        Assert.assertEquals("0FTYPE15", result);
+
+        result = mapper.getStringMapping(Type.TYPE16);
+        Assert.assertSame(Type.TYPE16, mapper.getKeyMapping(result));
+        Assert.assertEquals("10TYPE16", result);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<? extends KeyFormat<?>> createPersistenceList(int size) {
+        return java.util.stream.IntStream.range(0, size).mapToObj(index -> new SimpleKeyFormat<>((Class<Type>) Type.values()[index].getClass(), value -> Type.valueOf(value), Type::name)).collect(Collectors.toList());
+    }
+}

--- a/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatMapperTestCase.java
+++ b/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatMapperTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import static org.mockito.Mockito.*;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SimpleKeyFormatMapperTestCase {
+
+    @Test
+    public void test() {
+        KeyFormat<Object> keyFormat = mock(KeyFormat.class);
+        TwoWayKey2StringMapper mapper = new SimpleKeyFormatMapper(keyFormat);
+
+        Object key = new Object();
+        String formatted = "foo";
+
+        when(keyFormat.getTargetClass()).thenReturn(Object.class);
+        when(keyFormat.format(key)).thenReturn(formatted);
+        when(keyFormat.parse(formatted)).thenReturn(key);
+
+        Assert.assertSame(formatted, mapper.getStringMapping(key));
+        Assert.assertSame(key, mapper.getKeyMapping(formatted));
+        Assert.assertTrue(mapper.isSupportedType(Object.class));
+        Assert.assertFalse(mapper.isSupportedType(Integer.class));
+    }
+}

--- a/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatTestCase.java
+++ b/clustering/infinispan/spi/src/test/java/org/wildfly/clustering/infinispan/spi/persistence/SimpleKeyFormatTestCase.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.spi.persistence;
+
+import static org.mockito.Mockito.*;
+
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SimpleKeyFormatTestCase {
+    @Test
+    public void test() {
+        Function<String, Object> parser = mock(Function.class);
+        Function<Object, String> formatter = mock(Function.class);
+        KeyFormat<Object> keyFormat = new SimpleKeyFormat<>(Object.class, parser, formatter);
+
+        Object object = new Object();
+        String result = "foo";
+
+        when(formatter.apply(object)).thenReturn(result);
+        when(parser.apply(result)).thenReturn(object);
+
+        Assert.assertSame(result, keyFormat.format(object));
+        Assert.assertSame(object, keyFormat.parse(result));
+    }
+}

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/KeyMapper.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/KeyMapper.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.DynamicKeyFormatMapper;
+
+/**
+ * @author Paul Ferraro
+ */
+@MetaInfServices(TwoWayKey2StringMapper.class)
+public class KeyMapper extends DynamicKeyFormatMapper {
+
+    public KeyMapper() {
+        super(KeyMapper.class.getClassLoader());
+    }
+}

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/LocalNodeExternalizer.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/LocalNodeExternalizer.java
@@ -27,14 +27,20 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.DelimitedKeyFormat;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 
 /**
  * Marshalling externalizer for a {@link LocalNode}.
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
-public class LocalNodeExternalizer implements Externalizer<LocalNode> {
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
+public class LocalNodeExternalizer extends DelimitedKeyFormat<LocalNode> implements Externalizer<LocalNode> {
+
+    public LocalNodeExternalizer() {
+        super(LocalNode.class, "|", parts -> new LocalNode(parts[0], parts[1]), node -> new String[] { node.getCluster(), node.getName() });
+    }
 
     @Override
     public void writeObject(ObjectOutput output, LocalNode node) throws IOException {
@@ -45,10 +51,5 @@ public class LocalNodeExternalizer implements Externalizer<LocalNode> {
     @Override
     public LocalNode readObject(ObjectInput input) throws IOException {
         return new LocalNode(input.readUTF(), input.readUTF());
-    }
-
-    @Override
-    public Class<LocalNode> getTargetClass() {
-        return LocalNode.class;
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/ServiceNameExternalizer.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/ServiceNameExternalizer.java
@@ -27,14 +27,20 @@ import java.io.ObjectOutput;
 
 import org.jboss.msc.service.ServiceName;
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
+import org.wildfly.clustering.infinispan.spi.persistence.SimpleKeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 
 /**
  * {@link Externalizer} for a {@link ServiceName}.
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
-public class ServiceNameExternalizer implements Externalizer<ServiceName> {
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
+public class ServiceNameExternalizer extends SimpleKeyFormat<ServiceName> implements Externalizer<ServiceName> {
+
+    public ServiceNameExternalizer() {
+        super(ServiceName.class, ServiceName::parse, ServiceName::getCanonicalName);
+    }
 
     @Override
     public void writeObject(ObjectOutput output, ServiceName name) throws IOException {
@@ -44,10 +50,5 @@ public class ServiceNameExternalizer implements Externalizer<ServiceName> {
     @Override
     public ServiceName readObject(ObjectInput input) throws IOException {
         return ServiceName.parse(input.readUTF());
-    }
-
-    @Override
-    public Class<ServiceName> getTargetClass() {
-        return ServiceName.class;
     }
 }

--- a/clustering/server/src/test/java/org/wildfly/clustering/server/KeyMapperTestCase.java
+++ b/clustering/server/src/test/java/org/wildfly/clustering/server/KeyMapperTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.jboss.msc.service.ServiceName;
+import org.jgroups.util.UUID;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.group.Node;
+import org.wildfly.clustering.server.group.AddressableNode;
+import org.wildfly.clustering.server.group.LocalNode;
+
+/**
+ * @author Paul Ferraro
+ */
+public class KeyMapperTestCase {
+    @Test
+    public void test() throws UnknownHostException {
+        TwoWayKey2StringMapper mapper = new KeyMapper();
+        Assert.assertTrue(mapper.isSupportedType(LocalNode.class));
+        Assert.assertTrue(mapper.isSupportedType(AddressableNode.class));
+        Assert.assertTrue(mapper.isSupportedType(ServiceName.class));
+
+        Set<String> formatted = new HashSet<>();
+
+        Node localNode = new LocalNode("cluster", "node");
+        String mappedLocalNode = mapper.getStringMapping(localNode);
+        Assert.assertEquals(localNode, mapper.getKeyMapping(mappedLocalNode));
+        Assert.assertTrue(formatted.add(mappedLocalNode));
+
+        Node addressableNode = new AddressableNode(UUID.randomUUID(), "node", new InetSocketAddress(InetAddress.getLocalHost(), 0));
+        String mappedAddressableNode = mapper.getStringMapping(addressableNode);
+        Assert.assertEquals(addressableNode, mapper.getKeyMapping(mappedAddressableNode));
+        Assert.assertTrue(formatted.add(mappedAddressableNode));
+
+        ServiceName serviceName = ServiceName.of("node");
+        String mappedServiceName = mapper.getStringMapping(serviceName);
+        Assert.assertEquals(serviceName, mapper.getKeyMapping(mappedServiceName));
+        Assert.assertTrue(formatted.add(mappedServiceName));
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/IndexedSessionKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/IndexedSessionKeyExternalizer.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -25,37 +25,40 @@ package org.wildfly.clustering.web.infinispan;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.ServiceLoader;
-import java.util.function.Function;
-import java.util.stream.StreamSupport;
+import java.util.function.BiFunction;
+import java.util.function.ToIntFunction;
 
 import org.wildfly.clustering.infinispan.spi.distribution.Key;
-import org.wildfly.clustering.infinispan.spi.persistence.SimpleKeyFormat;
+import org.wildfly.clustering.infinispan.spi.persistence.DelimitedKeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
-import org.wildfly.clustering.web.IdentifierExternalizerProvider;
+import org.wildfly.clustering.marshalling.spi.IndexExternalizer;
 
 /**
- * Base externalizer for cache keys containing session identifiers.
  * @author Paul Ferraro
  */
-public abstract class SessionKeyExternalizer<K extends Key<String>> extends SimpleKeyFormat<K> implements Externalizer<K> {
+public class IndexedSessionKeyExternalizer<K extends Key<String>> extends DelimitedKeyFormat<K> implements Externalizer<K> {
 
-    static final Externalizer<String> EXTERNALIZER = StreamSupport.stream(ServiceLoader.load(IdentifierExternalizerProvider.class, IdentifierExternalizerProvider.class.getClassLoader()).spliterator(), false).findFirst().get().getExternalizer();
+    private static final Externalizer<String> EXTERNALIZER = SessionKeyExternalizer.EXTERNALIZER;
 
-    private final Function<String, K> resolver;
+    private final BiFunction<String, Integer, K> resolver;
+    private final ToIntFunction<K> index;
 
-    protected SessionKeyExternalizer(Class<K> targetClass, Function<String, K> resolver) {
-        super(targetClass, resolver, Key::getValue);
+    protected IndexedSessionKeyExternalizer(Class<K> targetClass, ToIntFunction<K> index, BiFunction<String, Integer, K> resolver) {
+        super(targetClass, "#", parts -> resolver.apply(parts[0], Integer.valueOf(parts[1])), key -> new String[] { key.getValue(), Integer.toString(index.applyAsInt(key)) });
+        this.index = index;
         this.resolver = resolver;
     }
 
     @Override
     public void writeObject(ObjectOutput output, K key) throws IOException {
         EXTERNALIZER.writeObject(output, key.getValue());
+        IndexExternalizer.VARIABLE.writeData(output, this.index.applyAsInt(key));
     }
 
     @Override
     public K readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-        return this.resolver.apply(EXTERNALIZER.readObject(input));
+        String id = EXTERNALIZER.readObject(input);
+        int index = IndexExternalizer.VARIABLE.readData(input);
+        return this.resolver.apply(id, index);
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/KeyMapper.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/KeyMapper.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2017, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,21 +19,20 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.infinispan.session.fine;
 
+package org.wildfly.clustering.web.infinispan;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
 import org.kohsuke.MetaInfServices;
-import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
-import org.wildfly.clustering.marshalling.Externalizer;
-import org.wildfly.clustering.web.infinispan.IndexedSessionKeyExternalizer;
+import org.wildfly.clustering.infinispan.spi.persistence.DynamicKeyFormatMapper;
 
 /**
- * Externalizer for a {@link SessionAttributeKey}.
  * @author Paul Ferraro
  */
-@MetaInfServices({ Externalizer.class, KeyFormat.class })
-public class SessionAttributeKeyExternalizer extends IndexedSessionKeyExternalizer<SessionAttributeKey> {
+@MetaInfServices(TwoWayKey2StringMapper.class)
+public class KeyMapper extends DynamicKeyFormatMapper {
 
-    public SessionAttributeKeyExternalizer() {
-        super(SessionAttributeKey.class, SessionAttributeKey::getAttributeId, (sessionId, attributeId) -> new SessionAttributeKey(sessionId, attributeId));
+    public KeyMapper() {
+        super(KeyMapper.class.getClassLoader());
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionAccessMetaDataKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionAccessMetaDataKeyExternalizer.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
@@ -30,7 +31,7 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
  * Externalizer for {@link SessionAccessMetaDataKey}
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class SessionAccessMetaDataKeyExternalizer extends SessionKeyExternalizer<SessionAccessMetaDataKey> {
 
     public SessionAccessMetaDataKeyExternalizer() {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionCreationMetaDataKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionCreationMetaDataKeyExternalizer.java
@@ -23,13 +23,14 @@
 package org.wildfly.clustering.web.infinispan.session;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
 /**
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class SessionCreationMetaDataKeyExternalizer extends SessionKeyExternalizer<SessionCreationMetaDataKey> {
 
     public SessionCreationMetaDataKeyExternalizer() {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesKeyExternalizer.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.web.infinispan.session.coarse;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
@@ -29,7 +30,7 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
  * Externalizer for {@link SessionAttributesKey}.
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class SessionAttributesKeyExternalizer extends SessionKeyExternalizer<SessionAttributesKey> {
 
     public SessionAttributesKeyExternalizer() {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeNamesKeyExternalizer.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.web.infinispan.session.fine;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
@@ -29,7 +30,7 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
  * Externalizer for {@link SessionAttributeNamesKey}.
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class SessionAttributeNamesKeyExternalizer extends SessionKeyExternalizer<SessionAttributeNamesKey> {
 
     public SessionAttributeNamesKeyExternalizer() {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/AuthenticationKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/AuthenticationKeyExternalizer.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.web.infinispan.sso;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
@@ -30,7 +31,7 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
  * Externalizer for {@link AuthenticationKey}
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class AuthenticationKeyExternalizer extends SessionKeyExternalizer<AuthenticationKey> {
 
     public AuthenticationKeyExternalizer() {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSessionsKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSessionsKeyExternalizer.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.web.infinispan.sso.coarse;
 
 import org.kohsuke.MetaInfServices;
+import org.wildfly.clustering.infinispan.spi.persistence.KeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
 import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
 
@@ -30,7 +31,7 @@ import org.wildfly.clustering.web.infinispan.SessionKeyExternalizer;
  * Externalizer for {@link CoarseSessionsKey}.
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+@MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class CoarseSessionsKeyExternalizer extends SessionKeyExternalizer<CoarseSessionsKey> {
 
     public CoarseSessionsKeyExternalizer() {

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/KeyMapperTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/KeyMapperTestCase.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.clustering.web.infinispan.session.SessionAccessMetaDataKey;
+import org.wildfly.clustering.web.infinispan.session.SessionCreationMetaDataKey;
+import org.wildfly.clustering.web.infinispan.session.coarse.SessionAttributesKey;
+import org.wildfly.clustering.web.infinispan.session.fine.SessionAttributeKey;
+import org.wildfly.clustering.web.infinispan.session.fine.SessionAttributeNamesKey;
+import org.wildfly.clustering.web.infinispan.sso.AuthenticationKey;
+import org.wildfly.clustering.web.infinispan.sso.coarse.CoarseSessionsKey;
+
+/**
+ * @author Paul Ferraro
+ */
+public class KeyMapperTestCase {
+    @Test
+    public void test() {
+        TwoWayKey2StringMapper mapper = new KeyMapper();
+        Assert.assertTrue(mapper.isSupportedType(SessionCreationMetaDataKey.class));
+        Assert.assertTrue(mapper.isSupportedType(SessionAccessMetaDataKey.class));
+        Assert.assertTrue(mapper.isSupportedType(SessionAttributesKey.class));
+        Assert.assertTrue(mapper.isSupportedType(SessionAttributeNamesKey.class));
+        Assert.assertTrue(mapper.isSupportedType(SessionAttributeKey.class));
+        Assert.assertTrue(mapper.isSupportedType(AuthenticationKey.class));
+        Assert.assertTrue(mapper.isSupportedType(CoarseSessionsKey.class));
+
+        Set<String> formatted = new HashSet<>();
+        String id = "ABC123";
+
+        SessionCreationMetaDataKey creationMetaDataKey = new SessionCreationMetaDataKey(id);
+        String formattedCreationMetaDataKey = mapper.getStringMapping(creationMetaDataKey);
+        Assert.assertEquals(creationMetaDataKey, mapper.getKeyMapping(formattedCreationMetaDataKey));
+        Assert.assertTrue(formatted.add(formattedCreationMetaDataKey));
+
+        SessionAccessMetaDataKey accessMetaDataKey = new SessionAccessMetaDataKey(id);
+        String formattedAccessMetaDataKey = mapper.getStringMapping(accessMetaDataKey);
+        Assert.assertEquals(accessMetaDataKey, mapper.getKeyMapping(formattedAccessMetaDataKey));
+        Assert.assertTrue(formatted.add(formattedAccessMetaDataKey));
+
+        SessionAttributesKey attributesKey = new SessionAttributesKey(id);
+        String formattedAttributesKey = mapper.getStringMapping(attributesKey);
+        Assert.assertEquals(attributesKey, mapper.getKeyMapping(formattedAttributesKey));
+        Assert.assertTrue(formatted.add(formattedAttributesKey));
+
+        SessionAttributeNamesKey attributeNamesKey = new SessionAttributeNamesKey(id);
+        String formattedAttributeNamesKey = mapper.getStringMapping(attributeNamesKey);
+        Assert.assertEquals(attributeNamesKey, mapper.getKeyMapping(formattedAttributeNamesKey));
+        Assert.assertTrue(formatted.add(formattedAttributeNamesKey));
+
+        for (int i = 0; i < 10; ++i) {
+            SessionAttributeKey attributeKey = new SessionAttributeKey(id, i);
+            String formattedAttributeKey = mapper.getStringMapping(attributeKey);
+            Assert.assertEquals(attributeKey, mapper.getKeyMapping(formattedAttributeKey));
+            Assert.assertTrue(formatted.add(formattedAttributeKey));
+        }
+
+        AuthenticationKey authKey = new AuthenticationKey(id);
+        String formattedAuthKey = mapper.getStringMapping(authKey);
+        Assert.assertEquals(authKey, mapper.getKeyMapping(formattedAuthKey));
+        Assert.assertTrue(formatted.add(formattedAuthKey));
+
+        CoarseSessionsKey sessionsKey = new CoarseSessionsKey(id);
+        String formattedSessionsKey = mapper.getStringMapping(sessionsKey);
+        Assert.assertEquals(sessionsKey, mapper.getKeyMapping(formattedSessionsKey));
+        Assert.assertTrue(formatted.add(formattedSessionsKey));
+    }
+}

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/ServiceLoaderTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/ServiceLoaderTestCase.java
@@ -24,6 +24,7 @@ package org.wildfly.clustering.web.infinispan;
 
 import java.util.ServiceLoader;
 
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
 import org.jboss.logging.Logger;
 import org.junit.Test;
 import org.wildfly.clustering.marshalling.Externalizer;
@@ -56,5 +57,6 @@ public class ServiceLoaderTestCase {
         load(DistributedCacheBuilderProvider.class);
         load(LocalCacheBuilderProvider.class);
         load(CacheAliasBuilderProvider.class);
+        load(TwoWayKey2StringMapper.class);
     }
 }

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -69,6 +69,7 @@
         <module name="org.wildfly.clustering.marshalling.infinispan"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
@@ -59,6 +59,7 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.singleton"/>
         <module name="org.wildfly.clustering.spi"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8342

TwoWayKey2StringMapper implementation will be loaded from the associated module.