### PR TITLE
[WFLY-8684] in case that required mechanism is not available, show available mechanisms list to user.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -482,7 +482,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
                 authMethods.forEach(c -> {
                     String name = c.getName();
                     if (availableMechanisms.contains(name) == false) {
-                        throw ROOT_LOGGER.requiredMechanismNotAvailable(name);
+                        throw ROOT_LOGGER.requiredMechanismNotAvailable(name, availableMechanisms);
                     }
 
                     Map<String, String> mechanismConfiguration;

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -29,6 +29,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -355,8 +356,8 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 84, value = "There are no mechanisms available from the HttpAuthenticationFactory.")
     IllegalStateException noMechanismsAvailable();
 
-    @Message(id = 85, value = "The required mechanism '%s' is not available from the HttpAuthenticationFactory.")
-    IllegalStateException requiredMechanismNotAvailable(String mechanismName);
+    @Message(id = 85, value = "The required mechanism '%s' is not available in mechanisms %s from the HttpAuthenticationFactory.")
+    IllegalStateException requiredMechanismNotAvailable(String mechanismName, Collection<String> availableMechanisms);
 
     @Message(id = 86, value = "No authentication mechanisms have been selected.")
     IllegalStateException noMechanismsSelected();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8684
JBEAP issue: https://issues.jboss.org/browse/JBEAP-9943

In the report scenario
>  In case when ldap-realm is configured with direct-verification=false and no identity-mapping.user-password-mapper is provided

This changes WFLYUT0085 to: _The required mechanism 'BASIC' is not available in mechanisms [CLIENT_CERT, FORM, SPNEGO, BEARER_TOKEN] from the HttpAuthenticationFactory._ to indicate that required mechanism is unavailable in mechanisms list,