### PR TITLE
[WFLY-8406] Referencing credential store from mail subsystem without …

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
@@ -251,7 +251,7 @@ class MailSessionAdd extends AbstractAddStepHandler {
     private static Credentials readCredentials(final OperationContext operationContext, final ModelNode model) throws OperationFailedException {
         if (model.get(USER_NAME).isDefined()) {
             String un = MailServerDefinition.USERNAME.resolveModelAttribute(operationContext, model).asString();
-            String pw = MailServerDefinition.PASSWORD.resolveModelAttribute(operationContext, model).asString();
+            String pw = MailServerDefinition.PASSWORD.resolveModelAttribute(operationContext, model).asStringOrNull();
             ModelNode value = MailServerDefinition.CREDENTIAL_REFERENCE.resolveValue(operationContext, model);
             String secret = null;
             if (value.isDefined()) {

--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -200,7 +200,7 @@ class SessionProviderFactory {
                 }
             }
 
-            if (c != null) {
+            if (c != null && c.getPassword() != null) {
                 return new javax.mail.PasswordAuthentication(c.getUsername(), c.getPassword());
             }
             return null;


### PR DESCRIPTION
…alias results in returned password "undefined"

WFLY: https://issues.jboss.org/browse/WFLY-8406