### PR TITLE
[WFLY-7893] RegistryTestCase and ServiceProviderRegistrationTestCase fail with security manager

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolBuilder.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 
@@ -61,7 +63,9 @@ public class ThreadPoolBuilder extends ComponentBuilder<ThreadPoolConfiguration>
         ) {
             @Override
             public ExecutorService createExecutor(ThreadFactory factory) {
-                return super.createExecutor(new ClassLoaderThreadFactory(factory, ClassLoaderThreadFactory.class.getClassLoader()));
+                return super.createExecutor(new ClassLoaderThreadFactory(factory, AccessController.doPrivileged(
+                        (PrivilegedAction<ClassLoader>) () -> ClassLoaderThreadFactory.class.getClassLoader()))
+                );
             }
         };
         this.builder.threadPoolFactory(factory);

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.clustering.server.provider;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.AbstractMap;
 import java.util.Collection;
@@ -68,7 +69,8 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
 
     private static ThreadFactory createThreadFactory(Class<?> targetClass) {
         PrivilegedAction<ThreadFactory> action = () -> new JBossThreadFactory(new ThreadGroup(targetClass.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null);
-        return new ClassLoaderThreadFactory(WildFlySecurityManager.doUnchecked(action), targetClass.getClassLoader());
+        return new ClassLoaderThreadFactory(WildFlySecurityManager.doUnchecked(action),
+                AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> targetClass.getClassLoader()));
     }
 
     private final ConcurrentMap<T, Map.Entry<Listener, ExecutorService>> listeners = new ConcurrentHashMap<>();

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.clustering.server.registry;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.AbstractMap;
 import java.util.Collections;
@@ -74,7 +75,8 @@ public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
 
     private static ThreadFactory createThreadFactory(Class<?> targetClass) {
         PrivilegedAction<ThreadFactory> action = () -> new JBossThreadFactory(new ThreadGroup(targetClass.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null);
-        return new ClassLoaderThreadFactory(WildFlySecurityManager.doUnchecked(action), targetClass.getClassLoader());
+        return new ClassLoaderThreadFactory(WildFlySecurityManager.doUnchecked(action),
+                AccessController.doPrivileged((PrivilegedAction<ClassLoader>) () -> targetClass.getClassLoader()));
     }
 
     private final ExecutorService topologyChangeExecutor = Executors.newSingleThreadExecutor(createThreadFactory(this.getClass()));


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-7893

This will continue to fail per comments on tests:
```
// TODO Elytron: Once support for legacy EJB properties has been added back, actually set the EJB properties
// that should be used for this test using CLIENT_PROPERTIES and ensure the EJB client context is reset
// to its original state at the end of the test
```