### PR TITLE
[WFLY-8450] marking org.wildfly.transaction.client module unsupported

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.wildfly.transaction.client">
+    <properties>
+        <property name="jboss.api" value="unsupported"/>
+    </properties>
+
     <exports>
         <exclude path="org/wildfly/transaction/client/_private" />
     </exports>


### PR DESCRIPTION
The wfly txn client is not supposed to be supported under EAP 7.1 but users should give the chance to hack on it. The support could be considered in later releases. See discussion on JBEAP-9368.

https://issues.jboss.org/browse/WFLY-8450
https://issues.jboss.org/browse/JBEAP-9368

https://github.com/jbossas/jboss-eap7/pull/1582