### PR TITLE
Revert "[WFLY-8904] Fix AuthenticationTestCase and GetCallerPrincipalTestCase for Elytron and unignore it"

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -57,15 +57,16 @@ import org.jboss.as.test.integration.ejb.security.base.WhoAmIBean;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * Test case to hold the authentication scenarios, these range from calling a servlet which calls a bean to calling a bean which
@@ -84,6 +85,12 @@ public class AuthenticationTestCase {
 
     private static final Logger log = Logger.getLogger(AuthenticationTestCase.class.getName());
 
+    @BeforeClass
+    public static void beforeClass() {
+        //Conditionally ignore all the tests, although only testICIR_TwoBeans_ViaServlet() needs this treatment.
+        //There seems to be an issue with the system property not getting propagated to the server
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
     /*
      * Authentication Scenarios
      *
@@ -247,11 +254,7 @@ public class AuthenticationTestCase {
             getWhoAmI("?method=doubleWhoAmI&username=user2&password=bad_password");
             fail("Expected IOException");
         } catch (IOException e) {
-            if (SecurityDomain.getCurrent() == null) {
-                assertTrue(e.getMessage().contains("javax.ejb.EJBAccessException"));
-            } else {
-                assertTrue(e.getMessage().contains("javax.ejb.EJBException: java.lang.SecurityException: ELY01151"));
-            }
+            assertTrue(e.getMessage().contains("javax.ejb.EJBAccessException"));
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -40,6 +40,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.junit.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -62,6 +63,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -94,6 +96,11 @@ public class GetCallerPrincipalTestCase {
     private static final String OK = "OK";
 
     public static final String LOCAL_USER = "$local";
+
+    @BeforeClass
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
 
     @ArquillianResource
     Deployer deployer;
@@ -217,11 +224,7 @@ public class GetCallerPrincipalTestCase {
 
             bean.remove();
 
-            if (System.getProperty("elytron") == null) {
-                Assert.assertEquals(LOCAL_USER + "stop", results.getSfsb("predestroy"));
-            } else {
-                Assert.assertEquals(ANONYMOUS + "stop", results.getSfsb("predestroy"));
-            }
+            Assert.assertEquals(LOCAL_USER +  "stop", results.getSfsb("predestroy"));
             return null;
         };
         try {


### PR DESCRIPTION
Reverts wildfly/wildfly#10165