### PR TITLE
[WFLY-8546] Throw StartException in case of Artemis startup failure

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -200,7 +200,7 @@ public class JMSService implements Service<JMSServerManager> {
         } catch(StartException e){
             throw e;
         } catch (Throwable t) {
-            throw MessagingLogger.ROOT_LOGGER.failedToStartService(t);
+            throw new StartException(t);
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }


### PR DESCRIPTION
If Artemis throws any throwable when it is started, throw a corresonding
StartException to prevent the server to start instead of logging an
error.

JIRA: https://issues.jboss.org/browse/WFLY-8546