### PR TITLE
Fix resolveRealMethod to return the correct matching overloaded method

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/ApplicableMethodInformation.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/ApplicableMethodInformation.java
@@ -190,17 +190,18 @@ public class ApplicableMethodInformation<T> {
                     return method.getDeclaringClass().getDeclaredMethods();
                 }
             });
+            methodLoop:
             for (Method m : declaredMethods) {
                 if (m.getName().equals(method.getName())
                         && m.getParameterTypes().length == method.getParameterTypes().length
                         && !m.isBridge()
                         && !m.isSynthetic()) {
                     if(!method.getReturnType().isAssignableFrom(m.getReturnType())) {
-                        continue;
+                        continue methodLoop;
                     }
                     for(int i = 0; i < method.getParameterTypes().length; ++i) {
                         if(!method.getParameterTypes()[i].isAssignableFrom(m.getParameterTypes()[i])) {
-                            continue;
+                            continue methodLoop;
                         }
                     }
                     return m;


### PR DESCRIPTION
Last week, we had some serious issues with the @RolesAllowed annotation on method level. We have one StatelessSessionBean with a remote interface. The bean has two overloaded method (same method name, same return type, same number of arguments, different types of arguments). The first method has a @RolesAllowed annotation, the second one a @PermitAll annotation. It was not possible to call the second method without authentication. After setting the log level of ‘org.jboss.security’ to ‘TRACE’ we detected, that the second method inherited the @RolesAllowed annotation from the first method.

After some serious debugging into the EAP6 / Wildfly code we discovered a bug in the ejb3 code.

In the method org.jboss.as.ejb3.deployment.ApplicableMethodInformation#resolveRealMethod two loops exists. The outer loop iterates over all methods of a class to match name, return type and number of parameters. The inner loop then iterates over the parameters of a matching method. If one parameter type does not match, the next method should be considered. Unfortunately, the inner loop uses a continue without a label. Therefore the inner loop is continued, not the outer one. This will lead to a wrong match and a wrong return value.

The inner loop in the method resolveRealMethod must not continue the inner loop, but the outer one. Otherwise a wrong method could be returned, if a class contains overloaded methods with matching return types and the same number of arguments. This could result in problems when evaluating annotations etc.

I have created a JUnit test that uses two method of the Integer class (valueOf(String), valueOf(int)) to show the bug. The test uses reflection to call the “resolveRealMethod” method and to prepare the parameters.

`package de.hansemerkur.jboss.as.ejb3.deployment;

import java.lang.reflect.Field;
import java.lang.reflect.Method;

import org.jboss.as.ejb3.deployment.ApplicableMethodInformation;
import org.junit.Assert;
import org.junit.Test;

public class ApplicableMethodInformationTest {

	// Taken from java.lang.reflect.Modifier
	private static final int SYNTHETIC = 0x00001000;

	@SuppressWarnings({
		"rawtypes", "unchecked"
	})
	@Test
	public void testResolveRealMethod()
		throws Exception {

		// lookup two methods with the same name, same result type, and same number of args
		Method method1 = Integer.class.getDeclaredMethod("valueOf", String.class);
		Method method2 = Integer.class.getDeclaredMethod("valueOf", Integer.TYPE);

		// create a synthetic version of these two methods
		Method syntheticMethod1 = synthesize(method1);
		Method syntheticMethod2 = synthesize(method2);

		// Use reflection to access the broken method
		ApplicableMethodInformation methodInformation = new ApplicableMethodInformation(null, null);
		Method resolveRealMethod = methodInformation.getClass().getDeclaredMethod("resolveRealMethod", Method.class);
		resolveRealMethod.setAccessible(true);

		// call the broken method to get the real methods
		Method resolvedMethod1 = (Method) resolveRealMethod.invoke(methodInformation, syntheticMethod1);
		Method resolvedMethod2 = (Method) resolveRealMethod.invoke(methodInformation, syntheticMethod2);

		// one of the following asserts will fail, which one depends on the method ordering of the JVM
		Assert.assertEquals(method1, resolvedMethod1);
		Assert.assertEquals(method2, resolvedMethod2);
	}

	private Method synthesize(Method method)
		throws Exception {

		Method syntheticMethod =
			method.getDeclaringClass().getDeclaredMethod(method.getName(), method.getParameterTypes());
		Field modifierField = Method.class.getDeclaredField("modifiers");
		modifierField.setAccessible(true);
		modifierField.set(syntheticMethod, syntheticMethod.getModifiers() | SYNTHETIC);
		return syntheticMethod;
	}
}
`