### PR TITLE
[WFLY-8955 WFLY-8928 WFLY-8833] Upgrade Artemis 1.5.5.jbossorg-004

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -560,6 +560,8 @@ public class MigrateOperation implements OperationStepHandler {
     private void migratePooledConnectionFactory(ModelNode addOperation) {
         migrateConnectorAttribute(addOperation);
         migrateDiscoveryGroupNameAttribute(addOperation);
+        // WFLY-8928 - allow local transacted JMS session
+        addOperation.get("allow-local-transactions").set(new ModelNode(true));
     }
 
     private void migrateClusterConnection(ModelNode addOperation, List<String> warnings) {

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -185,6 +185,7 @@ public class MigrateTestCase extends AbstractSubsystemTest {
 
         assertEquals("STRICT", newServer.get("cluster-connection", "cc2", "message-load-balancing-type").asString());
         assertEquals("ON_DEMAND", newServer.get("cluster-connection", "cc3", "message-load-balancing-type").asString());
+        assertEquals(true, newServer.get("pooled-connection-factory", "hornetq-ra", "allow-local-transactions").asBoolean());
 
         if (addLegacyEntries) {
             // check that legacy entries were added to JMS resources

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_1.java
@@ -566,12 +566,16 @@ public class MessagingSubsystemParser_1_1 extends PersistentResourceXMLParser {
                                                         ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
                                                         ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
                                                         // pooled
+                                                        // inbound config
                                                         ConnectionFactoryAttributes.Pooled.USE_JNDI,
                                                         ConnectionFactoryAttributes.Pooled.JNDI_PARAMS,
                                                         ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS,
                                                         ConnectionFactoryAttributes.Pooled.USE_LOCAL_TX,
                                                         ConnectionFactoryAttributes.Pooled.SETUP_ATTEMPTS,
                                                         ConnectionFactoryAttributes.Pooled.SETUP_INTERVAL,
+                                                        // outbound config
+                                                        ConnectionFactoryAttributes.Pooled.ALLOW_LOCAL_TRANSACTIONS,
+
                                                         ConnectionFactoryAttributes.Pooled.TRANSACTION,
                                                         ConnectionFactoryAttributes.Pooled.USER,
                                                         ConnectionFactoryAttributes.Pooled.PASSWORD,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -158,7 +158,8 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         defaultValueAttributeConverter(pooledConnectionFactory, ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE);
         rejectDefinedAttributeWithDefaultValue(pooledConnectionFactory, ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE,
                 ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
-                ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST);
+                ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
+                ConnectionFactoryAttributes.Pooled.ALLOW_LOCAL_TRANSACTIONS);
 
         TransformationDescription.Tools.register(subsystem.build(), subsystemRegistration, MessagingExtension.VERSION_1_0_0);
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -308,7 +308,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
                 continue;
             }
 
-            props.add(new PooledConnectionFactoryConfigProperties(attribute.getPropertyName(), property.getValue().asString(), attribute.getClassType()));
+            props.add(new PooledConnectionFactoryConfigProperties(attribute.getPropertyName(), property.getValue().asString(), attribute.getClassType(), attribute.getConfigType()));
         }
         return props;
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttribute.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttribute.java
@@ -31,18 +31,23 @@ import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
  */
 public class ConnectionFactoryAttribute {
+    enum ConfigType {
+        INBOUND, OUTBOUND;
+    }
+
     private final AttributeDefinition attributeDefinition;
     private String propertyName;
     private final boolean resourceAdapterProperty;
-    private final boolean inboundConfig;
+    private ConfigType configType;
 
     public static ConnectionFactoryAttribute create(final AttributeDefinition attributeDefinition, final String propertyName, boolean resourceAdapterProperty) {
-        return new ConnectionFactoryAttribute(attributeDefinition, propertyName, resourceAdapterProperty, false);
+        return new ConnectionFactoryAttribute(attributeDefinition, propertyName, resourceAdapterProperty, null);
     }
 
-    public static ConnectionFactoryAttribute create(final AttributeDefinition attributeDefinition, final String propertyName, boolean resourceAdapterProperty, boolean inboundConfig) {
+    public static ConnectionFactoryAttribute create(final AttributeDefinition attributeDefinition, final String propertyName, boolean resourceAdapterProperty, ConfigType inboundConfig) {
         return new ConnectionFactoryAttribute(attributeDefinition, propertyName, resourceAdapterProperty, inboundConfig);
     }
+
 
     public static AttributeDefinition[] getDefinitions(final ConnectionFactoryAttribute... attrs) {
         AttributeDefinition[] definitions = new AttributeDefinition[attrs.length];
@@ -53,11 +58,11 @@ public class ConnectionFactoryAttribute {
         return definitions;
     }
 
-    private ConnectionFactoryAttribute(final AttributeDefinition attributeDefinition, final String propertyName, boolean resourceAdapterProperty, boolean inboundConfig) {
+    private ConnectionFactoryAttribute(final AttributeDefinition attributeDefinition, final String propertyName, boolean resourceAdapterProperty, ConfigType configType) {
         this.attributeDefinition = attributeDefinition;
         this.propertyName = propertyName;
         this.resourceAdapterProperty = resourceAdapterProperty;
-        this.inboundConfig = inboundConfig;
+        this.configType = configType;
     }
 
     public String getClassType() {
@@ -91,7 +96,7 @@ public class ConnectionFactoryAttribute {
         return resourceAdapterProperty;
     }
 
-    public boolean isInboundConfig() {
-        return inboundConfig;
+    public ConfigType getConfigType() {
+        return configType;
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -31,6 +31,8 @@ import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 import static org.wildfly.extension.messaging.activemq.MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET;
+import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttribute.ConfigType.INBOUND;
+import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttribute.ConfigType.OUTBOUND;
 import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttribute.create;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
@@ -331,12 +333,22 @@ public interface ConnectionFactoryAttributes {
     }
 
     interface Pooled {
+        String ALLOW_LOCAL_TRANSACTIONS_PROP_NAME = "allowLocalTransactions";
         String USE_JNDI_PROP_NAME = "useJNDI";
         String SETUP_ATTEMPTS_PROP_NAME = "setupAttempts";
         String SETUP_INTERVAL_PROP_NAME = "setupInterval";
         String REBALANCE_CONNECTIONS_PROP_NAME = "rebalanceConnections";
         String RECONNECT_ATTEMPTS_PROP_NAME = "reconnectAttempts";
         String PASSWORD_PROP_NAME = "password";
+
+
+        SimpleAttributeDefinition ALLOW_LOCAL_TRANSACTIONS = SimpleAttributeDefinitionBuilder.create("allow-local-transactions", BOOLEAN)
+                .setAttributeGroup("outbound-config")
+                .setRequired(false)
+                .setAllowExpression(true)
+                .setDefaultValue(new ModelNode(false))
+                .setRestartAllServices()
+                .build();
 
         ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE =
                 CredentialReference.getAttributeBuilder(true, false)
@@ -480,12 +492,14 @@ public interface ConnectionFactoryAttributes {
          */
         ConnectionFactoryAttribute[] ATTRIBUTES = {
                 /* inbound config */
-                create(USE_JNDI, USE_JNDI_PROP_NAME, true, true),
-                create(JNDI_PARAMS, "jndiParams", true, true),
-                create(REBALANCE_CONNECTIONS, REBALANCE_CONNECTIONS_PROP_NAME, true, true),
-                create(USE_LOCAL_TX, "useLocalTx", true, true),
-                create(SETUP_ATTEMPTS, SETUP_ATTEMPTS_PROP_NAME, true, true),
-                create(SETUP_INTERVAL, SETUP_INTERVAL_PROP_NAME, true, true),
+                create(USE_JNDI, USE_JNDI_PROP_NAME, true, INBOUND),
+                create(JNDI_PARAMS, "jndiParams", true, INBOUND),
+                create(REBALANCE_CONNECTIONS, REBALANCE_CONNECTIONS_PROP_NAME, true, INBOUND),
+                create(USE_LOCAL_TX, "useLocalTx", true, INBOUND),
+                create(SETUP_ATTEMPTS, SETUP_ATTEMPTS_PROP_NAME, true, INBOUND),
+                create(SETUP_INTERVAL, SETUP_INTERVAL_PROP_NAME, true, INBOUND),
+                /* outbound config */
+                create(ALLOW_LOCAL_TRANSACTIONS, ALLOW_LOCAL_TRANSACTIONS_PROP_NAME, false, OUTBOUND),
 
                 create(STATISTICS_ENABLED, null, false),
                 create(TRANSACTION, null, false),

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
@@ -162,7 +162,7 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
                 } else {
                     value = node.asString();
                 }
-                configs.add(new PooledConnectionFactoryConfigProperties(nodeAttribute.getPropertyName(), value, nodeAttribute.getClassType()));
+                configs.add(new PooledConnectionFactoryConfigProperties(nodeAttribute.getPropertyName(), value, nodeAttribute.getClassType(), nodeAttribute.getConfigType()));
             }
         }
         return configs;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryConfigProperties.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryConfigProperties.java
@@ -33,11 +33,16 @@ public class PooledConnectionFactoryConfigProperties {
     private final String value;
 
     private String type;
+    private final ConnectionFactoryAttribute.ConfigType configType;
 
-    public PooledConnectionFactoryConfigProperties(String name, String value, String type) {
+    /**
+     * @param configType can be {@code null} to configure a property on the resource adapter.
+     */
+    public PooledConnectionFactoryConfigProperties(String name, String value, String type, ConnectionFactoryAttribute.ConfigType configType) {
         this.name = name;
         this.value = value;
         this.type = type;
+        this.configType = configType;
     }
 
     public String getName() {
@@ -52,4 +57,7 @@ public class PooledConnectionFactoryConfigProperties {
         return type;
     }
 
+    public ConnectionFactoryAttribute.ConfigType getConfigType() {
+        return configType;
+    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
@@ -72,7 +72,7 @@ public class PooledConnectionFactoryDefinition extends PersistentResourceDefinit
                 newAttr = ConnectionFactoryAttribute.create(copy, Pooled.RECONNECT_ATTEMPTS_PROP_NAME, true);
             } else {
                 AttributeDefinition copy = copy(definition, AttributeAccess.Flag.RESTART_ALL_SERVICES);
-                newAttr = ConnectionFactoryAttribute.create(copy, attr.getPropertyName(), attr.isResourceAdapterProperty(), attr.isInboundConfig());
+                newAttr = ConnectionFactoryAttribute.create(copy, attr.getPropertyName(), attr.isResourceAdapterProperty(), attr.getConfigType());
             }
             result[specific.length + i] = newAttr;
         }

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -669,6 +669,7 @@ path.relative-to=The name of another previously named path, or of one of the sta
 path.remove=Remove a path.
 path=A filesystem path pointing to one of the locations where ActiveMQ stores persistent data.
 pooled-connection-factory.add=Adds a managed connection factory.
+pooled-connection-factory.allow-local-transactions=Allow local transactions.
 pooled-connection-factory.auto-group=The autogroup.
 pooled-connection-factory.block-on-acknowledge=True to set block on acknowledge.
 pooled-connection-factory.block-on-durable-send=True to set block on durable send.

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_1.xsd
@@ -589,6 +589,11 @@
                                 <xs:attribute name="setup-interval" type="xs:long" use="optional" />
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="outbound-config" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="allow-local-transactions" type="xs:boolean" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_1_1_TestCase.java
@@ -190,6 +190,7 @@ public class MessagingActiveMQSubsystem_1_1_TestCase extends AbstractSubsystemBa
                                 ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST))
                 .addFailedAttribute(subsystemAddress.append(SERVER_PATH, POOLED_CONNECTION_FACTORY_PATH),
                         new FailedOperationTransformationConfig.NewAttributesConfig(
+                                ConnectionFactoryAttributes.Pooled.ALLOW_LOCAL_TRANSACTIONS,
                                 ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS,
                                 ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED,
                                 ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE,

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
@@ -42,6 +42,7 @@ public class PooledConnectionFactoryAttributesTestCase extends AttributesTestBas
         KNOWN_ATTRIBUTES.add(Pooled.SETUP_INTERVAL_PROP_NAME);
         KNOWN_ATTRIBUTES.add(Pooled.USE_JNDI_PROP_NAME);
         KNOWN_ATTRIBUTES.add(Pooled.REBALANCE_CONNECTIONS_PROP_NAME);
+        KNOWN_ATTRIBUTES.add(Pooled.ALLOW_LOCAL_TRANSACTIONS_PROP_NAME);
     }
 
     @Test

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1.xml
@@ -439,6 +439,8 @@
                     use-local-tx="${use.local.tx:true}"
                     setup-attempts="${setup-attempts:123}"
                     setup-interval="${setup-interval:456}" />
+            <outbound-config
+                    allow-local-transactions="${allow.local.transactions:true}" />
         </pooled-connection-factory>
         <pooled-connection-factory name="pcf-with-credential-reference"
                                    entries="java:/JmsLocal2"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_reject_transform.xml
@@ -63,8 +63,11 @@
                                    connectors="in-vm"
                                    entries="java:/JmsLocal"
                                    statistics-enabled="true">
-        <inbound-config
-                rebalance-connections="true" />
+            <inbound-config
+                    rebalance-connections="true" />
+            <outbound-config
+                    allow-local-transactions="true" />
+
         </pooled-connection-factory>
         <pooled-connection-factory name="pcf-with-credential-reference"
                                    entries="java:/JmsLocal2"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_1_transform.xml
@@ -399,6 +399,8 @@
                     use-local-tx="${use.local.tx:true}"
                     setup-attempts="${setup-attempts:123}"
                     setup-interval="${setup-interval:456}" />
+            <outbound-config
+                    allow-local-transactions="false" />
         </pooled-connection-factory>
     </server>
 </subsystem>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.5.5.jbossorg-002</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.5.5.jbossorg-004</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.8.1</version.org.apache.avro>
         <version.org.apache.cxf>3.1.11</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/LocalTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/LocalTransactionTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.localtransaction;
+
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the behaviour of allowing local transactions for a JMS session from a Servlet.
+ *
+ * Default behaviour is to disallow it.
+ * It can be overridden by specifying allow-local-transactions=true on the pooled-connection-factory resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class LocalTransactionTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static WebArchive createArchive() {
+        return create(WebArchive.class, "LocalTransactionTestCase.war")
+                .addClass(MessagingServlet.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testAllowLocalTransactions() throws Exception {
+        callServlet(true);
+    }
+
+    @Test
+    public void testDisallowLocalTransactions() throws Exception {
+        callServlet(false);
+    }
+
+    private void callServlet(boolean allowLocalTransactions) throws Exception {
+        URL url = new URL(this.url.toExternalForm() + "LocalTransactionTestCase?allowLocalTransactions=" + allowLocalTransactions);
+        String reply  = HttpRequest.get(url.toExternalForm(), 10, TimeUnit.SECONDS);
+        System.out.println(">>> reply = " + reply);
+        assertNotNull(reply);
+        assertEquals(allowLocalTransactions, Boolean.valueOf(reply));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/MessagingServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/MessagingServlet.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.localtransaction;
+
+import java.io.IOException;
+
+import javax.annotation.Resource;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@JMSConnectionFactoryDefinition(
+        name="java:module/CF_allow_local_tx",
+        properties = {
+                "connectors=in-vm",
+                "allow-local-transactions=true"
+        }
+)
+@WebServlet("/LocalTransactionTestCase")
+public class MessagingServlet extends HttpServlet {
+
+    @Resource(lookup = "java:module/CF_allow_local_tx")
+    private ConnectionFactory cFwithLocalTransaction;
+
+    @Resource
+    private ConnectionFactory defaultCF;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        boolean allowLocalTransactions = Boolean.valueOf(req.getParameter("allowLocalTransactions"));
+
+        final ConnectionFactory cf = allowLocalTransactions ? cFwithLocalTransaction : defaultCF;
+        Connection connection = null;
+        try {
+            connection = cf.createConnection();
+            try {
+                connection.createSession(true, 0);
+                if (!allowLocalTransactions) {
+                    Assert.fail("Local transactions are not allowed");
+                }
+                resp.getWriter().write("" + allowLocalTransactions);
+            } catch (JMSException e) {
+                if (allowLocalTransactions) {
+                    Assert.fail("Local transactions are allowed");
+                }
+                resp.getWriter().write("" + allowLocalTransactions);
+            }
+        } catch (Throwable t) {
+            resp.setStatus(500);
+            t.printStackTrace(resp.getWriter());
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (JMSException e) {
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-8955

---
[WFLY-8928] Allow local transactions for JMS RA session

By default, a JMS session created from a RA does not allow local
transactions (as specified by the JMS 2.0 API).
However, for legacy compatibility, this behaviour can be changed by
setting the allow-local-transactions attribute to true on the
pooled-connection-factory resource.

During migration of the legacy messaging subsystem, this attribute
is set to true to preserve the behaviour of HornetQ RA that was
allowing local transactions.

JIRA: https://issues.jboss.org/browse/WFLY-8928

---
[WFLY-8833] JMS ObjectMessage deserialization
add test for black listing deserialization on regular JMS connection
factories

JIRA: https://issues.jboss.org/browse/WFLY-8833