### PR TITLE
WFLY-8808/WFLY-8019 Elytron integration for AUTH protocol

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryRequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryRequirementCapability.java
@@ -23,12 +23,11 @@
 package org.jboss.as.clustering.controller;
 
 
-import java.util.stream.Stream;
+import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.clustering.service.BinaryRequirement;
-import org.wildfly.clustering.service.Requirement;
 
 /**
  * Provides a capability definition provider built from a binary requirement.
@@ -39,8 +38,21 @@ public class BinaryRequirementCapability implements Capability {
     private final RuntimeCapability<Void> definition;
     private final BinaryRequirement requirement;
 
-    public BinaryRequirementCapability(BinaryRequirement requirement, Requirement... requirements) {
-        this.definition = RuntimeCapability.Builder.of(requirement.getName(), true, requirement.getType()).addRequirements(Stream.of(requirements).map(Requirement::getName).toArray(String[]::new)).build();
+    /**
+     * Creates a new capability based on the specified requirement
+     * @param requirement the requirement basis
+     */
+    public BinaryRequirementCapability(BinaryRequirement requirement) {
+        this(requirement, UnaryOperator.identity());
+    }
+
+    /**
+     * Creates a new capability based on the specified requirement
+     * @param requirement the requirement basis
+     * @param configurator configures the capability
+     */
+    public BinaryRequirementCapability(BinaryRequirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> configurator) {
+        this.definition = configurator.apply(RuntimeCapability.Builder.of(requirement.getName(), true).setServiceType(requirement.getType())).build();
         this.requirement = requirement;
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CredentialSourceDependency.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CredentialSourceDependency.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.security.CredentialReference;
@@ -54,9 +55,9 @@ public class CredentialSourceDependency implements ValueDependency<CredentialSou
     private final ExceptionSupplier<CredentialSource, Exception> supplier;
     private final Iterable<Dependency> dependencies;
 
-    public CredentialSourceDependency(OperationContext context, ModelNode model) throws OperationFailedException {
+    public CredentialSourceDependency(OperationContext context, Attribute attribute, ModelNode model) throws OperationFailedException {
         DependencyCollectingServiceBuilder builder = new DependencyCollectingServiceBuilder();
-        this.supplier = CredentialReference.getCredentialSourceSupplier(context, CredentialReference.getAttributeDefinition(), model, builder);
+        this.supplier = CredentialReference.getCredentialSourceSupplier(context, (ObjectTypeAttributeDefinition) attribute.getDefinition(), model, builder);
         this.dependencies = builder;
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequirementCapability.java
@@ -23,7 +23,6 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.function.UnaryOperator;
-import java.util.stream.Stream;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.clustering.service.Requirement;
@@ -39,19 +38,18 @@ public class RequirementCapability implements Capability {
     /**
      * Creates a new capability based on the specified requirement
      * @param requirement the requirement basis
-     * @param requirements a list of requirements of this capability
      */
-    public RequirementCapability(Requirement requirement, Requirement... requirements) {
-        this(requirement, builder -> builder.addRequirements(Stream.of(requirements).map(Requirement::getName).toArray(String[]::new)));
+    public RequirementCapability(Requirement requirement) {
+        this(requirement, UnaryOperator.identity());
     }
 
     /**
      * Creates a new capability based on the specified requirement
      * @param requirement the requirement basis
-     * @param builder configures the capability
+     * @param configurator configures the capability
      */
-    public RequirementCapability(Requirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> builder) {
-        this.definition = builder.apply(RuntimeCapability.Builder.of(requirement.getName(), requirement.getType())).build();
+    public RequirementCapability(Requirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> configurator) {
+        this.definition = configurator.apply(RuntimeCapability.Builder.of(requirement.getName()).setServiceType(requirement.getType())).build();
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
@@ -22,10 +22,9 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.stream.Stream;
+import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.wildfly.clustering.service.Requirement;
 import org.wildfly.clustering.service.UnaryRequirement;
 
 /**
@@ -41,8 +40,17 @@ public class UnaryRequirementCapability implements Capability {
      * @param requirement the unary requirement basis
      * @param requirements a list of requirements of this capability
      */
-    public UnaryRequirementCapability(UnaryRequirement requirement, Requirement... requirements) {
-        this.definition = RuntimeCapability.Builder.of(requirement.getName(), true, requirement.getType()).addRequirements(Stream.of(requirements).map(Requirement::getName).toArray(String[]::new)).build();
+    public UnaryRequirementCapability(UnaryRequirement requirement) {
+        this(requirement, UnaryOperator.identity());
+    }
+
+    /**
+     * Creates a new capability based on the specified unary requirement
+     * @param requirement the unary requirement basis
+     * @param configurator configures the capability
+     */
+    public UnaryRequirementCapability(UnaryRequirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> configurator) {
+        this.definition = configurator.apply(RuntimeCapability.Builder.of(requirement.getName(), true).setServiceType(requirement.getType())).build();
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/auth/BinaryAuthToken.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/auth/BinaryAuthToken.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.auth;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.util.Arrays;
+
+import org.jgroups.Message;
+import org.jgroups.auth.AuthToken;
+import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.util.Util;
+
+/**
+ * An AUTH token, analogous to {@link org.jgroups.auth.SimpleToken}, but uses a binary shared secret, instead of a case-insensitive string comparison.
+ * @author Paul Ferraro
+ */
+public class BinaryAuthToken extends AuthToken {
+
+    static {
+        ClassConfigurator.add((short) 1100, BinaryAuthToken.class);
+    }
+
+    private volatile byte[] sharedSecret;
+
+    public BinaryAuthToken() {
+        this.sharedSecret = null;
+    }
+
+    public BinaryAuthToken(byte[] sharedSecret) {
+        this.sharedSecret = sharedSecret;
+    }
+
+    public byte[] getSharedSecret() {
+        return this.sharedSecret;
+    }
+
+    @Override
+    public boolean authenticate(AuthToken token, Message message) {
+        if ((this.sharedSecret == null) || !(token instanceof BinaryAuthToken)) return false;
+        return Arrays.equals(this.sharedSecret, ((BinaryAuthToken) token).sharedSecret);
+    }
+
+    @Override
+    public String getName() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public int size() {
+        return Util.size(this.sharedSecret);
+    }
+
+    @Override
+    public void writeTo(DataOutput output) throws Exception {
+        Util.writeByteBuffer(this.sharedSecret, output);
+    }
+
+    @Override
+    public void readFrom(DataInput input) throws Exception {
+        this.sharedSecret = Util.readByteBuffer(input);
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/auth/CipherAuthToken.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/auth/CipherAuthToken.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.auth;
+
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.util.Arrays;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+
+import org.jgroups.Message;
+import org.jgroups.auth.AuthToken;
+import org.jgroups.conf.ClassConfigurator;
+
+/**
+ * An AUTH token, functionally equivalent to {@link org.jgroups.auth.X509Token}, but configured using Elytron resources.
+ * @author Paul Ferraro
+ */
+public class CipherAuthToken extends BinaryAuthToken {
+
+    static {
+        ClassConfigurator.add((short) 1101, CipherAuthToken.class);
+    }
+
+    private final Cipher cipher;
+    private final byte[] rawSharedSecret;
+
+    public CipherAuthToken() {
+        super();
+        this.cipher = null;
+        this.rawSharedSecret = null;
+    }
+
+    public CipherAuthToken(Cipher cipher, KeyPair pair, byte[] rawSharedSecret) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        super(encryptedSharedSecret(cipher, pair.getPublic(), rawSharedSecret));
+        this.cipher = cipher;
+        this.rawSharedSecret = rawSharedSecret;
+        this.cipher.init(Cipher.DECRYPT_MODE, pair.getPrivate());
+    }
+
+    private static byte[] encryptedSharedSecret(Cipher cipher, Key key, byte[] data) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        return cipher.doFinal(data);
+    }
+
+    @Override
+    public synchronized boolean authenticate(AuthToken token, Message message) {
+        if ((this.getSharedSecret() == null) || !(token instanceof CipherAuthToken)) return false;
+        try {
+            byte[] decrypted = this.cipher.doFinal(((CipherAuthToken) token).getSharedSecret());
+            return Arrays.equals(decrypted, this.rawSharedSecret);
+        } catch (GeneralSecurityException e) {
+            return false;
+        }
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
@@ -28,6 +28,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 
 import org.jboss.as.clustering.controller.AttributeMarshallers;
 import org.jboss.as.clustering.controller.AttributeParsers;
@@ -179,7 +180,13 @@ public class AbstractProtocolResourceDefinition<P extends Protocol, C extends Pr
         }
 
         LegacyAddOperationTransformation(Set<? extends org.jboss.as.clustering.controller.Attribute> attributes) {
+            // If none of the specified attributes are defined, then this is a legacy operation
             this(operation -> attributes.stream().noneMatch(attribute -> operation.hasDefined(attribute.getName())));
+        }
+
+        LegacyAddOperationTransformation(String... legacyProperties) {
+            // If any of the specified properties are defined, then this is a legacy operation
+            this(operation -> operation.hasDefined(Attribute.PROPERTIES.getName()) && Stream.of(legacyProperties).anyMatch(legacyProperty -> operation.get(Attribute.PROPERTIES.getName()).hasDefined(legacyProperty)));
         }
 
         LegacyAddOperationTransformation(Predicate<ModelNode> legacy) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolConfigurationBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceTarget;
+import org.jgroups.auth.AuthToken;
+import org.jgroups.protocols.AUTH;
+import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
+import org.wildfly.clustering.service.InjectedValueDependency;
+import org.wildfly.clustering.service.ValueDependency;
+
+/**
+ * @author Paul Ferraro
+ */
+public class AuthProtocolConfigurationBuilder extends ProtocolConfigurationBuilder<AUTH> {
+
+    private final ValueDependency<AuthToken> token;
+
+    public AuthProtocolConfigurationBuilder(PathAddress address) {
+        super(address);
+        this.token = new InjectedValueDependency<>(AuthTokenResourceDefinition.Capability.AUTH_TOKEN.getServiceName(address.append(AuthTokenResourceDefinition.WILDCARD_PATH)), AuthToken.class);
+    }
+
+    @Override
+    public ServiceBuilder<ProtocolConfiguration<AUTH>> build(ServiceTarget target) {
+        return this.token.register(super.build(target));
+    }
+
+    @Override
+    public void accept(AUTH protocol) {
+        protocol.setAuthToken(this.token.getValue());
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import java.util.function.Consumer;
+
+import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
+import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jgroups.protocols.AUTH;
+import org.wildfly.clustering.jgroups.spi.ChannelFactory;
+
+/**
+ * @author Paul Ferraro
+ */
+public class AuthProtocolResourceDefinition extends ProtocolResourceDefinition<AUTH> {
+
+    static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
+
+        ProtocolResourceDefinition.addTransformations(version, builder);
+    }
+
+    AuthProtocolResourceDefinition(String name, Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
+        super(pathElement(name), descriptorConfigurator.andThen(descriptor -> descriptor
+                .setAddOperationTransformation(new LegacyAddOperationTransformation("auth_class"))
+                .addResourceCapabilityReference(new CapabilityReference(Capability.PROTOCOL, AuthTokenResourceDefinition.Capability.AUTH_TOKEN), address -> address.getParent().getLastElement().getValue()))
+            , address -> new AuthProtocolConfigurationBuilder(address), parentBuilderFactory, (parent, registration) -> {
+                new PlainAuthTokenResourceDefinition().register(registration);
+                new DigestAuthTokenResourceDefinition().register(registration);
+                new CipherAuthTokenResourceDefinition().register(registration);
+        });
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenBuilder.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.clustering.jgroups.subsystem.AuthTokenResourceDefinition.Capability.AUTH_TOKEN;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import org.jboss.as.clustering.controller.CapabilityServiceNameProvider;
+import org.jboss.as.clustering.controller.CredentialSourceDependency;
+import org.jboss.as.clustering.controller.ResourceServiceBuilder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceTarget;
+import org.jgroups.auth.AuthToken;
+import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.MappedValueService;
+import org.wildfly.clustering.service.ValueDependency;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ * @author Paul Ferraro
+ */
+public abstract class AuthTokenBuilder<T extends AuthToken> extends CapabilityServiceNameProvider implements ResourceServiceBuilder<T>, Function<String, T> {
+    private volatile ValueDependency<CredentialSource> sharedSecretSource;
+
+    public AuthTokenBuilder(PathAddress address) {
+        super(AUTH_TOKEN, address);
+    }
+
+    @Override
+    public Builder<T> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        this.sharedSecretSource = new CredentialSourceDependency(context, AuthTokenResourceDefinition.Attribute.SHARED_SECRET, model);
+        return this;
+    }
+
+    @Override
+    public ServiceBuilder<T> build(ServiceTarget target) {
+        Function<CredentialSource, String> sharedSecret = sharedSecretSource -> {
+            try {
+                PasswordCredential credential = sharedSecretSource.getCredential(PasswordCredential.class);
+                ClearPassword password = credential.getPassword(ClearPassword.class);
+                return String.valueOf(password.getPassword());
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+        };
+        return this.sharedSecretSource.register(target.addService(this.getServiceName(), new MappedValueService<>(sharedSecret.andThen(this), this.sharedSecretSource)));
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import java.util.function.Consumer;
+
+import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
+import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
+import org.jboss.as.clustering.controller.SimpleResourceRegistration;
+import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jgroups.auth.AuthToken;
+import org.wildfly.clustering.service.UnaryRequirement;
+
+/**
+ * @author Paul Ferraro
+ */
+public class AuthTokenResourceDefinition<T extends AuthToken> extends ChildResourceDefinition<ManagementResourceRegistration> {
+    static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
+
+    static PathElement pathElement(String value) {
+        return PathElement.pathElement("token", value);
+    }
+
+    enum Capability implements org.jboss.as.clustering.controller.Capability, UnaryRequirement {
+        AUTH_TOKEN("org.wildfly.clustering.jgroups.auth-token", AuthToken.class),
+        ;
+        private final RuntimeCapability<Void> definition;
+
+        Capability(String name, Class<?> type) {
+            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setAllowMultipleRegistrations(true).build();
+        }
+
+        @Override
+        public RuntimeCapability<?> getDefinition() {
+            return this.definition;
+        }
+
+        @Override
+        public RuntimeCapability<?> resolve(PathAddress address) {
+            return this.definition.fromBaseCapability(address.getParent().getParent().getLastElement().getValue());
+        }
+    }
+
+    enum Attribute implements org.jboss.as.clustering.controller.Attribute {
+        SHARED_SECRET(CredentialReference.getAttributeBuilder("shared-secret-reference", null, false, new CapabilityReference(Capability.AUTH_TOKEN, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
+        ;
+        private final AttributeDefinition definition;
+
+        Attribute(AttributeDefinition definition) {
+            this.definition = definition;
+        }
+
+        @Override
+        public AttributeDefinition getDefinition() {
+            return this.definition;
+        }
+    }
+
+    static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
+
+        ProtocolResourceDefinition.addTransformations(version, builder);
+    }
+
+    private final Consumer<ResourceDescriptor> configurator;
+    private final ResourceServiceBuilderFactory<T> builderFactory;
+
+    AuthTokenResourceDefinition(PathElement path, Consumer<ResourceDescriptor> configurator, ResourceServiceBuilderFactory<T> builderFactory) {
+        super(path, new JGroupsResourceDescriptionResolver(path, WILDCARD_PATH));
+        this.configurator = configurator;
+        this.builderFactory = builderFactory;
+    }
+
+    @Override
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addCapabilities(Capability.class)
+                ;
+        this.configurator.accept(descriptor);
+        new SimpleResourceRegistration(descriptor, new SimpleResourceServiceHandler<>(this.builderFactory)).register(registration);
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.clustering.jgroups.subsystem.CipherAuthTokenResourceDefinition.Attribute.*;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyStore;
+
+import javax.crypto.Cipher;
+
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
+import org.jboss.as.clustering.controller.CredentialSourceDependency;
+import org.jboss.as.clustering.jgroups.auth.CipherAuthToken;
+import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.InjectedValueDependency;
+import org.wildfly.clustering.service.ValueDependency;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ * @author Paul Ferraro
+ */
+public class CipherAuthTokenBuilder extends AuthTokenBuilder<CipherAuthToken> {
+
+    private volatile ValueDependency<KeyStore> keyStore;
+    private volatile ValueDependency<CredentialSource> keyCredentialSource;
+    private volatile String keyAlias;
+    private volatile String transformation;
+
+    public CipherAuthTokenBuilder(PathAddress address) {
+        super(address);
+    }
+
+    @Override
+    public Builder<CipherAuthToken> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        String keyStore = KEY_STORE.resolveModelAttribute(context, model).asString();
+        this.keyStore = new InjectedValueDependency<>(CommonUnaryRequirement.KEY_STORE.getServiceName(context, keyStore), KeyStore.class);
+        this.keyAlias = KEY_ALIAS.resolveModelAttribute(context, model).asString();
+        this.keyCredentialSource = new CredentialSourceDependency(context, KEY_CREDENTIAL, model);
+        this.transformation = ALGORITHM.resolveModelAttribute(context, model).asString();
+        return super.configure(context, model);
+    }
+
+    @Override
+    public CipherAuthToken apply(String authValue) {
+        KeyStore store = this.keyStore.getValue();
+        String alias = this.keyAlias;
+        try {
+            if (!store.containsAlias(alias)) {
+                throw JGroupsLogger.ROOT_LOGGER.keyEntryNotFound(alias);
+            }
+            if (!store.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                throw JGroupsLogger.ROOT_LOGGER.privateKeyStoreEntryExpected(alias);
+            }
+            PasswordCredential credential = this.keyCredentialSource.getValue().getCredential(PasswordCredential.class);
+            if (credential == null) {
+                throw JGroupsLogger.ROOT_LOGGER.unexpectedCredentialSource();
+            }
+            ClearPassword password = credential.getPassword(ClearPassword.class);
+            if (password == null) {
+                throw JGroupsLogger.ROOT_LOGGER.unexpectedCredentialSource();
+            }
+            KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry) store.getEntry(alias, new KeyStore.PasswordProtection(password.getPassword()));
+            KeyPair pair = new KeyPair(entry.getCertificate().getPublicKey(), entry.getPrivateKey());
+            Cipher cipher = Cipher.getInstance(this.transformation);
+            return new CipherAuthToken(cipher, pair, authValue.getBytes());
+        } catch (GeneralSecurityException | IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenResourceDefinition.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import java.util.function.UnaryOperator;
+
+import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.CommonUnaryRequirement;
+import org.jboss.as.clustering.jgroups.auth.CipherAuthToken;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author Paul Ferraro
+ */
+public class CipherAuthTokenResourceDefinition extends AuthTokenResourceDefinition<CipherAuthToken> {
+
+    static final PathElement PATH = pathElement("cipher");
+
+    enum Attribute implements org.jboss.as.clustering.controller.Attribute {
+        KEY_CREDENTIAL(CredentialReference.getAttributeBuilder("key-credential-reference", null, false, new CapabilityReference(Capability.AUTH_TOKEN, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
+        KEY_ALIAS("key-alias", ModelType.STRING, builder -> builder.setAllowExpression(true)),
+        KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.AUTH_TOKEN, CommonUnaryRequirement.KEY_STORE))),
+        ALGORITHM("algorithm", ModelType.STRING, builder -> builder.setAllowExpression(true).setRequired(false).setDefaultValue(new ModelNode("RSA"))),
+        ;
+        private final AttributeDefinition definition;
+
+        Attribute(String name, ModelType type, UnaryOperator<SimpleAttributeDefinitionBuilder> configurator) {
+            this.definition = configurator.apply(new SimpleAttributeDefinitionBuilder(name, type)
+                    .setRequired(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    ).build();
+        }
+
+        Attribute(AttributeDefinition definition) {
+            this.definition = definition;
+        }
+
+        @Override
+        public AttributeDefinition getDefinition() {
+            return this.definition;
+        }
+    }
+
+    CipherAuthTokenResourceDefinition() {
+        super(PATH, descriptor -> descriptor.addAttributes(Attribute.class), address -> new CipherAuthTokenBuilder(address));
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenBuilder.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import static org.jboss.as.clustering.jgroups.subsystem.DigestAuthTokenResourceDefinition.Attribute.*;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.jboss.as.clustering.jgroups.auth.BinaryAuthToken;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jgroups.auth.MD5Token;
+import org.wildfly.clustering.service.Builder;
+
+/**
+ * Builds an AUTH token, functionally equivalent to {@link MD5Token}, but can use any digest algorithm supported by the default security provider.
+ * @author Paul Ferraro
+ */
+public class DigestAuthTokenBuilder extends AuthTokenBuilder<BinaryAuthToken> {
+
+    private volatile String algorithm;
+
+    public DigestAuthTokenBuilder(PathAddress address) {
+        super(address);
+    }
+
+    @Override
+    public Builder<BinaryAuthToken> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        this.algorithm = ALGORITHM.resolveModelAttribute(context, model).asString();
+        return super.configure(context, model);
+    }
+
+    @Override
+    public BinaryAuthToken apply(String sharedSecret) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(this.algorithm);
+            return new BinaryAuthToken(digest.digest(sharedSecret.getBytes()));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenResourceDefinition.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import org.jboss.as.clustering.jgroups.auth.BinaryAuthToken;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DigestAuthTokenResourceDefinition extends AuthTokenResourceDefinition<BinaryAuthToken> {
+
+    static final PathElement PATH = pathElement("digest");
+
+    enum Attribute implements org.jboss.as.clustering.controller.Attribute {
+        ALGORITHM("algorithm", ModelType.STRING, new ModelNode("SHA-256")),
+        ;
+        private final AttributeDefinition definition;
+
+        Attribute(String name, ModelType type, ModelNode defaultValue) {
+            this.definition = new SimpleAttributeDefinitionBuilder(name, type)
+                    .setAllowExpression(true)
+                    .setDefaultValue(defaultValue)
+                    .setRequired(false)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
+        }
+
+        @Override
+        public AttributeDefinition getDefinition() {
+            return this.definition;
+        }
+    }
+
+    DigestAuthTokenResourceDefinition() {
+        super(PATH, descriptor -> descriptor.addAttributes(Attribute.class), address -> new DigestAuthTokenBuilder(address));
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolConfigurationBuilder.java
@@ -66,7 +66,7 @@ public class EncryptProtocolConfigurationBuilder<P extends EncryptBase & Encrypt
         String keyStore = KEY_STORE.resolveModelAttribute(context, model).asString();
         this.keyStore = new InjectedValueDependency<>(CommonUnaryRequirement.KEY_STORE.getServiceName(context, keyStore), KeyStore.class);
         this.keyAlias = KEY_ALIAS.resolveModelAttribute(context, model).asString();
-        this.credentialSource = new CredentialSourceDependency(context, model);
+        this.credentialSource = new CredentialSourceDependency(context, CREDENTIAL, model);
         return super.configure(context, model);
     }
 
@@ -93,8 +93,8 @@ public class EncryptProtocolConfigurationBuilder<P extends EncryptBase & Encrypt
             if (password == null) {
                 throw JGroupsLogger.ROOT_LOGGER.unexpectedCredentialSource();
             }
-            protocol.setKeyStore(this.keyStore.getValue());
-            protocol.setKeyAlias(this.keyAlias);
+            protocol.setKeyStore(store);
+            protocol.setKeyAlias(alias);
             protocol.setKeyPassword(new KeyStore.PasswordProtection(password.getPassword()));
         } catch (KeyStoreException | IOException e) {
             throw new IllegalArgumentException(e);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolConfigurationBuilder.java
@@ -66,7 +66,7 @@ public class EncryptProtocolConfigurationBuilder<P extends EncryptBase & Encrypt
         String keyStore = KEY_STORE.resolveModelAttribute(context, model).asString();
         this.keyStore = new InjectedValueDependency<>(CommonUnaryRequirement.KEY_STORE.getServiceName(context, keyStore), KeyStore.class);
         this.keyAlias = KEY_ALIAS.resolveModelAttribute(context, model).asString();
-        this.credentialSource = new CredentialSourceDependency(context, CREDENTIAL, model);
+        this.credentialSource = new CredentialSourceDependency(context, KEY_CREDENTIAL, model);
         return super.configure(context, model);
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -47,7 +47,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 public class EncryptProtocolResourceDefinition<P extends EncryptBase & EncryptProtocol> extends ProtocolResourceDefinition<P> {
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CREDENTIAL(CredentialReference.getAttributeBuilder(CredentialReference.CREDENTIAL_REFERENCE, CredentialReference.CREDENTIAL_REFERENCE, false, new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
+        KEY_CREDENTIAL(CredentialReference.getAttributeBuilder("key-credential-reference", null, false, new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.CREDENTIAL_STORE)).build()),
         KEY_ALIAS("key-alias", ModelType.STRING, builder -> builder.setAllowExpression(true)),
         KEY_STORE("key-store", ModelType.STRING, builder -> builder.setCapabilityReference(new CapabilityReference(Capability.PROTOCOL, CommonUnaryRequirement.KEY_STORE))),
         ;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
@@ -609,8 +609,8 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
         ModelNode operation = operations.get(address);
         XMLElement element = XMLElement.forName(reader.getLocalName());
         switch (element) {
-            case CREDENTIAL_REFERENCE: {
-                readElement(reader, operation, EncryptProtocolResourceDefinition.Attribute.CREDENTIAL);
+            case KEY_CREDENTIAL_REFERENCE: {
+                readElement(reader, operation, EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL);
                 break;
             }
             default: {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
@@ -143,7 +143,7 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
         } else if (ProtocolRegistration.ProtocolType.JDBC.contains(property.getName())) {
             writeAttributes(writer, property.getValue(), EnumSet.allOf(JDBCProtocolResourceDefinition.Attribute.class));
         } else if (ProtocolRegistration.ProtocolType.ENCRYPT.contains(property.getName())) {
-            EnumSet<EncryptProtocolResourceDefinition.Attribute> elementAttributes = EnumSet.of(EncryptProtocolResourceDefinition.Attribute.CREDENTIAL);
+            EnumSet<EncryptProtocolResourceDefinition.Attribute> elementAttributes = EnumSet.of(EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL);
             writeAttributes(writer, property.getValue(), EnumSet.complementOf(elementAttributes));
 
             if (hasDefined(property.getValue(), elementAttributes)) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import org.jboss.as.controller.PathAddress;
+import org.jgroups.auth.SimpleToken;
+
+/**
+ * @author Paul Ferraro
+ */
+public class PlainAuthTokenBuilder extends AuthTokenBuilder<SimpleToken> {
+
+    public PlainAuthTokenBuilder(PathAddress address) {
+        super(address);
+    }
+
+    @Override
+    public SimpleToken apply(String sharedSecret) {
+        return new SimpleToken(sharedSecret);
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenResourceDefinition.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import org.jboss.as.clustering.function.Consumers;
+import org.jboss.as.controller.PathElement;
+import org.jgroups.auth.SimpleToken;
+
+/**
+ * @author Paul Ferraro
+ */
+public class PlainAuthTokenResourceDefinition extends AuthTokenResourceDefinition<SimpleToken> {
+
+    static final PathElement PATH = pathElement("plain");
+
+    PlainAuthTokenResourceDefinition() {
+        super(PATH, Consumers.empty(), address -> new PlainAuthTokenBuilder(address));
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLAttribute.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLAttribute.java
@@ -31,6 +31,7 @@ public enum XMLAttribute {
     // must be first
     UNKNOWN(""),
 
+    ALGORITHM(DigestAuthTokenResourceDefinition.Attribute.ALGORITHM),
     CHANNEL(RemoteSiteResourceDefinition.Attribute.CHANNEL),
     CLUSTER(ChannelResourceDefinition.Attribute.CLUSTER),
     DATA_SOURCE(JDBCProtocolResourceDefinition.Attribute.DATA_SOURCE),

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLElement.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLElement.java
@@ -36,19 +36,24 @@ public enum XMLElement {
     // must be first
     UNKNOWN(""),
 
+    AUTH_PROTOCOL("auth-protocol"),
+    CIPHER_TOKEN("cipher-token"),
     CHANNEL(ChannelResourceDefinition.WILDCARD_PATH),
     CHANNELS("channels"),
     DEFAULT_THREAD_POOL("default-thread-pool"),
+    DIGEST_TOKEN("digest-token"),
     ENCRYPT_PROTOCOL("encrypt-protocol"),
     FORK(ForkResourceDefinition.WILDCARD_PATH),
     INTERNAL_THREAD_POOL("internal-thread-pool"),
     JDBC_PROTOCOL("jdbc-protocol"),
     KEY_CREDENTIAL_REFERENCE(EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL),
     OOB_THREAD_POOL("oob-thread-pool"),
+    PLAIN_TOKEN("plain-token"),
     PROPERTY(ModelDescriptionConstants.PROPERTY),
     PROTOCOL(ProtocolResourceDefinition.WILDCARD_PATH),
     RELAY(RelayResourceDefinition.WILDCARD_PATH),
     REMOTE_SITE(RemoteSiteResourceDefinition.WILDCARD_PATH),
+    SHARED_SECRET_CREDENTIAL_REFERENCE(AuthTokenResourceDefinition.Attribute.SHARED_SECRET),
     SOCKET_PROTOCOL("socket-protocol"),
     SOCKET_DISCOVERY_PROTOCOL("socket-discovery-protocol"),
     STACK(StackResourceDefinition.WILDCARD_PATH),
@@ -81,6 +86,8 @@ public enum XMLElement {
     }
 
     private static final Map<String, XMLElement> elements = new HashMap<>();
+    private static final Map<String, XMLElement> protocols = new HashMap<>();
+    private static final Map<String, XMLElement> tokens = new HashMap<>();
 
     static {
         for (XMLElement element : values()) {
@@ -89,6 +96,16 @@ public enum XMLElement {
                 elements.put(name, element);
             }
         }
+
+        ProtocolType.MULTICAST_SOCKET.forEach(protocol -> protocols.put(protocol, XMLElement.SOCKET_PROTOCOL));
+        ProtocolType.JDBC.forEach(protocol -> protocols.put(protocol, XMLElement.JDBC_PROTOCOL));
+        ProtocolType.ENCRYPT.forEach(protocol -> protocols.put(protocol, XMLElement.ENCRYPT_PROTOCOL));
+        ProtocolType.SOCKET_DISCOVERY.forEach(protocol -> protocols.put(protocol, XMLElement.SOCKET_DISCOVERY_PROTOCOL));
+        ProtocolType.AUTH.forEach(protocol -> protocols.put(protocol, XMLElement.AUTH_PROTOCOL));
+
+        tokens.put(PlainAuthTokenResourceDefinition.PATH.getValue(), XMLElement.PLAIN_TOKEN);
+        tokens.put(DigestAuthTokenResourceDefinition.PATH.getValue(), XMLElement.DIGEST_TOKEN);
+        tokens.put(CipherAuthTokenResourceDefinition.PATH.getValue(), XMLElement.CIPHER_TOKEN);
     }
 
     public static XMLElement forName(String localName) {
@@ -96,11 +113,14 @@ public enum XMLElement {
         return (element != null) ? element : UNKNOWN;
     }
 
-    public static XMLElement forProtocol(String protocol) {
-        if (ProtocolType.MULTICAST_SOCKET.contains(protocol)) return XMLElement.SOCKET_PROTOCOL;
-        if (ProtocolType.JDBC.contains(protocol)) return XMLElement.JDBC_PROTOCOL;
-        if (ProtocolType.ENCRYPT.contains(protocol)) return XMLElement.ENCRYPT_PROTOCOL;
-        if (ProtocolType.SOCKET_DISCOVERY.contains(protocol)) return XMLElement.SOCKET_DISCOVERY_PROTOCOL;
-        return XMLElement.PROTOCOL;
+    public static XMLElement forProtocolName(String protocol) {
+        XMLElement element = protocols.get(protocol);
+        return (element != null) ? element : XMLElement.PROTOCOL;
+    }
+
+    public static XMLElement forAuthTokenName(String token) {
+        XMLElement element = tokens.get(token);
+        if (element == null) throw new IllegalArgumentException(token);
+        return element;
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLElement.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/XMLElement.java
@@ -24,10 +24,10 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.clustering.jgroups.subsystem.ProtocolRegistration.ProtocolType;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.security.CredentialReference;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -38,12 +38,12 @@ public enum XMLElement {
 
     CHANNEL(ChannelResourceDefinition.WILDCARD_PATH),
     CHANNELS("channels"),
-    CREDENTIAL_REFERENCE(CredentialReference.CREDENTIAL_REFERENCE),
     DEFAULT_THREAD_POOL("default-thread-pool"),
     ENCRYPT_PROTOCOL("encrypt-protocol"),
     FORK(ForkResourceDefinition.WILDCARD_PATH),
     INTERNAL_THREAD_POOL("internal-thread-pool"),
     JDBC_PROTOCOL("jdbc-protocol"),
+    KEY_CREDENTIAL_REFERENCE(EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL),
     OOB_THREAD_POOL("oob-thread-pool"),
     PROPERTY(ModelDescriptionConstants.PROPERTY),
     PROTOCOL(ProtocolResourceDefinition.WILDCARD_PATH),
@@ -61,6 +61,10 @@ public enum XMLElement {
 
     XMLElement(PathElement path) {
         this.name = path.isWildcard() ? path.getKey() : path.getValue();
+    }
+
+    XMLElement(Attribute attribute) {
+        this.name = attribute.getName();
     }
 
     XMLElement(String name) {

--- a/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
+++ b/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
@@ -98,12 +98,31 @@ jgroups.protocol.key-credential-reference.alias=The alias which denotes stored s
 jgroups.protocol.key-credential-reference.type=The type of credential this reference is denoting.
 jgroups.protocol.key-credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
 jgroups.protocol.statistics-enabled=Indicates whether or not this protocol will collect statistics overriding stack configuration.
+jgroups.protocol.token=An authentication token
 
 jgroups.protocol.org.jgroups.protocols.ASYM_ENCRYPT.deprecated=Deprecated. Use protocol=ASYM_ENCRYPT instead.
 jgroups.protocol.org.jgroups.protocols.SYM_ENCRYPT.deprecated=Deprecated. Use protocol=SYM_ENCRYPT instead.
 jgroups.protocol.org.jgroups.protocols.JDBC_PING.deprecated=Deprecated. Use protocol=JDBC_PING instead.
 jgroups.protocol.org.jgroups.protocols.TCPGOSSIP.deprecated=Deprecated. Use protocol=TCPGOSSIP instead.
 jgroups.protocol.org.jgroups.protocols.TCPPING.deprecated=Deprecated. Use protocol=TCPPING instead.
+jgroups.protocol.org.jgroups.protocols.AUTH.deprecated=Deprecated. Use protocol=AUTH instead.
+
+jgroups.token=An authentication token
+jgroups.token.add=Adds an authentication token
+jgroups.token.remove=Removes an authentication token
+jgroups.token.shared-secret-reference=The credentials required to obtain the shared secret from the key store.
+jgroups.token.shared-secret-reference.store=The name of the credential store holding the alias to credential.
+jgroups.token.shared-secret-reference.alias=The alias which denotes stored secret or credential in the store.
+jgroups.token.shared-secret-reference.type=The type of credential this reference is denoting.
+jgroups.token.shared-secret-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
+jgroups.token.algorithm=The algorithm with which to transform the shared secret
+jgroups.token.key-alias=The alias of the encryption key from the specified key store
+jgroups.token.key-store=A reference to a key store containing the encryption key
+jgroups.token.key-credential-reference=The credentials required to obtain the encryption key from the key store.
+jgroups.token.key-credential-reference.store=The name of the credential store holding the alias to credential.
+jgroups.token.key-credential-reference.alias=The alias which denotes stored secret or credential in the store.
+jgroups.token.key-credential-reference.type=The type of credential this reference is denoting.
+jgroups.token.key-credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
 
 # property resource
 jgroups.property=A protocol property with name and value.
@@ -111,6 +130,7 @@ jgroups.property.deprecated=Deprecated. Protocol properties are defined via the 
 jgroups.property.add=Adds a protocol property.
 jgroups.property.remove=Removes a protocol property.
 jgroups.property.value=The value of a protocol property.
+
 # channel resource
 jgroups.channel=A JGroups channel.
 jgroups.channel.add=Add a JGroups channel

--- a/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
+++ b/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
@@ -92,11 +92,11 @@ jgroups.protocol.properties=The properties of this protocol.
 jgroups.protocol.property=A JGroups protocol property.
 jgroups.protocol.key-alias=The alias of the encryption key from the specified key store
 jgroups.protocol.key-store=A reference to a key store containing the encryption key
-jgroups.protocol.credential-reference=The credentials required to obtain the encryption key from the key store.
-jgroups.protocol.credential-reference.store=The name of the credential store holding the alias to credential.
-jgroups.protocol.credential-reference.alias=The alias which denotes stored secret or credential in the store.
-jgroups.protocol.credential-reference.type=The type of credential this reference is denoting.
-jgroups.protocol.credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
+jgroups.protocol.key-credential-reference=The credentials required to obtain the encryption key from the key store.
+jgroups.protocol.key-credential-reference.store=The name of the credential store holding the alias to credential.
+jgroups.protocol.key-credential-reference.alias=The alias which denotes stored secret or credential in the store.
+jgroups.protocol.key-credential-reference.type=The type of credential this reference is denoting.
+jgroups.protocol.key-credential-reference.clear-text=The secret specified using clear text. Check credential store way of supplying credential/secrets to services.
 jgroups.protocol.statistics-enabled=Indicates whether or not this protocol will collect statistics overriding stack configuration.
 
 jgroups.protocol.org.jgroups.protocols.ASYM_ENCRYPT.deprecated=Deprecated. Use protocol=ASYM_ENCRYPT instead.

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_4_1.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_4_1.xsd
@@ -265,7 +265,11 @@
         <xs:complexContent>
             <xs:extension base="tns:generic-protocol">
                 <xs:sequence>
-                    <xs:element name="credential-reference" type="tns:credential-reference" minOccurs="0"/>
+                    <xs:element name="key-credential-reference" type="tns:credential-reference">
+                        <xs:annotation>
+                            <xs:documentation>References the password credential with which the key is protected.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                 </xs:sequence>
                 <xs:attribute name="key-store" type="xs:string" use="required">
                     <xs:annotation>

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_4_1.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_4_1.xsd
@@ -169,6 +169,11 @@
                         <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="auth-protocol" type="tns:auth-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
             </xs:choice>
             <xs:element name="relay" type="tns:relay" minOccurs="0">
                 <xs:annotation>
@@ -273,12 +278,87 @@
                 </xs:sequence>
                 <xs:attribute name="key-store" type="xs:string" use="required">
                     <xs:annotation>
-                        <xs:documentation>References key store containing the key used to sign and verify logout requests.</xs:documentation>
+                        <xs:documentation>References key store containing the key used to encrypt messages.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
                 <xs:attribute name="key-alias" type="xs:string" use="required">
                     <xs:annotation>
-                        <xs:documentation>The alias of the key used to sign and verify logout requests.</xs:documentation>
+                        <xs:documentation>The alias of the key used to encrypt.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auth-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:choice>
+                    <xs:element name="plain-token" type="tns:plain-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using a plain text shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="digest-token" type="tns:digest-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using a digest of a shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="cipher-token" type="tns:cipher-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using an encrypted shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="plain-token">
+        <xs:sequence>
+            <xs:element name="shared-secret-reference" type="tns:credential-reference">
+                <xs:annotation>
+                    <xs:documentation>References a shared secret used to authenticate new members.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="digest-token">
+        <xs:complexContent>
+            <xs:extension base="tns:plain-token">
+                <xs:attribute name="algorithm" type="xs:string" default="SHA-265">
+                    <xs:annotation>
+                        <xs:documentation>The digest algorithm with which to obfuscate the shared secret.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="cipher-token">
+        <xs:complexContent>
+            <xs:extension base="tns:plain-token">
+                <xs:sequence>
+                    <xs:element name="key-credential-reference" type="tns:credential-reference">
+                        <xs:annotation>
+                            <xs:documentation>References the credential required to obtain the specified key from the specified store.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References key store containing the private key and certificate used to authenticate new members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-alias" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The alias of the private key and certificate used to authenticate new members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="algorithm" type="xs:string" default="RSA">
+                    <xs:annotation>
+                        <xs:documentation>The encryption algorithm/transformation used to protect the shared secret during transmission.</xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
             </xs:extension>
@@ -456,5 +536,9 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
+
+    <xs:simpleType name="list">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
 
 </xs:schema>

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemParsingTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemParsingTestCase.java
@@ -73,7 +73,7 @@ public class JGroupsSubsystemParsingTestCase extends ClusteringSubsystemTest {
                 { JGroupsSchema.VERSION_2_0, 22 },
                 { JGroupsSchema.VERSION_3_0, 29 },
                 { JGroupsSchema.VERSION_4_0, 29 },
-                { JGroupsSchema.VERSION_4_1, 31 },
+                { JGroupsSchema.VERSION_4_1, 33 },
         };
         return Arrays.asList(data);
     }

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_1.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_1.xml
@@ -70,6 +70,9 @@
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
+            <encrypt-protocol type="SYM_ENCRYPT" key-store="my-key-store" key-alias="alias">
+                <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
+            </encrypt-protocol>
             <protocol type="pbcast.NAKACK2"/>
             <protocol type="UNICAST2"/>
             <protocol type="pbcast.STABLE"/>
@@ -78,9 +81,6 @@
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>
             <protocol type="RSVP"/>
-            <encrypt-protocol type="SYM_ENCRYPT" key-store="my-key-store" key-alias="alias">
-                <credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
-            </encrypt-protocol>
             <relay site="LON">
                 <remote-site name="SFO" channel="bridge"/>
                 <remote-site name="NYC" channel="bridge"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_1.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_1.xml
@@ -77,6 +77,12 @@
             <protocol type="UNICAST2"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
+            <auth-protocol type="AUTH">
+                <cipher-token algorithm="RSA" key-store="my-key-store" key-alias="alias">
+                    <shared-secret-reference clear-text="changeme"/>
+                    <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
+                </cipher-token>
+            </auth-protocol>
             <protocol type="UFC"/>
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnSessionFactoryBuilder.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnSessionFactoryBuilder.java
@@ -78,7 +78,7 @@ public class SingleSignOnSessionFactoryBuilder extends SingleSignOnSessionFactor
         String keyStore = KEY_STORE.resolveModelAttribute(context, model).asString();
         this.keyStore = new InjectedValueDependency<>(CommonUnaryRequirement.KEY_STORE.getServiceName(context, keyStore), KeyStore.class);
         this.keyAlias = KEY_ALIAS.resolveModelAttribute(context, model).asString();
-        this.credentialSource = new CredentialSourceDependency(context, model);
+        this.credentialSource = new CredentialSourceDependency(context, CREDENTIAL, model);
         Optional<String> sslContext = ModelNodes.optionalString(SSL_CONTEXT.resolveModelAttribute(context, model));
         this.sslContext = sslContext.map(value -> new InjectedValueDependency<>(CommonUnaryRequirement.SSL_CONTEXT.getServiceName(context, value), SSLContext.class)).orElse(null);
         return this;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8019
https://issues.jboss.org/browse/WFLY-8808

Uses credential reference to obtain shared secret used by AUTH tokens.  Adds explicit resource definitions for supported tokens:
* /protocol=AUTH/token=plain - uses org.jgroups.auth.SimpleToken
* /protocol=AUTH/token=digest - replaces org.jgroups.auth.MD5Token
* /protocol=AUTH/token=cipher - replaces org.jgroups.auth.X509Token