### PR TITLE
[WFLY-8593] Wildfly should log bound ports

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
@@ -63,7 +63,8 @@ public class AjpListenerService extends ListenerService {
     void startListening(XnioWorker worker, InetSocketAddress socketAddress, ChannelListener<AcceptingChannel<StreamConnection>> acceptListener) throws IOException {
         server = worker.createStreamConnectionServer(socketAddress, acceptListener, OptionMap.builder().addAll(commonOptions).addAll(socketOptions).getMap());
         server.resumeAccepts();
-        UndertowLogger.ROOT_LOGGER.listenerStarted("AJP", getName(), NetworkUtils.formatIPAddressForURI(binding.getValue().getSocketAddress().getAddress()), getBinding().getValue().getSocketAddress().getPort());
+        final InetSocketAddress boundAddress = server.getLocalAddress(InetSocketAddress.class);
+        UndertowLogger.ROOT_LOGGER.listenerStarted("AJP", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
     }
 
     @Override
@@ -73,10 +74,11 @@ public class AjpListenerService extends ListenerService {
 
     @Override
     void stopListening() {
+        final InetSocketAddress boundAddress = server.getLocalAddress(InetSocketAddress.class);
         server.suspendAccepts();
         UndertowLogger.ROOT_LOGGER.listenerSuspend("AJP", getName());
         IoUtils.safeClose(server);
-        UndertowLogger.ROOT_LOGGER.listenerStopped("AJP", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getSocketAddress().getPort());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("AJP", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
@@ -105,7 +105,9 @@ public class HttpListenerService extends ListenerService {
             throws IOException {
         server = worker.createStreamConnectionServer(socketAddress, acceptListener, OptionMap.builder().addAll(commonOptions).addAll(socketOptions).getMap());
         server.resumeAccepts();
-        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTP", getName(), NetworkUtils.formatIPAddressForURI(socketAddress.getAddress()), socketAddress.getPort());
+
+        final InetSocketAddress boundAddress = server.getLocalAddress(InetSocketAddress.class);
+        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTP", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
     }
 
     @Override
@@ -120,11 +122,12 @@ public class HttpListenerService extends ListenerService {
 
     @Override
     protected void stopListening() {
+        final InetSocketAddress boundAddress = server.getLocalAddress(InetSocketAddress.class);
         server.suspendAccepts();
         UndertowLogger.ROOT_LOGGER.listenerSuspend("HTTP", getName());
         IoUtils.safeClose(server);
         server = null;
-        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTP", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getSocketAddress().getPort());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTP", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
@@ -127,7 +127,8 @@ public class HttpsListenerService extends HttpListenerService {
         sslServer = xnioSsl.createSslConnectionServer(worker, socketAddress, (ChannelListener) acceptListener, combined);
         sslServer.resumeAccepts();
 
-        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(socketAddress.getAddress()), socketAddress.getPort());
+        final InetSocketAddress boundAddress = sslServer.getLocalAddress(InetSocketAddress.class);
+        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
     }
 
     @Override
@@ -137,11 +138,12 @@ public class HttpsListenerService extends HttpListenerService {
 
     @Override
     protected void stopListening() {
+        final InetSocketAddress boundAddress = sslServer.getLocalAddress(InetSocketAddress.class);
         sslServer.suspendAccepts();
         UndertowLogger.ROOT_LOGGER.listenerSuspend("HTTPS", getName());
         IoUtils.safeClose(sslServer);
         sslServer = null;
-        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getSocketAddress().getPort());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(boundAddress.getAddress()), boundAddress.getPort());
         httpListenerRegistry.getValue().removeListener(getName());
     }
 


### PR DESCRIPTION
When specifying that Wildfly should bind to an ephemeral port (by specifying the port number as 0), Wildfly dutifully logs that it is bound to port 0. Yet, this is not right as instead the networking layer determined an actual port number when binding the socket. Instead, Wildfly should log the actual port that it is bound to. This commit causes this to be the case.

Relates https://issues.jboss.org/browse/WFLY-8593
