### PR TITLE
WFLY-8482 increased CLI connectionTimeout for ObjectStoreTypeTestCase

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -59,7 +60,7 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
     @Before
     public void before() throws Exception {
         container.start(CONTAINER);
-        initCLI();
+        initCLI(TimeoutUtil.adjust(20 * 1000));
     }
 
     @After


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8482

This is going to fail until https://issues.jboss.org/browse/WFCORE-2600, i.e. https://github.com/wildfly/wildfly-core/pull/2289, is fixed.