### PR TITLE
[WFLY-8309] build.sh and integration-tests.sh scripts doesn't work on Solaris 10 (Sparc)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@
 ##  feel free to use ./mvnw directly                                        ##
 ##                                                                          ##
 ### ====================================================================== ###
+BASH_INTERPRETER=${BASH_INTERPRETER:-${SHELL}}
 
 PROGNAME=`basename $0`
 DIRNAME=`dirname "${BASH_SOURCE[0]}"`
@@ -149,9 +150,9 @@ main() {
 
     #  Execute in debug mode, or simply execute.
     if [ "x$MVN_DEBUG" != "x" ]; then
-        eval /bin/sh -x $MVN $MVN_ARGS $MVN_GOAL $ADDIT_PARAMS
+        eval "${BASH_INTERPRETER}" -x $MVN $MVN_ARGS $MVN_GOAL $ADDIT_PARAMS
     else
-        eval exec       $MVN $MVN_ARGS $MVN_GOAL $ADDIT_PARAMS
+        eval exec ${BASH_INTERPRETER} $MVN $MVN_ARGS $MVN_GOAL $ADDIT_PARAMS
     fi
 }
 

--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Shell script to run the integration tests
+BASH_INTERPRETER=${BASH_INTERPRETER:-${SHELL}}
 
 PROGNAME=`basename $0`
 DIRNAME=`dirname "${BASH_SOURCE[0]}"`
@@ -172,9 +173,9 @@ main() {
 
     #  Execute in debug mode, or simply execute.
     if [ "x$MVN_DEBUG" != "x" ]; then
-        /bin/sh -x $MVN $MVN_ARGS $MVN_GOAL
+        "${BASH_INTERPRETER}" -x $MVN $MVN_ARGS $MVN_GOAL
     else
-        exec $MVN $MVN_ARGS $MVN_GOAL
+        exec "${BASH_INTERPRETER}" $MVN $MVN_ARGS $MVN_GOAL
     fi
 
     cd $DIRNAME

--- a/mvnw
+++ b/mvnw
@@ -206,13 +206,7 @@ concat_lines() {
   fi
 }
 
-# Workaround for JBEAP-8937 - Don't change lines below
-# as it may breaks build on Solaris 10 (Sparc)
-if [ -z "${MAVEN_PROJECTBASEDIR}" ]; then
-  export MAVEN_PROJECTBASEDIR=`find_maven_basedir`
-fi
-# End of workaround for JBEAP-8937
-
+export MAVEN_PROJECTBASEDIR="${MAVEN_BASEDIR:-`find_maven_basedir`}"
 MAVEN_OPTS="`(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config")` $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
Upstream Issue: [WFLY-8309](https://issues.jboss.org/browse/WFLY-8309)
Issue: [JBEAP-8937](https://issues.jboss.org/browse/JBEAP-8937)

Turns out previous fix did not solve the core issue - the bash interpreter used for testing has a bug, that cannot be workaround in a predictable fashion. To workaround the issue, the best approach is to provided a way to use an other interpreter. As the build.sh scripts has '/bin/sh' hardcoded in it, this commit provides a mechanism to override the path to the interpreter if needed.

_Note: this pull request revert the previous changes._