### PR TITLE
Fix test wildfly-config.xml for removal of the allow-all-sasl-mechani…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/wildfly-config.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/basic/wildfly-config.xml
@@ -25,7 +25,7 @@
         </authentication-rules>
         <authentication-configurations>
             <configuration name="default">
-                <allow-all-sasl-mechanisms />
+                <sasl-mechanism-selector selector="#ALL" />
                 <set-mechanism-properties>
                     <property key="wildfly.sasl.local-user.quiet-auth" value="true" />
                  </set-mechanism-properties>


### PR DESCRIPTION
…sms element due to WFCORE-2917.

The `<allow-all-sasl-mechanisms />` was removed in https://github.com/wildfly/wildfly-core/pull/2510. Test `wildfly-config.xml` need to use the new element.