### PR TITLE
[WFLY-8777] Allow skipTests in mixed-domain module

### DIFF
--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -47,6 +47,7 @@
         <xslt.scripts.dir>${basedir}/../integration/src/test/xslt</xslt.scripts.dir>
 
         <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
+	<ts.skipTests>${skipTests}</ts.skipTests>
     </properties>
 
     <!--
@@ -94,7 +95,7 @@
 
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
-                    <skipTests>false</skipTests>
+                    <skipTests>${ts.skipTests}</skipTests>
 
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>


### PR DESCRIPTION
As a part of our acceptance tests, we do verify the bits integrity by building EAP and all testing modules. There is currently no way to build mixed-domain module without running all tests. Add the possibility.

https://issues.jboss.org/browse/WFLY-8777 - Allow skipTests in mixed-domain module