### PR TITLE
[WFLY-8554] Add credential-reference to pooled-connection-factory resource

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -563,6 +563,7 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Pooled.TRANSACTION,
                                                         ConnectionFactoryAttributes.Pooled.USER,
                                                         ConnectionFactoryAttributes.Pooled.PASSWORD,
+                                                        ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE,
                                                         ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE,
                                                         ConnectionFactoryAttributes.Pooled.USE_AUTO_RECOVERY,
                                                         ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -154,6 +154,7 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         defaultValueAttributeConverter(pooledConnectionFactory, ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE);
         // reject min-pool-size whose default value has been changed in  management version 2.0.0
         defaultValueAttributeConverter(pooledConnectionFactory, ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE);
+        rejectDefinedAttributeWithDefaultValue(pooledConnectionFactory, ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE);
 
         TransformationDescription.Tools.register(subsystem.build(), subsystemRegistration, MessagingExtension.VERSION_1_0_0);
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -203,6 +203,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
         if (password != null && !password.isEmpty()) {
             model.get(ConnectionFactoryAttributes.Pooled.PASSWORD.getName()).set(password);
         }
+
         if (clientId != null && !clientId.isEmpty()) {
             model.get(CommonAttributes.CLIENT_ID.getName()).set(clientId);
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -38,12 +38,14 @@ import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 
@@ -314,6 +316,14 @@ public interface ConnectionFactoryAttributes {
         String SETUP_INTERVAL_PROP_NAME = "setupInterval";
         String REBALANCE_CONNECTIONS_PROP_NAME = "rebalanceConnections";
         String RECONNECT_ATTEMPTS_PROP_NAME = "reconnectAttempts";
+        String PASSWORD_PROP_NAME = "password";
+
+        ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
+                CredentialReference.getAttributeBuilder(true, false)
+                        .setRestartAllServices()
+                        .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
+                        .setAlternatives(PASSWORD_PROP_NAME)
+                        .build();
 
         SimpleAttributeDefinition ENLISTMENT_TRACE = SimpleAttributeDefinitionBuilder.create("enlistment-trace", BOOLEAN)
                 .setAllowNull(true)
@@ -363,12 +373,13 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
-        SimpleAttributeDefinition PASSWORD = SimpleAttributeDefinitionBuilder.create("password", STRING)
-                .setAllowNull(true)
+        SimpleAttributeDefinition PASSWORD = SimpleAttributeDefinitionBuilder.create(PASSWORD_PROP_NAME, STRING)
+                .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
                 .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
+                .addAlternatives(CREDENTIAL_REFERENCE.getName())
                 .build();
 
         SimpleAttributeDefinition REBALANCE_CONNECTIONS = SimpleAttributeDefinitionBuilder.create("rebalance-connections", BOOLEAN)
@@ -460,6 +471,7 @@ public interface ConnectionFactoryAttributes {
                 create(TRANSACTION, null, false),
                 create(USER, "userName", true),
                 create(PASSWORD, "password", true),
+                create(CREDENTIAL_REFERENCE, null, false),
                 create(MANAGED_CONNECTION_POOL, null, false),
                 create(ENLISTMENT_TRACE, null, false),
                 create(MIN_POOL_SIZE, null, false),

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes.Common;
@@ -114,7 +113,6 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
             txSupport = XA_TX;
         }
 
-        ServiceTarget serviceTarget = context.getServiceTarget();
         List<String> connectors = Common.CONNECTORS.unwrap(context, model);
         String discoveryGroupName = getDiscoveryGroup(resolvedModel);
         String jgroupsChannelName = null;
@@ -128,9 +126,9 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
 
         final PathAddress serverAddress = MessagingServices.getActiveMQServerPathAddress(address);
 
-        PooledConnectionFactoryService.installService(serviceTarget,
+        PooledConnectionFactoryService.installService(context,
                 name, serverAddress.getLastElement().getValue(), connectors, discoveryGroupName, jgroupsChannelName,
-                adapterParams, jndiNames, txSupport, minPoolSize, maxPoolSize, managedConnectionPoolClassName, enlistmentTrace);
+                adapterParams, jndiNames, txSupport, minPoolSize, maxPoolSize, managedConnectionPoolClassName, enlistmentTrace, model);
 
         boolean statsEnabled = ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
 

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -682,6 +682,12 @@ pooled-connection-factory.connection-ttl=The connection ttl.
 pooled-connection-factory.connectors=Defines the connectors. These are stored in a map by connector name (with an undefined value). It is possible to pass a list of connector names when writing this attribute.
 pooled-connection-factory.consumer-max-rate=The consumer max rate.
 pooled-connection-factory.consumer-window-size=The consumer window size.
+pooled-connection-factory.credential-reference=Credential (from Credential Store) to authenticate the pooled connection factory
+pooled-connection-factory.credential-reference.store=The name of the credential store holding the alias to credential
+pooled-connection-factory.credential-reference.type=The type of credential this reference is denoting
+pooled-connection-factory.credential-reference.alias=The alias which denotes stored secret or credential in the store
+pooled-connection-factory.credential-reference.clear-text=Secret specified using clear text (check credential store way of supplying credential/secrets to services)
+
 pooled-connection-factory.discovery-group=The discovery group name.
 pooled-connection-factory.discovery-initial-wait-timeout.deprecated=Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute.
 pooled-connection-factory.discovery-initial-wait-timeout=The discovery initial wait time out.

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
@@ -184,7 +184,9 @@ public class MessagingActiveMQSubsystem_1_1_TestCase extends AbstractSubsystemBa
                 .addFailedAttribute(subsystemAddress.append(SERVER_PATH, POOLED_CONNECTION_FACTORY_PATH),
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS,
-                                ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED))
+                                ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED,
+                                ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE
+                        ))
         );
     }
 

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
@@ -434,6 +434,12 @@
                     setup-attempts="${setup-attempts:123}"
                     setup-interval="${setup-interval:456}" />
         </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
     </server>
 
     <server name="empty"/>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
@@ -57,6 +57,12 @@
         <inbound-config
                 rebalance-connections="true" />
         </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
     </server>
     <server name="other">
         <replication-master />


### PR DESCRIPTION
credential-reference is an alternative to the password attribute to
configure the user credentials passed to Artemis RA.

wildfly-messaging-activemq_1_1.xsd is not touched as the schema is already defining the
credential-reference XML element inside pooled-connection-factory XML element.

JIRA: https://issues.jboss.org/browse/WFLY-8554