### PR TITLE
WFLY-8581-8583 Misc JGroups subsystem fixes and cleanup

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/Capability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/Capability.java
@@ -25,12 +25,24 @@ package org.jboss.as.clustering.controller;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.clustering.service.Requirement;
 
 /**
  * Interface to be implemented by capability enumerations.
  * @author Paul Ferraro
  */
-public interface Capability extends Definable<RuntimeCapability<?>>, ResourceServiceNameFactory {
+public interface Capability extends Definable<RuntimeCapability<?>>, Requirement, ResourceServiceNameFactory {
+
+    @Override
+    default String getName() {
+        return this.getDefinition().getName();
+    }
+
+    @Override
+    default Class<?> getType() {
+        return this.getDefinition().getCapabilityServiceValueType();
+    }
+
     /**
      * Resolves this capability against the specified path address
      * @param address a path address

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CommonRequirement.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CommonRequirement.java
@@ -34,6 +34,7 @@ import org.wildfly.clustering.service.Requirement;
  * @author Paul Ferraro
  */
 public enum CommonRequirement implements Requirement, ServiceNameFactoryProvider {
+    ELYTRON("org.wildfly.security.elytron", Void.class),
     MBEAN_SERVER("org.wildfly.management.jmx", MBeanServer.class),
     NAMING_STORE(NamingService.CAPABILITY_NAME, NamingStore.class),
     PATH_MANAGER("org.wildfly.management.path-manager", PathManager.class),

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -142,4 +142,7 @@ public interface JGroupsLogger extends BasicLogger {
 
     @Message(id = 26, value = "No %s operation registered at %s")
     OperationFailedException operationNotDefined(String operation, String address);
+
+    @Message(id = 27, value = "Failed to synthesize key-store add operation due to missing %s property")
+    OperationFailedException missingKeyStoreProperty(String propertyName);
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityProvider;
 import org.jboss.as.clustering.controller.CapabilityReference;
@@ -35,9 +36,7 @@ import org.jboss.as.clustering.controller.SimpleResourceRegistration;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
 import org.jboss.as.clustering.controller.validation.ModuleIdentifierValidatorBuilder;
-import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -99,40 +98,28 @@ public class ChannelResourceDefinition extends ChildResourceDefinition<Managemen
     }
 
     public enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        STACK("stack", ModelType.STRING, new CapabilityReference(Capability.JCHANNEL_FACTORY, JGroupsRequirement.CHANNEL_FACTORY)),
-        MODULE("module", ModelType.STRING, new ModelNode("org.wildfly.clustering.server"), new ModuleIdentifierValidatorBuilder()),
+        STACK("stack", ModelType.STRING, builder -> builder
+                .setRequired(true)
+                .setAllowExpression(false)
+                .setCapabilityReference(new CapabilityReference(Capability.JCHANNEL_FACTORY, JGroupsRequirement.CHANNEL_FACTORY))),
+        MODULE("module", ModelType.STRING, builder -> builder
+                .setDefaultValue(new ModelNode("org.wildfly.clustering.server"))
+                .setValidator(new ModuleIdentifierValidatorBuilder().configure(builder).build())),
         CLUSTER("cluster", ModelType.STRING),
-        STATISTICS_ENABLED("statistics-enabled", ModelType.BOOLEAN, new ModelNode(false)),
+        STATISTICS_ENABLED("statistics-enabled", ModelType.BOOLEAN, builder -> builder.setDefaultValue(new ModelNode(false))),
         ;
         private final AttributeDefinition definition;
 
         Attribute(String name, ModelType type) {
-            this.definition = createBuilder(name, type).build();
+            this(name,  type, UnaryOperator.identity());
         }
 
-        Attribute(String name, ModelType type, ModelNode defaultValue) {
-            this.definition = createBuilder(name, type).setDefaultValue(defaultValue).build();
-        }
-
-        Attribute(String name, ModelType type, ModelNode defaultValue, ParameterValidatorBuilder validator) {
-            SimpleAttributeDefinitionBuilder builder = createBuilder(name, type).setDefaultValue(defaultValue);
-            this.definition = builder.setValidator(validator.configure(builder).build()).build();
-        }
-
-        Attribute(String name, ModelType type, CapabilityReferenceRecorder reference) {
-            this.definition = createBuilder(name, type)
-                    .setAllowExpression(false)
-                    .setRequired(true)
-                    .setCapabilityReference(reference)
-                    .build();
-        }
-
-        private static SimpleAttributeDefinitionBuilder createBuilder(String name, ModelType type) {
-            return new SimpleAttributeDefinitionBuilder(name, type)
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
                     .setAllowExpression(true)
                     .setRequired(false)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            ;
+                    ).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -59,6 +59,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
@@ -107,7 +108,10 @@ public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptPr
         private final AttributeDefinition definition;
 
         Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
-            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type).setRequired(true)).build();
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
+                    .setRequired(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    ).build();
         }
 
         Attribute(AttributeDefinition definition) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -175,7 +175,10 @@ public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptPr
         private static final SYM_ENCRYPT DEFAULTS = new SYM_ENCRYPT();
         private final Map<String, ModelNode> properties;
 
