### PR TITLE
[WFLY-8819] Remove the username="$local" workaround

### DIFF
--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -64,7 +64,7 @@
     </management>
 
     <domain-controller>
-        <remote username="$local" security-realm="ManagementRealm">
+        <remote security-realm="ManagementRealm">
             <discovery-options>
                 <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
             </discovery-options>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -63,7 +63,7 @@
     </management>
 
     <domain-controller>
-        <remote username="$local" security-realm="ManagementRealm">
+        <remote security-realm="ManagementRealm">
             <discovery-options>
                 <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
             </discovery-options>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8819