### PR TITLE
[WFLY-8495] TS should pass with non-"en_US.UTF-8" locale settings

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
@@ -41,6 +41,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  * @author baranowb
  */
@@ -98,9 +100,12 @@ public class BadResourceTestCase {
         // just to blow up
         Assert.assertTrue("Failed to deploy: " + result, !Operations.isSuccessfulOutcome(result));
 
-        Assert.assertTrue("" + result, result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).toString()
-                .contains(Constants.ERROR_MESSAGE));
-
+        // asserts
+        String failureDescription = result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).toString();
+        Assert.assertThat(String.format("Results doesn't contain correct error code (%s): %s", Constants.ERROR_MESSAGE, result.toString()),
+                failureDescription, containsString(Constants.ERROR_MESSAGE));
+        Assert.assertThat(String.format("Results doesn't contain correct JNDI in error message (%s): %s", Constants.JNDI_NAME_BAD, result.toString()),
+                failureDescription, containsString(Constants.JNDI_NAME_BAD));
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
@@ -37,5 +37,5 @@ public interface Constants {
     String JNDI_NAME_GLOBAL = "java:global/" + TESTED_DU_NAME + "/ResourceEJBImpl";
     String JNDI_NAME_BAD = "java:jboss:/" + TESTED_DU_NAME + "/ResourceEJBImpl";
 
-    String ERROR_MESSAGE = "A valid JNDI name must be provided: java:jboss:/BadTest/ResourceEJBImpl";
+    String ERROR_MESSAGE = "WFLYNAM0033";
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.jca.workmanager;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.AllOf.allOf;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -83,7 +85,12 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
             Assert.fail("NOT HERE!");
         } catch (MgmtOperationException e) {
             String reason = e.getResult().get("failure-description").asString();
-            Assert.assertEquals("WFLYJCA0101: Thread pool: Long(type: long-running-threads) can not be added for workmanager: default, only one thread pool is allowed for each type.", reason);
+            Assert.assertThat("Wrong error message", reason, allOf(
+                    containsString("WFLYJCA0101"),
+                    containsString("Long"),
+                    containsString("long-running-threads"),
+                    containsString("default")
+            ));
         }
     }
 
@@ -104,7 +111,12 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
             Assert.fail("NOT HERE!");
         } catch (MgmtOperationException e) {
             String reason = e.getResult().get("failure-description").asString();
-            Assert.assertEquals("WFLYJCA0101: Thread pool: Short(type: short-running-threads) can not be added for workmanager: default, only one thread pool is allowed for each type.", reason);
+            Assert.assertThat("Wrong error message", reason, allOf(
+                    containsString("WFLYJCA0101"),
+                    containsString("Short"),
+                    containsString("short-running-threads"),
+                    containsString("default")
+            ));
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/slsbxpc/FailBecauseOfXPCNotInSFSBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/slsbxpc/FailBecauseOfXPCNotInSFSBTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.jpa.epcpropagation.slsbxpc;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,6 +36,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -73,17 +75,18 @@ public class FailBecauseOfXPCNotInSFSBTestCase {
 
     @Test
     public void testSerialization() throws Exception {
+        final String errorCode = "WFLYJPA0070";
         StatelessBeanWithXPC bean = lookup("StatelessBeanWithXPC", StatelessBeanWithXPC.class);
         try {
             bean.test();
         } catch (EJBException expected) {
             //expected.printStackTrace();
             Throwable cause = expected.getCause();
-            while (cause != null && !(cause.getMessage().contains("container-managed extended persistence context can only be"))) {
+            while (cause != null && !(cause.getMessage().contains(errorCode))) {
                 cause = cause.getCause();
             }
             assertTrue("expected IllegalStateException was not thrown", cause instanceof IllegalStateException);
-            assertTrue("expected 'container-managed extended persistence context can only be' in error exception message", cause.getMessage().contains("container-managed extended persistence context can only be"));
+            Assert.assertThat("Wrong error message", cause.getMessage(), containsString(errorCode));
         } catch (Throwable unexpected) {
             fail("unexcepted exception " + unexpected.toString());
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/TestForMixedSynchronizationTypes.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/unsync/TestForMixedSynchronizationTypes.java
@@ -74,18 +74,20 @@ public class TestForMixedSynchronizationTypes {
 
     @Test
     public void testShouldGetEjbExceptionBecauseEPCIsAddedToTxAfterPc() throws Exception {
+        final String errorCode = "WFLYJPA0064";
         BMTEPCStatefulBean stateful = lookup("BMTEPCStatefulBean", BMTEPCStatefulBean.class);
         try {
             stateful.willThrowError();
         } catch (Throwable expected) {
             Throwable cause = expected.getCause();
             while(cause != null) {
-                if( cause instanceof IllegalStateException && cause.getMessage().contains("JTA transaction already has a 'SynchronizationType.UNSYNCHRONIZED'")) {
+                if( cause instanceof IllegalStateException && cause.getMessage().contains(errorCode)) {
                     break;  // success
                 }
                 cause = cause.getCause();
+
                 if (cause == null) {
-                    fail("didn't throw IllegalStateException that contains 'JTA transaction already has a 'SynchronizationType.UNSYNCHRONIZED'', instead got message chain: " + messages(expected));
+                    fail(String.format("didn't throw IllegalStateException that contains '%s', instead got message chain: %s", errorCode, messages(expected)));
                 }
             }
         }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase.java
@@ -42,6 +42,8 @@ import org.junit.runner.RunWith;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  * Tests for authentication against EJB endpoint with no class level security annotation on the endpoint
  * https://issues.jboss.org/browse/WFLY-3988
@@ -90,7 +92,7 @@ public class EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke hello method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("Invocation on hello method should not be allowed", e.getCause().getMessage().contains("not allowed"));
+            Assert.assertThat("Invocation on hello method should not be allowed", e.getCause().getMessage(), containsString("WFLYEJB0364"));
         }
     }
 


### PR DESCRIPTION
JBEAP jira: https://issues.jboss.org/browse/JBEAP-9969
WFLY jira: https://issues.jboss.org/browse/WFLY-8495
EAP PR: https://github.com/jbossas/jboss-eap7/pull/1636

WF TS should pass with non-"en_US.UTF-8" locale settings. These tests needs to be fixed:
* org.jboss.as.test.integration.ee.injection.resource.jndi.bad.BadResourceTestCase#testBadDU
* org.jboss.as.test.integration.jca.workmanager.WorkManagerThreadsCheckTestCase#testOneLongRunningThreadPool
* org.jboss.as.test.integration.jca.workmanager.WorkManagerThreadsCheckTestCase#testOneShortRunningThreadPool
* org.jboss.as.test.integration.jpa.epcpropagation.slsbxpc.FailBecauseOfXPCNotInSFSBTestCase#testSerialization
* org.jboss.as.test.integration.jpa.epcpropagation.unsync.TestForMixedSynchronizationTypes#testShouldGetEjbExceptionBecauseEPCIsAddedToTxAfterPc
* org.jboss.as.test.integration.ws.authentication.EJBEndpointNoClassLevelSecurityAnnotationAuthenticationTestCase#accessHelloWithAuthenticatedUser