### PR TITLE
[WFLY-8507] resolve-path does not check absolute path

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/PathDefinition.java
@@ -160,6 +160,7 @@ public class PathDefinition extends PersistentResourceDefinition {
             final ResolvePathHandler resolvePathHandler = ResolvePathHandler.Builder.of(context.getPathManager())
                     .setPathAttribute(PATHS.get(registry.getPathAddress().getLastElement().getValue()))
                     .setRelativeToAttribute(PathDefinition.RELATIVE_TO)
+                    .setCheckAbsolutePath(true)
                     .build();
             registry.registerOperationHandler(resolvePathHandler.getOperationDefinition(), resolvePathHandler);
         }


### PR DESCRIPTION
Customize resolve-path builder to check absolute path.

JIRA: https://issues.jboss.org/browse/WFLY-8507