### PR TITLE
WFLY-8409 Do not stop IIOP from starting with invalid SSL configurati…

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -203,9 +203,6 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         String sslSocketBinding = props.getProperty(Constants.ORB_SSL_SOCKET_BINDING);
         if(sslSocketBinding != null) {
-            if (!sslConfigured) {
-                throw IIOPLogger.ROOT_LOGGER.sslPortWithoutSslConfiguration();
-            }
             builder.addDependency(SocketBinding.JBOSS_BINDING_NAME.append(sslSocketBinding), SocketBinding.class,
                     orbService.getIIOPSSLSocketBindingInjector());
         }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/logging/IIOPLogger.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/logging/IIOPLogger.java
@@ -22,17 +22,6 @@
 
 package org.wildfly.iiop.openjdk.logging;
 
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.WARN;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-
-import javax.naming.ConfigurationException;
-import javax.naming.InvalidNameException;
-import javax.naming.NamingException;
-
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -43,13 +32,20 @@ import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
 import org.jboss.msc.service.StartException;
 import org.omg.CORBA.BAD_INV_ORDER;
-import org.omg.CORBA.COMM_FAILURE;
 import org.omg.CORBA.CompletionStatus;
 import org.omg.CORBA.INTERNAL;
 import org.omg.CORBA.MARSHAL;
 import org.omg.CORBA.NO_PERMISSION;
 import org.wildfly.iiop.openjdk.rmi.RMIIIOPViolationException;
 import org.wildfly.iiop.openjdk.rmi.ir.IRConstructionException;
+
+import javax.naming.ConfigurationException;
+import javax.naming.InvalidNameException;
+import javax.naming.NamingException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import static org.jboss.logging.Logger.Level.*;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -399,14 +395,16 @@ public interface IIOPLogger extends BasicLogger {
     @Message(id = 108, value = "Security attribute server-requires-ssl is not supported in previous iiop-openjdk versions and can't be converted")
     String serverRequiresSslNotSupportedInPreviousVersions();
 
+    @LogMessage(level = WARN)
     @Message(id = 109, value = "SSL socket is required by server but secure connections have not been configured")
-    COMM_FAILURE cannotCreateSSLSocket();
+    void cannotCreateSSLSocket();
 
     @Message(id = 110, value = "Client requires SSL but server does not support it")
     IllegalStateException serverDoesNotSupportSsl();
 
-    @Message(id = 111, value = "SSL has not been configured but ssl-port property has been specified")
-    OperationFailedException sslPortWithoutSslConfiguration();
+    @LogMessage(level = WARN)
+    @Message(id = 111, value = "SSL has not been configured but ssl-port property has been specified - the connection will use clear-text protocol")
+    void sslPortWithoutSslConfiguration();
 
     @Message(id = 112, value = "Security initializer was set to 'elytron' but no authentication-context has been specified")
     OperationFailedException elytronInitializerMissingAuthContext();

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/security/NoSSLSocketFactory.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/security/NoSSLSocketFactory.java
@@ -43,20 +43,20 @@ public class NoSSLSocketFactory extends SocketFactoryBase {
 
     @Override
     public ServerSocket createServerSocket(String type, InetSocketAddress inetSocketAddress) throws IOException {
+        //we can only warn here because of backward compatibility
         if (type.equals(Constants.SSL_SOCKET_TYPE)) {
-            throw IIOPLogger.ROOT_LOGGER.cannotCreateSSLSocket();
-        } else {
-            return super.createServerSocket(type, inetSocketAddress);
+            IIOPLogger.ROOT_LOGGER.cannotCreateSSLSocket();
         }
+        return super.createServerSocket(type, inetSocketAddress);
     }
 
     @Override
     public Socket createSocket(String type, InetSocketAddress inetSocketAddress) throws IOException {
+        //we can only warn here because of backward compatibility
         if (type.contains(Constants.SSL_SOCKET_TYPE)){
-            throw IIOPLogger.ROOT_LOGGER.cannotCreateSSLSocket();
-        } else {
-            return super.createSocket(type, inetSocketAddress);
+            IIOPLogger.ROOT_LOGGER.cannotCreateSSLSocket();
         }
+        return super.createSocket(type, inetSocketAddress);
     }
 
 }


### PR DESCRIPTION
…on (backward compatibility)

This is the upstream fix for the problem with turned out in JBEAP-8525 - the IIOP subsystem currently refuses to start with invalid configuration (SSL socket configured without proper SSL configuration). Because such configuration was legal in the previous versions the previously working configurations stopped working. As a result, I have changed the validation behavior so that it only warn against invalid configuration.