### PR TITLE
[WFLY-8920] Adding application-security-domain in EJB subsystem requires server reload

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ApplicationSecurityDomainDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ApplicationSecurityDomainDefinition.java
@@ -166,6 +166,11 @@ public class ApplicationSecurityDomainDefinition extends SimpleResourceDefinitio
             }
 
             serviceBuilder.install();
+
+            if (!context.isBooting()) {
+                context.reloadRequired();
+                context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
+            }
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-8920