### PR TITLE
WFLY-8925 - Mark attribute 'outbound-socket-binding' in a reverse-proxy handler as 'required'

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
@@ -84,7 +84,9 @@ public class ReverseProxyHandlerHost extends PersistentResourceDefinition {
                                             path.getLastElement().getValue()})
                         .build();
 
-    public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder("outbound-socket-binding", ModelType.STRING, true) //todo consider what we can do to make this non nullable
+    public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder("outbound-socket-binding", ModelType.STRING, true)
+            .setRequired(true)
+            .setValidator(new StringLengthValidator(1, false))
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)


### PR DESCRIPTION
Upstream Issue: [WFLY-8925](https://issues.jboss.org/browse/WFLY-8925)
Issue: [JBEAP-11257](https://issues.jboss.org/browse/JBEAP-11257)
Downstream PR: https://github.com/jbossas/jboss-eap7/pull/1994

