### PR TITLE
WFLY-8335 - User should be informed when switching between JDBC and ournal store in transactions subsystem

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
@@ -21,6 +21,16 @@
  */
 package org.jboss.as.test.manualmode.transaction;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROCESS_STATE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,24 +45,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-import java.util.Map;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROCESS_STATE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 /**
  * @author Ivo Studensky
  */
 @RunWith(Arquillian.class)
 @RunAsClient
 public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
+    @SuppressWarnings("unused")
     private static Logger log = Logger.getLogger(ObjectStoreTypeTestCase.class);
 
     private static final String CONTAINER = "default-jbossas";
+    private static final String JDBC_STORE_DS_NAME = "ObjectStoreTestDS";
 
     @ArquillianResource
     private static ContainerController container;
@@ -61,6 +64,9 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
     public void before() throws Exception {
         container.start(CONTAINER);
         initCLI(TimeoutUtil.adjust(20 * 1000));
+        String objectStoreType = readObjectStoreType();
+        assertTrue("Invalid store type: " + objectStoreType,
+                objectStoreType.equals("journal") || objectStoreType.equals("default"));
     }
 
     @After
@@ -69,197 +75,181 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
         container.stop(CONTAINER);
     }
 
+    @SuppressWarnings("rawtypes")
+    private void check(String objectStoreTypeExpected) throws IOException, MgmtOperationException {
+        final CLIOpResult ret = cli.readAllAsOpResult();
+        if (ret != null && ret.getFromResponse(RESPONSE_HEADERS) != null) {
+            assertEquals("restart-required", (String) ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
+            cli.sendLine("reload");
+        }
+
+        String objectStoreType = readObjectStoreType();
+        assertEquals(objectStoreTypeExpected, objectStoreType);
+    }
+
     @Test
     public void testHornetQObjectStore() throws IOException, MgmtOperationException {
         try {
-            String objectStoreType = readObjectStoreType();
-            assertEquals("default", objectStoreType);
-
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-hornetq-store, value=true)");
-            final CLIOpResult ret = cli.readAllAsOpResult();
-            assertEquals("restart-required", (String) ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
-
-            cli.sendLine("reload");
-
-            objectStoreType = readObjectStoreType();
-
-            // use-hornetq-store should have the same effect of use-journal-store even if it was deprecated
-            assertEquals("journal", objectStoreType);
-
+            useJournalStore();
         } finally {
             setDefaultObjectStore();
         }
-
     }
 
     @Test
     public void testJournalObjectStore() throws IOException, MgmtOperationException {
         try {
-            String objectStoreType = readObjectStoreType();
-            assertEquals("default", objectStoreType);
-
             cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=true)");
-            final CLIOpResult ret = cli.readAllAsOpResult();
-            assertEquals("restart-required", (String) ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
-
-            cli.sendLine("reload");
-
-            objectStoreType = readObjectStoreType();
-            assertEquals("journal", objectStoreType);
-
+            check("journal");
         } finally {
             setDefaultObjectStore();
         }
-
     }
 
     @Test
     public void testJdbcObjectStore() throws IOException, MgmtOperationException {
-
         try {
-            String objectStoreType = readObjectStoreType();
-            assertEquals("default", objectStoreType);
-
-            // add data source
-            createDataSource();
-
-            cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/ObjectStoreTestDS)");
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
-            final CLIOpResult ret = cli.readAllAsOpResult();
-            assertEquals("restart-required", ((Map) ret.getFromResponse(RESPONSE_HEADERS)).get(PROCESS_STATE));
-
-            cli.sendLine("reload");
-
-            objectStoreType = readObjectStoreType();
-            assertEquals("jdbc", objectStoreType);
-
+            useJdbcStore();
+            check("jdbc");
         } finally {
-            try {
-                setDefaultObjectStore(true);
-            } finally {
-                // remove data source
-                removeDataSource();
-            }
+            cleanJdbcSettingsAndResetToObjectStore();
         }
+    }
+
+    @Test
+    public void ifJournalIsTrueThenHornetQToo() {
+        // default is 'journal' so checking directly
+        checkThatAllUseAttributesAreConsistent("true", "false", "true");
+    }
+
+    private void useJdbcStore() throws IOException {
+        useJdbcStore(true);
+    }
+
+    private void useJdbcStore(boolean expectedResults) throws IOException {
+        // 1 - Create DS - required for the JDBC store
+        createDataSource();
+        // 2 - Set the value for 'jdbc-store-datasource'
+        cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/"
+                + JDBC_STORE_DS_NAME + ")");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertTrue("Failed to set jdbc-store-datasource.", result.isIsOutcomeSuccess());
+        // 3 - set 'use-jdbc-store' to true
+        cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
+        result = cli.readAllAsOpResult();
+        assertEquals("Failed to set use-jdbc-store to expected value", expectedResults, result.isIsOutcomeSuccess());
     }
 
     @Test
     public void testUseJdbcStoreWithoutDatasource() throws Exception {
         try {
-            String objectStoreType = readObjectStoreType();
-            assertEquals("default", objectStoreType);
-
-            createDataSource();
-
-            // try to undefine use-jdbc-store
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=use-jdbc-store)");
-            CLIOpResult result = cli.readAllAsOpResult();
-            assertTrue("Failed to undefine use-jdbc-store.", result.isIsOutcomeSuccess());
-
-            // try to set use-jdbc-store to false without defining datasource
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=false)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-jdbc-store to false.", result.isIsOutcomeSuccess());
-
             // try to set use-jdbc-store to true without defining datasource
             cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)", true);
