### PR TITLE
[WFLY-8475]: JBoss-Product-Release-Name has changed in eap manifest, breaking tools expectations.

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -58,7 +58,11 @@
 
     <properties>
         <product.release.name>WildFly Full</product.release.name>
+        <verifier.slot.name>wildfly-full</verifier.slot.name>
+        <verifier.product.release.name>WildFly Full</verifier.product.release.name>
+        <verifier.product.release.version>11.0</verifier.product.release.version>
     </properties>
+
     <build>
         <finalName>${server.output.dir.prefix}-${project.version}</finalName>
         <plugins>
@@ -99,7 +103,28 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>verifications-configuration</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/target/verifier</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/verifier</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-verifier-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 JBoss by Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+<!--
+    1) bin/product.conf exists
+    2) bin/product.conf has slot = "wildfly-full"
+    3) jboss-modules.jar must exist
+    4) standalone/configuration/standalone.xml must exist
+    5) modules/system/layers/base/org/jboss/as/product/wildfly-full/dir/META-INF/MANIFEST.MF exists
+    6) JBoss-Product-Release-Name key in manifest.mf above has value "WildFly Full"
+    7) JBoss-Product-Release-Version key in manifest.mf has value starting with "11.0"
+-->
+  <files>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/bin/product.conf</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/bin/product.conf</location>
+      <contains>slot=${verifier.slot.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/jboss-modules.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/standalone/configuration/standalone.xml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+  </files>
+</verifications>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
         <version.jacoco.plugin>0.6.3.201306030806</version.jacoco.plugin> <!-- Needs to be set explicitely to match with org.jacoco:org.jacoco.ant - see testsuite. -->
         <version.properties.plugin>2.0.1</version.properties.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>
+        <version.verifier.plugin>1.1</version.verifier.plugin>
 
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
         <modular.jdk.args/>
@@ -820,6 +821,23 @@
                     <groupId>org.wildfly.build</groupId>
                     <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
                     <version>${version.org.wildfly.build-tools}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-verifier-plugin</artifactId>
+                    <version>${version.verifier.plugin}</version>
+                    <configuration>
+                        <verificationFile>target/verifier/verifications.xml</verificationFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>main</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -58,6 +58,9 @@
 
     <properties>
         <product.release.name>WildFly Servlet</product.release.name>
+        <verifier.slot.name>wildfly-web</verifier.slot.name>
+        <verifier.product.release.name>WildFly Servlet</verifier.product.release.name>
+        <verifier.product.release.version>11.0</verifier.product.release.version>
     </properties>
     <build>
         <finalName>${server.output.dir.prefix}-servlet-${project.version}</finalName>
@@ -99,7 +102,28 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>verifications-configuration</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/target/verifier</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/verifier</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-verifier-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/servlet-dist/src/verifier/verifications.xml
+++ b/servlet-dist/src/verifier/verifications.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 JBoss by Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+<!--
+    1) bin/product.conf exists
+    2) bin/product.conf has slot = "wildfly-web"
+    3) jboss-modules.jar must exist
+    4) standalone/configuration/standalone.xml must exist
+    5) modules/system/layers/base/org/jboss/as/product/wildfly-web/dir/META-INF/MANIFEST.MF exists
+    6) JBoss-Product-Release-Name key in manifest.mf above has value "WildFly Servlet"
+    7) JBoss-Product-Release-Version key in manifest.mf has value starting with "11.0"
+-->
+  <files>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/bin/product.conf</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/bin/product.conf</location>
+      <contains>slot=${verifier.slot.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/jboss-modules.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/standalone/configuration/standalone.xml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+  </files>
+</verifications>


### PR DESCRIPTION
Verifying the servlet and full distributions :
1) bin/product.conf exists
2) bin/product.conf has slot correctly set
3) jboss-modules.jar must exist
4) standalone/configuration/standalone.xml must exist
5) modules/system/layers/base/org/jboss/as/product/wildfly-full/dir/META-INF/MANIFEST.MF exists
6) JBoss-Product-Release-Name key in manifest.mf above has correct value
7) JBoss-Product-Release-Version key in manifest.mf has correct value

Jira: https://issues.jboss.org/browse/WFLY-8475
JBEAP: https://issues.jboss.org/browse/JBEAP-3664