### PR TITLE
[WFLY-8427] Ignore XADatasourceCapacityPoliciesTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
@@ -25,6 +25,8 @@ package org.jboss.as.test.integration.jca.capacitypolicies;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -49,4 +51,9 @@ public class XADatasourceCapacityPoliciesTestCase extends AbstractDatasourceCapa
         }
     }
 
+    @Test
+    @Ignore("WFLY-8427")
+    public void testNonDefaultDecrementerAndIncrementer() throws Exception {
+
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8427