### PR TITLE
WFLY-8447 JGroups default TCP stack takes too long to detect hung members

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -14,7 +14,7 @@
                 <?UDP-DISCOVERY?>
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK"/>
-                <?UDP-FD?>
+                <protocol type="FD_ALL"/>
                 <protocol type="VERIFY_SUSPECT"/>
                 <protocol type="pbcast.NAKACK2">
                     <?NAKACK-PROPERTIES?>
@@ -31,7 +31,7 @@
                 <?TCP-DISCOVERY?>
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK"/>
-                <protocol type="FD"/>
+                <protocol type="FD_ALL"/>
                 <protocol type="VERIFY_SUSPECT"/>
                 <protocol type="pbcast.NAKACK2"/>
                 <protocol type="UNICAST3"/>
@@ -49,9 +49,6 @@
         <replacement placeholder="UDP-DISCOVERY">
             <protocol type="PING"/>
         </replacement>
-        <replacement placeholder="UDP-FD">
-            <protocol type="FD_ALL"/>
-        </replacement>
         <replacement placeholder="UDP-MULTICAST-FLOW-CONTROL">
             <protocol type="MFC"/>
         </replacement>
@@ -62,9 +59,6 @@
     <supplement name="no-multicast">
         <replacement placeholder="UDP-PROPERTIES">
             <property name="ip_mcast">false</property>
-        </replacement>
-        <replacement placeholder="UDP-FD">
-            <protocol type="FD"/>
         </replacement>
         <replacement placeholder="NAKACK-PROPERTIES">
             <property name="use_mcast_xmit">false</property>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -78,8 +78,8 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
             originalSlaveStack.protect();
             Assert.assertEquals(originalMasterStack, originalSlaveStack);
 
-            //FD is normally in the middle somewhere
-            final String protocolName = "FD";
+            //FD_ALL is normally in the middle somewhere
+            final String protocolName = "FD_ALL";
             int index = -1;
             ModelNode value = null;
             Iterator<Property> it = originalMasterStack.get(PROTOCOL).asPropertyList().iterator();


### PR DESCRIPTION
Replace FD -> FD_ALL.
https://issues.jboss.org/browse/WFLY-8447