### PR TITLE
[WFLY-8370] change of transaction timeout in model to be propagated to WFTC

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/DefaultTimeoutMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/DefaultTimeoutMDB.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
+
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.as.test.integration.transactions.TxTestUtil;
+import org.jboss.logging.Logger;
+
+/**
+ * Message driven bean that receiving from queue
+ * {@link TransactionTimeoutQueueSetupTask#DEFAULT_TIMEOUT_JNDI_NAME}.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+@MessageDriven(activationConfig = {
+    @ActivationConfigProperty(
+        propertyName = "destination",
+        propertyValue = TransactionTimeoutQueueSetupTask.DEFAULT_TIMEOUT_JNDI_NAME)
+})
+public class DefaultTimeoutMDB implements MessageListener {
+    private static final Logger log = Logger.getLogger(DefaultTimeoutMDB.class);
+    public static final String REPLY_PREFIX = "replying ";
+
+    @Resource(lookup = "java:/JmsXA")
+    private ConnectionFactory factory;
+
+    @Resource(name = "java:jboss/TransactionManager")
+    private TransactionManager tm;
+
+    @Inject
+    private TransactionCheckerSingleton checker;
+
+    @Resource
+    private TransactionSynchronizationRegistry synchroRegistry;
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            log.tracef("onMessage received message: %s '%s'", message, ((TextMessage) message).getText());
+
+            final Destination replyTo = message.getJMSReplyTo();
+
+            if (replyTo == null) {
+                throw new RuntimeException("ReplyTo info in message was not specified"
+                    + " and bean does not know where to reply to");
+            }
+
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
+
+            try (JMSContext context = factory.createContext()) {
+                context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, REPLY_PREFIX + ((TextMessage) message).getText());
+            }
+
+            // waiting up to 2.5 sec - expecting transaction timeout to happen
+            TxTestUtil.waitForTimeout(tm);
+        } catch (Exception e) {
+            throw new RuntimeException("onMessage method execution failed", e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.util.PropertyPermission;
+
+import javax.inject.Inject;
+import javax.jms.Queue;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.as.test.integration.transactions.TxTestUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>
+ * Test of timeouting a global transaction on MDB because of default transaction
+ * timeout is redefined to be small enough to timeout being hit.
+ * <p>
+ * Default transaction timeout is defined under {@link TransactionDefaultTimeoutSetupTask}
+ * and the timeout time in MDB is specified by {@link TxTestUtil#waitForTimeout(javax.transaction.TransactionManager)}.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({TransactionTimeoutQueueSetupTask.class, TransactionDefaultTimeoutSetupTask.class})
+public class MessageDrivenDefaultTimeoutTestCase {
+
+    @ArquillianResource
+    private InitialContext initCtx;
+
+    @Inject
+    private TransactionCheckerSingleton checker;
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final Archive<?> deployment = ShrinkWrap.create(JavaArchive.class, "mdb-default-timeout.jar")
+            .addPackage(MessageDrivenDefaultTimeoutTestCase.class.getPackage())
+            .addPackage(TxTestUtil.class.getPackage())
+            .addClass(TimeoutUtil.class)
+            // grant necessary permissions for -Dsecurity.manager because of usage TimeoutUtil
+            .addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("ts.timeout.factor", "read")), "META-INF/jboss-permissions.xml");
+        return deployment;
+    }
+
+    @Before
+    public void startUp() throws NamingException {
+        checker.resetAll();
+    }
+
+    /**
+     * MDB receives a message with default transaction timeout redefined.
+     * The bean waits till timeout occurs and the transaction should be rolled-back.
+     */
+    @Test
+    public void defaultTimeout() throws Exception {
+        String text = "default timeout";
+        Queue q = MessageDrivenTimeoutTestCase.sendMessage(text, TransactionTimeoutQueueSetupTask.DEFAULT_TIMEOUT_JNDI_NAME, initCtx);
+        Assert.assertNull("No message should be received as mdb timeouted", MessageDrivenTimeoutTestCase.receiveMessage(q, initCtx));
+
+        Assert.assertEquals("Expecting no commmit happened as default timeout was hit", 0, checker.getCommitted());
+        Assert.assertTrue("Expecting a rollback happened as default timeout was hit", checker.getRolledback() > 0);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenTimeoutTestCase.java
@@ -92,9 +92,9 @@ public class MessageDrivenTimeoutTestCase {
     @Test
     public void noTimeout() throws Exception {
         String text = "no timeout";
-        Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.NO_TIMEOUT_JNDI_NAME);
+        Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.NO_TIMEOUT_JNDI_NAME, initCtx);
         Assert.assertEquals("Sent and received message does not match at expected way",
-                NoTimeoutMDB.REPLY_PREFIX + text, receiveMessage(q));
+                NoTimeoutMDB.REPLY_PREFIX + text, receiveMessage(q, initCtx));
 
         Assert.assertEquals("Synchronization before completion has to be called", 1, checker.countSynchronizedBefore());
         Assert.assertEquals("Synchronization after completion has to be called", 1, checker.countSynchronizedAfter());
