### PR TITLE
[WFLY-8818] Skip VirtualHostTestCase#testDefaultHost if ServerAddress is not localhost

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -49,6 +50,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -144,7 +146,9 @@ public class VirtualHostTestCase {
 
     @Test
     public void testDefaultHost() throws IOException {
-        callAndTest("http://localhost:8080/", "ROOT"); //this needs to be localhost, as it is by host mapping
+        Assume.assumeTrue("This needs to be localhost, as it is by host mapping",
+                InetAddress.getByName(TestSuiteEnvironment.getServerAddress()).isLoopbackAddress());
+        callAndTest("http://localhost:8080/", "ROOT");
     }
 
     @Test


### PR DESCRIPTION
VirtualHostTestCase#testDefaultHost pass in case when ServerAddress (node0 property) is bind to localhost, or an alias in /etc/hosts file pointing ServerAddress to localhost exists.

We are using a non localhost address as ServerAddress and the test is always failing in our environment.

See JBEAP-6934 for more details.

Jira:
https://issues.jboss.org/browse/WFLY-8818 Skip VirtualHostTestCase#testDefaultHost if ServerAddress is not localhost
