### PR TITLE
Fix servlet-build to build use the wildfly-servlet-* name for the zip…

### DIFF
--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -90,7 +90,7 @@
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
                             <recompressZippedFiles>true</recompressZippedFiles>
-                            <finalName>${server.output.dir.prefix}-web-${project.version}</finalName>
+                            <finalName>${project.build.finalName}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <workDirectory>${project.build.directory}/assembly/work</workDirectory>


### PR DESCRIPTION
… instead of wildfly-web-*.

I didn't really thing a JIRA was required here since it's a small pom change. The zip was being created as `wildfly-web` instead of `wildfly-servlet`.