-        LegacySymmetricEncryptDescriptor(Map<String, ModelNode> properties) {
+        LegacySymmetricEncryptDescriptor(Map<String, ModelNode> properties) throws OperationFailedException {
+            if (!properties.containsKey("keystore_name")) {
+                throw JGroupsLogger.ROOT_LOGGER.missingKeyStoreProperty("keystore_name");
+            }
             this.properties = properties;
         }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -56,7 +56,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -79,31 +78,10 @@ import org.wildfly.security.x500.cert.X509CertificateBuilder;
  */
 public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptProtocol> extends ProtocolResourceDefinition<P> {
 
-    enum Capability implements org.jboss.as.clustering.controller.Capability {
-        ENCRYPT_CREDENTIAL_STORE("org.wildfly.clustering.jgroups.protocol.credential-store"),
-        ENCRYPT_KEY_STORE("org.wildfly.clustering.jgroups.protocol.key-store"),
-        ;
-        private final RuntimeCapability<Void> definition;
-
-        Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).build();
-        }
-
-        @Override
-        public RuntimeCapability<Void> getDefinition() {
-            return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability<?> resolve(PathAddress address) {
-            return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue());
-        }
-    }
-
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false, new CapabilityReference(Capability.ENCRYPT_CREDENTIAL_STORE, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
+        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false, new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
         KEY_ALIAS("key-alias", ModelType.STRING, builder -> builder.setAllowExpression(true)),
-        KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.ENCRYPT_KEY_STORE, CommonUnaryRequirement.KEY_STORE))),
+        KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.KEY_STORE))),
         ;
         private final AttributeDefinition definition;
 
@@ -306,8 +284,7 @@ public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptPr
     public EncryptProtocolResourceDefinition(String name, Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
         super(pathElement(name), descriptorConfigurator.andThen(descriptor -> descriptor
                 .addAttributes(Attribute.class)
-                .addCapabilities(Capability.class)
                 .addOperationTranslator(ADD_OPERATION_TRANSLATOR)
-            ), address -> new EncryptProtocolConfigurationBuilder<>(address), parentBuilderFactory);
+                ), address -> new EncryptProtocolConfigurationBuilder<>(address), parentBuilderFactory);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -80,8 +80,8 @@ import org.wildfly.security.x500.cert.X509CertificateBuilder;
 public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptProtocol> extends ProtocolResourceDefinition<P> {
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        ENCRYPT_CREDENTIAL_STORE("org.wildfly.extension.undertow.application-security-domain.single-sign-on.credential-store"),
-        ENCRYPT_KEY_STORE("org.wildfly.extension.undertow.application-security-domain.single-sign-on.key-store"),
+        ENCRYPT_CREDENTIAL_STORE("org.wildfly.clustering.jgroups.protocol.credential-store"),
+        ENCRYPT_KEY_STORE("org.wildfly.clustering.jgroups.protocol.key-store"),
         ;
         private final RuntimeCapability<Void> definition;
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import javax.security.auth.x500.X500Principal;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.CommonRequirement;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -112,6 +113,9 @@ public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptPr
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             if (!operation.hasDefined(Attribute.KEY_STORE.getName()) && !operation.hasDefined(Attribute.KEY_ALIAS.getName()) && !operation.hasDefined(Attribute.CREDENTIAL.getName())) {
+                // Ensure Elytron subsystem exists
+                context.requireOptionalCapability(CommonRequirement.ELYTRON.getName(), Capability.PROTOCOL.getName(), AbstractProtocolResourceDefinition.Attribute.PROPERTIES.getName());
+
                 // Locate subsystem address
                 PathAddress subsystemAddress = context.getCurrentAddress().getParent();
                 while (!subsystemAddress.getLastElement().getKey().equals(ModelDescriptionConstants.SUBSYSTEM)) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JDBCProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JDBCProtocolResourceDefinition.java
@@ -32,9 +32,7 @@ import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.jgroups.protocol.JDBCProtocol;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelType;
@@ -47,28 +45,8 @@ import org.wildfly.clustering.jgroups.spi.ChannelFactory;
  */
 public class JDBCProtocolResourceDefinition<P extends Protocol & JDBCProtocol> extends ProtocolResourceDefinition<P> {
 
-    enum Capability implements org.jboss.as.clustering.controller.Capability {
-        DATA_SOURCE("org.wildfly.clustering.jgroups.jdbc-ping.data-source"),
-        ;
-        private final RuntimeCapability<Void> definition;
-
-        Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).build();
-        }
-
-        @Override
-        public RuntimeCapability<Void> getDefinition() {
-            return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability<Void> resolve(PathAddress address) {
-            return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue(), address.getLastElement().getValue());
-        }
-    }
-
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DATA_SOURCE("data-source", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.DATA_SOURCE, CommonUnaryRequirement.DATA_SOURCE))),
+        DATA_SOURCE("data-source", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.DATA_SOURCE))),
         ;
         private final AttributeDefinition definition;
 
