### PR TITLE
[WFLY-8559] Implement test coverage for DWM

### DIFF
--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -134,6 +134,39 @@
                 <property name="waitForPortsTimeoutInSeconds">8</property>
             </configuration>
         </container>
+
+        <container qualifier="dwm-container-0">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-dwm-0</property>
+                <!-- AS7-2493 different jboss.node.name must be specified -->
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-dwm-0 -Djboss.node.name=node-0 -Djboss.socket.binding.port-offset=200</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:10190}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8987} ${as.managementPort:10190}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="dwm-container-1">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/jbossas-dwm-1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-dwm-1 -Djboss.node.name=node-1 -Djboss.socket.binding.port-offset=300</property>
+                <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node1:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort.node1:10290}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1:9087} ${as.managementPort.node1:10290}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
     </group>
 
 </arquillian>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
@@ -1,0 +1,395 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_THREADS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedConnection1;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.wildfly.test.api.Authentication;
+
+/**
+ * Tests distributed work manager and whether it really distributes work over multiple nodes. Test cases use two servers
+ * both with a deployed resource adapter configured to use the DWM.
+ *
+ * Work is scheduled via a stateless ejb proxy. This allows us to schedule work from within the test, without the need
+ * to marshall anything not serializable (such as the resource adapter).
+ */
+public abstract class AbstractDwmTestCase {
+
+    private static Logger log = Logger.getLogger(AbstractDwmTestCase.class.getCanonicalName());
+
+    private static final String DEFAULT_DWM_NAME = "newdwm";
+    private static final String DEFAULT_CONTEXT_NAME = "customContext1";
+    private static final ModelNode DEFAULT_DWM_ADDRESS = new ModelNode()
+            .add(SUBSYSTEM, "jca")
+            .add("distributed-workmanager", DEFAULT_DWM_NAME);
+    private static final String DEPLOYMENT_0 =  "deployment-0";
+    private static final String DEPLOYMENT_1 =  "deployment-1";
+    private static final String CONTAINER_0 = "dwm-container-0";
+    private static final String CONTAINER_1 = "dwm-container-1";
+    // can be used in extending test cases to control test logic
+    protected static final int SRT_MAX_THREADS = 1;
+    protected static final int SRT_QUEUE_LENGTH = 1;
+    protected static final int WORK_FINISH_MAX_TIMEOUT = 10_000;
+
+    protected enum Policy {
+        ALWAYS,
+        NEVER,
+        WATERMARK
+    }
+
+    protected enum Selector {
+        FIRST_AVAILABLE,
+        MAX_FREE_THREADS,
+        PING_TIME
+    }
+
+    // --------------------------------------------------------------------------------
+    // deployment setup
+    // --------------------------------------------------------------------------------
+
+    @Deployment(name = DEPLOYMENT_0)
+    @TargetsContainer(CONTAINER_0)
+    public static Archive<?> deploy0 () {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_1)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> deploy1 () {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
+        JavaArchive jar = createLibJar();
+        ResourceAdapterArchive rar = createResourceAdapterArchive();
+        JavaArchive ejbJar = createEjbJar();
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "dwmtest.ear");
+        ear.addAsLibrary(jar).addAsModule(rar).addAsModule(ejbJar);
+        ear.addAsManifestResource(AbstractDwmTestCase.class.getPackage(), "application.xml", "application.xml");
+
+        return ear;
+    }
+
+    private static JavaArchive createLibJar() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "lib.jar");
+        jar.addClass(LongWork.class).addClass(ShortWork.class)
+                .addPackage(DistributedConnection1.class.getPackage());
+        jar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector,"
+                + "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper,"
+                + "org.jboss.ironjacamar.impl\n"), "MANIFEST.MF");
+        return jar;
+    }
+
+    private static ResourceAdapterArchive createResourceAdapterArchive() {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "dwm.rar");
+        rar.addAsManifestResource(AbstractDwmTestCase.class.getPackage(), "ra-distributed.xml", "ra.xml")
+                .addAsManifestResource(AbstractDwmTestCase.class.getPackage(), "ironjacamar-distributed-1.xml",
+                        "ironjacamar.xml")
+                .addAsManifestResource(
+                        new StringAsset(
+                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.as.connector \n"),
+                        "MANIFEST.MF");
+        return rar;
+    }
+
+    private static JavaArchive createEjbJar() {
+        JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
+        ejbJar.addClass(DwmAdminObjectEjb.class).addClass(DwmAdminObjectEjbImpl.class);
+        ejbJar.addAsManifestResource(AbstractDwmTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.ironjacamar.api"), "MANIFEST.MF");
+        return ejbJar;
+    }
+
+    // --------------------------------------------------------------------------------
+    // test setup
+    // --------------------------------------------------------------------------------
+
+    private static ModelControllerClient client1;
+    private static ModelControllerClient client2;
+
+    static {
+        try {
+            client1 = createClient1();
+            client2 = createClient2();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ModelControllerClient createClient1() throws UnknownHostException {
+        return ModelControllerClient.Factory.create(InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                TestSuiteEnvironment.getServerPort() + 200,
+                Authentication.getCallbackHandler());
+    }
+
+    private static ModelControllerClient createClient2() throws UnknownHostException {
+        return ModelControllerClient.Factory.create(InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                TestSuiteEnvironment.getServerPort() + 300,
+                Authentication.getCallbackHandler());
+    }
+
+    abstract static class DwmServerSetupTask implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            log.info("Setting up " + containerId);
+            setUpServer(containerId);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            log.info("Tearing down " + containerId);
+            tearDownServer(containerId);
+        }
+
+        private void setUpServer(String containerId) throws Exception {
+            ModelControllerClient mcc = CONTAINER_0.equals(containerId) ? client1 : client2;
+
+            log.info("Setting up Policy/Selector: " + getPolicy() + "/" + getSelector());
+            ModelNode addBasicDwm = addBasicDwm();
+            ModelNode setUpPolicy = setUpPolicy(getPolicy());
+            ModelNode setUpPolicyOptions = setUpWatermarkPolicyOption(getWatermarkPolicyOption());
+            ModelNode setUpSelector = setUpSelector(getSelector());
+            ModelNode setUpShortRunningThreads = setUpShortRunningThreads(getSrtMaxThreads(), getSrtQueueLength());
+
+            List<ModelNode> operationList = new ArrayList<>(Arrays.asList(addBasicDwm, setUpPolicy, setUpSelector, setUpShortRunningThreads));
+            if (getPolicy().equals(Policy.WATERMARK)) {
+                operationList.add(setUpPolicyOptions);
+            }
+            ModelNode compositeOp = ModelUtil.createCompositeNode(operationList.toArray(new ModelNode[1]));
+            ModelNode result = mcc.execute(compositeOp);
+            log.info("Setting up DWM: " + result);
+
+            result = mcc.execute(setUpCustomContext());
+            log.info("Setting up CustomContext: " + result);
+        }
+
+        private void tearDownServer(String containerId) throws Exception {
+            ModelControllerClient mcc = CONTAINER_0.equals(containerId) ? client1 : client2;
+            int serverPort = CONTAINER_0.equals(containerId) ? TestSuiteEnvironment.getServerPort() + 200 : TestSuiteEnvironment.getServerPort() + 300;
+
+            ModelNode removeDwm = new ModelNode();
+            removeDwm.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS);
+            removeDwm.get(OP).set(REMOVE);
+
+            ModelNode removeContext = new ModelNode();
+            removeContext.get(OP_ADDR).set((new ModelNode())
+                    .add(SUBSYSTEM, "jca")
+                    .add("bootstrap-context", DEFAULT_CONTEXT_NAME));
+            removeContext.get(OP).set(REMOVE);
+
+            ModelNode compositeOp = ModelUtil.createCompositeNode(
+                    new ModelNode[] { removeDwm, removeContext });
+            mcc.execute(compositeOp);
+            ServerReload.executeReloadAndWaitForCompletion(mcc, 60000, false,
+                    TestSuiteEnvironment.getServerAddress(), serverPort);
+        }
+
+        protected abstract Policy getPolicy();
+        protected abstract Selector getSelector();
+        protected int getWatermarkPolicyOption() {
+            return 0;
+        }
+        protected int getSrtMaxThreads() {
+            return SRT_MAX_THREADS;
+        }
+        protected int getSrtQueueLength() {
+            return SRT_QUEUE_LENGTH;
+        }
+
+        private ModelNode addBasicDwm() {
+            ModelNode setUpDwm = new ModelNode();
+
+            setUpDwm.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS);
+            setUpDwm.get(OP).set(ADD);
+            setUpDwm.get(NAME).set(DEFAULT_DWM_NAME);
+
+            return setUpDwm;
+        }
+
+        private ModelNode setUpShortRunningThreads(int maxThreads, int queueLength) {
+            ModelNode setUpSrt = new ModelNode();
+
+            // the thread pool name must be the same as the DWM it belongs to
+            setUpSrt.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS.clone().add("short-running-threads", DEFAULT_DWM_NAME));
+            setUpSrt.get(OP).set(ADD);
+            setUpSrt.get(MAX_THREADS).set(maxThreads);
+            setUpSrt.get("queue-length").set(queueLength);
+
+            return setUpSrt;
+        }
+
+        private ModelNode setUpCustomContext() {
+            ModelNode setUpCustomContext = new ModelNode();
+
+            setUpCustomContext.get(OP_ADDR).set(new ModelNode()
+                    .add(SUBSYSTEM, "jca")
+                    .add("bootstrap-context", DEFAULT_CONTEXT_NAME));
+            setUpCustomContext.get(OP).set(ADD);
+            setUpCustomContext.get(NAME).set(DEFAULT_CONTEXT_NAME);
+            setUpCustomContext.get("workmanager").set(DEFAULT_DWM_NAME);
+
+            return setUpCustomContext;
+        }
+
+        private ModelNode setUpPolicy(Policy policy) {
+            ModelNode setUpPolicy = new ModelNode();
+
+            setUpPolicy.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS);
+            setUpPolicy.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            setUpPolicy.get(NAME).set("policy");
+            setUpPolicy.get(VALUE).set(policy.toString());
+
+            return setUpPolicy;
+        }
+
+        private ModelNode setUpWatermarkPolicyOption(int waterMarkPolicyOption) {
+            ModelNode setUpWatermarkPolicyOption = new ModelNode();
+
+            setUpWatermarkPolicyOption.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS);
+            setUpWatermarkPolicyOption.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            setUpWatermarkPolicyOption.get(NAME).set("policy-options");
+            setUpWatermarkPolicyOption.get(VALUE).set(new ModelNode().add("watermark", waterMarkPolicyOption));
+
+            return setUpWatermarkPolicyOption;
+        }
+
+        private ModelNode setUpSelector(Selector selector) {
+            ModelNode setUpSelector = new ModelNode();
+
+            setUpSelector.get(OP_ADDR).set(DEFAULT_DWM_ADDRESS);
+            setUpSelector.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            setUpSelector.get(NAME).set("selector");
+            setUpSelector.get(VALUE).set(selector.toString());
+
+            return setUpSelector;
+        }
+    }
+
+    // --------------------------------------------------------------------------------
+    // test related abstractions
+    // --------------------------------------------------------------------------------
+
+    protected DwmAdminObjectEjb server1Proxy;
+    protected DwmAdminObjectEjb server2Proxy;
+
+    @Before
+    public void setUpAdminObjects() throws NamingException {
+        server1Proxy = lookupAdminObject(TestSuiteEnvironment.getServerAddress(), "8280");
+        server2Proxy = lookupAdminObject(TestSuiteEnvironment.getServerAddress(), "8380");
+        Assert.assertNotNull(server1Proxy);
+        Assert.assertNotNull(server2Proxy);
+    }
+
+    private DwmAdminObjectEjb lookupAdminObject(String address, String port) throws NamingException {
+        Properties properties = new Properties();
+        properties.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
+        properties.put(Context.PROVIDER_URL, String.format("%s%s:%s", "http-remoting://", address, port));
+        Context context = new InitialContext(properties);
+
+        String ejbExportedName = String.format("%s/%s/%s!%s", "dwm-ejb-application", "dwm-ejb-module",
+                DwmAdminObjectEjbImpl.class.getSimpleName(), DwmAdminObjectEjb.class.getCanonicalName());
+        return (DwmAdminObjectEjb) context.lookup(ejbExportedName);
+    }
+
+    private enum WorkScheduleType {
+        DO_WORK,
+        START_WORK,
+        SCHEDULE_WORK
+    }
+
+    protected boolean waitForDoWork(DwmAdminObjectEjb proxy, int expectedWorkAmount, int timeout) throws InterruptedException {
+        return waitForWork(proxy, expectedWorkAmount, timeout, WorkScheduleType.DO_WORK);
+    }
+
+    protected boolean waitForStartWork(DwmAdminObjectEjb proxy, int expectedWorkAmount, int timeout) throws InterruptedException {
+        return waitForWork(proxy, expectedWorkAmount, timeout, WorkScheduleType.START_WORK);
+    }
+
+    protected boolean waitForScheduleWork(DwmAdminObjectEjb proxy, int expectedWorkAmount, int timeout) throws InterruptedException {
+        return waitForWork(proxy, expectedWorkAmount, timeout, WorkScheduleType.SCHEDULE_WORK);
+    }
+
+    private boolean waitForWork(DwmAdminObjectEjb proxy, int expectedWorkAmount, int timeout, WorkScheduleType wst) throws InterruptedException {
+        long finish = System.currentTimeMillis() + timeout;
+
+        while (System.currentTimeMillis() <= finish) {
+            if (getCurrentWorkAmount(proxy, wst) == expectedWorkAmount) {
+                return true;
+            }
+            Thread.sleep(100L);
+        }
+
+        return getCurrentWorkAmount(proxy, wst) == expectedWorkAmount;
+    }
+
+    private int getCurrentWorkAmount(DwmAdminObjectEjb proxy, WorkScheduleType wst) {
+        switch (wst) {
+            case DO_WORK:
+                return proxy.getDoWorkAccepted();
+            case START_WORK:
+                return proxy.getStartWorkAccepted();
+            case SCHEDULE_WORK:
+                return proxy.getScheduleWorkAccepted();
+            default:
+                throw new IllegalStateException("Bad work schedule type - test error");
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAdminObjectEjb.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAdminObjectEjb.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+
+public interface DwmAdminObjectEjb {
+    int getDoWorkAccepted();
+
+    int getDoWorkRejected();
+
+    int getStartWorkAccepted();
+
+    int getStartWorkRejected();
+
+    int getScheduleWorkAccepted();
+
+    int getScheduleWorkRejected();
+
+    int getDistributedDoWorkAccepted();
+
+    int getDistributedDoWorkRejected();
+
+    int getDistributedStartWorkAccepted();
+
+    int getDistributedStartWorkRejected();
+
+    int getDistributedScheduleWorkAccepted();
+
+    int getDistributedScheduleWorkRejected();
+
+    boolean isDoWorkDistributionEnabled();
+
+    void doWork(Work work) throws WorkException;
+
+    void startWork(Work work) throws WorkException;
+
+    void scheduleWork(Work work) throws WorkException;
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAdminObjectEjbImpl.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAdminObjectEjbImpl.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+
+import org.jboss.as.connector.services.workmanager.NamedDistributedWorkManager;
+import org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedAdminObject1;
+import org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedAdminObject1Impl;
+import org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedResourceAdapter1;
+
+@Stateless
+@Remote
+public class DwmAdminObjectEjbImpl implements DwmAdminObjectEjb {
+
+    @Resource(mappedName = "java:jboss/A1")
+    private DistributedAdminObject1 dao;
+
+    private NamedDistributedWorkManager dwm;
+
+    @PostConstruct
+    public void initialize() {
+        if (!(dao instanceof DistributedAdminObject1Impl)) {
+            throw new IllegalStateException("DwmAdminObjectEjbImpl expects that its DistributedAdminObject1 will be of certain implemnetation");
+        }
+        DistributedAdminObject1Impl daoi = (DistributedAdminObject1Impl) dao;
+
+        if (!(daoi.getResourceAdapter() instanceof DistributedResourceAdapter1)) {
+            throw new IllegalStateException("DwmAdminObjectEjbImpl expects that its resource adapter will be distributable");
+        }
+        DistributedResourceAdapter1 dra = (DistributedResourceAdapter1) daoi.getResourceAdapter();
+        dwm = dra.getDwm();
+    }
+
+    @Override
+    public int getDoWorkAccepted() {
+        return dwm.getStatistics().getDoWorkAccepted();
+    }
+
+    @Override
+    public int getDoWorkRejected() {
+        return dwm.getStatistics().getDoWorkRejected();
+    }
+
+    @Override
+    public int getStartWorkAccepted() {
+        return dwm.getStatistics().getStartWorkAccepted();
+    }
+
+    @Override
+    public int getStartWorkRejected() {
+        return dwm.getStatistics().getStartWorkRejected();
+    }
+
+    @Override
+    public int getScheduleWorkAccepted() {
+        return dwm.getStatistics().getScheduleWorkAccepted();
+    }
+
+    @Override
+    public int getScheduleWorkRejected() {
+        return dwm.getStatistics().getScheduleWorkRejected();
+    }
+
+    @Override
+    public int getDistributedDoWorkAccepted() {
+        return dwm.getDistributedStatistics().getDoWorkAccepted();
+    }
+
+    @Override
+    public int getDistributedDoWorkRejected() {
+        return dwm.getDistributedStatistics().getDoWorkRejected();
+    }
+
+    @Override
+    public int getDistributedStartWorkAccepted() {
+        return dwm.getDistributedStatistics().getStartWorkAccepted();
+    }
+
+    @Override
+    public int getDistributedStartWorkRejected() {
+        return dwm.getDistributedStatistics().getStartWorkRejected();
+    }
+
+    @Override
+    public int getDistributedScheduleWorkAccepted() {
+        return dwm.getDistributedStatistics().getScheduleWorkAccepted();
+    }
+
+    @Override
+    public int getDistributedScheduleWorkRejected() {
+        return dwm.getDistributedStatistics().getScheduleWorkRejected();
+    }
+
+    @Override
+    public boolean isDoWorkDistributionEnabled() {
+        return dwm.isDoWorkDistributionEnabled();
+    }
+
+    @Override
+    public void doWork(Work work) throws WorkException {
+        dwm.doWork(work);
+    }
+
+    @Override
+    public void startWork(Work work) throws WorkException {
+        dwm.startWork(work);
+    }
+
+    @Override
+    public void scheduleWork(Work work) throws WorkException {
+        dwm.scheduleWork(work);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAlwaysTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmAlwaysTestCase.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.naming.NamingException;
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Uses policy = ALWAYS and selector = FIRST_AVAILABLE.
+ *
+ * InSequence is necessary since we can't tell whether a work instance has already finished executing and has freed all
+ * the threads it was occupying (if started via startWork or scheduleWork). The last two test cases could mess with
+ * each other. The test methods will still run separately without issues.
+ */
+@ServerSetup(DwmAlwaysTestCase.DwmAlwaysServerSetupTask.class)
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DwmAlwaysTestCase extends AbstractDwmTestCase {
+
+    static class DwmAlwaysServerSetupTask extends DwmServerSetupTask {
+        @Override
+        protected Policy getPolicy() {
+            return Policy.ALWAYS;
+        }
+
+        @Override
+        protected Selector getSelector() {
+            return Selector.FIRST_AVAILABLE;
+        }
+    }
+
+    /**
+     * Executes a few short work instances and verifies that they executed on the expected node (the other one since
+     * we have Policy.ALWAYS)
+     */
+    @Test
+    @InSequence(1)
+    public void testDoWork() throws IOException, NamingException, WorkException, InterruptedException {
+        int doWorkAccepted = server2Proxy.getDoWorkAccepted();
+        int distributedDoWorkAccepted = server1Proxy.getDistributedDoWorkAccepted();
+
+        server1Proxy.doWork(new ShortWork());
+        server1Proxy.doWork(new ShortWork());
+
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForDoWork(server2Proxy, doWorkAccepted + 2, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT)));
+        Assert.assertTrue("Expected distributedDoWorkAccepted = " + (distributedDoWorkAccepted + 2) + " but was: " + server1Proxy.getDistributedDoWorkAccepted(),
+                server1Proxy.getDistributedDoWorkAccepted() == distributedDoWorkAccepted + 2);
+    }
+
+    /**
+     * Submits a few (less than our max threads) short work instances and verifies that
+     * {@link org.jboss.jca.core.api.workmanager.DistributedWorkManager#startWork(Work)} starts the work on the
+     * expected node (the other one since we have Policy.ALWAYS).
+     */
+    @Test
+    @InSequence(2)
+    public void testStartWork() throws IOException, NamingException, WorkException, InterruptedException {
+        int startWorkAccepted = server2Proxy.getStartWorkAccepted();
+        int distributedStartWorkAccepted = server1Proxy.getDistributedStartWorkAccepted();
+
+        server1Proxy.startWork(new ShortWork());
+
+        // the short work was already started and will finish momentarily, however, it still hogs the thread for testScheduleWork
+        // this will allow it to finish for good (short work takes no time to finish)
+        Thread.sleep(TimeoutUtil.adjust(1000));
+
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForStartWork(server2Proxy, startWorkAccepted + 1, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT)));
+        Assert.assertTrue("Expected distributedStartWorkAccepted = " + (distributedStartWorkAccepted + 1) + " but was: " + server1Proxy.getDistributedStartWorkAccepted(),
+                server1Proxy.getDistributedStartWorkAccepted() == distributedStartWorkAccepted + 1);
+    }
+
+    /**
+     * Schedules several (one more than our max threads) long work instances and verifies that
+     * {@link org.jboss.jca.core.api.workmanager.DistributedWorkManager#scheduleWork(Work)} returns sooner than the time
+     * needed for the work items to actually finish. Also verifies that work was executed on both nodes (Policy.ALWAYS
+     * selects the other node first, then the first node is selected because the second one is already full).
+     */
+    @Test
+    @InSequence(3)
+    public void testScheduleWork() throws WorkException, InterruptedException {
+        int scheduleWorkAcceptedServer1 = server1Proxy.getScheduleWorkAccepted();
+        int scheduleWorkAcceptedServer2 = server2Proxy.getScheduleWorkAccepted();
+        int distributedScheduleWorkAccepted = server1Proxy.getDistributedScheduleWorkAccepted();
+
+        for (int i = 0; i < SRT_MAX_THREADS + 1; i++) {
+            server1Proxy.scheduleWork(new LongWork());
+        }
+
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForScheduleWork(server2Proxy, scheduleWorkAcceptedServer2 + SRT_MAX_THREADS, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT * (SRT_MAX_THREADS + 1))));
+        Assert.assertTrue("Work was not scheduled on nodes as was expected",
+                waitForScheduleWork(server1Proxy, scheduleWorkAcceptedServer1 + 1, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT * (SRT_MAX_THREADS + 1))));
+        Assert.assertTrue("Expected distributedScheduleWorkAccepted = " + (distributedScheduleWorkAccepted + SRT_MAX_THREADS + 1) + " but was: " + server1Proxy.getDistributedScheduleWorkAccepted(),
+                server1Proxy.getDistributedScheduleWorkAccepted() == distributedScheduleWorkAccepted + SRT_MAX_THREADS + 1);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmNeverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmNeverTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.naming.NamingException;
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Uses policy = NEVER and selector = MAX_FREE_THREADS.
+ *
+ * InSequence is necessary since testScheduleWork messes with the thread pools for testNeverPolicy. We'd have to wait
+ * for the work instances to actually finish and free the thread pools otherwise. The test methods will still run
+ * separately without issues.
+ */
+@ServerSetup(DwmNeverTestCase.DwmNeverServerSetupTask.class)
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DwmNeverTestCase extends AbstractDwmTestCase {
+
+    static class DwmNeverServerSetupTask extends AbstractDwmTestCase.DwmServerSetupTask {
+        @Override
+        protected Policy getPolicy() {
+            return Policy.NEVER;
+        }
+
+        @Override
+        protected Selector getSelector() {
+            return Selector.MAX_FREE_THREADS;
+        }
+    }
+
+    /**
+     * Does a few instances of short work with {@code policy = NEVER} and expects that they will be executed on the node
+     * where started.
+     */
+    @Test
+    @InSequence(1)
+    public void testNeverPolicy() throws IOException, NamingException, WorkException {
+        int doWorkAccepted = server1Proxy.getDoWorkAccepted();
+
+        for (int i = 0; i < 10; i++) {
+            server1Proxy.doWork(new ShortWork());
+        }
+
+        Assert.assertTrue("Expected doWorkAccepted = " + (doWorkAccepted + 10) + ", actual: " + server1Proxy.getDoWorkAccepted(),
+                server1Proxy.getDoWorkAccepted() == doWorkAccepted + 10);
+    }
+
+    /**
+     * Schedules several (one more than our max threads) long work instances and verifies that
+     * {@link org.jboss.jca.core.api.workmanager.DistributedWorkManager#scheduleWork(Work)} executes work on the local
+     * node (Policy.NEVER only selects the local node, regardless of the selector).
+     */
+    @Test
+    @InSequence(2)
+    public void testScheduleWork() throws WorkException, InterruptedException {
+        int scheduleWorkAcceptedServer1 = server1Proxy.getScheduleWorkAccepted();
+        int distributedScheduleWorkAccepted = server2Proxy.getDistributedScheduleWorkAccepted();
+
+        for (int i = 0; i < SRT_MAX_THREADS + 1; i++) {
+            server1Proxy.scheduleWork(new LongWork());
+        }
+
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForScheduleWork(server1Proxy, scheduleWorkAcceptedServer1 + SRT_MAX_THREADS + 1, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT)));
+        Assert.assertTrue("Expected distributedScheduleWorkAccepted = " + (distributedScheduleWorkAccepted + SRT_MAX_THREADS + 1) + " but was: " + server2Proxy.getDistributedScheduleWorkAccepted(),
+                server2Proxy.getDistributedScheduleWorkAccepted() == distributedScheduleWorkAccepted + SRT_MAX_THREADS + 1);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmWatermarkTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/DwmWatermarkTestCase.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.resource.spi.work.Work;
+import javax.resource.spi.work.WorkException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests distributed work manager and whether it really distributes work over multiple nodes. Test cases use two servers
+ * both with a deployed resource adapter configured to use the DWM. Tests with WATERMARK policy.
+ */
+@ServerSetup(DwmWatermarkTestCase.DwmWatermarkServerSetupTask.class)
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DwmWatermarkTestCase extends AbstractDwmTestCase {
+
+    private static final int WATERMARK_MAX_THREADS = 2;
+
+    static class DwmWatermarkServerSetupTask extends AbstractDwmTestCase.DwmServerSetupTask {
+        @Override
+        protected Policy getPolicy() {
+            return Policy.WATERMARK;
+        }
+
+        @Override
+        protected Selector getSelector() {
+            return Selector.MAX_FREE_THREADS;
+        }
+
+        @Override
+        protected int getWatermarkPolicyOption() {
+            return WATERMARK_MAX_THREADS - 1;
+        }
+
+        @Override
+        protected int getSrtMaxThreads() {
+            return WATERMARK_MAX_THREADS;
+        }
+
+        @Override
+        protected int getSrtQueueLength() {
+            return WATERMARK_MAX_THREADS;
+        }
+    }
+
+    /**
+     * Schedules several (one more than our max threads) long work instances and verifies that
+     * {@link org.jboss.jca.core.api.workmanager.DistributedWorkManager#scheduleWork(Work)} schedules the work on both
+     * nodes. Policy.WATERMARK will select the local node once, then we hit the watermark limit, and the other node is
+     * selected.
+     */
+    @Test
+    public void testWatermarkPolicy() throws WorkException, InterruptedException {
+        int scheduleWorkAcceptedServer1 = server1Proxy.getScheduleWorkAccepted();
+        int scheduleWorkAcceptedServer2 = server2Proxy.getScheduleWorkAccepted();
+        int distributedScheduleWorkAccepted = server1Proxy.getDistributedScheduleWorkAccepted();
+
+        for (int i = 0; i < WATERMARK_MAX_THREADS; i++) {
+            server1Proxy.scheduleWork(new LongWork());
+        }
+
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForScheduleWork(server2Proxy, scheduleWorkAcceptedServer2 + 1, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT)));
+        Assert.assertTrue("Work did not finish in the expected time on the expected node",
+                waitForScheduleWork(server1Proxy, scheduleWorkAcceptedServer1 + 1, TimeoutUtil.adjust(WORK_FINISH_MAX_TIMEOUT)));
+        Assert.assertTrue("Expected distributedScheduleWorkAccepted = " + (distributedScheduleWorkAccepted + WATERMARK_MAX_THREADS)
+                        + " but was: " + server2Proxy.getDistributedScheduleWorkAccepted(),
+                server2Proxy.getDistributedScheduleWorkAccepted() == distributedScheduleWorkAccepted + WATERMARK_MAX_THREADS);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/LongWork.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/LongWork.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.resource.spi.work.DistributableWork;
+import java.io.Serializable;
+
+public class LongWork implements DistributableWork, Serializable {
+
+    private boolean quit = false;
+
+    /**
+     * Note that some distributed workmanager threads may depend on the exact time long work takes.
+     */
+    public static final long WORK_TIMEOUT = 1000L; // 1 second
+    public static final long SLEEP_STEP = 50L; // 0.05 seconds
+
+    @Override
+    public void release() {
+        quit = true;
+    }
+
+    @Override
+    public void run() {
+        long startTime = System.currentTimeMillis();
+        long finishTime = startTime + WORK_TIMEOUT;
+
+        while (!quit) {
+            try {
+                Thread.sleep(SLEEP_STEP);
+            } catch (InterruptedException ignored) {
+                // ignored
+            }
+            if (System.currentTimeMillis() >= finishTime) quit = true;
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ShortWork.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ShortWork.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed;
+
+import javax.resource.spi.work.DistributableWork;
+import java.io.Serializable;
+
+public class ShortWork implements DistributableWork, Serializable {
+
+    @Override
+    public void release() {
+        // do nothing
+    }
+
+    @Override
+    public void run() {
+        // just finish quickly
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/application.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/application.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      	http://java.sun.com/xml/ns/javaee/application_6.xsd"
+      version="7">
+
+    <application-name>dwm-ejb-application</application-name>
+
+    <initialize-in-order>true</initialize-in-order>
+
+    <module>
+        <connector>dwm.rar</connector>
+    </module>
+    <module>
+        <ejb>ejb.jar</ejb>
+    </module>
+
+</application>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ejb-jar.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ejb-jar.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+         version="3.2">
+    <module-name>dwm-ejb-module</module-name>
+</ejb-jar>
+
+

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ironjacamar-distributed-1.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ironjacamar-distributed-1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<ironjacamar>
+    <bootstrap-context>customContext1</bootstrap-context>
+    <connection-definitions>
+        <connection-definition
+                class-name="org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedManagedConnectionFactory1"
+                jndi-name="java:jboss/CF1">
+        </connection-definition>
+    </connection-definitions>
+    <admin-objects>
+        <admin-object
+                class-name="org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedAdminObject1Impl"
+                jndi-name="java:jboss/A1">
+        </admin-object>
+    </admin-objects>
+</ironjacamar>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra-distributed.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra-distributed.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<connector xmlns="http://java.sun.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+           http://java.sun.com/xml/ns/j2ee/connector_1_6.xsd"
+           version="1.6" metadata-complete="true">
+
+    <vendor-name>Red Hat Middleware LLC</vendor-name>
+    <eis-type>Test RA</eis-type>
+    <resourceadapter-version>0.1</resourceadapter-version>
+
+    <resourceadapter>
+        <resourceadapter-class>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedResourceAdapter1
+        </resourceadapter-class>
+
+        <outbound-resourceadapter>
+            <connection-definition>
+                <managedconnectionfactory-class>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedManagedConnectionFactory1
+                </managedconnectionfactory-class>
+                <connectionfactory-interface>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedConnectionFactory1
+                </connectionfactory-interface>
+                <connectionfactory-impl-class>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedConnectionFactory1Impl
+                </connectionfactory-impl-class>
+                <connection-interface>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedConnection1
+                </connection-interface>
+                <connection-impl-class>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedConnection1Impl
+                </connection-impl-class>
+            </connection-definition>
+            <transaction-support>NoTransaction</transaction-support>
+            <reauthentication-support>false</reauthentication-support>
+        </outbound-resourceadapter>
+        <adminobject>
+            <adminobject-interface>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedAdminObject1
+            </adminobject-interface>
+            <adminobject-class>org.jboss.as.test.manualmode.jca.workmanager.distributed.ra.DistributedAdminObject1Impl
+            </adminobject-class>
+        </adminobject>
+    </resourceadapter>
+</connector>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedAdminObject1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedAdminObject1.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.Referenceable;
+import java.io.Serializable;
+
+/**
+ * DistributedAdminObject1 allows the tester to use the resource adapter and workmanager from
+ * outside EAP.
+ */
+public interface DistributedAdminObject1 extends Referenceable, Serializable {
+
+    void setName(String name);
+
+    String getName();
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedAdminObject1Impl.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedAdminObject1Impl.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.Referenceable;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import java.io.Serializable;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Note that since the implementation contains a {@link ResourceAdapter} field, and that field is
+ * not serializable, the admin object can only be injected via {@link javax.annotation.Resource}.
+ *
+ * That means that the tests that you write can't use
+ * {@link org.jboss.arquillian.container.test.api.RunAsClient} and look up the object remotely.
+ *
+ * What you can do, is deploy an ejb, that will report the statistics via its admin object. You
+ * should be able to lookup that ejb and use it as a proxy to the resource adapter below. However,
+ * the ejb has to be {@link javax.ejb.Stateless}, otherwise, once started in a cluster, a session is
+ * going to be created for it which has to be serializable.
+ */
+public class DistributedAdminObject1Impl implements DistributedAdminObject1,
+        ResourceAdapterAssociation, Referenceable, Serializable {
+
+    private static final Logger log = Logger.getLogger(DistributedAdminObject1Impl.class.getSimpleName());
+    private static final long serialVersionUID = 466880381773994922L;
+
+    static {
+        log.trace("Initializing DistributedAdminObject1Impl");
+    }
+
+    private ResourceAdapter ra;
+    private Reference reference;
+    private String name;
+
+    public DistributedAdminObject1Impl() {
+        setName("DistributedAdminObject1Impl");
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ResourceAdapter getResourceAdapter() {
+        return ra;
+    }
+
+    public void setResourceAdapter(ResourceAdapter ra) {
+        this.ra = ra;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Reference getReference() throws NamingException {
+        return reference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReference(Reference reference) {
+        this.reference = reference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = 17;
+        if (name != null) { result += 31 * result + 7 * name.hashCode(); } else { result += 31 * result + 7; }
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) { return false; }
+        if (other == this) { return true; }
+        if (!(other instanceof DistributedAdminObject1Impl)) { return false; }
+        DistributedAdminObject1Impl obj = (DistributedAdminObject1Impl) other;
+        boolean result = true;
+        if (result) {
+            if (name == null) { result = obj.getName() == null; } else { result = name.equals(obj.getName()); }
+        }
+        return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return this.getClass().toString() + "name=" + name;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnection1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnection1.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+public interface DistributedConnection1 {
+
+    String test(String s);
+
+    void close();
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnection1Impl.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnection1Impl.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+public class DistributedConnection1Impl implements DistributedConnection1 {
+
+    private DistributedManagedConnection1 dmc;
+    private DistributedManagedConnectionFactory1 dmcf;
+
+    public DistributedConnection1Impl(DistributedManagedConnection1 dmc, DistributedManagedConnectionFactory1 dmcf) {
+        this.dmc = dmc;
+        this.dmcf = dmcf;
+    }
+
+    public String test(String s) {
+        return null;
+    }
+
+    public void close() {
+        dmc.closeHandle(this);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnectionFactory1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnectionFactory1.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.Referenceable;
+import javax.resource.ResourceException;
+import java.io.Serializable;
+
+public interface DistributedConnectionFactory1 extends Serializable, Referenceable {
+
+    DistributedConnection1 getConnection() throws ResourceException;
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnectionFactory1Impl.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedConnectionFactory1Impl.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+
+public class DistributedConnectionFactory1Impl implements DistributedConnectionFactory1 {
+
+    private static final long serialVersionUID = 812283381273295931L;
+
+    private Reference reference;
+    private DistributedManagedConnectionFactory1 dmcf;
+    private ConnectionManager connectionManager;
+
+    public DistributedConnectionFactory1Impl() {
+        // empty
+    }
+
+    public DistributedConnectionFactory1Impl(DistributedManagedConnectionFactory1 dmcf, ConnectionManager cxManager) {
+        this.dmcf = dmcf;
+        this.connectionManager = cxManager;
+    }
+
+    @Override
+    public DistributedConnection1 getConnection() throws ResourceException {
+        return (DistributedConnection1) connectionManager.allocateConnection(dmcf, null);
+    }
+
+    public Reference getReference() throws NamingException {
+        return reference;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setReference(Reference reference) {
+        this.reference = reference;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnection1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnection1.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionEvent;
+import javax.resource.spi.ConnectionEventListener;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LocalTransaction;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionMetaData;
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DistributedManagedConnection1 implements ManagedConnection {
+
+    private PrintWriter logWriter;
+    private DistributedManagedConnectionFactory1 dmcf;
+    private List<ConnectionEventListener> listeners;
+    private Object connection;
+
+    public DistributedManagedConnection1(DistributedManagedConnectionFactory1 dmcf) {
+        this.dmcf = dmcf;
+        this.logWriter = null;
+        this.listeners = new ArrayList<>(1);
+        this.connection = null;
+    }
+
+    /**
+     * Creates a new connection handle for the underlying physical connection
+     * represented by the ManagedConnection instance.
+     *
+     * @param subject       Security context as JAAS subject
+     * @param cxRequestInfo ConnectionRequestInfo instance
+     * @return generic Object instance representing the connection handle.
+     * @throws ResourceException generic exception if operation fails
+     */
+    public Object getConnection(Subject subject,
+                                ConnectionRequestInfo cxRequestInfo) throws ResourceException {
+        connection = new DistributedConnection1Impl(this, dmcf);
+        return connection;
+    }
+
+    /**
+     * Used by the container to change the association of an
+     * application-level connection handle with a ManagedConneciton instance.
+     *
+     * @param connection Application-level connection handle
+     * @throws ResourceException generic exception if operation fails
+     */
+    public void associateConnection(Object connection) throws ResourceException {
+    }
+
+    /**
+     * Application server calls this method to force any cleanup on the ManagedConnection instance.
+     *
+     * @throws ResourceException generic exception if operation fails
+     */
+    public void cleanup() throws ResourceException {
+    }
+
+    /**
+     * Destroys the physical connection to the underlying resource manager.
+     *
+     * @throws ResourceException generic exception if operation fails
+     */
+    public void destroy() throws ResourceException {
+    }
+
+    /**
+     * Adds a connection event listener to the ManagedConnection instance.
+     *
+     * @param listener A new ConnectionEventListener to be registered
+     */
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        listeners.add(listener);
+    }
+
+    /**
+     * Removes an already registered connection event listener from the ManagedConnection instance.
+     *
+     * @param listener already registered connection event listener to be removed
+     */
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+        if (listener == null) { throw new IllegalArgumentException("Listener is null"); }
+        listeners.remove(listener);
+    }
+
+    public void closeHandle(DistributedConnection1 handle) {
+        ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_CLOSED);
+        event.setConnectionHandle(handle);
+        for (ConnectionEventListener cel : listeners) {
+            cel.connectionClosed(event);
+        }
+    }
+
+    /**
+     * Gets the log writer for this ManagedConnection instance.
+     *
+     * @return Character ourput stream associated with this Managed-Connection instance
+     * @throws ResourceException generic exception if operation fails
+     */
+    public PrintWriter getLogWriter() throws ResourceException {
+        return logWriter;
+    }
+
+    /**
+     * Sets the log writer for this ManagedConnection instance.
+     *
+     * @param out Character Output stream to be associated
+     * @throws ResourceException generic exception if operation fails
+     */
+    public void setLogWriter(PrintWriter out) throws ResourceException {
+        logWriter = out;
+    }
+
+    /**
+     * Returns an <code>javax.resource.spi.LocalTransaction</code> instance.
+     *
+     * @return LocalTransaction instance
+     * @throws ResourceException generic exception if operation fails
+     */
+    public LocalTransaction getLocalTransaction() throws ResourceException {
+        throw new NotSupportedException("LocalTransaction not supported");
+    }
+
+    /**
+     * Returns an <code>javax.transaction.xa.XAresource</code> instance.
+     *
+     * @return XAResource instance
+     * @throws ResourceException generic exception if operation fails
+     */
+    public XAResource getXAResource() throws ResourceException {
+        throw new NotSupportedException("GetXAResource not supported not supported");
+    }
+
+    /**
+     * Gets the metadata information for this connection's underlying EIS resource manager instance.
+     *
+     * @return ManagedConnectionMetaData instance
+     * @throws ResourceException generic exception if operation fails
+     */
+    public ManagedConnectionMetaData getMetaData() throws ResourceException {
+        return new DistributedManagedConnectionMetadata1();
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnectionFactory1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnectionFactory1.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import javax.security.auth.Subject;
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.Set;
+
+public class DistributedManagedConnectionFactory1 implements ManagedConnectionFactory, ResourceAdapterAssociation {
+
+    private static final long serialVersionUID = 112183388263932951L;
+
+    private ResourceAdapter ra;
+    private PrintWriter logwriter;
+    private String name;
+
+    public DistributedManagedConnectionFactory1() {
+        // empty
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Creates a Connection Factory instance.
+     *
+     * @param cxManager ConnectionManager to be associated with created EIS connection factory instance
+     * @return EIS-specific Connection Factory instance or javax.resource.cci.ConnectionFactory instance
+     * @throws ResourceException Generic exception
+     */
+    public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException {
+        return new DistributedConnectionFactory1Impl(this, cxManager);
+    }
+
+    /**
+     * Creates a Connection Factory instance.
+     *
+     * @return EIS-specific Connection Factory instance or javax.resource.cci.ConnectionFactory instance
+     * @throws ResourceException Generic exception
+     */
+    public Object createConnectionFactory() throws ResourceException {
+        throw new ResourceException("This resource adapter doesn't support non-managed environments");
+    }
+
+    /**
+     * Creates a new physical connection to the underlying EIS resource manager.
+     *
+     * @param subject       Caller's security information
+     * @param cxRequestInfo Additional resource adapter specific connection request information
+     * @return ManagedConnection instance
+     * @throws ResourceException generic exception
+     */
+    public ManagedConnection createManagedConnection(Subject subject,
+                                                     ConnectionRequestInfo cxRequestInfo) throws ResourceException {
+        return new DistributedManagedConnection1(this);
+    }
+
+    /**
+     * Returns a matched connection from the candidate set of connections.
+     *
+     * @param connectionSet Candidate connection set
+     * @param subject       Caller's security information
+     * @param cxRequestInfo Additional resource adapter specific connection request information
+     * @return ManagedConnection if resource adapter finds an acceptable match otherwise null
+     * @throws ResourceException generic exception
+     */
+    public ManagedConnection matchManagedConnections(Set connectionSet,
+                                                     Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException {
+        ManagedConnection result = null;
+        Iterator it = connectionSet.iterator();
+        while (result == null && it.hasNext()) {
+            ManagedConnection mc = (ManagedConnection) it.next();
+            if (mc instanceof DistributedManagedConnection1) {
+                result = mc;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Get the log writer for this ManagedConnectionFactory instance.
+     *
+     * @return PrintWriter
+     * @throws ResourceException generic exception
+     */
+    public PrintWriter getLogWriter() throws ResourceException {
+        return logwriter;
+    }
+
+    /**
+     * Set the log writer for this ManagedConnectionFactory instance.
+     *
+     * @param out PrintWriter - an out stream for error logging and tracing
+     * @throws ResourceException generic exception
+     */
+    public void setLogWriter(PrintWriter out) throws ResourceException {
+        logwriter = out;
+    }
+
+    /**
+     * Get the resource adapter
+     *
+     * @return The handle
+     */
+    public ResourceAdapter getResourceAdapter() {
+        return ra;
+    }
+
+    /**
+     * Set the resource adapter
+     *
+     * @param ra The handle
+     */
+    public void setResourceAdapter(ResourceAdapter ra) {
+        this.ra = ra;
+    }
+
+    /**
+     * Returns a hash code value for the object.
+     *
+     * @return A hash code value for this object.
+     */
+    @Override
+    public int hashCode() {
+        int result = 17;
+        if (name != null) { result += 31 * result + 7 * name.hashCode(); } else { result += 31 * result + 7; }
+        return result;
+    }
+
+    /**
+     * Indicates whether some other object is equal to this one.
+     *
+     * @param other The reference object with which to compare.
+     * @return true if this object is the same as the obj argument, false otherwise.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) { return false; }
+        if (other == this) { return true; }
+        if (!(other instanceof DistributedManagedConnectionFactory1)) { return false; }
+        DistributedManagedConnectionFactory1 obj = (DistributedManagedConnectionFactory1) other;
+
+        return name == null ?
+                obj.getName() == null :
+                name.equals(obj.getName());
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnectionMetadata1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedManagedConnectionMetadata1.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnectionMetaData;
+
+public class DistributedManagedConnectionMetadata1 implements ManagedConnectionMetaData {
+
+    public DistributedManagedConnectionMetadata1() {
+        // empty
+    }
+
+    /**
+     * Returns Product name of the underlying EIS instance connected through the ManagedConnection.
+     *
+     * @return Product name of the EIS instance
+     * @throws ResourceException Thrown if an error occurs
+     */
+    @Override
+    public String getEISProductName() throws ResourceException {
+        return "Red Hat Middleware LLC - Test RA";
+    }
+
+    /**
+     * Returns Product version of the underlying EIS instance connected through the ManagedConnection.
+     *
+     * @return Product version of the EIS instance
+     * @throws ResourceException Thrown if an error occurs
+     */
+    @Override
+    public String getEISProductVersion() throws ResourceException {
+        return "0.1";
+    }
+
+    /**
+     * Returns maximum limit on number of active concurrent connections
+     *
+     * @return Maximum limit for number of active concurrent connections
+     * @throws ResourceException Thrown if an error occurs
+     */
+    @Override
+    public int getMaxConnections() throws ResourceException {
+        return 100;
+    }
+
+    /**
+     * Returns name of the user associated with the ManagedConnection instance
+     *
+     * @return Name of the user
+     * @throws ResourceException Thrown if an error occurs
+     */
+    @Override
+    public String getUserName() throws ResourceException {
+        return "user";
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedResourceAdapter1.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/ra/DistributedResourceAdapter1.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.jca.workmanager.distributed.ra;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.resource.spi.work.WorkManager;
+import javax.transaction.xa.XAResource;
+
+import org.jboss.as.connector.services.workmanager.NamedDistributedWorkManager;
+
+/**
+ * DistributedResourceAdapter1 for use with DistributableWorkManager.
+ *
+ * In conjunction with {@link DistributedAdminObject1}, this class allows the tester to create workloads on
+ * the servers as well as obtain statistics on where that workload was executed.
+ */
+public class DistributedResourceAdapter1 implements ResourceAdapter {
+
+    private NamedDistributedWorkManager dwm;
+
+    public DistributedResourceAdapter1() {
+        // empty
+    }
+
+    public void setDwm(NamedDistributedWorkManager dwm) {
+        this.dwm = dwm;
+    }
+
+    public NamedDistributedWorkManager getDwm() {
+        return dwm;
+    }
+
+    /**
+     * This is called during the activation of a message endpoint.
+     *
+     * @param endpointFactory A message endpoint factory instance.
+     * @param spec            An activation spec JavaBean instance.
+     * @throws ResourceException generic exception
+     */
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) throws ResourceException {
+    }
+
+    /**
+     * This is called when a message endpoint is deactivated.
+     *
+     * @param endpointFactory A message endpoint factory instance.
+     * @param spec            An activation spec JavaBean instance.
+     */
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) {
+    }
+
+    /**
+     * This is called when a resource adapter instance is bootstrapped.
+     *
+     * @param ctx A bootstrap context containing references
+     * @throws ResourceAdapterInternalException indicates bootstrap failure.
+     */
+    public void start(BootstrapContext ctx) throws ResourceAdapterInternalException {
+        WorkManager wm = ctx.getWorkManager();
+
+        if (wm instanceof NamedDistributedWorkManager) {
+            NamedDistributedWorkManager ndwm = (NamedDistributedWorkManager) wm;
+            setDwm(ndwm);
+        }
+    }
+
+    /**
+     * This is called when a resource adapter instance is undeployed or during application server shutdown.
+     */
+    public void stop() {
+    }
+
+    /**
+     * This method is called by the application server during crash recovery.
+     *
+     * @param specs An array of ActivationSpec JavaBeans
+     * @return An array of XAResource objects
+     * @throws ResourceException generic exception
+     */
+    public XAResource[] getXAResources(ActivationSpec[] specs) throws ResourceException {
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return 17;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) { return false; }
+        if (other == this) { return true; }
+        if (!(other instanceof DistributedResourceAdapter1)) { return false; }
+        DistributedResourceAdapter1 obj = (DistributedResourceAdapter1) other;
+        boolean result;
+        if (dwm == null) { result = obj.getDwm() == null; } else { result = dwm.equals(obj.getDwm()); }
+        return result;
+    }
+
+}

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -39,7 +39,6 @@
         <ts.config-as.change-jgroups-multicast-interface name="jbossas"
                                                          interface="multicast"/>
 
-
         <echo message="Copying and configuring instance jbossas-with-remote-outbound-connection"/>
         <copy todir="target/jbossas-with-remote-outbound-connection">
             <fileset dir="target/jbossas"/>
@@ -65,6 +64,19 @@
         <copy todir="target/jbossas-parse-marshal/modules">
             <fileset dir="${jboss.dist}/modules"/>
         </copy>
+
+        <echo message="Copying and configuring instances jbossas-dwm-0 and jbossas-dwm-1  =========  "/>
+        <copy todir="target/jbossas-dwm-0" overwrite="true">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <copy todir="target/jbossas-dwm-1" overwrite="true">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <ts.config-as.change-transport-stack name="jbossas-dwm-0"
+                                             stack="tcp"/>
+        <ts.config-as.change-transport-stack name="jbossas-dwm-1"
+                                             stack="tcp"/>
+
         <!-- Connects back to original host (node0) -->
         <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
                                                      remotePort="8080" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>


### PR DESCRIPTION
upstream issue
https://issues.jboss.org/browse/WFLY-8559

downstream PR
https://github.com/jbossas/jboss-eap7/pull/1935

eap7 issue
https://issues.jboss.org/browse/EAP7-495

previously seen in this PR
https://github.com/wildfly/wildfly/pull/9953/

then removed based on this issue and now reintroduced to manualmode module as suggested*
https://issues.jboss.org/browse/WFLY-8716

All checks pass for me. I wasn't able to reproduce the Windows failures from PR 9953 (Win 2k12 R2, latest Oracle JDK), all looked clean, but since there have been many changes, I suspect the issues were fixed.

*Please note that the content is not the exact same as in PR 9953, there have been additions and fixes to the tests.