### PR TITLE
WFLY-8620 wildfly-bean-validation LazyValidatorFactoryTestCase test failed when running with JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6362,6 +6362,7 @@
                     --add-opens=java.naming/javax.naming=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+                    --add-modules=java.xml.bind
                 </modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Dsun.reflect.debugModuleAccessChecks=true</modular.jdk.props>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8620