### PR TITLE
[WFLY-8309] build.sh and integration-tests.sh scripts doesn't work on Solaris SPARC

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -206,7 +206,13 @@ concat_lines() {
   fi
 }
 
-export MAVEN_PROJECTBASEDIR="${MAVEN_BASEDIR:-`find_maven_basedir`}"
+# Workaround for JBEAP-8937 - Don't change lines below
+# as it may breaks build on Solaris 10 (Sparc)
+if [ -z "${MAVEN_PROJECTBASEDIR}" ]; then
+  export MAVEN_PROJECTBASEDIR=`find_maven_basedir`
+fi
+# End of workaround for JBEAP-8937
+
 MAVEN_OPTS="`(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config")` $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
Upstream Issue: [WFLY-8309](https://issues.jboss.org/browse/WFLY-8309)
Issue: [JBEAP-8937](https://issues.jboss.org/browse/JBEAP-8937)