@@ -94,7 +72,6 @@ public class JDBCProtocolResourceDefinition<P extends Protocol & JDBCProtocol> e
     JDBCProtocolResourceDefinition(String name, Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
         super(pathElement(name), descriptorConfigurator.andThen(descriptor -> descriptor
                 .addAttributes(Attribute.class)
-                .addCapabilities(Capability.class)
-            ), address -> new JDBCProtocolConfigurationBuilder<>(address), parentBuilderFactory);
+                ), address -> new JDBCProtocolConfigurationBuilder<>(address), parentBuilderFactory);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JDBCProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JDBCProtocolResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
@@ -30,7 +31,6 @@ import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.jgroups.protocol.JDBCProtocol;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -68,17 +68,16 @@ public class JDBCProtocolResourceDefinition<P extends Protocol & JDBCProtocol> e
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        DATA_SOURCE("data-source", ModelType.STRING, new CapabilityReference(Capability.DATA_SOURCE, CommonUnaryRequirement.DATA_SOURCE)),
+        DATA_SOURCE("data-source", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.DATA_SOURCE, CommonUnaryRequirement.DATA_SOURCE))),
         ;
         private final AttributeDefinition definition;
 
-        Attribute(String name, ModelType type, CapabilityReferenceRecorder reference) {
-            this.definition = new SimpleAttributeDefinitionBuilder(name, type)
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
                     .setAllowExpression(false)
                     .setRequired(true)
-                    .setCapabilityReference(reference)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                    .build();
+                    ).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
@@ -344,6 +344,10 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
                     readAttribute(reader, i, operation, TransportResourceDefinition.Attribute.SHARED);
                     break;
                 }
+                case SOCKET_BINDING: {
+                    readAttribute(reader, i, operation, TransportResourceDefinition.Attribute.SOCKET_BINDING);
+                    break;
+                }
                 case DIAGNOSTICS_SOCKET_BINDING: {
                     readAttribute(reader, i, operation, TransportResourceDefinition.Attribute.DIAGNOSTICS_SOCKET_BINDING);
                     break;
@@ -383,7 +387,7 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
                     }
                 }
                 default: {
-                    this.parseSocketProtocolAttribute(reader, i, operation);
+                    this.parseProtocolAttribute(reader, i, operation);
                 }
             }
         }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
@@ -110,7 +110,6 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
         writer.writeStartElement(XMLElement.TRANSPORT.getLocalName());
         writeGenericProtocolAttributes(writer, property);
         ModelNode transport = property.getValue();
-        writeAttributes(writer, transport, SocketBindingProtocolResourceDefinition.Attribute.class);
         writeAttributes(writer, transport, TransportResourceDefinition.Attribute.class);
         writeAttributes(writer, transport, TransportResourceDefinition.ThreadingAttribute.class);
         writeElement(writer, transport, AbstractProtocolResourceDefinition.Attribute.PROPERTIES);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -36,8 +36,10 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
