### PR TITLE
[WFLY-8402] : DescriptorScheduleTestCase fails when upgrading to jboss metadata 10.0.1.Final.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/schedule/descriptor/DescriptorScheduleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/schedule/descriptor/DescriptorScheduleTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.ejb.timerservice.schedule.descriptor;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -58,7 +59,8 @@ public class DescriptorScheduleTestCase {
         DescriptorScheduleBean bean = (DescriptorScheduleBean) ctx.lookup("java:module/" + DescriptorScheduleBean.class.getSimpleName());
         Assert.assertTrue(DescriptorScheduleBean.awaitTimer());
         Assert.assertEquals("INFO", DescriptorScheduleBean.getTimerInfo());
-        Assert.assertEquals(new Date(90, 0, 1, 0, 0, 0), DescriptorScheduleBean.getStart());
+        TimeZone.setDefault(TimeZone.getTimeZone("CET"));
+        Assert.assertEquals((new Date(90, 0, 1, 0, 0, 0)), DescriptorScheduleBean.getStart());
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/schedule/descriptor/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/schedule/descriptor/ejb-jar.xml
@@ -19,8 +19,8 @@
                     <month>*</month>
                     <day-of-week>*</day-of-week>
                 </schedule>
-                <start>1990-01-01T00:00:00</start>
-                <end>9000-12-31T00:00:00</end>
+                <start>1990-01-01T00:00:00[CET]</start>
+                <end>9000-12-31T00:00:00[CET]</end>
                 <timeout-method>
                     <method-name>descriptorScheduledMethod</method-name>
                 </timeout-method>


### PR DESCRIPTION
[WFLY-8402] : https://issues.jboss.org/browse/WFLY-8402

The PR will fail till the upgrade of JBoss Metadata to version 10.0.1.Final.