### PR TITLE
[WFLY-8854] Clean up messaging resources in domain mode

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AbstractActiveMQComponentControlHandler.java
@@ -160,10 +160,12 @@ public abstract class AbstractActiveMQComponentControlHandler<T extends ActiveMQ
 
     public void registerOperations(final ManagementResourceRegistration registry, final ResourceDescriptionResolver resolver) {
         final OperationDefinition startOp = new SimpleOperationDefinitionBuilder(START, resolver)
+                .setRuntimeOnly()
                 .build();
         registry.registerOperationHandler(startOp, this);
         final OperationDefinition stopOp = new SimpleOperationDefinitionBuilder(STOP, resolver)
-        .build();
+                .setRuntimeOnly()
+                .build();
         registry.registerOperationHandler(stopOp, this);
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AbstractTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AbstractTransportDefinition.java
@@ -43,10 +43,11 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  */
 public abstract class AbstractTransportDefinition extends PersistentResourceDefinition {
 
+    private final boolean registerRuntimeOnly;
     private final AttributeDefinition[] attrs;
     protected final boolean isAcceptor;
 
-    protected AbstractTransportDefinition(final boolean isAcceptor, final String specificType, AttributeDefinition... attrs) {
+    protected AbstractTransportDefinition(final boolean isAcceptor, final String specificType, final boolean registerRuntimeOnly, AttributeDefinition... attrs) {
         super(PathElement.pathElement(specificType),
                 new StandardResourceDescriptionResolver((isAcceptor ? CommonAttributes.ACCEPTOR : CommonAttributes.CONNECTOR),
                         MessagingExtension.RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, false) {
@@ -58,6 +59,7 @@ public abstract class AbstractTransportDefinition extends PersistentResourceDefi
                 new ActiveMQReloadRequiredHandlers.AddStepHandler(attrs),
                 new ActiveMQReloadRequiredHandlers.RemoveStepHandler());
         this.isAcceptor = isAcceptor;
+        this.registerRuntimeOnly = registerRuntimeOnly;
         this.attrs = attrs;
     }
 
@@ -82,7 +84,7 @@ public abstract class AbstractTransportDefinition extends PersistentResourceDefi
 
     @Override
     public void registerOperations(ManagementResourceRegistration registry) {
-        if (isAcceptor) {
+        if (isAcceptor && registerRuntimeOnly) {
             AcceptorControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
         }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -161,14 +161,14 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             CONNECTOR_REFS, DISCOVERY_GROUP_NAME
     };
 
+    private final boolean registerRuntimeOnly;
 
-    static final BridgeDefinition INSTANCE = new BridgeDefinition();
-
-    private BridgeDefinition() {
+    BridgeDefinition(boolean registerRuntimeOnly) {
         super(MessagingExtension.BRIDGE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.BRIDGE),
                 BridgeAdd.INSTANCE,
                 BridgeRemove.INSTANCE);
+        this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
     @Override
@@ -191,6 +191,8 @@ public class BridgeDefinition extends PersistentResourceDefinition {
     @Override
     public void registerOperations(ManagementResourceRegistration registry) {
         super.registerOperations(registry);
-        BridgeControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+        if (registerRuntimeOnly) {
+            BridgeControlHandler.INSTANCE.registerOperations(registry, getResourceDescriptionResolver());
+        }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GenericTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GenericTransportDefinition.java
@@ -44,10 +44,15 @@ public class GenericTransportDefinition extends AbstractTransportDefinition {
 
     static AttributeDefinition[] ATTRIBUTES = { CommonAttributes.FACTORY_CLASS, SOCKET_BINDING, CommonAttributes.PARAMS };
 
-    static final GenericTransportDefinition CONNECTOR_INSTANCE = new GenericTransportDefinition(false, CommonAttributes.CONNECTOR);
-    static final GenericTransportDefinition ACCEPTOR_INSTANCE = new GenericTransportDefinition(true, CommonAttributes.ACCEPTOR);
+    static GenericTransportDefinition createAcceptorDefinition(boolean registerRuntimeOnly) {
+        return new GenericTransportDefinition(true, registerRuntimeOnly, CommonAttributes.ACCEPTOR);
+    }
 
-    private GenericTransportDefinition(boolean isAcceptor, String specificType) {
-        super(isAcceptor, specificType, ATTRIBUTES);
+    static GenericTransportDefinition createConnectorDefinition(boolean registerRuntimeOnly) {
+        return new GenericTransportDefinition(false, registerRuntimeOnly, CommonAttributes.CONNECTOR);
+    }
+
+    private GenericTransportDefinition(boolean isAcceptor, boolean registerRuntimeOnly, String specificType) {
+        super(isAcceptor, specificType, registerRuntimeOnly, ATTRIBUTES);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
@@ -66,9 +66,7 @@ public class HTTPConnectorDefinition extends AbstractTransportDefinition {
             .setAllowExpression(false)
             .build();
 
-    static final HTTPConnectorDefinition INSTANCE = new HTTPConnectorDefinition();
-
-    public HTTPConnectorDefinition() {
-        super(false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING, ENDPOINT, SERVER_NAME, PARAMS);
+    public HTTPConnectorDefinition(boolean registerRuntimeOnly) {
+        super(false, CommonAttributes.HTTP_CONNECTOR, registerRuntimeOnly, SOCKET_BINDING, ENDPOINT, SERVER_NAME, PARAMS);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InVMTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InVMTransportDefinition.java
@@ -55,9 +55,6 @@ public class InVMTransportDefinition extends AbstractTransportDefinition {
 
     static AttributeDefinition[] ATTRIBUTES = { SERVER_ID, PARAMS };
 
-    static final InVMTransportDefinition CONNECTOR_INSTANCE = createConnectorDefinition(false);
-    static final InVMTransportDefinition ACCEPTOR_INSTANCE = createAcceptorDefinition(false);
-
     public static InVMTransportDefinition createAcceptorDefinition(final boolean registerRuntimeOnly) {
         return new InVMTransportDefinition(registerRuntimeOnly, true, CommonAttributes.IN_VM_ACCEPTOR);
     }
@@ -67,6 +64,6 @@ public class InVMTransportDefinition extends AbstractTransportDefinition {
     }
 
     private InVMTransportDefinition(final boolean registerRuntimeOnly, boolean isAcceptor, String specificType) {
-        super(isAcceptor, specificType, ATTRIBUTES);
+        super(isAcceptor, specificType, registerRuntimeOnly, ATTRIBUTES);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -35,6 +35,7 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTO
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.GROUPING_HANDLER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLICY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HTTP_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.HTTP_CONNECTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JMS_QUEUE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JMS_TOPIC;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JOURNAL_DIRECTORY;
@@ -122,6 +123,7 @@ public class MessagingExtension implements Extension {
     static final PathElement QUEUE_PATH = pathElement(QUEUE);
     static final PathElement RUNTIME_QUEUE_PATH = pathElement(RUNTIME_QUEUE);
     static final PathElement GROUPING_HANDLER_PATH = pathElement(GROUPING_HANDLER);
+    static final PathElement HTTP_CONNECTOR_PATH = pathElement(HTTP_CONNECTOR);
     static final PathElement HTTP_ACCEPTOR_PATH = pathElement(HTTP_ACCEPTOR);
     static final PathElement BROADCAST_GROUP_PATH = pathElement(BROADCAST_GROUP);
     static final PathElement CLUSTER_CONNECTION_PATH = pathElement(CLUSTER_CONNECTION);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -22,7 +22,14 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
 
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
@@ -276,51 +283,51 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                         AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES,
                                                         AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES))
                                 .addChild(
-                                        builder(HTTPConnectorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_CONNECTOR_PATH)
                                                 .addAttributes(
                                                         HTTPConnectorDefinition.SOCKET_BINDING,
                                                         HTTPConnectorDefinition.ENDPOINT,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(RemoteTransportDefinition.CONNECTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(REMOTE_CONNECTOR))
                                                 .addAttributes(
                                                         RemoteTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(InVMTransportDefinition.CONNECTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(IN_VM_CONNECTOR))
                                                 .addAttributes(
                                                         InVMTransportDefinition.SERVER_ID,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(GenericTransportDefinition.CONNECTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(CONNECTOR))
                                                 .addAttributes(
                                                         GenericTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_ACCEPTOR_PATH)
                                                 .addAttributes(
                                                         HTTPAcceptorDefinition.HTTP_LISTENER,
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(RemoteTransportDefinition.ACCEPTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(REMOTE_ACCEPTOR))
                                                 .addAttributes(
                                                         RemoteTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(InVMTransportDefinition.ACCEPTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(IN_VM_ACCEPTOR))
                                                 .addAttributes(
                                                         InVMTransportDefinition.SERVER_ID,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(GenericTransportDefinition.ACCEPTOR_INSTANCE.getPathElement())
+                                        builder(pathElement(ACCEPTOR))
                                                 .addAttributes(
                                                         GenericTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(BroadcastGroupDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BROADCAST_GROUP_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.SOCKET_BINDING,
                                                         BroadcastGroupDefinition.JGROUPS_STACK,
@@ -336,7 +343,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                         DiscoveryGroupDefinition.REFRESH_TIMEOUT,
                                                         DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT))
                                 .addChild(
-                                        builder(ClusterConnectionDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
                                                 .addAttributes(
                                                         ClusterConnectionDefinition.ADDRESS,
                                                         ClusterConnectionDefinition.CONNECTOR_NAME,
@@ -377,7 +384,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                         CommonAttributes.TRANSFORMER_CLASS_NAME,
                                                         DivertDefinition.EXCLUSIVE))
                                 .addChild(
-                                        builder(BridgeDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BRIDGE_PATH)
                                                 .addAttributes(
                                                         BridgeDefinition.QUEUE_NAME,
                                                         BridgeDefinition.FORWARDING_ADDRESS,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -22,7 +22,14 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
 
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
@@ -290,24 +297,24 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES,
                                                         AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES))
                                 .addChild(
-                                        builder(HTTPConnectorDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.HTTP_CONNECTOR_PATH)
                                                 .addAttributes(
                                                         HTTPConnectorDefinition.SOCKET_BINDING,
                                                         HTTPConnectorDefinition.ENDPOINT,
                                                         HTTPConnectorDefinition.SERVER_NAME,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(RemoteTransportDefinition.CONNECTOR_INSTANCE)
+                                        builder(pathElement(REMOTE_CONNECTOR))
                                                 .addAttributes(
                                                         RemoteTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(InVMTransportDefinition.CONNECTOR_INSTANCE)
+                                        builder(pathElement(IN_VM_CONNECTOR))
                                                 .addAttributes(
                                                         InVMTransportDefinition.SERVER_ID,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(GenericTransportDefinition.CONNECTOR_INSTANCE)
+                                        builder(pathElement(CONNECTOR))
                                                 .addAttributes(
                                                         GenericTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.FACTORY_CLASS,
@@ -319,23 +326,23 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         HTTPAcceptorDefinition.UPGRADE_LEGACY,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(RemoteTransportDefinition.ACCEPTOR_INSTANCE)
+                                        builder(pathElement(REMOTE_ACCEPTOR))
                                                 .addAttributes(
                                                         RemoteTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(InVMTransportDefinition.ACCEPTOR_INSTANCE)
+                                        builder(pathElement(IN_VM_ACCEPTOR))
                                                 .addAttributes(
                                                         InVMTransportDefinition.SERVER_ID,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(GenericTransportDefinition.ACCEPTOR_INSTANCE)
+                                        builder(pathElement(ACCEPTOR))
                                                 .addAttributes(
                                                         GenericTransportDefinition.SOCKET_BINDING,
                                                         CommonAttributes.FACTORY_CLASS,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
-                                        builder(BroadcastGroupDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BROADCAST_GROUP_PATH)
                                                 .addAttributes(
                                                         CommonAttributes.SOCKET_BINDING,
                                                         BroadcastGroupDefinition.JGROUPS_STACK,
@@ -351,7 +358,7 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         DiscoveryGroupDefinition.REFRESH_TIMEOUT,
                                                         DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT))
                                 .addChild(
-                                        builder(ClusterConnectionDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
                                                 .addAttributes(
                                                         ClusterConnectionDefinition.ADDRESS,
                                                         ClusterConnectionDefinition.CONNECTOR_NAME,
@@ -393,7 +400,7 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         CommonAttributes.TRANSFORMER_CLASS_NAME,
                                                         DivertDefinition.EXCLUSIVE))
                                 .addChild(
-                                        builder(BridgeDefinition.INSTANCE.getPathElement())
+                                        builder(MessagingExtension.BRIDGE_PATH)
                                                 .addAttributes(
                                                         BridgeDefinition.QUEUE_NAME,
                                                         BridgeDefinition.FORWARDING_ADDRESS,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -133,7 +133,7 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         bridge.getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.ALWAYS, BridgeDefinition.CREDENTIAL_REFERENCE)
                 .addRejectCheck(DEFINED, BridgeDefinition.CREDENTIAL_REFERENCE);
-        ResourceTransformationDescriptionBuilder httpConnector = server.addChildResource(HTTPConnectorDefinition.INSTANCE);
+        ResourceTransformationDescriptionBuilder httpConnector = server.addChildResource(MessagingExtension.HTTP_CONNECTOR_PATH);
         // reject server-name introduced in management version 2.0.0 if it is defined
         rejectDefinedAttributeWithDefaultValue(httpConnector, HTTPConnectorDefinition.SERVER_NAME);
         // reject producer-window-size introduced in management version 2.0.0 if it is defined and different from the default value.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/RemoteTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/RemoteTransportDefinition.java
@@ -54,18 +54,15 @@ public class RemoteTransportDefinition extends AbstractTransportDefinition {
 
     static AttributeDefinition[] ATTRIBUTES = { SOCKET_BINDING, CommonAttributes.PARAMS };
 
-    static final RemoteTransportDefinition CONNECTOR_INSTANCE = createConnectorDefinition();
-    static final RemoteTransportDefinition ACCEPTOR_INSTANCE = createAcceptorDefinition();
-
-    private static RemoteTransportDefinition createAcceptorDefinition() {
-        return new RemoteTransportDefinition(true, CommonAttributes.REMOTE_ACCEPTOR);
+    static RemoteTransportDefinition createAcceptorDefinition(boolean registerRuntimeOnly) {
+        return new RemoteTransportDefinition(true, CommonAttributes.REMOTE_ACCEPTOR, registerRuntimeOnly);
     }
 
-    private static RemoteTransportDefinition createConnectorDefinition() {
-        return new RemoteTransportDefinition(false, CommonAttributes.REMOTE_CONNECTOR);
+    static RemoteTransportDefinition createConnectorDefinition(boolean registerRuntimeOnly) {
+        return new RemoteTransportDefinition(false, CommonAttributes.REMOTE_CONNECTOR, registerRuntimeOnly);
     }
 
-    private RemoteTransportDefinition(boolean isAcceptor, String specificType) {
-        super(isAcceptor, specificType, ATTRIBUTES);
+    private RemoteTransportDefinition(boolean isAcceptor, String specificType, boolean registerRuntimeOnly) {
+        super(isAcceptor, specificType, registerRuntimeOnly, ATTRIBUTES);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -617,22 +617,10 @@ public class ServerDefinition extends PersistentResourceDefinition {
                 AddressSettingDefinition.INSTANCE,
                 SecuritySettingDefinition.INSTANCE,
 
-                // Connectors
-                HTTPConnectorDefinition.INSTANCE,
-                RemoteTransportDefinition.CONNECTOR_INSTANCE,
-                InVMTransportDefinition.CONNECTOR_INSTANCE,
-                GenericTransportDefinition.CONNECTOR_INSTANCE,
-
                 // Acceptors
                 HTTPAcceptorDefinition.INSTANCE,
-                RemoteTransportDefinition.ACCEPTOR_INSTANCE,
-                InVMTransportDefinition.ACCEPTOR_INSTANCE,
-                GenericTransportDefinition.ACCEPTOR_INSTANCE,
 
-                BroadcastGroupDefinition.INSTANCE,
                 DiscoveryGroupDefinition.INSTANCE,
-                BridgeDefinition.INSTANCE,
-                ClusterConnectionDefinition.INSTANCE,
                 DivertDefinition.INSTANCE,
                 ConnectorServiceDefinition.INSTANCE,
                 GroupingHandlerDefinition.INSTANCE,
@@ -642,6 +630,19 @@ public class ServerDefinition extends PersistentResourceDefinition {
                 PooledConnectionFactoryDefinition.INSTANCE));
 
         // Dynamic resources (depending on registerRuntimeOnly)
+        // acceptors
+        children.add(GenericTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
+        children.add(InVMTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
+        children.add(RemoteTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
+        // connectors
+        children.add(GenericTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
+        children.add(InVMTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
+        children.add(RemoteTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
+        children.add(new HTTPConnectorDefinition(registerRuntimeOnly));
+
+        children.add(new BridgeDefinition(registerRuntimeOnly));
+        children.add(new BroadcastGroupDefinition(registerRuntimeOnly));
+        children.add(new ClusterConnectionDefinition(registerRuntimeOnly));
         children.add(new QueueDefinition(registerRuntimeOnly, MessagingExtension.QUEUE_PATH));
         children.add(new JMSQueueDefinition(false, registerRuntimeOnly));
         children.add(new JMSTopicDefinition(false, registerRuntimeOnly));


### PR DESCRIPTION
Clean up messaging resources in domain mode so that runtime operations
and attributes are not part of the profile's model.
These runtime operations and attributes relies on the presence of
ActivemQ objects that are not started in HC.

Impacted resources and operations:
* start and stop operations for acceptor, in-vm-acceptor,
  remote-acceptor, bridge, broadcast-group, cluster-connection resources
* get-connector-pairs-as-json operation for broadcast-group resource
* get-nodes operation for cluster-connection resource

JIRA: https://issues.jboss.org/browse/WFLY-8854