### PR TITLE
WFLY-459 javassist should be exported to JPA/Hibernate (native) applications

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
@@ -40,7 +40,7 @@
         <module name="org.apache.commons.collections"/>
         <module name="org.dom4j"/>
         <module name="org.infinispan" services="import"/>
-        <module name="org.javassist"/>
+        <module name="org.javassist" export="true"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
@@ -39,7 +39,7 @@
         <module name="org.antlr"/>
         <module name="org.dom4j"/>
         <module name="org.infinispan" services="import"/>
-        <module name="org.javassist"/>
+        <module name="org.javassist" export="true"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -42,7 +42,7 @@
         <module name="javax.xml.bind.api"/>
         <module name="org.antlr"/>
         <module name="org.dom4j"/>
-        <module name="org.javassist"/>
+        <module name="org.javassist" export="true"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -26,7 +26,6 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
-import java.net.URLConnection;
 
 import javax.ejb.EJBException;
 import javax.persistence.EntityManager;
@@ -41,7 +40,6 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -191,8 +189,8 @@ public interface JpaLogger extends BasicLogger {
      * @param name  the name of the integration.
      * @return a {@link RuntimeException} for the error.
      */
-    @Message(id = 13, value = "Could not add %s integration module to deployment")
-    RuntimeException cannotAddIntegration(@Cause Throwable cause, String name);
+    //@Message(id = 13, value = "Could not add %s integration module to deployment")
+    // RuntimeException cannotAddIntegration(@Cause Throwable cause, String name);
 
     /**
      * Creates an exception indicating the input stream reference cannot be changed.
@@ -325,8 +323,8 @@ public interface JpaLogger extends BasicLogger {
      * @param name     the name of the adapter.
      * @return a {@link RuntimeException} for the error.
      */
-    @Message(id = 26, value = "Could not load module %s to add %s adapter to deployment")
-    RuntimeException cannotLoadModule(@Cause Throwable cause, ModuleIdentifier moduleId, String name);
+    //@Message(id = 26, value = "Could not load module %s to add %s adapter to deployment")
+    //RuntimeException cannotLoadModule(@Cause Throwable cause, ModuleIdentifier moduleId, String name);
 
     /**
      * Creates an exception indicating the persistence provider module, represented by the
@@ -345,8 +343,8 @@ public interface JpaLogger extends BasicLogger {
      *
      * @return a {@link RuntimeException} for the error.
      */
-    @Message(id = 28, value = "Internal error: Cannot replace top of stack as stack is null (same as being empty).")
-    RuntimeException cannotReplaceStack();
+    //@Message(id = 28, value = "Internal error: Cannot replace top of stack as stack is null (same as being empty).")
+    //RuntimeException cannotReplaceStack();
 
     /**
      * Creates an exception indicating that both {@code key1} and {@code key2} cannot be specified for the object.
@@ -521,8 +519,8 @@ public interface JpaLogger extends BasicLogger {
      * @param connection      the invalid connection.
      * @return a {@link RuntimeException} for the error.
      */
-    @Message(id = 45, value = "Could not add %s integration module to deployment, did not get expected JarUrlConnection, got %s")
-    RuntimeException invalidUrlConnection(String integrationName, URLConnection connection);
+    //@Message(id = 45, value = "Could not add %s integration module to deployment, did not get expected JarUrlConnection, got %s")
+    //RuntimeException invalidUrlConnection(String integrationName, URLConnection connection);
 
     //@Message(id = 46, value = "Could not load %s")
     //XMLStreamException errorLoadingJBossJPAFile(@Cause Throwable cause, String path);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -24,22 +24,15 @@ package org.jboss.as.jpa.processor;
 
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
-import java.io.IOException;
-import java.net.JarURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.jar.JarFile;
 
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.jpa.config.Configuration;
 import org.jboss.as.jpa.config.PersistenceUnitMetadataHolder;
 import org.jboss.as.jpa.config.PersistenceUnitsInApplication;
-import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -52,10 +45,7 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
-import org.jboss.modules.ResourceLoaderSpec;
-import org.jboss.modules.ResourceLoaders;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
@@ -70,13 +60,6 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
     private static final ModuleIdentifier JAVAX_PERSISTENCE_API_ID = ModuleIdentifier.create("javax.persistence.api");
     private static final ModuleIdentifier JBOSS_AS_JPA_ID = ModuleIdentifier.create("org.jboss.as.jpa");
     private static final ModuleIdentifier JBOSS_AS_JPA_SPI_ID = ModuleIdentifier.create("org.jboss.as.jpa.spi");
-    private static final ModuleIdentifier JAVASSIST_ID = ModuleIdentifier.create("org.javassist");
-
-    private static final ModuleIdentifier HIBERNATE_3_PROVIDER = ModuleIdentifier.create("org.jboss.as.jpa.hibernate", "3");
-    private static final String HIBERNATE3_PROVIDER_ADAPTOR = "org.jboss.as.jpa.hibernate3.HibernatePersistenceProviderAdaptor";
-    // module dependencies for hibernate3
-    private static final ModuleIdentifier JBOSS_AS_NAMING_ID = ModuleIdentifier.create("org.jboss.as.naming");
-    private static final ModuleIdentifier JBOSS_JANDEX_ID = ModuleIdentifier.create("org.jboss.jandex");
 
     /**
      * Add dependencies for modules required for JPA deployments
@@ -92,10 +75,9 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
         if (!JPADeploymentMarker.isJPADeployment(deploymentUnit)) {
             return; // Skip if there are no persistence use in the deployment
         }
-        addDependency(moduleSpecification, moduleLoader, deploymentUnit, JBOSS_AS_JPA_ID, JBOSS_AS_JPA_SPI_ID, JAVASSIST_ID);
+        addDependency(moduleSpecification, moduleLoader, deploymentUnit, JBOSS_AS_JPA_ID, JBOSS_AS_JPA_SPI_ID);
         addPersistenceProviderModuleDependencies(phaseContext, moduleSpecification, moduleLoader);
     }
-
 
     private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
                                DeploymentUnit deploymentUnit, ModuleIdentifier... moduleIdentifiers) {
@@ -225,33 +207,4 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
         }
         return defaultProviderCount;
     }
-
-    private void addHibernate3AdaptorToDeployment(final ModuleLoader moduleLoader, final DeploymentUnit deploymentUnit) {
-        final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
-        try {
-            final Module module = moduleLoader.loadModule(HIBERNATE_3_PROVIDER);
-            //use a trick to get to the root of the class loader
-            final URL url = module.getClassLoader().getResource(HIBERNATE3_PROVIDER_ADAPTOR.replace('.', '/') + ".class");
-
-            final URLConnection connection = url.openConnection();
-            if (!(connection instanceof JarURLConnection)) {
-                throw JpaLogger.ROOT_LOGGER.invalidUrlConnection("hibernate 3", connection);
-            }
-
-            final JarFile jarFile = ((JarURLConnection) connection).getJarFile();
-
-            moduleSpecification.addResourceLoader(ResourceLoaderSpec.createResourceLoaderSpec(ResourceLoaders.createJarResourceLoader("hibernate3integration", jarFile)));
-
-            // hack in the dependencies which are part of hibernate3integration
-            // TODO:  do this automatically (adding dependencies found in HIBERNATE_3_PROVIDER).
-            addDependency(moduleSpecification, moduleLoader, deploymentUnit, JBOSS_AS_NAMING_ID, JBOSS_JANDEX_ID);
-        } catch (ModuleLoadException e) {
-            throw JpaLogger.ROOT_LOGGER.cannotLoadModule(e, HIBERNATE_3_PROVIDER, "hibernate 3");
-        } catch (MalformedURLException e) {
-            throw JpaLogger.ROOT_LOGGER.cannotAddIntegration(e, "hibernate 3");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
 }

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
@@ -81,7 +81,7 @@ public class HibernateJarsInDeploymentTestCase {
         lib.addClasses(SFSB1.class, HibernateJarsInDeploymentTestCase.class);
         lib.addAsManifestResource(HibernateJarsInDeploymentTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         ear.addAsManifestResource(HibernateJarsInDeploymentTestCase.class.getPackage(), "permissions.xml", "permissions.xml");
-        ear.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jandex\n"), "MANIFEST.MF");
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.javassist export, org.jboss.jandex\n"), "MANIFEST.MF");
         ear.addAsModule(lib);
 
         lib = ShrinkWrap.create(JavaArchive.class,"lib.jar");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
@@ -56,7 +56,7 @@ import org.junit.runner.RunWith;
 public class Hibernate2LCacheStatsTestCase {
 
     private static final String FACTORY_CLASS = "<property name=\"hibernate.cache.region.factory_class\">org.jboss.as.jpa.hibernate5.infinispan.InfinispanRegionFactory</property>";
-    private static final String MODULE_DEPENDENCIES = "Dependencies: org.javassist export, org.infinispan export,org.hibernate.envers export,org.hibernate\n";
+    private static final String MODULE_DEPENDENCIES = "Dependencies: org.infinispan export,org.hibernate.envers export,org.hibernate\n";
 
     private static final String ARCHIVE_NAME = "hibernateSecondLevelStats_test";
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
@@ -84,7 +84,7 @@ public class Hibernate4NativeAPIProviderTestCase {
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
         // add required jars as manifest dependencies
-        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate, org.javassist\n"), "MANIFEST.MF");
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate\n"), "MANIFEST.MF");
 
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
         lib.addClasses(SFSBHibernateSessionFactory.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
@@ -84,7 +84,7 @@ public class HibernateNativeAPITransactionTestCase {
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
         // add required jars as manifest dependencies
-        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate, org.javassist\n"), "MANIFEST.MF");
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate\n"), "MANIFEST.MF");
 
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
         lib.addClasses(SFSBHibernateTransaction.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
@@ -83,7 +83,7 @@ public class Hibernate4NativeAPIEnversTestCase {
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
         // add required jars as manifest dependencies
-        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate.envers export,org.hibernate, org.javassist\n"), "MANIFEST.MF");
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate.envers export,org.hibernate\n"), "MANIFEST.MF");
 
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
         lib.addClasses(SFSBHibernateEnversSessionFactory.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
@@ -51,7 +51,7 @@ import org.junit.runner.RunWith;
 public class HibernateSecondLevelCacheTestCase {
 
     private static final String FACTORY_CLASS = "<property name=\"hibernate.cache.region.factory_class\">org.jboss.as.jpa.hibernate5.infinispan.InfinispanRegionFactory</property>";
-    private static final String MODULE_DEPENDENCIES = "Dependencies: org.infinispan,org.hibernate.envers export,org.hibernate, org.javassist\n";
+    private static final String MODULE_DEPENDENCIES = "Dependencies: org.infinispan,org.hibernate.envers export,org.hibernate\n";
 
     private static final String ARCHIVE_NAME = "hibernateSecondLevel_test";
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-5309
https://github.com/jbossas/jboss-eap7/pull/1679
https://issues.jboss.org/browse/WFLY-459

reopens https://github.com/wildfly/wildfly/pull/8474, which was closed due to concern about Hibernate application users wanting to use a different version of Javassist, which we do not support.  So, reopening.