### PR TITLE
WFLY-8870: AuthenticationTestCase fails with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -67,6 +67,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 
 /**
  * Test case to hold the authentication scenarios, these range from calling a servlet which calls a bean to calling a bean which
@@ -135,7 +136,11 @@ public class AuthenticationTestCase {
                         // TestSuiteEnvironment reads system properties
                         new PropertyPermission("management.address", "read"),
                         new PropertyPermission("node0", "read"),
-                        new PropertyPermission("jboss.http.port", "read")),
+                        new PropertyPermission("jboss.http.port", "read"),
+                        new PropertyPermission("jboss.bind.address", "read"),
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                        ),
                         "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationTestCase.java
@@ -64,6 +64,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 import org.wildfly.test.integration.elytron.ejb.authentication.EntryBean;
 import org.wildfly.test.integration.elytron.ejb.base.WhoAmIBean;
 import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
@@ -127,7 +128,11 @@ public class AuthenticationTestCase {
                         // TestSuiteEnvironment reads system properties
                         new PropertyPermission("management.address", "read"),
                         new PropertyPermission("node0", "read"),
-                        new PropertyPermission("jboss.http.port", "read")),
+                        new PropertyPermission("jboss.http.port", "read"),
+                        new PropertyPermission("jboss.bind.address", "read"),
+                        new ElytronPermission("getSecurityDomain"),
+                        new ElytronPermission("authenticate")
+                        ),
                         "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;


### PR DESCRIPTION
Added missing required permissions on these tests when they are executed using -Dsecurity.manager

Jira issues:
https://issues.jboss.org/browse/WFLY-8870
https://issues.jboss.org/browse/JBEAP-11267