### PR TITLE
[WFLY-8622] EJB subsystem: synchronize enable-statistics attribute name with other subsystems

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem13Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem13Parser.java
@@ -82,7 +82,7 @@ public class EJB3Subsystem13Parser extends EJB3Subsystem12Parser {
             final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ENABLED:
-                    EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    EJB3SubsystemRootResourceDefinition.STATISTICS_ENABLED.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     // found the mandatory attribute
                     missingRequiredAttributes.remove(EJB3SubsystemXMLAttribute.ENABLED);
                     break;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -431,7 +431,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                     .setInitialMode(ServiceController.Mode.PASSIVE)
                     .install();
 
-            EnableStatisticsWriteHandler.INSTANCE.updateToRuntime(context, model);
+            StatisticsEnabledWriteHandler.INSTANCE.updateToRuntime(context, model);
 
 
             if(context.hasOptionalCapability(UNDERTOW_HTTP_INVOKER_CAPABILITY_NAME, EJB3SubsystemRootResourceDefinition.EJB_CAPABILITY.getName(), null)) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -66,6 +66,7 @@ public interface EJB3SubsystemModel {
     String LOG_SYSTEM_EXCEPTIONS = "log-system-exceptions";
 
     String ENABLE_STATISTICS = "enable-statistics";
+    String STATISTICS_ENABLED = "statistics-enabled";
 
     String FILE_DATA_STORE = "file-data-store";
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -268,9 +268,9 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         }
 
         // statistics element
-        if (model.hasDefined(ENABLE_STATISTICS)) {
+        if (model.hasDefined(STATISTICS_ENABLED)) {
             writer.writeStartElement(EJB3SubsystemXMLElement.STATISTICS.getLocalName());
-            writer.writeAttribute(EJB3SubsystemXMLAttribute.ENABLED.getLocalName(), model.get(EJB3SubsystemModel.ENABLE_STATISTICS).asString());
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.ENABLED.getLocalName(), model.get(EJB3SubsystemModel.STATISTICS_ENABLED).asString());
             writer.writeEndElement();
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
@@ -100,6 +100,11 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         } else if (version.equals(VERSION_1_3_0)) {
             TimerServiceResourceDefinition.registerTransformers_1_3_0(builder);
         }
+
+        // Rename new statistics-enabled attribute to old enable-statistics
+        builder.getAttributeBuilder()
+               .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
+
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, version);
     }
 
@@ -116,6 +121,11 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         StrictMaxPoolResourceDefinition.registerTransformers_3_0_0(builder);
         ApplicationSecurityDomainDefinition.registerTransformers_3_0_0(builder);
         IdentityResourceDefinition.registerTransformers_3_0_0(builder);
+
+        // Rename new statistics-enabled attribute to old enable-statistics
+        builder.getAttributeBuilder()
+               .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
+
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_3_0_0);
     }
 
@@ -131,6 +141,10 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
 
         builder.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
         builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
+
+        // Rename new statistics-enabled attribute to old enable-statistics
+        builder.getAttributeBuilder()
+               .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
 
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_4_0_0);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StatisticsEnabledWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StatisticsEnabledWriteHandler.java
@@ -29,16 +29,16 @@ import org.jboss.as.ejb3.component.EJBUtilities;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceRegistry;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.STATISTICS_ENABLED;
 
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
-class EnableStatisticsWriteHandler extends AbstractWriteAttributeHandler<Void> {
-    static EnableStatisticsWriteHandler INSTANCE = new EnableStatisticsWriteHandler();
+class StatisticsEnabledWriteHandler extends AbstractWriteAttributeHandler<Void> {
+    static StatisticsEnabledWriteHandler INSTANCE = new StatisticsEnabledWriteHandler();
 
-    EnableStatisticsWriteHandler() {
-        super(ENABLE_STATISTICS);
+    StatisticsEnabledWriteHandler(){
+        super(STATISTICS_ENABLED);
     }
 
     @Override
@@ -56,9 +56,8 @@ class EnableStatisticsWriteHandler extends AbstractWriteAttributeHandler<Void> {
     }
 
     void updateToRuntime(final OperationContext context, final ModelNode model) throws OperationFailedException {
-        final ModelNode enableStatisticsModel = ENABLE_STATISTICS.resolveModelAttribute(context, model);
-        final boolean enableStatistics = enableStatisticsModel.isDefined() && enableStatisticsModel.asBoolean();
-        utilities(context).setStatisticsEnabled(enableStatistics);
+        final boolean statisticsEnabled = STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
+        utilities(context).setStatisticsEnabled(statisticsEnabled);
     }
 
     private static EJBUtilities utilities(final OperationContext context) {

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -1,6 +1,8 @@
 ejb3=The configuration of the ejb3 subsystem.
 ejb3.add=Adds the ejb3 subsystem.
-ejb3.enable-statistics=If set to true, enable the collection of invocation statistics.
+ejb3.enable-statistics=If set to true, enable the collection of invocation statistics. Deprecated in favour of "statistics-enabled"
+ejb3.enable-statistics.deprecated=If set to true, enable the collection of invocation statistics. Deprecated in favour of "statistics-enabled"
+ejb3.statistics-enabled=If set to true, enable the collection of invocation statistics.
 ejb3.remove=Removes the ejb3 subsystem.
 
 ejb3.lite=Specifies whether the ejb3 container need only provide the "LITE" profile of the specification. This value should only be false when using the "everything" distro.


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-8622