### PR TITLE
[core-management]: core-management subsystem is missing from alternate standalone configurations.

### DIFF
--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
@@ -4,6 +4,7 @@
     <subsystems>
         <subsystem>logging.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -4,6 +4,7 @@
     <subsystems>
         <subsystem>logging.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -5,6 +5,7 @@
         <subsystem>logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
+        <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>ee.xml</subsystem>


### PR DESCRIPTION
Adding the missing subsystem in those configurations from https://github.com/wildfly/wildfly/pull/9690

Jira: https://issues.jboss.org/browse/WFLY-8180
JBEAP: https://issues.jboss.org/browse/JBEAP-9001