@@ -64,7 +66,11 @@ public class ProtocolResourceDefinition<P extends Protocol> extends AbstractProt
         private final AttributeDefinition definition;
 
         DeprecatedAttribute(String name, ModelType type, JGroupsModel deprecation) {
-            this.definition = createBuilder(name, type, null).setDeprecated(deprecation.getVersion()).build();
+            this.definition = new SimpleAttributeDefinitionBuilder(name, type)
+                    .setRequired(false)
+                    .setDeprecated(deprecation.getVersion())
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -132,9 +132,9 @@ public class ProtocolResourceDefinition<P extends Protocol> extends AbstractProt
     }
 
     ProtocolResourceDefinition(Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ProtocolConfiguration<P>> builderFactory, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
-        super(new Parameters(WILDCARD_PATH, new JGroupsResourceDescriptionResolver(WILDCARD_PATH)).setOrderedChild(), descriptor -> descriptor
+        super(new Parameters(WILDCARD_PATH, new JGroupsResourceDescriptionResolver(WILDCARD_PATH)).setOrderedChild(), descriptorConfigurator.andThen(descriptor -> descriptor
                 .addExtraParameters(DeprecatedAttribute.class)
-            , builderFactory, parentBuilderFactory, (parent, registration) -> {
+            ), builderFactory, parentBuilderFactory, (parent, registration) -> {
                 EnumSet.allOf(DeprecatedAttribute.class).forEach(attribute -> registration.registerReadOnlyAttribute(attribute.getDefinition(), null));
             });
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import java.util.function.UnaryOperator;
+
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
@@ -29,7 +31,6 @@ import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceRegistration;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -80,15 +81,15 @@ public class RemoteSiteResourceDefinition extends ChildResourceDefinition<Manage
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CHANNEL("channel", ModelType.STRING, new CapabilityReference(Capability.RELAY_CHANNEL_SOURCE, JGroupsRequirement.CHANNEL_SOURCE)),
+        CHANNEL("channel", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.RELAY_CHANNEL_SOURCE, JGroupsRequirement.CHANNEL_SOURCE))),
         ;
         private final AttributeDefinition definition;
 
-        Attribute(String name, ModelType type, CapabilityReferenceRecorder reference) {
-            this.definition = createBuilder(name, type)
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, ModelType.STRING)
                     .setRequired(true)
-                    .setCapabilityReference(reference)
-                    .build();
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    ).build();
         }
 
         @Override
@@ -104,14 +105,12 @@ public class RemoteSiteResourceDefinition extends ChildResourceDefinition<Manage
         private final AttributeDefinition definition;
 
         DeprecatedAttribute(String name, ModelType type, JGroupsModel deprecation) {
-            this.definition = createBuilder(name, type).setRequired(false).setDeprecated(deprecation.getVersion()).build();
-        }
-
-        private static SimpleAttributeDefinitionBuilder createBuilder(String name, ModelType type) {
-            return new SimpleAttributeDefinitionBuilder(name, ModelType.STRING)
-                .setAllowExpression(true)
-                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            ;
+            this.definition = new SimpleAttributeDefinitionBuilder(name, ModelType.STRING)
+                    .setRequired(false)
+                    .setAllowExpression(true)
+                    .setDeprecated(deprecation.getVersion())
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
@@ -61,7 +61,7 @@ public class RemoteSiteResourceDefinition extends ChildResourceDefinition<Manage
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        RELAY_CHANNEL_SOURCE("org.wildfly.clustering.jgroups.stack.relay.site-channel-source"),
+        REMOTE_SITE("org.wildfly.clustering.jgroups.remote-site"),
         ;
         private final RuntimeCapability<Void> definition;
 
@@ -81,7 +81,7 @@ public class RemoteSiteResourceDefinition extends ChildResourceDefinition<Manage
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CHANNEL("channel", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.RELAY_CHANNEL_SOURCE, JGroupsRequirement.CHANNEL_SOURCE))),
+        CHANNEL("channel", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.REMOTE_SITE, JGroupsRequirement.CHANNEL_SOURCE))),
         ;
         private final AttributeDefinition definition;
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/SocketBindingProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/SocketBindingProtocolResourceDefinition.java
@@ -31,10 +31,8 @@ import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -49,30 +47,10 @@ import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
  */
 public class SocketBindingProtocolResourceDefinition<P extends Protocol> extends ProtocolResourceDefinition<P> {
 
-    enum Capability implements org.jboss.as.clustering.controller.Capability {
-        SOCKET_BINDING("org.wildfly.clustering.protocol.socket-binding"),
-        ;
-        private final RuntimeCapability<Void> definition;
-
-        Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).build();
-        }
-
-        @Override
-        public RuntimeCapability<Void> getDefinition() {
-            return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability<Void> resolve(PathAddress address) {
-            return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue(), address.getLastElement().getValue());
-        }
-    }
-
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, builder -> builder
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
-                .setCapabilityReference(new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
+                .setCapabilityReference(new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.SOCKET_BINDING))),
         ;
         private final AttributeDefinition definition;
 
