### PR TITLE
WFLY-8919: Remove case-sensitive attribute from Elytron realm test case

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
@@ -547,7 +547,7 @@ public class AggregateRealmTestCase {
                         PROPERTIES_REALM_AUTHZ_NAME, asAbsolutePath(usersAuthzRealmFile),
                         asAbsolutePath(rolesAuthzRealmFile)));
                 cli.sendLine(String.format(
-                        "/subsystem=elytron/filesystem-realm=%s:add(case-sensitive=true,path=%s)",
+                        "/subsystem=elytron/filesystem-realm=%s:add(path=%s)",
                         FILESYSTEM_REALM_AUTHN_NAME, fsRealmPath));
                 addUserToFilesystemRealm(cli, USER_WITHOUT_ROLE, CORRECT_PASSWORD);
                 addUserToFilesystemRealm(cli, USER_WITH_ONE_ROLE, CORRECT_PASSWORD);


### PR DESCRIPTION
case-sensitive attribute has been removed from Elytron, this commit fix AggregateRealmTestCase to work without this removed attribute

Jira issues:
https://issues.jboss.org/browse/WFLY-8919
https://issues.jboss.org/browse/JBEAP-10255

it depends on https://github.com/wildfly/wildfly-core/pull/2499
