### PR TITLE
[WFLY-8476 WFLY-8494] Upgrade Artemis 1.5.4.jbossorg-002

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PropertySQLProviderFactory.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PropertySQLProviderFactory.java
@@ -64,10 +64,10 @@ public class PropertySQLProviderFactory implements SQLProvider.Factory {
     }
 
     @Override
-    public SQLProvider create(String tableName) {
+    public SQLProvider create(String tableName, SQLProvider.DatabaseStoreType storeType) {
         // WFLY-8307 - Oracle driver does not support lower case for table names
         String name = ORACLE.equals(database) ? tableName.toUpperCase() : tableName;
-        return new PropertySQLProvider(name);
+        return new PropertySQLProvider(name, storeType);
     }
 
     /**
@@ -139,7 +139,12 @@ public class PropertySQLProviderFactory implements SQLProvider.Factory {
 
         private final String tableName;
 
-        public PropertySQLProvider(String tableName) {
+        public PropertySQLProvider(String tableName, DatabaseStoreType storeType) {
+            if (ORACLE.equals(database)
+                    && tableName.length() > 10
+                    && storeType == DatabaseStoreType.PAGE) {
+                throw MessagingLogger.ROOT_LOGGER.tableNameIsTooLong();
+            }
             this.tableName = tableName;
         }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -86,6 +86,7 @@ public class TransportConfigOperationHandlers {
     static {
         CONNECTORS_KEYS_MAP.put(InVMTransportDefinition.SERVER_ID.getName(),
                 org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("buffer-pooling", "bufferPooling");
         CONNECTORS_KEYS_MAP.put(SSL_ENABLED,
                 TransportConstants.SSL_ENABLED_PROP_NAME);
         CONNECTORS_KEYS_MAP.put("http-enabled",
@@ -149,6 +150,7 @@ public class TransportConfigOperationHandlers {
                 org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
         ACCEPTOR_KEYS_MAP.put(BATCH_DELAY,
                 TransportConstants.BATCH_DELAY);
+        ACCEPTOR_KEYS_MAP.put("buffer-pooling", "bufferPooling");
         ACCEPTOR_KEYS_MAP.put("cluster-connection",
                 TransportConstants.CLUSTER_CONNECTION);
         ACCEPTOR_KEYS_MAP.put("connection-ttl",

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -86,7 +86,7 @@ public class TransportConfigOperationHandlers {
     static {
         CONNECTORS_KEYS_MAP.put(InVMTransportDefinition.SERVER_ID.getName(),
                 org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
-        CONNECTORS_KEYS_MAP.put("buffer-pooling", "bufferPooling");
+        CONNECTORS_KEYS_MAP.put("buffer-pooling", org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.BUFFER_POOLING);
         CONNECTORS_KEYS_MAP.put(SSL_ENABLED,
                 TransportConstants.SSL_ENABLED_PROP_NAME);
         CONNECTORS_KEYS_MAP.put("http-enabled",
@@ -150,7 +150,7 @@ public class TransportConfigOperationHandlers {
                 org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
         ACCEPTOR_KEYS_MAP.put(BATCH_DELAY,
                 TransportConstants.BATCH_DELAY);
-        ACCEPTOR_KEYS_MAP.put("buffer-pooling", "bufferPooling");
+        ACCEPTOR_KEYS_MAP.put("buffer-pooling", org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.BUFFER_POOLING);
         ACCEPTOR_KEYS_MAP.put("cluster-connection",
                 TransportConstants.CLUSTER_CONNECTION);
         ACCEPTOR_KEYS_MAP.put("connection-ttl",

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -847,4 +847,8 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 94, value = "Unable to detect database dialect from connection metadata or JDBC driver name. Please configure this manually using the 'journal-database' property in your configuration.  Known database dialect strings are %s")
     void jdbcDatabaseDialectDetectionFailed(String databaseDialects);
+
+    @Message(id = 95, value = "The maximum name size for the paging store table, when using Oracle12C is 10 characters.")
+    IllegalArgumentException tableNameIsTooLong();
+
 }

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -26,7 +26,9 @@
                        value="50"/>
             </http-connector>
             <in-vm-connector name="in-vm"
-                             server-id="0"/>
+                             server-id="0">
+                <param name="buffer-pooling" value="false" />
+            </in-vm-connector>
 
             <http-acceptor name="http-acceptor"
                            http-listener="default" />
@@ -38,7 +40,9 @@
                        value="false"/>
             </http-acceptor>
             <in-vm-acceptor name="in-vm"
-                            server-id="0"/>
+                            server-id="0">
+                <param name="buffer-pooling" value="false" />
+            </in-vm-acceptor>
 
             <?BROADCAST-GROUPS?>
             <?DISCOVERY-GROUPS?>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.5.3.jbossorg-003</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.5.4.jbossorg-002</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.8.1</version.org.apache.avro>
         <version.org.apache.cxf>3.1.10</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
* [WFLY-8476] Upgrade Artemis 1.5.4.jbossorg-002

JIRA: https://issues.jboss.org/browse/WFLY-8476

* [WFLY-8494] Disable Artemis Buffer Pooling  …

Udpate default messaging-activemq configuration to disable
buffer-pooling for in-vm connector/acceptor that were increasing the
initial memory footprint by 50MiB.

JIRA: https://issues.jboss.org/browse/WFLY-8494