### PR TITLE
[WFLY-8396] Remove extra server reloads from jca tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestBase.java
@@ -91,8 +91,7 @@ public abstract class DatasourceEnableAttributeTestBase extends DsMgmtTestBase {
                 // expecting that datasource won't be available 'online'
             }
 
-            writeAttribute(getDataSourceAddress(ds), "enabled", "true");
-            reload();
+            enableDatasource(ds);
             testConnection(ds);
 
         } finally {
@@ -159,13 +158,13 @@ public abstract class DatasourceEnableAttributeTestBase extends DsMgmtTestBase {
             createDataSource(ds);
             testConnection(ds);
         } finally {
+            removeDataSourceSilently(ds);
             removeSystemPropertySilently(url);
             removeSystemPropertySilently(username);
             removeSystemPropertySilently(password);
             removeSystemPropertySilently(jndiName);
             removeSystemPropertySilently(driverName);
             removeSystemPropertySilently(DS_ENABLED_SYSTEM_PROPERTY_NAME);
-            removeDataSourceSilently(ds);
         }
     }
 
@@ -193,6 +192,13 @@ public abstract class DatasourceEnableAttributeTestBase extends DsMgmtTestBase {
         operation.get("user-name").set(datasource.getUserName());
         operation.get("password").set(datasource.getPassword());
         return operation;
+    }
+
+    protected void enableDatasource(Datasource ds) throws Exception {
+        ModelNode address = getDataSourceAddress(ds);
+        writeAttribute(address, "enabled", "true");
+        // enabling datasource requires reload
+        reload();
     }
 
     protected ModelNode writeAttribute(ModelNode address, String attribute, String value) throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceXaEnableAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceXaEnableAttributeTestCase.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -62,7 +64,6 @@ public class DatasourceXaEnableAttributeTestCase extends DatasourceEnableAttribu
         batch.get(STEPS).add(operationXAProperty);
 
         executeOperation(batch);
-        reload();
         return address;
     }
 
@@ -74,8 +75,9 @@ public class DatasourceXaEnableAttributeTestCase extends DatasourceEnableAttribu
 
         ModelNode address = getDataSourceAddress(datasource);
         try {
-            remove(address);
-            reload();
+            ModelNode removeOperation = Operations.createRemoveOperation(address);
+            removeOperation.get(ModelDescriptionConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(true);
+            executeOperation(removeOperation);
         } catch (Exception e) {
             log.debugf(e, "Can't remove xa datasource at address '%s'", address);
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/jca/DsMgmtTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/jca/DsMgmtTestBase.java
@@ -26,8 +26,11 @@ import java.util.List;
 
 import org.jboss.as.connector.subsystems.datasources.DataSourcesExtension.DataSourceSubsystemParser;
 import org.jboss.as.connector.subsystems.datasources.Namespace;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -53,13 +56,14 @@ public class DsMgmtTestBase extends ContainerResourceMgmtTestBase {
      * @throws Exception
      */
     public void reload() throws Exception {
-        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient(), 50000);
+        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient(), TimeoutUtil.adjust(50000));
     }
 
     //@After - called after each test
     protected void removeDs() throws Exception {
-        remove(baseAddress);
-        reload();
+        final ModelNode removeOperation = Operations.createRemoveOperation(baseAddress);
+        removeOperation.get(ModelDescriptionConstants.OPERATION_HEADERS).get("allow-resource-service-restart").set(true);
+        executeOperation(removeOperation);
     }
 
 


### PR DESCRIPTION
There are some unnecessary server reloads in jca tests (integration basic module). Revisit the tests and remove all reloads which are no longer needed.

Jira:
https://issues.jboss.org/browse/WFLY-8396