### PR TITLE
WFLY-8378 Disable BootstrapBeanDeploymentArchiveTestCase if a SecurityManager is used

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
@@ -30,10 +30,12 @@ import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.SecurityManagerFailure;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,6 +51,11 @@ public class BootstrapBeanDeploymentArchiveTestCase {
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(WebArchive.class).addPackage(BootstrapBeanDeploymentArchiveTestCase.class.getPackage())
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addAsServiceProvider(Extension.class, TestExtension.class);
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        SecurityManagerFailure.thisTestIsFailingUnderSM("WFLY-8378");
     }
 
     @Test


### PR DESCRIPTION
* https://issues.jboss.org/browse/WFLY-8378
* downstream issue: https://issues.jboss.org/browse/JBEAP-9598
* downstream PR: https://github.com/jbossas/jboss-eap7/pull/1614