### PR TITLE
[WFLY-8546] Handle Artemis activation failure

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -135,6 +135,10 @@ public class JMSService implements Service<JMSServerManager> {
         try {
             jmsServer = new JMSServerManagerImpl(activeMQServer.getValue(), new WildFlyBindingRegistry(context.getController().getServiceContainer()));
 
+            activeMQServer.getValue().registerActivationFailureListener(e -> {
+                StartException se = new StartException(e);
+                context.failed(se);
+            });
             activeMQServer.getValue().registerActivateCallback(new ActivateCallback() {
                 private volatile ServiceController<Void> activeMQActivationController;
 


### PR DESCRIPTION
Register an ActivationFailureListener before an embedded Artemis server is
started to be notified of any error caught by Artemis when it is
activated and ensures that the corresponding MSc service is identified
as failed.

JIRA: https://issues.jboss.org/browse/WFLY-8546