### PR TITLE
[WFLY-8140] Fix anonymous authentication for Elytron

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ElytronSecurityManager.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ElytronSecurityManager.java
@@ -86,12 +86,17 @@ public class ElytronSecurityManager implements ActiveMQSecurityManager {
         ServerAuthenticationContext context = this.securityDomain.createNewAuthenticationContext();
         PasswordGuessEvidence evidence = null;
         try {
-            // check for anonymous connection
-            if (username == null || password == null) {
-                if (context.authorizeAnonymous()) {
-                    context.succeed();
-                    return context.getAuthorizedIdentity();
+            if (password == null) {
+                if (username == null) {
+                    if (context.authorizeAnonymous()) {
+                        context.succeed();
+                        return context.getAuthorizedIdentity();
+                    } else {
+                        context.fail();
+                        return null;
+                    }
                 } else {
+                    // treat a non-null user name with a null password as a auth failure
                     context.fail();
                     return null;
                 }


### PR DESCRIPTION
Fail authentication when password is null and username non-null.

JIRA: https://issues.jboss.org/browse/WFLY-8140