### PR TITLE
[WFLY-8782] reenable RemoteIdentityTestCase with elytron profile

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/RemoteIdentityTestCase.java
@@ -34,10 +34,8 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.permission.ElytronPermission;
@@ -55,11 +53,6 @@ public class RemoteIdentityTestCase {
 
     @ArquillianResource
     private ManagementClient mgmtClient;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     /**
      * Creates a deployment application for this test.


### PR DESCRIPTION
One more try (originally was https://github.com/wildfly/wildfly/pull/10069) - the remoting should be fixed now properly 

JIRA: https://issues.jboss.org/browse/WFLY-8782
Downstream JIRA: https://issues.jboss.org/browse/JBEAP-10945

Reenable `RemoteIdentityTestCase` in AS TS when running with `-Delytron` switch.