@@ -110,9 +110,9 @@ public class MessageDrivenTimeoutTestCase {
     @Test
     public void transactionTimeoutAnnotation() throws Exception {
         String text = "annotation timeout";
-        Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.ANNOTATION_TIMEOUT_JNDI_NAME);
+        Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.ANNOTATION_TIMEOUT_JNDI_NAME, initCtx);
         Assert.assertEquals("Sent and received message does not match at expected way",
-                AnnotationTimeoutMDB.REPLY_PREFIX + text, receiveMessage(q));
+                AnnotationTimeoutMDB.REPLY_PREFIX + text, receiveMessage(q, initCtx));
 
         Assert.assertEquals("Expecting one test XA resources being commmitted", 1, checker.getCommitted());
         Assert.assertEquals("Expecting no rollback happened", 0, checker.getRolledback());
@@ -127,15 +127,15 @@ public class MessageDrivenTimeoutTestCase {
     @Test
     public void transactionTimeoutActivationProperty() throws Exception {
         String text = "activation property timeout";
-            Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.PROPERTY_TIMEOUT_JNDI_NAME);
-        Assert.assertNull("No message should be received as mdb timeouted", receiveMessage(q));
+            Queue q = sendMessage(text, TransactionTimeoutQueueSetupTask.PROPERTY_TIMEOUT_JNDI_NAME, initCtx);
+        Assert.assertNull("No message should be received as mdb timeouted", receiveMessage(q, initCtx));
 
         Assert.assertEquals("Expecting no commmit happened", 0, checker.getCommitted());
         Assert.assertTrue("Expecting a rollback happened", checker.getRolledback() > 0);
     }
 
