### PR TITLE
WFLY-8455: Upgrade HAL to 2.9.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.hal.release-stream>2.9.5.Final</version.org.jboss.hal.release-stream>
+        <version.org.jboss.hal.release-stream>2.9.6.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.ejb-client>4.0.0.Beta22</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.0.Alpha2</version.org.jboss.genericjms>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8455