### PR TITLE
[WFLY-8492] Cannot cleanly shutdown server

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -38,6 +38,7 @@ public class MessagingServices {
      */
     static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
     static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
+    static final ServiceName ACTIVEMQ_CLIENT_THREAD_POOL = JBOSS_MESSAGING_ACTIVEMQ.append("client-thread-pool");
 
    public static ServiceName getActiveMQServiceName(PathAddress pathAddress) {
          // We need to figure out what ActiveMQ this operation is targeting.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -32,6 +32,8 @@ import java.util.Collection;
 
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -82,7 +84,13 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         super(MessagingExtension.SUBSYSTEM_PATH,
                 MessagingExtension.getResourceDescriptionResolver(MessagingExtension.SUBSYSTEM_NAME),
                 MessagingSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+                new ReloadRequiredRemoveStepHandler() {
+                    @Override
+                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+                        super.performRuntime(context, operation, model);
+                        context.removeService(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL);
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
Add Msc service to clear Artemis global client thread pools when the
server is stopped (or the subsystem is removed).

JIRA: https://issues.jboss.org/browse/WFLY-8492