-    private Queue sendMessage(String text, String queueJndi) throws Exception {
-        QueueConnection connection = getConnection();
+    static Queue sendMessage(String text, String queueJndi, InitialContext initCtx) throws Exception {
+        QueueConnection connection = getConnection(initCtx);
         connection.start();
 
         Queue replyDestination = null;
@@ -157,8 +157,8 @@ public class MessageDrivenTimeoutTestCase {
         return replyDestination;
     }
 
-    private String receiveMessage(Queue replyQueue) throws Exception {
-        QueueConnection connection = getConnection();
+    static String receiveMessage(Queue replyQueue, InitialContext initCtx) throws Exception {
+        QueueConnection connection = getConnection(initCtx);
         connection.start();
 
         try {
@@ -174,7 +174,7 @@ public class MessageDrivenTimeoutTestCase {
         }
     }
 
-    private QueueConnection getConnection() throws Exception {
+    static QueueConnection getConnection(InitialContext initCtx) throws Exception {
         final QueueConnectionFactory factory = (QueueConnectionFactory) initCtx.lookup("java:/JmsXA");
         return factory.createQueueConnection();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/TransactionDefaultTimeoutSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/TransactionDefaultTimeoutSetupTask.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.mdb.timeout;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Setup task to set default transaction timeout for 1 second.
+ *
+ * @author Ondrej Chaloupka <ochaloup@redhat.com>
+ */
+public class TransactionDefaultTimeoutSetupTask implements ServerSetupTask {
+
+    private static final String DEFAULT_TIMEOUT_PARAM_NAME = "default-timeout";
+    private static ModelNode address = new ModelNode().add(ClientConstants.SUBSYSTEM, "transactions");
+    private static ModelNode operation = new ModelNode();
+
+    static {
+        operation.get(ClientConstants.OP_ADDR).set(address);
+    }
+
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        operation.get(ClientConstants.OP).set(ClientConstants.WRITE_ATTRIBUTE_OPERATION);
+        operation.get(ClientConstants.NAME).set(DEFAULT_TIMEOUT_PARAM_NAME);
+        operation.get(ClientConstants.VALUE).set(1); // 1 second
+
+        managementClient.getControllerClient().execute(operation);
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        operation.get(ClientConstants.OP).set(ClientConstants.UNDEFINE_ATTRIBUTE_OPERATION);
+        operation.get(ClientConstants.NAME).set(DEFAULT_TIMEOUT_PARAM_NAME);
+
+        managementClient.getControllerClient().execute(operation);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/TransactionTimeoutQueueSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/TransactionTimeoutQueueSetupTask.java
@@ -31,6 +31,8 @@ public class TransactionTimeoutQueueSetupTask implements ServerSetupTask {
 
     public static final String NO_TIMEOUT_QUEUE_NAME = "noTimeoutQueue";
     public static final String NO_TIMEOUT_JNDI_NAME = "queue/" + NO_TIMEOUT_QUEUE_NAME;
+    public static final String DEFAULT_TIMEOUT_QUEUE_NAME = "defaultTimeoutQueue";
+    public static final String DEFAULT_TIMEOUT_JNDI_NAME = "queue/" + DEFAULT_TIMEOUT_QUEUE_NAME;
     public static final String ANNOTATION_TIMEOUT_QUEUE_NAME = "annotationTimeoutQueue";
     public static final String ANNOTATION_TIMEOUT_JNDI_NAME = "queue/" + ANNOTATION_TIMEOUT_QUEUE_NAME;
     public static final String PROPERTY_TIMEOUT_QUEUE_NAME = "propertyTimeoutQueue";
@@ -46,6 +48,7 @@ public class TransactionTimeoutQueueSetupTask implements ServerSetupTask {
     public void setup(ManagementClient managementClient, String containerId) throws Exception {
         adminOperations = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
         adminOperations.createJmsQueue(NO_TIMEOUT_QUEUE_NAME, NO_TIMEOUT_JNDI_NAME);
+        adminOperations.createJmsQueue(DEFAULT_TIMEOUT_QUEUE_NAME, DEFAULT_TIMEOUT_JNDI_NAME);
         adminOperations.createJmsQueue(ANNOTATION_TIMEOUT_QUEUE_NAME, ANNOTATION_TIMEOUT_JNDI_NAME);
         adminOperations.createJmsQueue(PROPERTY_TIMEOUT_QUEUE_NAME, PROPERTY_TIMEOUT_JNDI_NAME);
         adminOperations.createJmsQueue(REPLY_QUEUE_NAME, REPLY_QUEUE_JNDI_NAME);
@@ -56,6 +59,7 @@ public class TransactionTimeoutQueueSetupTask implements ServerSetupTask {
         if (adminOperations != null) {
             try {
                 adminOperations.removeJmsQueue(NO_TIMEOUT_QUEUE_NAME);
+                adminOperations.removeJmsQueue(DEFAULT_TIMEOUT_QUEUE_NAME);
                 adminOperations.removeJmsQueue(ANNOTATION_TIMEOUT_QUEUE_NAME);
                 adminOperations.removeJmsQueue(PROPERTY_TIMEOUT_QUEUE_NAME);
                 adminOperations.removeJmsQueue(REPLY_QUEUE_NAME);

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.txn.logging.TransactionLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
@@ -496,6 +497,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                                                final ModelNode currentValue, final HandbackHolder<Void> handbackHolder)
             throws OperationFailedException {
             TxControl.setDefaultTimeout(resolvedValue.asInt());
+            ContextTransactionManager.setGlobalDefaultTransactionTimeout(resolvedValue.asInt());
             return false;
         }
 
@@ -505,6 +507,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                                              final ModelNode valueToRevert, final Void handback)
             throws OperationFailedException {
             TxControl.setDefaultTimeout(valueToRestore.asInt());
+            ContextTransactionManager.setGlobalDefaultTransactionTimeout(valueToRestore.asInt());
         }
     }
 


### PR DESCRIPTION
When transaction timeout is changed in model this change was not propagated to WFTC and e.g. MDB txn timeout was left as it was at time of container startup(reload).

https://issues.jboss.org/browse/WFLY-8370
https://issues.jboss.org/browse/JBEAP-9602

eap7: https://github.com/jbossas/jboss-eap7/pull/1524