### PR TITLE
[WFLY-8021] jms-bridge credential-reference attribute

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -102,7 +102,7 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final ObjectTypeAttributeDefinition SOURCE_CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder(SOURCE_CREDENTIAL_REFERENCE_NAME, CredentialReference.CREDENTIAL_REFERENCE, true)
+            CredentialReference.getAttributeBuilder(SOURCE_CREDENTIAL_REFERENCE_NAME, SOURCE_CREDENTIAL_REFERENCE_NAME, true)
                     .setAttributeGroup(SOURCE)
                     .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
@@ -146,7 +146,7 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final ObjectTypeAttributeDefinition TARGET_CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder(TARGET_CREDENTIAL_REFERENCE_NAME, CredentialReference.CREDENTIAL_REFERENCE, true)
+            CredentialReference.getAttributeBuilder(TARGET_CREDENTIAL_REFERENCE_NAME, TARGET_CREDENTIAL_REFERENCE_NAME, true)
                     .setAttributeGroup(TARGET)
                     .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
@@ -779,10 +779,10 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="source-context" type="contextType" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
+                        <xs:element name="source-credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>
-                                    Credential to be used by the configuration.
+                                    Credential to be used by the configuration to connect to the source destination.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
@@ -797,10 +797,10 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="target-context" type="contextType" minOccurs="0" maxOccurs="1" />
-                        <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
+                        <xs:element name="target-credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>
-                                    Credential to be used by the configuration.
+                                    Credential to be used by the configuration to connect to the target destination.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
@@ -494,4 +494,24 @@
             </target-context>
         </target>
     </jms-bridge>
+
+    <jms-bridge name="bridge-with-credential-reference"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser">
+            <source-credential-reference clear-text="passwordOut!"/>
+        </source>
+
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser">
+            <target-credential-reference alias="bob" store="jms-bridge-store" />
+        </target>
+    </jms-bridge>
 </subsystem>


### PR DESCRIPTION
Do not use the same XML element name for source-credential-reference
and target-credential-reference as the parser is not able to distinguish
those and ignore one of the 2 attributes (thus leaving its model node
undefined).

Note that this is consistent with target-context and source-context
attributes.

JIRA: https://issues.jboss.org/browse/WFLY-8021