### PR TITLE
[WFLY-8837] consider other format of ipv6 address than just ::1 for xts coordinator

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -46,6 +46,7 @@
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.deployment-repository"/>
         <module name="org.jboss.as.transactions"/>
+        <module name="org.jboss.as.network"/>
         <!-- need this for the endpoint service -->
         <module name="org.jboss.as.webservices.server.integration"/>
         <!-- need this for the endpoint security context -->

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -58,6 +58,10 @@
             <artifactId>wildfly-security</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-network</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-idlj</artifactId>
         </dependency>


### PR DESCRIPTION
Simple parse of ip address passed in the url element for xts coordinator which recognize other variants of ipv6 addresses than just `::1`.

https://issues.jboss.org/browse/WFLY-8837