### PR TITLE
[WFLY-8487] Use the corrected CredentialReference APIs that allow pro…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -100,7 +100,7 @@ public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptPr
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false).setCapabilityReference(new CapabilityReference(Capability.ENCRYPT_CREDENTIAL_STORE, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
+        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false, new CapabilityReference(Capability.ENCRYPT_CREDENTIAL_STORE, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
         KEY_ALIAS("key-alias", ModelType.STRING, builder -> builder.setAllowExpression(true)),
         KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.ENCRYPT_KEY_STORE, CommonUnaryRequirement.KEY_STORE))),
         ;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -430,8 +430,7 @@ public class Constants {
             .build();
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, true)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
+            CredentialReference.getAttributeBuilder(true, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(DS_SECURITY_DEF)
@@ -768,8 +767,7 @@ public class Constants {
             .build();
 
     static final ObjectTypeAttributeDefinition RECOVERY_CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder("recovery-credential-reference", CredentialReference.CREDENTIAL_REFERENCE, true)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
+            CredentialReference.getAttributeBuilder("recovery-credential-reference", CredentialReference.CREDENTIAL_REFERENCE, true, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(DS_SECURITY_DEF)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -601,7 +601,6 @@ public class Constants {
 
     static ObjectTypeAttributeDefinition RECOVERY_CREDENTIAL_REFERENCE =
             CredentialReference.getAttributeBuilder(RECOVERY_CREDENTIAL_REFERENCE_NAME, CredentialReference.CREDENTIAL_REFERENCE, true)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .setMeasurementUnit(MeasurementUnit.NONE)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(ResourceAdaptersExtension.RA_SECURITY_DEF)

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.AttributesPathAddressConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -105,7 +106,8 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
         // capabilities used by the various configs used in this test class
         return AdditionalInitialization.withCapabilities(
                 Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY + ".DsAuthCtxt",
-                Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY + ".CredentialAuthCtxt"
+                Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY + ".CredentialAuthCtxt",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".test-store"
         );
     }
 

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailServerDefinition.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailServerDefinition.java
@@ -99,8 +99,7 @@ class MailServerDefinition extends PersistentResourceDefinition {
                     .build();
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, true)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
+            CredentialReference.getAttributeBuilder(true, false)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(MAIL_SERVER_SECURITY_DEF)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -112,8 +112,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, true)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
+            CredentialReference.getAttributeBuilder(true, false)
                     .setRestartAllServices()
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -86,9 +86,8 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
-            CredentialReference.getAttributeBuilder("cluster-" + CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, true)
+            CredentialReference.getAttributeBuilder("cluster-" + CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, true, true)
                     .setAttributeGroup("cluster")
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .setRestartAllServices()
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -104,7 +104,6 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
     public static final ObjectTypeAttributeDefinition SOURCE_CREDENTIAL_REFERENCE =
             CredentialReference.getAttributeBuilder(SOURCE_CREDENTIAL_REFERENCE_NAME, SOURCE_CREDENTIAL_REFERENCE_NAME, true)
                     .setAttributeGroup(SOURCE)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
                     .setAlternatives(SOURCE_PASSWORD.getName())
@@ -148,7 +147,6 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
     public static final ObjectTypeAttributeDefinition TARGET_CREDENTIAL_REFERENCE =
             CredentialReference.getAttributeBuilder(TARGET_CREDENTIAL_REFERENCE_NAME, TARGET_CREDENTIAL_REFERENCE_NAME, true)
                     .setAttributeGroup(TARGET)
-                    .setCapabilityReference(CredentialReference.CREDENTIAL_STORE_CAPABILITY)
                     .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                     .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
                     .setAlternatives(TARGET_PASSWORD.getName())

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
@@ -44,6 +44,7 @@ import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -191,7 +192,8 @@ public class MessagingActiveMQSubsystem_1_1_TestCase extends AbstractSubsystemBa
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.withCapabilities(JGroupsRequirement.CHANNEL_FACTORY.resolve("udp"),
                 Capabilities.ELYTRON_DOMAIN_CAPABILITY,
-                Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain");
+                Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".cs1");
     }
 
     private static class ChangeToTrueConfig extends FailedOperationTransformationConfig.AttributesPathAddressConfig<ChangeToTrueConfig> {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
@@ -65,7 +65,7 @@ public class ApplicationSecurityDomainSingleSignOnDefinition extends SingleSignO
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false).setCapabilityReference(new CapabilityReference(Capability.SSO_CREDENTIAL_STORE, CommonUnaryRequirement.CREDENTIAL_STORE)).setAccessConstraints(SensitiveTargetAccessConstraintDefinition.CREDENTIAL).build()),
+        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false, new CapabilityReference(Capability.SSO_CREDENTIAL_STORE, CommonUnaryRequirement.CREDENTIAL_STORE)).setAccessConstraints(SensitiveTargetAccessConstraintDefinition.CREDENTIAL).build()),
         KEY_ALIAS("key-alias", ModelType.STRING, builder -> builder.setAllowExpression(true).addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SSL_REF)),
         KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.SSO_KEY_STORE, CommonUnaryRequirement.KEY_STORE)).addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SSL_REF)),
         SSL_CONTEXT("client-ssl-context", ModelType.STRING, builder -> builder.setRequired(false).setCapabilityReference(new CapabilityReference(Capability.SSO_SSL_CONTEXT, CommonUnaryRequirement.SSL_CONTEXT)).setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SSL_REF)),


### PR DESCRIPTION
…per registration of requirements for credential store capabilities

Note that in a number of places this change removes configuration of a capability requirement. In these places the config being removed did not have any actual effect, and the code attempting to register a requirement was doing something invalid. These places are all resources that themselves do not expose a capability, and hence cannot require other capabilities.

https://issues.jboss.org/browse/WFLY-8487