### PR TITLE
[WFLY-8644] unignored naming tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -51,11 +51,9 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.Utils;
-import org.jboss.as.test.shared.util.DisableInvocationTestUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -77,15 +75,10 @@ public class LdapUrlInSearchBaseTestCase {
     @ArquillianResource
     URL webAppURL;
 
-    @BeforeClass
-    public static void beforeClass() {
-        DisableInvocationTestUtil.disable();
-    }
-
     // Public methods --------------------------------------------------------
 
     /**
-     * Creates {@link WebArchive} with the {@link OKServlet}.
+     * Creates {@link WebArchive} with the {@link LdapUrlTestServlet}.
      *
      * @return
      */

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/ConnectionListenerTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/ConnectionListenerTestCase.java
@@ -12,12 +12,10 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.manualmode.ejb.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.jca.adapters.jdbc.spi.listener.ConnectionListener;
 import org.jboss.logging.Logger;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,11 +34,6 @@ public class ConnectionListenerTestCase extends AbstractTestsuite {
     private ContainerController controller;
     @ArquillianResource
     private Deployer deployer;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeInvocationTestsEnabled();
-    }
 
     @Before
     public void init() throws Exception {


### PR DESCRIPTION
Unignored tests, which are green after https://issues.jboss.org/browse/WFNC-35 fixing.

Requires https://github.com/wildfly/wildfly-naming-client/pull/35 (merged into wildfly-naming-client 1.0.0.Beta16 - not tagged yet)
**Green tests requires wildfly-naming-client tag and upgrade.**

https://issues.jboss.org/browse/WFLY-8644
https://issues.jboss.org/browse/JBEAP-10563