### PR TITLE
[WFLY-8720] Fix bind address in Elytron version of AuthenticationTestCase

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
@@ -80,7 +80,7 @@ import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
 @Category(CommonCriteria.class)
 public class AuthenticationTestCase {
 
-    private static final String SERVER_HOST_PORT = TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort();
+    private static final String SERVER_HOST_PORT = TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort();
     private static final String WAR_URL = "http://" + SERVER_HOST_PORT + "/ejb3security/";
 
     /*


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8720
https://issues.jboss.org/browse/JBEAP-10788

One more fix is needed after unignoring  the testcase. Incorrect bind address was used.