### PR TITLE
[WFLY-8427] compare destroyedCount with real value after pool has bee…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/XADatasourceCapacityPoliciesTestCase.java
@@ -25,8 +25,6 @@ package org.jboss.as.test.integration.jca.capacitypolicies;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
-import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -51,9 +49,4 @@ public class XADatasourceCapacityPoliciesTestCase extends AbstractDatasourceCapa
         }
     }
 
-    @Test
-    @Ignore("WFLY-8427")
-    public void testNonDefaultDecrementerAndIncrementer() throws Exception {
-
-    }
 }


### PR DESCRIPTION
…n filled, not with 0

https://issues.jboss.org/browse/WFLY-8427

