### PR TITLE
[WFLY-8746] RejectedExecutionException in the MDB during shutdown

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -38,7 +38,7 @@ public class MessagingServices {
      */
     static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
     static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
-    static final ServiceName ACTIVEMQ_CLIENT_THREAD_POOL = JBOSS_MESSAGING_ACTIVEMQ.append("client-thread-pool");
+    public static final ServiceName ACTIVEMQ_CLIENT_THREAD_POOL = JBOSS_MESSAGING_ACTIVEMQ.append("client-thread-pool");
 
    public static ServiceName getActiveMQServiceName(PathAddress pathAddress) {
          // We need to figure out what ActiveMQ this operation is targeting.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -317,6 +317,8 @@ public class PooledConnectionFactoryService implements Service<Void> {
                 .addDependency(serverServiceName, ActiveMQServer.class, service.activeMQServer)
                 .addDependency(ActiveMQActivationService.getServiceName(serverServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(serverServiceName))
+                // ensures that Artemis client thread pools are not stopped before any deployment depending on a pooled-connection-factory
+                .addDependency(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL)
                 // WFLY-6652 this dependency ensures that Artemis will be able to destroy any queues created on behalf of a
                 // pooled-connection-factory client during server stop
                 .addDependency(SecurityBootstrapService.SERVICE_NAME)


### PR DESCRIPTION
The PooledConnectionFactoryService was is used by MDB was not depending
on the service controlling the lifecycle of Artemis client thread pools.
It was possible that the thread pools were cleaned (and stopped) before
the MDB was stopped causing RejectedExecutionException during MDB code
execution.

JIRA: https://issues.jboss.org/browse/WFLY-8746