### PR TITLE
[WFLY-8368] InterDeploymentDependenciesEarTestCase may fail with NoSuchEJBException

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/InterDeploymentDependenciesEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/dependencies/ear/InterDeploymentDependenciesEarTestCase.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Hashtable;
 
+import javax.ejb.NoSuchEJBException;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -141,7 +142,7 @@ public class InterDeploymentDependenciesEarTestCase {
         try {
             helloApp2.getLog();
             fail("Calling EJB from dependent application should fail");
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException | NoSuchEJBException e) {
             //OK
         }
         // cleanUp will undeploy DEP_APP2
@@ -176,7 +177,7 @@ public class InterDeploymentDependenciesEarTestCase {
         try {
             helloApp2.getLog();
             fail("Calling EJB from dependent application should fail");
-        } catch (IllegalStateException e) {
+        } catch (IllegalStateException | NoSuchEJBException e) {
             //OK
         }
         // cleanUp will undeploy DEP_APP2


### PR DESCRIPTION
InterDeploymentDependenciesEarTestCase fails from time to time with NoSuchEJBException, however only IllegalStateException is expected by test case. Adding NSEE into catch block. Please see WFLY-8368 description for complete stack trace of both exceptions.

Jira:
https://issues.jboss.org/browse/WFLY-8368