### PR TITLE
[WFLY-8748] Remove the console handler by default for domain configurations

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -3,7 +3,7 @@
 <config>
     <subsystems name="default">
         <!-- Each subsystem to be included relative to the src/main/resources directory -->
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
@@ -35,7 +35,7 @@
     </subsystems>
     <subsystems name="ha">
         <!-- Each subsystem to be included relative to the src/main/resources directory -->
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
@@ -70,7 +70,7 @@
     </subsystems>
     <subsystems name="full">
         <!-- Each subsystem to be included relative to the src/main/resources directory -->
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
@@ -105,7 +105,7 @@
     </subsystems>
     <subsystems name="full-ha">
         <!-- Each subsystem to be included relative to the src/main/resources directory -->
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>batch-jberet.xml</subsystem>
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
@@ -142,7 +142,7 @@
         <subsystem>weld.xml</subsystem>
     </subsystems>
     <subsystems name="load-balancer">
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>io.xml</subsystem>
         <subsystem>undertow-load-balancer.xml</subsystem>
     </subsystems>

--- a/feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
+++ b/feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
@@ -1,0 +1,44 @@
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Additional loggers to configure (the root logger is always configured)
+loggers=com.arjuna,org.jboss.as.config,sun.rmi
+
+logger.level=INFO
+logger.handlers=FILE
+
+logger.com.arjuna.level=WARN
+logger.com.arjuna.useParentHandlers=true
+
+logger.org.jboss.as.config.level=DEBUG
+logger.org.jboss.as.config.useParentHandlers=true
+
+logger.sun.rmi.level=WARN
+logger.sun.rmi.useParentHandlers=true
+
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=ALL
+handler.FILE.formatter=PATTERN
+handler.FILE.properties=autoFlush,append,fileName,suffix
+handler.FILE.constructorProperties=fileName,append
+handler.FILE.autoFlush=true
+handler.FILE.append=true
+handler.FILE.fileName=${org.jboss.boot.log.file:server.log}
+handler.FILE.suffix=.yyyy-MM-dd
+
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/servlet-feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <subsystems name="default">
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem supplement="web-build">ee.xml</subsystem>
         <subsystem>io.xml</subsystem>
@@ -14,7 +14,7 @@
         <subsystem>undertow.xml</subsystem>
     </subsystems>
     <subsystems name="load-balancer">
-        <subsystem>logging.xml</subsystem>
+        <subsystem supplement="no-console">logging.xml</subsystem>
         <subsystem>io.xml</subsystem>
         <subsystem>undertow-load-balancer.xml</subsystem>
     </subsystems>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -260,6 +260,33 @@
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                 </configuration>
             </plugin>
+            <!-- Add the console-handler to each profile for the test server -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <offline>true</offline>
+                    <fail-on-error>true</fail-on-error>
+                    <jboss-home>${project.build.directory}/jbossas</jboss-home>
+                    <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                    <scripts>
+                        <script>${project.basedir}/../shared/enable-domain-console-logging.cli</script>
+                    </scripts>
+                    <system-properties>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                        <module.path>${jboss.home}/modules</module.path>
+                    </system-properties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -109,7 +109,34 @@
                          <include>**/*TestSuite.java</include>
                     </includes>
                 </configuration>                        
-            </plugin>  
+            </plugin>
+            <!-- Add the console-handler to each profile for the test server -->
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>execute-commands</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <offline>true</offline>
+                    <fail-on-error>true</fail-on-error>
+                    <jboss-home>${project.build.directory}/jbossas</jboss-home>
+                    <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                    <scripts>
+                        <script>${project.basedir}/../shared/enable-domain-console-logging.cli</script>
+                    </scripts>
+                    <system-properties>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                        <module.path>${jboss.dist}/modules</module.path>
+                    </system-properties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/testsuite/shared/enable-domain-console-logging.cli
+++ b/testsuite/shared/enable-domain-console-logging.cli
@@ -1,0 +1,20 @@
+embed-host-controller
+batch
+
+/profile=default/subsystem=logging/console-handler=CONSOLE:add(level=INFO, named-formatter=COLOR-PATTERN, autoflush=true,target=System.out)
+/profile=default/subsystem=logging/root-logger=ROOT:add-handler(name=CONSOLE)
+
+/profile=full/subsystem=logging/console-handler=CONSOLE:add(level=INFO, named-formatter=COLOR-PATTERN, autoflush=true,target=System.out)
+/profile=full/subsystem=logging/root-logger=ROOT:add-handler(name=CONSOLE)
+
+/profile=full-ha/subsystem=logging/console-handler=CONSOLE:add(level=INFO, named-formatter=COLOR-PATTERN, autoflush=true,target=System.out)
+/profile=full-ha/subsystem=logging/root-logger=ROOT:add-handler(name=CONSOLE)
+
+/profile=ha/subsystem=logging/console-handler=CONSOLE:add(level=INFO, named-formatter=COLOR-PATTERN, autoflush=true,target=System.out)
+/profile=ha/subsystem=logging/root-logger=ROOT:add-handler(name=CONSOLE)
+
+/profile=load-balancer/subsystem=logging/console-handler=CONSOLE:add(level=INFO, named-formatter=COLOR-PATTERN, autoflush=true,target=System.out)
+/profile=load-balancer/subsystem=logging/root-logger=ROOT:add-handler(name=CONSOLE)
+
+run-batch
+stop-embedded-host-controller


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8748

Add a CLI script for the domain test suite to enable the console handler.