-            result = cli.readAllAsOpResult();
+            CLIOpResult result = cli.readAllAsOpResult();
             assertFalse("Expected failure when jdbc-store-datasource is not set.", result.isIsOutcomeSuccess());
-
-            // correctly set jdbc-store-datasource first and then use-jdbc-store to true
-            cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/ObjectStoreTestDS)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set jdbc-store-datasource.", result.isIsOutcomeSuccess());
-
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-jdbc-store.", result.isIsOutcomeSuccess());
-
-            // try to undefine jdbc-store-datasource when use-jdbc-store is set to true
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource)", true);
-            result = cli.readAllAsOpResult();
-            assertFalse("Expected failure when un-defining jdbc-store-datasource when use-jdbc-store is true.", result.isIsOutcomeSuccess());
-
-            // setting use-jdbc-store to false
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=false)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-jdbc-store to false.", result.isIsOutcomeSuccess());
-
-            // undefine jdbc-store-datasource
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to undefine jdbc-store-datasource.", result.isIsOutcomeSuccess());
         } finally {
-            try {
-                setDefaultObjectStore(true);
-            } finally {
-                removeDataSource();
-            }
+            setDefaultObjectStore();
         }
+    }
+
+    @Test
+    public void testUndefinedJdbcStoreDSWhenJDBCisUsed() throws Exception {
+        try {
+            // Use JDBC store
+            useJdbcStore();
+            // try, and fail, to undefine jdbc-store-datasource when use-jdbc-store is set to true
+            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource", true);
+            CLIOpResult result = cli.readAllAsOpResult();
+            if (result.isIsOutcomeSuccess())
+                fail("The jdbc-store-datasource attribute has been undefined, while JDBC store is in use.");
+        } finally {
+            cleanJdbcSettingsAndResetToObjectStore();
+        }
+    }
+
+    private void checkAttributeIsAsExpected(String attributeName, String expectedValue) {
+        try {
+            cli.sendLine("/subsystem=transactions:read-attribute(name=" + attributeName + ")");
+            CLIOpResult result = cli.readAllAsOpResult();
+            assertEquals(attributeName + " has not the expected value", expectedValue, result.getResult());
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+    }
+
+    private void checkThatAllUseAttributesAreConsistent(String useJournalStore, String useJdbcStore, String useHornetQStore) {
+        checkAttributeIsAsExpected("use-jdbc-store", useJdbcStore);
+        checkAttributeIsAsExpected("use-journal-store", useJournalStore);
+        checkAttributeIsAsExpected("use-hornetq-store", useHornetQStore);
     }
 
     @Test
     public void testEitherJdbcOrJournalStore() throws Exception {
         try {
-            String objectStoreType = readObjectStoreType();
-            assertEquals("default", objectStoreType);
-
-            createDataSource();
-
-            // set jdbc-store-datasource so that use-jdbc-store can be set to true
-            cli.sendLine("/subsystem=transactions:write-attribute(name=jdbc-store-datasource, value=java:jboss/datasources/ObjectStoreTestDS)");
-            CLIOpResult result = cli.readAllAsOpResult();
-            assertTrue("Failed to set jdbc-store-datasource.", result.isIsOutcomeSuccess());
-
-            // set use-jdbc-store to true
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-jdbc-store to true.", result.isIsOutcomeSuccess());
-
-            // set use-journal-store to true
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=true)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-journal-store to true.", result.isIsOutcomeSuccess());
-
-            // check that use-jdbc-store was automatically set to false
-            cli.sendLine("/subsystem=transactions:read-attribute(name=use-jdbc-store)");
-            result = cli.readAllAsOpResult();
-            assertEquals("use-jdbc-store was not automatically deactivated.", "false", result.getResult());
-
-            // set use-jdbc-store to true
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=true)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-journal-store to true.", result.isIsOutcomeSuccess());
-
-            // check that use-journal-store was automatically set to false
-            cli.sendLine("/subsystem=transactions:read-attribute(name=use-journal-store)");
-            result = cli.readAllAsOpResult();
-            assertEquals("use-journal-store was not automatically deactivated.", "false", result.getResult());
-
-            // set use-jdbc-store to false
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=false)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to set use-journal-store to false.", result.isIsOutcomeSuccess());
-
-            // undefine jdbc-store-datasource
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource)");
-            result = cli.readAllAsOpResult();
-            assertTrue("Failed to undefine jdbc-store-datasource.", result.isIsOutcomeSuccess());
+            // Set journal store
+            useJournalStore();
+            // Check that attributes are consistent with setting
+            checkThatAllUseAttributesAreConsistent("true", "false", "true");
+            // Use jdbcStore
+            useJdbcStore();
+            // Check that attributes are consistent with setting
+            checkThatAllUseAttributesAreConsistent("false", "true", "false");
         } finally {
-            try {
-                setDefaultObjectStore(true);
-            } finally {
-                removeDataSource();
-            }
+            cleanJdbcSettingsAndResetToObjectStore();
         }
     }
 
