### PR TITLE
[WFLY-8746] RejectedExecutionException in the MDB during shutdown

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -52,6 +52,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.messaging.activemq.ActiveMQActivationService;
 import org.wildfly.extension.messaging.activemq.DefaultCredentials;
+import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -71,6 +72,7 @@ public class JMSService implements Service<JMSServerManager> {
         final JMSService service = new JMSService(serverServiceName, overrideInVMSecurity);
         ServiceBuilder<JMSServerManager> builder = target.addService(JMSServices.getJmsManagerBaseServiceName(serverServiceName), service)
                 .addDependency(serverServiceName, ActiveMQServer.class, service.activeMQServer)
+                .addDependency(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL)
                 .setInitialMode(Mode.ACTIVE);
         addServerExecutorDependency(builder, service.serverExecutor);
         return builder.install();


### PR DESCRIPTION
Add a dependency from the JMS server service to the Artemis client
thread pools to ensure that the thread pools are cleaned up after the
JMS servers are stopped.

JIRA: https://issues.jboss.org/browse/WFLY-8746