### PR TITLE
[WFLY-8628] [WFLY-8630] Fix the client passwords specified in both SwitchIdentityTestCase#testClientLoginModule tests and unignore these tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
@@ -53,7 +53,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
@@ -86,10 +85,10 @@ public class SwitchIdentityTestCase {
 
     public SwitchIdentityTestCase() {
         passwordsToUse = new HashMap<>();
-        passwordsToUse.put("guest", "b5d048a237bfd2874b6928e1f37ee15e");
-        passwordsToUse.put("user1", "23624d2f74dfcb9688651a066d90b97e");
-        passwordsToUse.put("user2", "ab3f9e12039435236d89de9023a304b7");
-        passwordsToUse.put("remoteejbuser", "d37cd830cc282510807b82c4b861256d");
+        passwordsToUse.put("guest", "guest");
+        passwordsToUse.put("user1", "password1");
+        passwordsToUse.put("user2", "password2");
+        passwordsToUse.put("remoteejbuser", "rem@teejbpasswd1");
     }
 
     // Public methods --------------------------------------------------------
@@ -137,7 +136,6 @@ public class SwitchIdentityTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("WFLY-8630")
     public void testClientLoginModule() throws Exception {
         callUsingClientLoginModule("guest", false, false);
         callUsingClientLoginModule("user1", true, false);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
@@ -58,7 +58,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
@@ -88,10 +87,10 @@ public class SwitchIdentityTestCase {
 
     public SwitchIdentityTestCase() {
         passwordsToUse = new HashMap<>();
-        passwordsToUse.put("guest", "b5d048a237bfd2874b6928e1f37ee15e");
-        passwordsToUse.put("user1", "23624d2f74dfcb9688651a066d90b97e");
-        passwordsToUse.put("user2", "ab3f9e12039435236d89de9023a304b7");
-        passwordsToUse.put("remoteejbuser", "d37cd830cc282510807b82c4b861256d");
+        passwordsToUse.put("guest", "guest");
+        passwordsToUse.put("user1", "password1");
+        passwordsToUse.put("user2", "password2");
+        passwordsToUse.put("remoteejbuser", "rem@teejbpasswd1");
     }
 
     @ArquillianResource
@@ -160,7 +159,6 @@ public class SwitchIdentityTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("WFLY-8630")
     public void testClientLoginModule() throws Exception {
         callUsingClientLoginModule("guest", false, false);
         callUsingClientLoginModule("user1", true, false);


### PR DESCRIPTION
Both SwitchIdentityTestCase classes were [recently updated](https://github.com/wildfly/wildfly/pull/9959/commits/51b5f4ce004c55ea223e68a98bd38093dcc88e1d#diff-41a38e2cc0d77c3b9ce826e3d6801189R84) to specify the client passwords that should be used by these tests. Before this change, it turns out that these tests were only passing because the JBOSS-LOCAL-USER mechanism was erroneously getting used instead of the DIGEST-MD5 mechanism. These tests are currently failing because the client passwords should be clear passwords instead of the hashed passwords.

https://issues.jboss.org/browse/WFLY-8628
https://issues.jboss.org/browse/WFLY-8630