### PR TITLE
[WFCORE-2560] unignore regression test for case sensitive usernames in Elytron filesystem-realms

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/application/BasicAuthnTestCase.java
@@ -137,7 +137,6 @@ public class BasicAuthnTestCase {
         Utils.makeCallWithBasicAuthn(servletUrl, "user1", "password", SC_UNAUTHORIZED);
         Utils.makeCallWithBasicAuthn(servletUrl, "user1", "Password1", SC_UNAUTHORIZED);
         // unknown user
-        // ignored due to https://issues.jboss.org/browse/JBEAP-8810
-        // Utils.makeCallWithBasicAuthn(servletUrl, "User1", "password1", SC_UNAUTHORIZED);
+        Utils.makeCallWithBasicAuthn(servletUrl, "User1", "password1", SC_UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2560
https://issues.jboss.org/browse/JBEAP-8810

Unignores regression test for usernames case-sensitiveness in Elytron filesystem-realm on Windows.