-    private void createDataSource() {
-        cli.sendLine("data-source add --name=ObjectStoreTestDS --jndi-name=java:jboss/datasources/ObjectStoreTestDS --driver-name=h2 --connection-url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1 --jta=false");
+    private void useJournalStore() throws IOException, MgmtOperationException {
+        cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=true)");
+        check("journal");
     }
 
-    private void removeDataSource() {
-        cli.sendLine("data-source remove --name=ObjectStoreTestDS");
+    private void createDataSource() {
+        cli.sendLine("data-source add --name=" + JDBC_STORE_DS_NAME + " --jndi-name=java:jboss/datasources/"
+                + JDBC_STORE_DS_NAME + " --driver-name=h2 --connection-url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1 --jta=false");
+    }
+
+    private void undefinedAttributeIfDefined(String attributeName) {
+        try {
+            cli.sendLine("/subsystem=transactions:read-attribute(name=" + attributeName + ")");
+            CLIOpResult result = cli.readAllAsOpResult();
+            if (result.getResponseNode().isDefined())
+                cli.sendLine("/subsystem=transactions:undefine-attribute(name=" + attributeName + ")");
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void cleanJdbcSettingsAndResetToObjectStore() throws IOException, MgmtOperationException {
+        try {
+            cleanupSettingsUsedForJDBCStore();
+        } finally {
+            setDefaultObjectStore();
+        }
+    }
+
+    private void removeDatasource() {
+        try {
+            cli.sendLine("data-source remove --name=" + JDBC_STORE_DS_NAME);
+        } catch (Exception e) {
+            // if the DS does not exist, not need to delete it...
+        }
+    }
+
+    private void cleanupSettingsUsedForJDBCStore() {
+        try {
+            // Undefine 'use-jdbc-store' first, if defined
+            undefinedAttributeIfDefined("use-jdbc-store");
+            // then undefine 'jdbc-store'
+            undefinedAttributeIfDefined("jdbc-store-datasource");
+            // finally delete Datasource if exists
+            removeDatasource();
+            // Reload configuration
+            cli.sendLine("reload");
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private String readObjectStoreType() throws IOException, MgmtOperationException {
@@ -269,26 +259,15 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
     }
 
     private void setDefaultObjectStore() throws IOException, MgmtOperationException {
-        setDefaultObjectStore(false);
-    }
-
-    private void setDefaultObjectStore(boolean reload) throws IOException, MgmtOperationException {
         final String objectStoreType = readObjectStoreType();
-        if ("default".equals(objectStoreType)) {
+        if ("journal".equals(objectStoreType)) {
             return;
         }
 
         try {
-            // reset the object store settings
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=false)");
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-hornetq-store, value=false)");
-            cli.sendLine("/subsystem=transactions:write-attribute(name=use-jdbc-store, value=false)");
-            cli.sendLine("/subsystem=transactions:undefine-attribute(name=jdbc-store-datasource)");
+            cli.sendLine("/subsystem=transactions:write-attribute(name=use-journal-store, value=true)");
         } finally {
-            if (reload) {
-                cli.sendLine("reload");
-            }
+            cli.sendLine("reload");
         }
     }
-
 }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -171,6 +171,8 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     public static final SimpleAttributeDefinition USE_HORNETQ_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_HORNETQ_STORE, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode().set(false))
+            .setAlternatives(CommonAttributes.USE_JDBC_STORE)
+            .setAlternatives(CommonAttributes.USE_JOURNAL_STORE)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAllowExpression(false)
             .setDeprecated(ModelVersion.create(3)).build();
@@ -184,6 +186,8 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     public static final SimpleAttributeDefinition USE_JOURNAL_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_JOURNAL_STORE, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode().set(false))
+            .setAlternatives(CommonAttributes.USE_JDBC_STORE)
+            .setAlternatives(CommonAttributes.USE_HORNETQ_STORE)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAllowExpression(false).build();
     public static final SimpleAttributeDefinition JOURNAL_STORE_ENABLE_ASYNC_IO = new SimpleAttributeDefinitionBuilder(CommonAttributes.JOURNAL_STORE_ENABLE_ASYNC_IO, ModelType.BOOLEAN, true)
@@ -195,6 +199,9 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     public static final SimpleAttributeDefinition USE_JDBC_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_JDBC_STORE, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode(false))
+            .setAlternatives(CommonAttributes.USE_JOURNAL_STORE)
+            .setAlternatives(CommonAttributes.USE_HORNETQ_STORE)
+            .setRequires(CommonAttributes.JDBC_STORE_DATASOURCE)
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAllowExpression(false).build();
     public static final SimpleAttributeDefinition JDBC_STORE_DATASOURCE = new SimpleAttributeDefinitionBuilder(CommonAttributes.JDBC_STORE_DATASOURCE, ModelType.STRING, true)


### PR DESCRIPTION
Issue: [JBEAP-6449](https://issues.jboss.org/browse/JBEAP-6449)
Upstream Issue: [WFLY-8335](https://issues.jboss.org/browse/WFLY-8335)

This PR superseeds [PR 9772](https://github.com/wildfly/wildfly/pull/9797).

@tomjenkinson as discussed briefy by email, I had to rehaul a bit the ObjectStoreTypeTestCase to make it works with using "alternatives" validation for CLI. I'm sorry that the diff is thus a bit garbled, but there was no way around it. Let me know what you think and if you see things I can tweak / enhance.
