### PR TITLE
WFLY-8556  WFLY-8555 make web migration work with undertow capabilites

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
@@ -224,7 +224,9 @@ public class WebConnectorDefinition extends ModelOnlyResourceDefinition {
      * Undertow listener is registered for JBoss Web connectors so that the requirement can be satisfied for legacy profiles.
      */
     private final String UNDERTOW_LISTENER_CAPABILITY_NAME = "org.wildfly.undertow.listener";
-    private final RuntimeCapability<Void> FAKE_UNDERTOW_LISTENER_CAPABILITY = RuntimeCapability.Builder.of(UNDERTOW_LISTENER_CAPABILITY_NAME, true).build();
+    private final RuntimeCapability<Void> FAKE_UNDERTOW_LISTENER_CAPABILITY = RuntimeCapability.Builder.of(UNDERTOW_LISTENER_CAPABILITY_NAME, true)
+            .setAllowMultipleRegistrations(true)
+            .build();
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {

--- a/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
@@ -1117,7 +1117,12 @@ public class WebMigrateOperation implements OperationStepHandler {
     private void migrateSubsystem(Map<PathAddress, ModelNode> newAddOperations, ModelNode newAddOp) {
         newAddOp.get(ADDRESS).set(pathAddress(pathElement(SUBSYSTEM, UndertowExtension.SUBSYSTEM_NAME)).toModelNode());
         PathAddress address = pathAddress(newAddOp.get(OP_ADDR));
-        newAddOperations.put(address, createAddOperation(address));
+        ModelNode subsystemAdd = createAddOperation(address);
+        ModelNode defaultServer = newAddOperations.get(address.append(DEFAULT_SERVER_PATH));
+        if (defaultServer.hasDefined(Constants.DEFAULT_HOST)){
+            subsystemAdd.get(Constants.DEFAULT_VIRTUAL_HOST).set(defaultServer.get(Constants.DEFAULT_HOST));
+        }
+        newAddOperations.put(address, subsystemAdd);
     }
 
     private void describeLegacyWebResources(OperationContext context, ModelNode legacyModelDescription) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -75,6 +75,7 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
 
     static final RuntimeCapability<Void> LISTENER_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_LISTENER, true, UndertowListener.class)
             .addDynamicRequirements(Capabilities.CAPABILITY_SERVER)
+            .setAllowMultipleRegistrations(true) //hack to support mod_cluster's legacy profiles
             .build();
     protected static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(Constants.SOCKET_BINDING, ModelType.STRING)
             .setRequired(true)


### PR DESCRIPTION
-  WFLY-8556 Migration of ajp connector via migrate operation fails due …
- WFLY-8555 WebToUndertow default-virtual-host remains unchanged after … 