### PR TITLE
[WFLY-8500] JMXPropertyEditorsTestCase fails on some Windows machines

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
@@ -94,7 +94,11 @@ public class JMXPropertyEditorsTestCase {
     static {
         String osName = System.getProperty("os.name");
         if ( osName.contains( "Windows" ) ) {
-            USER_SYS_PROP = "USERNAME";
+            if (System.getenv().containsKey("USERNAME")) {
+                USER_SYS_PROP = "USERNAME";
+            } else {
+                USER_SYS_PROP = "USER";
+            }
         } else if ( osName.contains( "SunOS" ) ) {
             USER_SYS_PROP = "LOGNAME";
         } else {


### PR DESCRIPTION
* JBEAP jira: https://issues.jboss.org/browse/JBEAP-10029
* WFLY jira: https://issues.jboss.org/browse/WFLY-8500
* EAP PR: https://github.com/jbossas/jboss-eap7/pull/1650


JMXPropertyEditorsTestCase fails on some Windows machines, because some Windows machines doesn't have defined USERNAME env property.