### PR TITLE
[WFCORE-2899]: not possible to remove deployment-overlay in mixed domain when slave host is EAP 6.3. or older

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDeploymentOverlayTestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDeploymentOverlayTestCase.java
@@ -255,6 +255,13 @@ public class MixedDeploymentOverlayTestCase {
         }
         performHttpCall(DomainTestSupport.slaveAddress, 8280, "main-deployment/index.html", "Bonjour le monde");
         performHttpCall(DomainTestSupport.slaveAddress, 8380, "other-deployment/index.html", "Bonjour le monde");
+
+        //Remove all CLI style "deployment-overlay remove --name=overlay-test "
+        ModelNode cliRemoveOverlay = Operations.createCompositeOperation();
+        cliRemoveOverlay.get(STEPS).add(Operations.createOperation(REMOVE, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        cliRemoveOverlay.get(STEPS).add(Operations.createOperation(REMOVE, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        cliRemoveOverlay.get(STEPS).add(Operations.createOperation(REMOVE, PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        executeAsyncForResult(masterClient, cliRemoveOverlay);
     }
 
     private void executeAsyncForResult(DomainClient client, ModelNode op) {


### PR DESCRIPTION
Mixed domain test to ensure that the fix in core in working properly.

Jira: https://issues.jboss.org/browse/WFCORE-2899
JBEAP: https://issues.jboss.org/browse/JBEAP-10720

This requires a core update with https://github.com/wildfly/wildfly-core/pull/2500 merged