### PR TITLE
[WFLY-8429] Discovery-group does not create channel with the correct name

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -296,7 +296,7 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
                         String channelName = jgroupsChannels.get(key);
                         JChannel channel = channels.get(channelName);
                         if (channel == null) {
-                            channel = (JChannel) channelFactory.createChannel(key);
+                            channel = (JChannel) channelFactory.createChannel(channelName);
                             channels.put(channelName, channel);
                         }
                         config = DiscoveryGroupAdd.createDiscoveryGroupConfiguration(name, entry.getValue(), channel, channelName);


### PR DESCRIPTION
Create the JGroups channel using the channelName, not the (internal)
key.
This code is executed only when there is a discovery-group without a
corresponding broadcast-group (which is not a common configuration).

JIRA: https://issues.jboss.org/browse/WFLY-8429