@@ -97,7 +75,6 @@ public class SocketBindingProtocolResourceDefinition<P extends Protocol> extends
     SocketBindingProtocolResourceDefinition(String name, Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ProtocolConfiguration<P>> builderFactory, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
         super(pathElement(name), descriptorConfigurator.andThen(descriptor -> descriptor
                 .addAttributes(Attribute.class)
-                .addCapabilities(Capability.class)
-            ), builderFactory, parentBuilderFactory);
+                ), builderFactory, parentBuilderFactory);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/SocketBindingProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/SocketBindingProtocolResourceDefinition.java
@@ -23,17 +23,16 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -71,15 +70,17 @@ public class SocketBindingProtocolResourceDefinition<P extends Protocol> extends
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING)),
+        SOCKET_BINDING(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, builder -> builder
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+                .setCapabilityReference(new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
         ;
         private final AttributeDefinition definition;
 
-        Attribute(String name, ModelType type, AccessConstraintDefinition constraint, CapabilityReferenceRecorder reference) {
-            this.definition = new SimpleAttributeDefinitionBuilder(name, type)
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
                     .setRequired(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                    .setAccessConstraints(constraint).setCapabilityReference(reference).build();
+                    ).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
@@ -85,7 +85,7 @@ public class StackResourceDefinition extends ChildResourceDefinition<ManagementR
                     .setRequired(false)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            ).build();
+                    ).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.clustering.jgroups.subsystem.SocketBindingProtocolResourceDefinition.Attribute.*;
 import static org.jboss.as.clustering.jgroups.subsystem.TransportResourceDefinition.Attribute.*;
 
 import java.net.InetSocketAddress;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -27,6 +27,7 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
@@ -49,7 +50,6 @@ import org.jboss.as.clustering.controller.transform.SimpleReadAttributeOperation
 import org.jboss.as.clustering.controller.transform.SimpleRemoveOperationTransformer;
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -57,7 +57,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -112,8 +111,12 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        @Deprecated SHARED("shared", ModelType.BOOLEAN, new ModelNode(false), JGroupsModel.VERSION_4_0_0),
-        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF, new CapabilityReference(Capability.DIAGNOSTICS_SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING)),
+        @Deprecated SHARED("shared", ModelType.BOOLEAN, builder -> builder
+                .setDefaultValue(new ModelNode(false))
+                .setDeprecated(JGroupsModel.VERSION_4_0_0.getVersion())),
+        DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, builder -> builder
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+                .setCapabilityReference(new CapabilityReference(Capability.DIAGNOSTICS_SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
         SITE("site", ModelType.STRING),
         RACK("rack", ModelType.STRING),
         MACHINE("machine", ModelType.STRING),
@@ -121,23 +124,15 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
         private final AttributeDefinition definition;
 
         Attribute(String name, ModelType type) {
-            this.definition = createBuilder(name, type).build();
+            this(name, type, UnaryOperator.identity());
         }
 
-        Attribute(String name, ModelType type, ModelNode defaultValue, JGroupsModel deprecation) {
-            this.definition = createBuilder(name, type).setDefaultValue(defaultValue).setDeprecated(deprecation.getVersion()).build();
-        }
-
-        Attribute(String name, ModelType type, AccessConstraintDefinition constraint, CapabilityReferenceRecorder reference) {
-            this.definition = createBuilder(name, type).setAccessConstraints(constraint).setCapabilityReference(reference).build();
-        }
-
-        private static SimpleAttributeDefinitionBuilder createBuilder(String name, ModelType type) {
-            return new SimpleAttributeDefinitionBuilder(name, type)
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
                     .setAllowExpression(true)
                     .setRequired(false)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            ;
+                    ).build();
         }
 
         @Override
@@ -158,7 +153,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
         ThreadingAttribute(String name) {
             this.definition = new SimpleAttributeDefinitionBuilder(name, ModelType.STRING)
                     .setAllowExpression(false)
-                    .setAllowNull(true)
+                    .setRequired(false)
                     .setDeprecated(JGroupsModel.VERSION_3_0_0.getVersion())
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
                     .build();

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -91,6 +91,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
+        SOCKET_BINDING("org.wildfly.clustering.transport.socket-binding"),
         DIAGNOSTICS_SOCKET_BINDING("org.wildfly.clustering.transport.diagnostics-socket-binding"),
         ;
         private final RuntimeCapability<Void> definition;
@@ -114,6 +115,9 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
         @Deprecated SHARED("shared", ModelType.BOOLEAN, builder -> builder
                 .setDefaultValue(new ModelNode(false))
                 .setDeprecated(JGroupsModel.VERSION_4_0_0.getVersion())),
+        SOCKET_BINDING("socket-binding", ModelType.STRING, builder -> builder
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+                .setCapabilityReference(new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
         DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, builder -> builder
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
                 .setCapabilityReference(new CapabilityReference(Capability.DIAGNOSTICS_SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
@@ -232,9 +236,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
     private TransportResourceDefinition(Parameters parameters, ResourceServiceBuilderFactory<TransportConfiguration<T>> builderFactory, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
         super(parameters, descriptor -> descriptor
                 .addAttributes(Attribute.class)
-                .addAttributes(SocketBindingProtocolResourceDefinition.Attribute.class)
                 .addCapabilities(Capability.class)
-                .addCapabilities(SocketBindingProtocolResourceDefinition.Capability.class)
                 .addExtraParameters(ThreadingAttribute.class)
                 .addRequiredChildren(ThreadPoolResourceDefinition.class)
             , builderFactory, parentBuilderFactory, (parent, registration) -> {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -107,7 +107,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
 
         @Override
         public RuntimeCapability<Void> resolve(PathAddress address) {
-            return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue(), address.getLastElement().getValue());
+            return this.definition.fromBaseCapability(address.getParent().getLastElement().getValue());
         }
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -91,8 +91,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        SOCKET_BINDING("org.wildfly.clustering.transport.socket-binding"),
-        DIAGNOSTICS_SOCKET_BINDING("org.wildfly.clustering.transport.diagnostics-socket-binding"),
+        TRANSPORT("org.wildfly.clustering.jgroups.transport"),
         ;
         private final RuntimeCapability<Void> definition;
 
@@ -117,10 +116,10 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
                 .setDeprecated(JGroupsModel.VERSION_4_0_0.getVersion())),
         SOCKET_BINDING("socket-binding", ModelType.STRING, builder -> builder
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
-                .setCapabilityReference(new CapabilityReference(Capability.SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
+                .setCapabilityReference(new CapabilityReference(Capability.TRANSPORT, CommonUnaryRequirement.SOCKET_BINDING))),
         DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, builder -> builder
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
-                .setCapabilityReference(new CapabilityReference(Capability.DIAGNOSTICS_SOCKET_BINDING, CommonUnaryRequirement.SOCKET_BINDING))),
+                .setCapabilityReference(new CapabilityReference(Capability.TRANSPORT, CommonUnaryRequirement.SOCKET_BINDING))),
         SITE("site", ModelType.STRING),
         RACK("rack", ModelType.STRING),
         MACHINE("machine", ModelType.STRING),


### PR DESCRIPTION
WFLY-8581 Runtime resources not registered for JGroups fork protocols
https://issues.jboss.org/browse/WFLY-8581
WFLY-8582 Legacy encrypt protocol support is missing a requirement on elytron subsystem
https://issues.jboss.org/browse/WFLY-8582
WFLY-8583 Uninformative IAE when adding SYM_ENCRYPT via legacy properties
https://issues.jboss.org/browse/WFLY-8583