### PR TITLE
[WFLY-8995] Elytron - Kerberos SASL tests

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosMgmtSaslTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosMgmtSaslTestCase.java
@@ -1,0 +1,673 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.test.integration.security.common.SecurityTestConstants.KEYSTORE_PASSWORD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivilegedAction;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.security.sasl.SaslException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.annotations.CreateKdcServer;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.annotations.SaslMechanism;
+import org.apache.directory.server.core.annotations.AnnotationUtils;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.factory.DSAnnotationProcessor;
+import org.apache.directory.server.core.kerberos.KeyDerivationInterceptor;
+import org.apache.directory.server.factory.ServerAnnotationProcessor;
+import org.apache.directory.server.kerberos.kdc.KdcServer;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.ldap.handlers.sasl.cramMD5.CramMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.digestMD5.DigestMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.gssapi.GssapiMechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.ntlm.NtlmMechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.plain.PlainMechanismHandler;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.ldap.InMemoryDirectoryServiceFactory;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.AbstractKrb5ConfServerSetupTask;
+import org.jboss.as.test.integration.security.common.KDCServerAnnotationProcessor;
+import org.jboss.as.test.integration.security.common.KerberosSystemPropertiesSetupTask;
+import org.jboss.as.test.integration.security.common.Krb5LoginConfiguration;
+import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.negotiation.KerberosTestUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.SecurityFactory;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.security.ssl.SSLContextBuilder;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPermissionMapper;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.DirContext;
+import org.wildfly.test.security.common.elytron.IdentityMapping;
+import org.wildfly.test.security.common.elytron.KerberosSecurityFactory;
+import org.wildfly.test.security.common.elytron.LdapRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.Path;
+import org.wildfly.test.security.common.elytron.PermissionRef;
+import org.wildfly.test.security.common.elytron.SimpleConfigurableSaslServerFactory;
+import org.wildfly.test.security.common.elytron.SimpleKeyManager;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.SimpleTrustManager;
+import org.wildfly.test.security.common.other.AccessIdentityConfigurator;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+
+/**
+ * Tests Elytron Kerberos remoting (GSSAPI and GS2-KRB5* SASL mechanism) through management interface.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ KerberosMgmtSaslTestCase.Krb5ConfServerSetupTask.class, //
+        KerberosSystemPropertiesSetupTask.class, //
+        KerberosMgmtSaslTestCase.DirectoryServerSetupTask.class, //
+        KerberosMgmtSaslTestCase.KeyMaterialSetup.class, //
+        KerberosMgmtSaslTestCase.ServerSetup.class })
+@RunAsClient
+public class KerberosMgmtSaslTestCase {
+
+    private static Logger LOGGER = Logger.getLogger(KerberosMgmtSaslTestCase.class);
+
+    protected static final int PORT_NATIVE = 10567;
+    protected static final int CONNECTION_TIMEOUT_IN_MS = TimeoutUtil.adjust(6 * 1000);
+
+    private static final String NAME = KerberosMgmtSaslTestCase.class.getSimpleName();
+    private static final int LDAP_PORT = 10389;
+    private static final String LDAP_URL = "ldap://"
+            + NetworkUtils.formatPossibleIpv6Address(Utils.getSecondaryTestAddress(null, true)) + ":" + LDAP_PORT;
+
+    private static final File WORK_DIR_GSSAPI;
+    static {
+        try {
+            WORK_DIR_GSSAPI = Utils.createTemporaryFolder("gssapi-");
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create temporary folder", e);
+        }
+    }
+
+    private static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.SERVER_KEYSTORE);
+    private static final File SERVER_TRUSTSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.SERVER_TRUSTSTORE);
+    private static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.CLIENT_TRUSTSTORE);
+
+    private static Krb5LoginConfiguration KRB5_CONFIGURATION;
+
+    private static SecurityFactory<SSLContext> sslFactory;
+
+    @ArquillianResource
+    private ManagementClient client;
+
+    @BeforeClass
+    public static void beforeClass() {
+        KerberosTestUtils.assumeKerberosAuthenticationSupported();
+    }
+
+    @Deployment(testable = false)
+    public static WebArchive dummyDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war").addAsWebResource(new StringAsset("Test"), "index.html");
+    }
+
+    /**
+     * Test GSSAPI SASL mechanism configured on the server-side for management interface without using SSL.
+     */
+    @Test
+    public void testGssapiWithoutSsl() throws Exception {
+        configureSaslMechanismOnServer("GSSAPI", false);
+        assertKerberosSaslMechPasses("GSSAPI", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+    }
+
+    /**
+     * Tests that Kerberos login correctly fails when a wrong username or a wrong password is used.
+     */
+    @Test
+    public void testKerberosWrongCredentials() throws Exception {
+        assertKerberosLoginFails("hnelson", "wrongpassword");
+        assertKerberosLoginFails("wronguser", "secret");
+    }
+
+    /**
+     * Tests that ModelControllerClient is able to force using SSL (i.e. when SSL is not used the call should fail).
+     */
+    @Test
+    @Ignore("WFCORE-3002")
+    public void testClientForcingSsl() throws Exception {
+        configureSaslMechanismOnServer("GSSAPI", false);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", true);
+    }
+
+    /**
+     * Test GSSAPI SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    public void testGssapiOverSsl() throws Exception {
+        configureSaslMechanismOnServer("GSSAPI", true);
+        assertKerberosSaslMechPasses("GSSAPI", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", true);
+    }
+
+    /**
+     * Test GS2-KRB5 SASL mechanism configured on the server-side for management interface without using SSL.
+     */
+    @Test
+    public void testGs2Krb5WithoutSsl() throws Exception {
+        configureSaslMechanismOnServer("GS2-KRB5", false);
+        assertKerberosSaslMechPasses("GS2-KRB5", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+    }
+
+    /**
+     * Test GS2-KRB5 SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    public void testGs2Krb5OverSsl() throws Exception {
+        configureSaslMechanismOnServer("GS2-KRB5", true);
+        assertKerberosSaslMechPasses("GS2-KRB5", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", true);
+    }
+
+    /**
+     * Test GS2-KRB5-PLUS SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    public void testGs2Krb5PlusWithoutSsl() throws Exception {
+        configureSaslMechanismOnServer("GS2-KRB5-PLUS", false);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+    }
+
+    /**
+     * Test GS2-KRB5-PLUS SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    @Ignore("ELY-1232")
+    public void testGs2Krb5PlusOverSsl() throws Exception {
+        configureSaslMechanismOnServer("GS2-KRB5-PLUS", true);
+        assertKerberosSaslMechPasses("GS2-KRB5-PLUS", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+        assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", true);
+        assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", true);
+    }
+
+    /**
+     * Configures test sasl-server-factory to use given mechanism. It also enables/disables SSL based on provided flag.
+     */
+    private void configureSaslMechanismOnServer(String mechanism, boolean withSsl) throws Exception {
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/configurable-sasl-server-factory=%s:write-attribute(name=filters, value=[{pattern-filter=%s}])",
+                    NAME, mechanism));
+            String sslContextCli = withSsl
+                    ? String.format(
+                            "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context, value=%s)",
+                            NAME)
+                    : "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context)";
+            cli.sendLine(sslContextCli);
+        }
+        ServerReload.reloadIfRequired(client.getControllerClient());
+    }
+
+    /**
+     * Asserts that given user can authenticate with given Kerberos SASL mechanism.
+     */
+    private void assertKerberosSaslMechPasses(String mech, String user, String password, boolean withSsl)
+            throws MalformedURLException, LoginException, Exception {
+        // 1. Authenticate to Kerberos.
+        final LoginContext lc = Utils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+        try {
+            AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                    .setSaslMechanismSelector(SaslMechanismSelector.fromString(mech))
+                    .useGSSCredential(getGSSCredential(lc.getSubject()));
+
+            AuthenticationContext authnCtx = AuthenticationContext.empty().with(MatchRule.ALL, authCfg);
+            if (withSsl) {
+                authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
+            }
+            authnCtx.run(() -> assertWhoAmI(user + "@JBOSS.ORG", withSsl));
+        } finally {
+            lc.logout();
+        }
+    }
+
+    private void assertKerberosSaslMechFails(String mech, String user, String password, boolean withSsl)
+            throws MalformedURLException, LoginException, Exception {
+        // 1. Authenticate to Kerberos.
+        final LoginContext lc = Utils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+        try {
+            AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                    .setSaslMechanismSelector(SaslMechanismSelector.fromString(mech))
+                    .useGSSCredential(getGSSCredential(lc.getSubject()));
+
+            AuthenticationContext authnCtx = AuthenticationContext.empty().with(MatchRule.ALL, authCfg);
+            if (withSsl) {
+                authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
+            }
+            authnCtx.run(() -> assertAuthenticationFails(null, null, withSsl));
+        } finally {
+            lc.logout();
+        }
+    }
+
+    private void assertKerberosLoginFails(String user, String password) {
+        LoginContext lc = null;
+        try {
+            lc = Utils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+            fail("Kerberos authentication failure was expected.");
+        } catch (LoginException e) {
+            LOGGER.debug("Kerberos authentication failed as expected.");
+        } finally {
+            if (lc != null) {
+                try {
+                    lc.logout();
+                } catch (LoginException e) {
+                    LOGGER.warn("Unsuccessful logout", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves {@link GSSCredential} from given Subject
+     */
+    private GSSCredential getGSSCredential(Subject subject) {
+        return Subject.doAs(subject, new PrivilegedAction<GSSCredential>() {
+            @Override
+            public GSSCredential run() {
+                try {
+                    GSSManager gssManager = GSSManager.getInstance();
+                    return gssManager.createCredential(GSSCredential.INITIATE_ONLY);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to retrieve GSSCredential from given Subject.", e);
+                }
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Get the trust manager for {@link #CLIENT_TRUSTSTORE_FILE}.
+     *
+     * @return the trust manager
+     */
+    private static X509TrustManager getTrustManager() throws Exception {
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(loadKeyStore(CLIENT_TRUSTSTORE_FILE));
+
+        for (TrustManager current : trustManagerFactory.getTrustManagers()) {
+            if (current instanceof X509TrustManager) {
+                return (X509TrustManager) current;
+            }
+        }
+
+        throw new IllegalStateException("Unable to obtain X509TrustManager.");
+    }
+
+    private static KeyStore loadKeyStore(final File ksFile) throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        try (FileInputStream fis = new FileInputStream(ksFile)) {
+            ks.load(fis, KEYSTORE_PASSWORD.toCharArray());
+        }
+        return ks;
+    }
+
+    private static void assertAuthenticationFails(String message, Class<? extends Exception> secondCauseClass,
+            boolean withTls) {
+        if (message == null) {
+            message = "The failure of :whoami operation execution was expected, but the call passed";
+        }
+        final long startTime = System.currentTimeMillis();
+        try {
+            executeWhoAmI(withTls);
+            fail(message);
+        } catch (IOException | GeneralSecurityException e) {
+            assertTrue("Connection reached its timeout (hang).",
+                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+            Throwable cause = e.getCause();
+            assertThat("ConnectionException was expected as a cause when authentication fails", cause,
+                    is(instanceOf(ConnectException.class)));
+            assertThat("Unexpected type of inherited exception for authentication failure", cause.getCause(),
+                    anyOf(is(instanceOf(SSLException.class)), is(instanceOf(SaslException.class))));
+        }
+    }
+
+    private static ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException {
+        ModelControllerClientConfiguration.Builder clientConfigBuilder = new ModelControllerClientConfiguration.Builder()
+                .setHostName(Utils.getDefaultHost(false)).setPort(PORT_NATIVE)
+                // .setProtocol(withTls ? "remote+tls" : "remote")
+                .setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS);
+        if (withTls) {
+            clientConfigBuilder.setSslContext(sslFactory.create());
+        }
+        ModelControllerClient client = ModelControllerClient.Factory.create(clientConfigBuilder.build());
+
+        ModelNode operation = new ModelNode();
+        operation.get("operation").set("whoami");
+        operation.get("verbose").set("true");
+
+        return client.execute(operation);
+    }
+
+    private static void assertWhoAmI(String expected, boolean withTls) {
+        try {
+            ModelNode result = executeWhoAmI(withTls);
+            assertTrue("The whoami operation should finish with success", Operations.isSuccessfulOutcome(result));
+            assertEquals("The whoami operation returned unexpected value", expected,
+                    Operations.readResult(result).get("identity").get("username").asString());
+        } catch (Exception e) {
+            LOGGER.warn("Operation execution failed", e);
+            fail("The whoami operation failed - " + e.getMessage());
+        }
+    }
+
+    /**
+     * Setup task which configures Elytron security domains and remoting connectors for this test.
+     */
+    public static class ServerSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+
+            elements.add(ConstantPermissionMapper.builder().withName(NAME)
+                    .withPermissions(PermissionRef.fromPermission(new LoginPermission())).build());
+
+            final CredentialReference credentialReference = CredentialReference.builder().withClearText(KEYSTORE_PASSWORD)
+                    .build();
+
+            // KeyStores
+            final SimpleKeyStore.Builder ksCommon = SimpleKeyStore.builder().withType("JKS")
+                    .withCredentialReference(credentialReference);
+            elements.add(ksCommon.withName("server-keystore")
+                    .withPath(Path.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build()).build());
+            elements.add(ksCommon.withName("server-truststore")
+                    .withPath(Path.builder().withPath(SERVER_TRUSTSTORE_FILE.getAbsolutePath()).build()).build());
+
+            // Key and Trust Managers
+            elements.add(SimpleKeyManager.builder().withName("server-keymanager").withCredentialReference(credentialReference)
+                    .withKeyStore("server-keystore").build());
+            elements.add(
+                    SimpleTrustManager.builder().withName("server-trustmanager").withKeyStore("server-truststore").build());
+
+            // dir-context
+            elements.add(DirContext.builder().withName(NAME).withUrl(LDAP_URL).withPrincipal("uid=admin,ou=system")
+                    .withCredentialReference(CredentialReference.builder().withClearText("secret").build()).build());
+            // ldap-realm
+            elements.add(LdapRealm.builder()
+                    .withName(NAME).withDirContext(NAME).withIdentityMapping(IdentityMapping.builder()
+                            .withRdnIdentifier("krb5PrincipalName").withSearchBaseDn("ou=Users,dc=wildfly,dc=org").build())
+                    .build());
+            // security-domain
+            elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm(NAME).withPermissionMapper(NAME)
+                    .withRealms(SecurityDomainRealm.builder().withRealm(NAME).build()).build());
+            elements.add(AccessIdentityConfigurator.builder().build());
+
+            // kerberos-security-factory
+            elements.add(
+                    KerberosSecurityFactory
+                            .builder().withName(NAME).withPrincipal(Krb5ConfServerSetupTask.REMOTE_PRINCIPAL).withPath(Path
+                                    .builder().withPath(Krb5ConfServerSetupTask.REMOTE_KEYTAB_FILE.getAbsolutePath()).build())
+                            .build());
+
+            // SASL Authentication
+            elements.add(SimpleConfigurableSaslServerFactory.builder().withName(NAME).withSaslServerFactory("elytron").build());
+            MechanismConfiguration.Builder mechConfigBuilder = MechanismConfiguration.builder()
+                    .addMechanismRealmConfiguration(MechanismRealmConfiguration.builder().withRealmName(NAME).build())
+                    .withCredentialSecurityFactory(NAME);
+            elements.add(SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory(NAME)
+                    .withSecurityDomain(NAME).addMechanismConfiguration(mechConfigBuilder.withMechanismName("GSSAPI").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5-PLUS").build()).build());
+
+            // SSLContext
+            elements.add(SimpleServerSslContext.builder().withName(NAME).withKeyManagers("server-keymanager")
+                    .withTrustManagers("server-trustmanager").withSecurityDomain(NAME).withAuthenticationOptional(true)
+                    .withNeedClientAuth(false).build());
+
+            // Socket binding and native management interface
+            elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+            elements.add(SimpleMgmtNativeInterface.builder().withSocketBinding(NAME).withSaslAuthenticationFactory(NAME)
+                    .withSslContext(NAME).build());
+
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+
+    public static class KeyMaterialSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            FileUtils.deleteQuietly(WORK_DIR_GSSAPI);
+            WORK_DIR_GSSAPI.mkdir();
+            Utils.createKeyMaterial(WORK_DIR_GSSAPI);
+
+            sslFactory = new SSLContextBuilder().setClientMode(true).setTrustManager(getTrustManager()).build();
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            FileUtils.deleteQuietly(WORK_DIR_GSSAPI);
+        }
+
+    }
+
+    /**
+     * Task which generates krb5.conf and keytab file(s).
+     */
+    public static class Krb5ConfServerSetupTask extends AbstractKrb5ConfServerSetupTask {
+        public static final File HNELSON_KEYTAB_FILE = new File(WORK_DIR, "hnelson.keytab");
+        public static final File JDUKE_KEYTAB_FILE = new File(WORK_DIR, "jduke.keytab");
+        public static final String REMOTE_PRINCIPAL = "remote/" + Utils.getSecondaryTestAddress(null, true) + "@JBOSS.ORG";
+        public static final File REMOTE_KEYTAB_FILE = new File(WORK_DIR, "remote.keytab");
+
+        @Override
+        protected List<UserForKeyTab> kerberosUsers() {
+            List<UserForKeyTab> users = new ArrayList<UserForKeyTab>();
+            users.add(new UserForKeyTab("hnelson@JBOSS.ORG", "secret", HNELSON_KEYTAB_FILE));
+            users.add(new UserForKeyTab("jduke@JBOSS.ORG", "theduke", JDUKE_KEYTAB_FILE));
+            users.add(new UserForKeyTab(REMOTE_PRINCIPAL, "zelvicka", REMOTE_KEYTAB_FILE));
+            return users;
+        }
+
+    }
+
+    // @formatter:off
+    @CreateDS(name = "WildFlyDS", factory = InMemoryDirectoryServiceFactory.class, partitions = @CreatePartition(name = "wildfly", suffix = "dc=wildfly,dc=org"), additionalInterceptors = {
+            KeyDerivationInterceptor.class }, allowAnonAccess = true)
+    @CreateKdcServer(primaryRealm = "JBOSS.ORG", kdcPrincipal = "krbtgt/JBOSS.ORG@JBOSS.ORG", searchBaseDn = "dc=wildfly,dc=org", transports = {
+            @CreateTransport(protocol = "UDP", port = 6088) })
+    @CreateLdapServer(transports = {
+            @CreateTransport(protocol = "LDAP", port = LDAP_PORT) }, saslHost = "localhost", saslPrincipal = "ldap/localhost@JBOSS.ORG", saslMechanisms = {
+                    @SaslMechanism(name = SupportedSaslMechanisms.PLAIN, implClass = PlainMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.CRAM_MD5, implClass = CramMd5MechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.DIGEST_MD5, implClass = DigestMd5MechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.GSSAPI, implClass = GssapiMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.NTLM, implClass = NtlmMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.GSS_SPNEGO, implClass = NtlmMechanismHandler.class) })
+    // @formatter:on
+    static class DirectoryServerSetupTask implements ServerSetupTask {
+
+        private DirectoryService directoryService;
+        private KdcServer kdcServer;
+        private LdapServer ldapServer;
+        private boolean removeBouncyCastle = false;
+
+        /**
+         * Creates directory services, starts LDAP server and KDCServer
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            try {
+                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                    Security.addProvider(new BouncyCastleProvider());
+                    removeBouncyCastle = true;
+                }
+            } catch (SecurityException ex) {
+                LOGGER.warn("Cannot register BouncyCastleProvider", ex);
+            }
+            directoryService = DSAnnotationProcessor.getDirectoryService();
+            final String hostname = Utils.getCannonicalHost(managementClient);
+            final Map<String, String> map = new HashMap<String, String>();
+            map.put("hostname", NetworkUtils.formatPossibleIpv6Address(hostname));
+            final String secondaryTestAddress = NetworkUtils.canonize(Utils.getSecondaryTestAddress(managementClient, true));
+            map.put("ldaphost", secondaryTestAddress);
+            final String ldifContent = StrSubstitutor.replace(
+                    IOUtils.toString(KerberosMgmtSaslTestCase.class.getResourceAsStream("remoting-krb5-test.ldif"), "UTF-8"),
+                    map);
+            LOGGER.trace(ldifContent);
+            final SchemaManager schemaManager = directoryService.getSchemaManager();
+            try {
+                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
+                    directoryService.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Importing LDIF to a directoryService failed.", e);
+                throw e;
+            }
+            kdcServer = KDCServerAnnotationProcessor.getKdcServer(directoryService, 1024, hostname);
+            final ManagedCreateLdapServer createLdapServer = new ManagedCreateLdapServer(
+                    (CreateLdapServer) AnnotationUtils.getInstance(CreateLdapServer.class));
+            createLdapServer.setSaslHost(secondaryTestAddress);
+            createLdapServer.setSaslPrincipal("ldap/" + secondaryTestAddress + "@JBOSS.ORG");
+            Utils.fixApacheDSTransportAddress(createLdapServer, secondaryTestAddress);
+            ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, directoryService);
+            ldapServer.getSaslHost();
+            ldapServer.setSearchBaseDn("dc=wildfly,dc=org");
+            ldapServer.start();
+
+            KRB5_CONFIGURATION = new Krb5LoginConfiguration(Utils.getLoginConfiguration());
+            // Use our custom configuration to avoid reliance on external config
+            Configuration.setConfiguration(KRB5_CONFIGURATION);
+
+        }
+
+        /**
+         * Stops LDAP server and KDCServer and shuts down the directory service.
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            KRB5_CONFIGURATION.resetConfiguration();
+            ldapServer.stop();
+            kdcServer.stop();
+            directoryService.shutdown();
+            FileUtils.deleteDirectory(directoryService.getInstanceLayout().getInstanceDirectory());
+            if (removeBouncyCastle) {
+                try {
+                    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+                } catch (SecurityException ex) {
+                    LOGGER.warn("Cannot deregister BouncyCastleProvider", ex);
+                }
+            }
+
+        }
+    }
+
+}

--- a/testsuite/integration/elytron/src/test/resources/logging.properties
+++ b/testsuite/integration/elytron/src/test/resources/logging.properties
@@ -21,10 +21,14 @@
 #
 
 # Additional loggers to configure (the root logger is always configured)
-loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config,org.apache.directory,org.wildfly.security
 
 logger.level=INFO
-logger.handlers=FILE
+# we can log into CONSOLE as the Maven surefire-plugin redirects it to a file by default
+logger.handlers=CONSOLE
+
+logger.org.wildfly.security.level=${test.log.level:INFO}
+logger.org.wildfly.security.useParentHandlers=true
 
 logger.com.arjuna.level=WARN
 logger.com.arjuna.useParentHandlers=true
@@ -47,19 +51,11 @@ logger.sun.rmi.useParentHandlers=true
 logger.jacorb.config.level=ERROR
 logger.jacorb.config.useParentHandlers=true
 
-handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
-handler.FILE.level=ALL
-handler.FILE.formatter=PATTERN
-handler.FILE.properties=autoFlush,append,fileName,suffix
-handler.FILE.constructorProperties=fileName,append
-handler.FILE.autoFlush=true
-handler.FILE.append=true
-handler.FILE.fileName=${org.jboss.boot.log.file:boot.log}
-handler.FILE.suffix=.yyyy-MM-dd
-
-formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=ALL
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern

--- a/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/sasl/mgmt/remoting-krb5-test.ldif
+++ b/testsuite/integration/elytron/src/test/resources/org/wildfly/test/integration/elytron/sasl/mgmt/remoting-krb5-test.ldif
@@ -1,0 +1,77 @@
+version: 1
+
+dn: dc=wildfly,dc=org
+dc: wildfly
+objectClass: top
+objectClass: domain
+
+dn: ou=Users,dc=wildfly,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: uid=krbtgt,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: KDC Service
+sn: Service
+uid: krbtgt
+userPassword: secret
+krb5PrincipalName: krbtgt/JBOSS.ORG@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=ldap,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: LDAP
+sn: Service
+uid: ldap
+userPassword: randall
+krb5PrincipalName: ldap/${ldaphost}@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=remote,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: JBoss Remoting
+sn: Service
+uid: remote
+userPassword: zelvicka
+krb5PrincipalName: remote/${hostname}@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=hnelson,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: Horatio Nelson
+sn: Nelson
+uid: hnelson
+userPassword: secret
+krb5PrincipalName: hnelson@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=jduke,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: Java Duke
+mail: jduke@JBOSS.ORG
+sn: duke
+uid: jduke
+userPassword: theduke
+krb5PrincipalName: jduke@JBOSS.ORG
+krb5KeyVersionNumber: 0

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/KerberosSystemPropertiesSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/KerberosSystemPropertiesSetupTask.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.security.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ServerSetup task which configures server system properties for Kerberos testing - path to {@code krb5.conf} file etc.
+ *
+ * @author Josef Cacek
+ */
+public class KerberosSystemPropertiesSetupTask extends AbstractSystemPropertiesServerSetupTask {
+
+    /**
+     * Returns "java.security.krb5.conf" and "sun.security.krb5.debug" properties.
+     *
+     * @return Kerberos properties
+     * @see org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask#getSystemProperties()
+     */
+    @Override
+    protected SystemProperty[] getSystemProperties() {
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("java.security.krb5.conf", AbstractKrb5ConfServerSetupTask.getKrb5ConfFullPath());
+        map.put("sun.security.krb5.debug", "true");
+        return mapToSystemProperties(map);
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/KerberosTestUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/KerberosTestUtils.java
@@ -39,6 +39,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.util.ASN1Dump;
+import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.logging.Logger;
 import org.junit.AssumptionViolatedException;
 
@@ -84,12 +85,12 @@ public final class KerberosTestUtils {
     }
 
     /**
-     * Returns true if provided hostname is an IPv6 address.
+     * Returns true if the server bind address is an IPv6 address without canonical hostname.
      *
      * @return
      */
     private static boolean isIPV6() {
-        return System.getProperty("ipv6") != null;
+        return Utils.getDefaultHost(true).indexOf(':')>=0;
     }
 
     /**

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/ModelNodeUtil.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/ModelNodeUtil.java
@@ -22,7 +22,10 @@
 
 package org.wildfly.test.security.common;
 
+import java.util.Map;
+
 import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ModelNodeConvertable;
 
 /**
  * Helper methods for {@link ModelNode} class.
@@ -59,6 +62,39 @@ public class ModelNodeUtil {
     }
 
     /**
+     * Set attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, Long value) {
+        if (value != null) {
+            node.get(attribute).set(value.longValue());
+        }
+    }
+
+    /**
+     * Set attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, ModelNodeConvertable value) {
+        if (value != null) {
+            ModelNode modelNode = value.toModelNode();
+            if (modelNode != null) {
+                node.get(attribute).set(modelNode);
+            }
+        }
+    }
+
+    /**
+     * Set list attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, Map<String, String> objectValue) {
+        if (objectValue != null) {
+            ModelNode objectNode = node.get(attribute);
+            for (Map.Entry<String, String> entry : objectValue.entrySet()) {
+                objectNode.get(entry.getKey()).set(entry.getValue());
+            }
+        }
+    }
+
+    /**
      * Set list attribute of given node if the value is not-<code>null</code>.
      */
     public static void setIfNotNull(ModelNode node, String attribute, String... listValue) {
@@ -66,6 +102,18 @@ public class ModelNodeUtil {
             ModelNode listNode = node.get(attribute);
             for (String value : listValue) {
                 listNode.add(value);
+            }
+        }
+    }
+
+    /**
+     * Adds given items to list attribute.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, ModelNodeConvertable... items) {
+        if (items != null && items.length > 0) {
+            ModelNode listNode = node.get(attribute);
+            for (ModelNodeConvertable item : items) {
+                listNode.add(item.toModelNode());
             }
         }
     }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractMechanismConfiguration.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AbstractMechanismConfiguration.java
@@ -31,7 +31,7 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Josef Cacek
  */
-public class AbstractMechanismConfiguration {
+public class AbstractMechanismConfiguration implements ModelNodeConvertable {
 
     private final String preRealmPrincipalTransformer;
     private final String postRealmPrincipalTransformer;
@@ -61,7 +61,7 @@ public class AbstractMechanismConfiguration {
         return realmMapper;
     }
 
-    protected ModelNode toModelNode() {
+    public ModelNode toModelNode() {
         final ModelNode node= new ModelNode();
         setIfNotNull(node, "pre-realm-principal-transformer", preRealmPrincipalTransformer);
         setIfNotNull(node, "post-realm-principal-transformer", postRealmPrincipalTransformer);

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AttributeMapping.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/AttributeMapping.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an attribute-mapping configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class AttributeMapping implements ModelNodeConvertable {
+
+    private final String from;
+    private final String to;
+    private final String reference;
+    private final String filter;
+    private final String filterBaseDn;
+    private final Boolean searchRecursive;
+    private final Integer roleRecursion;
+    private final String roleRecursionName;
+    private final String extractRdn;
+
+
+    private AttributeMapping(Builder builder) {
+        this.from = builder.from;
+        this.to = builder.to;
+        this.reference = builder.reference;
+        this.filter = builder.filter;
+        this.filterBaseDn = builder.filterBaseDn;
+        this.searchRecursive = builder.searchRecursive;
+        this.roleRecursion = builder.roleRecursion;
+        this.roleRecursionName = builder.roleRecursionName;
+        this.extractRdn = builder.extractRdn;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "from", from);
+        setIfNotNull(modelNode, "to", to);
+        setIfNotNull(modelNode, "reference", reference);
+        setIfNotNull(modelNode, "filter", filter);
+        setIfNotNull(modelNode, "filter-base-dn", filterBaseDn);
+        setIfNotNull(modelNode, "search-recursive", searchRecursive);
+        setIfNotNull(modelNode, "role-recursion", roleRecursion);
+        setIfNotNull(modelNode, "role-recursion-name", roleRecursionName);
+        setIfNotNull(modelNode, "extract-rdn", extractRdn);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link AttributeMapping}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * Builder to build {@link AttributeMapping}.
+     */
+    public static final class Builder {
+        private String from;
+        private String to;
+        private String reference;
+        private String filter;
+        private String filterBaseDn;
+        private Boolean searchRecursive;
+        private Integer roleRecursion;
+        private String roleRecursionName;
+        private String extractRdn;
+
+        private Builder() {
+        }
+
+        public Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder withTo(String to) {
+            this.to = to;
+            return this;
+        }
+
+        public Builder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public Builder withFilter(String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder withFilterBaseDn(String filterBaseDn) {
+            this.filterBaseDn = filterBaseDn;
+            return this;
+        }
+
+        public Builder withSearchRecursive(Boolean searchRecursive) {
+            this.searchRecursive = searchRecursive;
+            return this;
+        }
+
+        public Builder withRoleRecursion(Integer roleRecursion) {
+            this.roleRecursion = roleRecursion;
+            return this;
+        }
+
+        public Builder withRoleRecursionName(String roleRecursionName) {
+            this.roleRecursionName = roleRecursionName;
+            return this;
+        }
+
+        public Builder withExtractRdn(String extractRdn) {
+            this.extractRdn = extractRdn;
+            return this;
+        }
+
+        public AttributeMapping build() {
+            return new AttributeMapping(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CredentialReference.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/CredentialReference.java
@@ -23,30 +23,35 @@
 package org.wildfly.test.security.common.elytron;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
 
 /**
  * Helper class for adding "credential-reference" attributes into CLI commands.
  *
  * @author Josef Cacek
  */
-public class CredentialReference implements CliFragment {
+public class CredentialReference implements CliFragment, ModelNodeConvertable {
 
     public static final CredentialReference EMPTY = CredentialReference.builder().build();
 
     private final String store;
     private final String alias;
+    private final String type;
     private final String clearText;
 
     private CredentialReference(Builder builder) {
         this.store = builder.store;
         this.alias = builder.alias;
+        this.type = builder.type;
         this.clearText = builder.clearText;
     }
 
     @Override
     public String asString() {
         StringBuilder sb = new StringBuilder();
-        if (isNotBlank(alias) || isNotBlank(clearText) || isNotBlank(store)) {
+        if (isNotBlank(alias) || isNotBlank(clearText) || isNotBlank(store) || isNotBlank(type)) {
             sb.append("credential-reference={ ");
             if (isNotBlank(alias)) {
                 sb.append(String.format("alias=\"%s\", ", alias));
@@ -54,12 +59,28 @@ public class CredentialReference implements CliFragment {
             if (isNotBlank(store)) {
                 sb.append(String.format("store=\"%s\", ", store));
             }
+            if (isNotBlank(type)) {
+                sb.append(String.format("type=\"%s\", ", type));
+            }
             if (isNotBlank(clearText)) {
                 sb.append(String.format("clear-text=\"%s\"", clearText));
             }
             sb.append("}, ");
         }
         return sb.toString();
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        if (this == EMPTY) {
+            return null;
+        }
+        final ModelNode node= new ModelNode();
+        setIfNotNull(node, "store", store);
+        setIfNotNull(node, "alias", alias);
+        setIfNotNull(node, "type", type);
+        setIfNotNull(node, "clear-text", clearText);
+        return node;
     }
 
     /**
@@ -77,6 +98,7 @@ public class CredentialReference implements CliFragment {
     public static final class Builder {
         private String store;
         private String alias;
+        private String type;
         private String clearText;
 
         private Builder() {
@@ -92,6 +114,11 @@ public class CredentialReference implements CliFragment {
             return this;
         }
 
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
         public Builder withClearText(String clearText) {
             this.clearText = clearText;
             return this;
@@ -101,5 +128,4 @@ public class CredentialReference implements CliFragment {
             return new CredentialReference(this);
         }
     }
-
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/DirContext.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/DirContext.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'dir-context' configuration.
+ *
+ * @author Josef Cacek
+ */
+public class DirContext extends AbstractConfigurableElement {
+
+    private final String url;
+    private final String authenticationContext;
+    private final String authenticationLevel;
+    private final Long connectionTimeout;
+    private final CredentialReference credentialReference;
+    private final Boolean enableConnectionPooling;
+    private final String module;
+    private final String principal;
+    private final Map<String, String> properties;
+    private final Long readTimeout;
+    private final String referralMode;
+    private final String sslContext;
+
+    private DirContext(Builder builder) {
+        super(builder);
+        this.url = Objects.requireNonNull(builder.url, "URL in Elytron dir-context configuration has to be provided.");
+        this.authenticationContext = builder.authenticationContext;
+        this.authenticationLevel = builder.authenticationLevel;
+        this.connectionTimeout = builder.connectionTimeout;
+        this.credentialReference = builder.credentialReference;
+        this.enableConnectionPooling = builder.enableConnectionPooling;
+        this.module = builder.module;
+        this.principal = builder.principal;
+        this.properties = new HashMap<>(builder.properties);
+        this.readTimeout = builder.readTimeout;
+        this.referralMode = builder.referralMode;
+        this.sslContext = builder.sslContext;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("dir-context", name));
+        op.get("url").set(url);
+        setIfNotNull(op, "authentication-context", authenticationContext);
+        setIfNotNull(op, "authentication-level", authenticationLevel);
+        setIfNotNull(op, "connection-timeout", connectionTimeout);
+        setIfNotNull(op, "credential-reference", credentialReference);
+        setIfNotNull(op, "enable-connection-pooling", enableConnectionPooling);
+        setIfNotNull(op, "module", module);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "properties", properties);
+        setIfNotNull(op, "read-timeout", readTimeout);
+        setIfNotNull(op, "referral-mode", referralMode);
+        setIfNotNull(op, "ssl-context", sslContext);
+
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(Util.createRemoveOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("dir-context", name)), client);
+    }
+
+    /**
+     * Creates builder to build {@link DirContext}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link DirContext}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String authenticationContext;
+        private String authenticationLevel;
+        private Long connectionTimeout;
+        private CredentialReference credentialReference;
+        private Boolean enableConnectionPooling;
+        private String module;
+        private String principal;
+        private Map<String, String> properties = new HashMap<String, String>();
+        private Long readTimeout;
+        private String referralMode;
+        private String sslContext;
+        private String url;
+
+        private Builder() {
+        }
+
+        public Builder withAuthenticationContext(String authenticationContext) {
+            this.authenticationContext = authenticationContext;
+            return self();
+        }
+
+        public Builder withAuthenticationLevel(String authenticationLevel) {
+            this.authenticationLevel = authenticationLevel;
+            return self();
+        }
+
+        public Builder withConnectionTimeout(Long connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return self();
+        }
+
+        public Builder withCredentialReference(CredentialReference credentialReference) {
+            this.credentialReference = credentialReference;
+            return self();
+        }
+
+        public Builder withEnableConnectionPooling(Boolean enableConnectionPooling) {
+            this.enableConnectionPooling = enableConnectionPooling;
+            return self();
+        }
+
+        public Builder withModule(String module) {
+            this.module = module;
+            return self();
+        }
+
+        public Builder withPrincipal(String principal) {
+            this.principal = principal;
+            return self();
+        }
+
+        public Builder addProperty(String key, String value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        public Builder withReadTimeout(Long readTimeout) {
+            this.readTimeout = readTimeout;
+            return self();
+        }
+
+        public Builder withReferralMode(String referralMode) {
+            this.referralMode = referralMode;
+            return self();
+        }
+
+        public Builder withSslContext(String sslContext) {
+            this.sslContext = sslContext;
+            return self();
+        }
+
+        public Builder withUrl(String url) {
+            this.url = url;
+            return self();
+        }
+
+        public DirContext build() {
+            return new DirContext(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of identity-mapping configuration in ldap-realm.
+ *
+ * @author Josef Cacek
+ */
+public class IdentityMapping implements ModelNodeConvertable {
+
+    private final String rdnIdentifier;
+    private final Boolean useRecursiveSearch;
+    private final String searchBaseDn;
+    private final AttributeMapping[] attributeMapping;
+    private final String filterName;
+    private final String iteratorFilter;
+    private final String newIdentityParentDn;
+    private final NameValue[] newIdentityAttributes;
+    private final UserPasswordMapper userPasswordMapper;
+    private final OtpCredentialMapper otpCredentialMapper;
+    private final X509CredentialMapper x509CredentialMapper;
+
+
+    private IdentityMapping(Builder builder) {
+        this.rdnIdentifier = Objects.requireNonNull(builder.rdnIdentifier, "The rdn-identifier has to be provided in identity-mapping.");
+        this.useRecursiveSearch = builder.useRecursiveSearch;
+        this.searchBaseDn = builder.searchBaseDn;
+        this.attributeMapping = builder.attributeMapping.toArray(new AttributeMapping[builder.attributeMapping.size()]);
+        this.filterName = builder.filterName;
+        this.iteratorFilter = builder.iteratorFilter;
+        this.newIdentityParentDn = builder.newIdentityParentDn;
+        this.newIdentityAttributes = builder.newIdentityAttributes;
+        this.userPasswordMapper = builder.userPasswordMapper;
+        this.otpCredentialMapper = builder.otpCredentialMapper;
+        this.x509CredentialMapper = builder.x509CredentialMapper;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        modelNode.get("rdn-identifier").set(rdnIdentifier);
+        setIfNotNull(modelNode, "use-recursive-search", useRecursiveSearch);
+        setIfNotNull(modelNode, "search-base-dn", searchBaseDn);
+        setIfNotNull(modelNode, "attribute-mapping", attributeMapping);
+        setIfNotNull(modelNode, "filter-name", filterName);
+        setIfNotNull(modelNode, "iterator-filter", iteratorFilter);
+        setIfNotNull(modelNode, "new-identity-parent-dn", newIdentityParentDn);
+        setIfNotNull(modelNode, "new-identity-attributes", newIdentityAttributes);
+        setIfNotNull(modelNode, "user-password-mapper", userPasswordMapper);
+        setIfNotNull(modelNode, "otp-credential-mapper", otpCredentialMapper);
+        setIfNotNull(modelNode, "x509-credential-mapper", x509CredentialMapper);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link IdentityMapping}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * Builder to build {@link IdentityMapping}.
+     */
+    public static final class Builder {
+        private String rdnIdentifier;
+        private Boolean useRecursiveSearch;
+        private String searchBaseDn;
+        private List<AttributeMapping> attributeMapping = new ArrayList<>();
+        private String filterName;
+        private String iteratorFilter;
+        private String newIdentityParentDn;
+        private NameValue[] newIdentityAttributes;
+        private UserPasswordMapper userPasswordMapper;
+        private OtpCredentialMapper otpCredentialMapper;
+        private X509CredentialMapper x509CredentialMapper;
+
+        private Builder() {
+        }
+
+        public Builder withRdnIdentifier(String rdnIdentifier) {
+            this.rdnIdentifier = rdnIdentifier;
+            return this;
+        }
+
+        public Builder withUseRecursiveSearch(Boolean useRecursiveSearch) {
+            this.useRecursiveSearch = useRecursiveSearch;
+            return this;
+        }
+
+        public Builder withSearchBaseDn(String searchBaseDn) {
+            this.searchBaseDn = searchBaseDn;
+            return this;
+        }
+
+        public Builder addAttributeMapping(AttributeMapping attributeMapping) {
+            this.attributeMapping.add(attributeMapping);
+            return this;
+        }
+
+        public Builder withFilterName(String filterName) {
+            this.filterName = filterName;
+            return this;
+        }
+
+        public Builder withIteratorFilter(String iteratorFilter) {
+            this.iteratorFilter = iteratorFilter;
+            return this;
+        }
+
+        public Builder withNewIdentityParentDn(String newIdentityParentDn) {
+            this.newIdentityParentDn = newIdentityParentDn;
+            return this;
+        }
+
+        public Builder withNewIdentityAttributes(NameValue... newIdentityAttributes) {
+            this.newIdentityAttributes = newIdentityAttributes;
+            return this;
+        }
+
+        public Builder withUserPasswordMapper(UserPasswordMapper userPasswordMapper) {
+            this.userPasswordMapper = userPasswordMapper;
+            return this;
+        }
+
+        public Builder withOtpCredentialMapper(OtpCredentialMapper otpCredentialMapper) {
+            this.otpCredentialMapper = otpCredentialMapper;
+            return this;
+        }
+
+        public Builder withX509CredentialMapper(X509CredentialMapper x509CredentialMapper) {
+            this.x509CredentialMapper = x509CredentialMapper;
+            return this;
+        }
+
+        public IdentityMapping build() {
+            return new IdentityMapping(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KerberosSecurityFactory.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/KerberosSecurityFactory.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Map;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'kerberos-security-factory' configuration helper.
+ *
+ * @author Josef Cacek
+ */
+public class KerberosSecurityFactory extends AbstractConfigurableElement {
+
+    private final Boolean debug;
+    private final String[] mechanismNames;
+    private final String[] mechanismOids;
+    private final Integer minimumRemainingLifetime;
+    private final Boolean obtainKerberosTicket;
+    private final Map<String, String> options;
+    private final String principal;
+    private final Integer requestLifetime;
+    private final Boolean server;
+    private final Boolean wrapGssCredential;
+    private final Path path;
+
+    private KerberosSecurityFactory(Builder builder) {
+        super(builder);
+        this.debug = builder.debug;
+        this.mechanismNames = builder.mechanismNames;
+        this.mechanismOids = builder.mechanismOids;
+        this.minimumRemainingLifetime = builder.minimumRemainingLifetime;
+        this.obtainKerberosTicket = builder.obtainKerberosTicket;
+        this.options = builder.options;
+        this.principal = builder.principal;
+        this.requestLifetime = builder.requestLifetime;
+        this.server = builder.server;
+        this.wrapGssCredential = builder.wrapGssCredential;
+        this.path = builder.path;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("kerberos-security-factory", name));
+        setIfNotNull(op, "debug", debug);
+        setIfNotNull(op, "mechanism-names", mechanismNames);
+        setIfNotNull(op, "mechanism-oids", mechanismOids);
+        setIfNotNull(op, "minimum-remaining-lifetime", minimumRemainingLifetime);
+        setIfNotNull(op, "obtain-kerberos-ticket", obtainKerberosTicket);
+        setIfNotNull(op, "obtain-kerberos-ticket", obtainKerberosTicket);
+        setIfNotNull(op, "options", options);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "request-lifetime", requestLifetime);
+        setIfNotNull(op, "server", server);
+        setIfNotNull(op, "wrap-gss-credential", wrapGssCredential);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "path", path.getPath());
+        setIfNotNull(op, "relative-to", path.getRelativeTo());
+
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(
+                Util.createRemoveOperation(
+                        PathAddress.pathAddress().append("subsystem", "elytron").append("kerberos-security-factory", name)),
+                client);
+    }
+
+    /**
+     * Creates builder to build {@link KerberosSecurityFactory}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link KerberosSecurityFactory}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Boolean debug;
+        private String[] mechanismNames;
+        private String[] mechanismOids;
+        private Integer minimumRemainingLifetime;
+        private Boolean obtainKerberosTicket;
+        private Map<String, String> options;
+        private String principal;
+        private Integer requestLifetime;
+        private Boolean server;
+        private Boolean wrapGssCredential;
+        private Path path;
+
+        private Builder() {
+        }
+
+        public Builder withDebug(Boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public Builder withMechanismNames(String[] mechanismNames) {
+            this.mechanismNames = mechanismNames;
+            return this;
+        }
+
+        public Builder withMechanismOids(String[] mechanismOids) {
+            this.mechanismOids = mechanismOids;
+            return this;
+        }
+
+        public Builder withMinimumRemainingLifetime(Integer minimumRemainingLifetime) {
+            this.minimumRemainingLifetime = minimumRemainingLifetime;
+            return this;
+        }
+
+        public Builder withObtainKerberosTicket(Boolean obtainKerberosTicket) {
+            this.obtainKerberosTicket = obtainKerberosTicket;
+            return this;
+        }
+
+        public Builder withOptions(Map<String, String> options) {
+            this.options = options;
+            return this;
+        }
+
+        public Builder withPrincipal(String principal) {
+            this.principal = principal;
+            return this;
+        }
+
+        public Builder withRequestLifetime(Integer requestLifetime) {
+            this.requestLifetime = requestLifetime;
+            return this;
+        }
+
+        public Builder withServer(Boolean server) {
+            this.server = server;
+            return this;
+        }
+
+        public Builder withWrapGssCredential(Boolean wrapGssCredential) {
+            this.wrapGssCredential = wrapGssCredential;
+            return this;
+        }
+
+        public Builder withPath(Path path) {
+            this.path = path;
+            return this;
+        }
+
+        public KerberosSecurityFactory build() {
+            return new KerberosSecurityFactory(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/LdapRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/LdapRealm.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'ldap-realm' configuration.
+ *
+ * @author Josef Cacek
+ */
+public class LdapRealm extends AbstractConfigurableElement implements SecurityRealm {
+
+    private final Boolean allowBlankPassword;
+    private final String dirContext;
+    private final Boolean directVerification;
+    private final IdentityMapping identityMapping;
+
+    private LdapRealm(Builder builder) {
+        super(builder);
+        this.allowBlankPassword = builder.allowBlankPassword;
+        this.dirContext = Objects.requireNonNull(builder.dirContext, "The 'dir-context' has to be provided.");
+        this.directVerification = builder.directVerification;
+        this.identityMapping = Objects.requireNonNull(builder.identityMapping, "The 'identity-mapping' has to be provided.");
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("ldap-realm", name));
+        op.get("dir-context").set(dirContext);
+        setIfNotNull(op, "allow-blank-password", allowBlankPassword);
+        setIfNotNull(op, "direct-verification", directVerification);
+        setIfNotNull(op, "identity-mapping", identityMapping);
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(
+                Util.createRemoveOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("ldap-realm", name)),
+                client);
+    }
+
+    /**
+     * Creates builder to build {@link LdapRealm}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link LdapRealm}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Boolean allowBlankPassword;
+        private String dirContext;
+        private Boolean directVerification;
+        private IdentityMapping identityMapping;
+
+        private Builder() {
+        }
+
+        public Builder withAllowBlankPassword(Boolean allowBlankPassword) {
+            this.allowBlankPassword = allowBlankPassword;
+            return this;
+        }
+
+        public Builder withDirContext(String dirContext) {
+            this.dirContext = dirContext;
+            return this;
+        }
+
+        public Builder withDirectVerification(Boolean directVerification) {
+            this.directVerification = directVerification;
+            return this;
+        }
+
+        public Builder withIdentityMapping(IdentityMapping identityMapping) {
+            this.identityMapping = identityMapping;
+            return this;
+        }
+
+        public LdapRealm build() {
+            return new LdapRealm(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/MechanismConfiguration.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/MechanismConfiguration.java
@@ -40,12 +40,14 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
     private final String hostName;
     private final String protocol;
     private final List<MechanismRealmConfiguration> mechanismRealmConfigurations;
+    private final String credentialSecurityFactory;
 
     private MechanismConfiguration(Builder builder) {
         super(builder);
         this.mechanismName = builder.mechanismName;
         this.hostName = builder.hostName;
         this.protocol = builder.protocol;
+        this.credentialSecurityFactory = builder.credentialSecurityFactory;
         this.mechanismRealmConfigurations = new ArrayList<>(builder.mechanismRealmConfigurations);
     }
 
@@ -80,6 +82,7 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
         setIfNotNull(node, "mechanism-name", mechanismName);
         setIfNotNull(node, "host-name", hostName);
         setIfNotNull(node, "protocol", protocol);
+        setIfNotNull(node, "credential-security-factory", credentialSecurityFactory);
         if (!mechanismRealmConfigurations.isEmpty()) {
             ModelNode confs = node.get("mechanism-realm-configurations");
             for (MechanismRealmConfiguration conf:mechanismRealmConfigurations) {
@@ -96,6 +99,7 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
         private String mechanismName;
         private String hostName;
         private String protocol;
+        private String credentialSecurityFactory;
         private List<MechanismRealmConfiguration> mechanismRealmConfigurations = new ArrayList<>();
 
         private Builder() {
@@ -113,6 +117,11 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
 
         public Builder withProtocol(String protocol) {
             this.protocol = protocol;
+            return this;
+        }
+
+        public Builder withCredentialSecurityFactory(String credentialSecurityFactory) {
+            this.credentialSecurityFactory = credentialSecurityFactory;
             return this;
         }
 

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ModelNodeConvertable.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ModelNodeConvertable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represents objects which are convertable to ModelNode instances.
+ *
+ * @author Josef Cacek
+ */
+public interface ModelNodeConvertable {
+
+    ModelNode toModelNode();
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/NameValue.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/NameValue.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Representation of name and value attribute pair in domain model.
+ *
+ * @author Josef Cacek
+ */
+public class NameValue implements ModelNodeConvertable {
+
+    private final String name;
+    private final String value;
+
+    private NameValue(Builder builder) {
+        this.name = Objects.requireNonNull(builder.name, "Value of 'name' attribute has to be provided.");
+        this.value = Objects.requireNonNull(builder.value, "Value of 'value' attribute has to be provided.");
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        final ModelNode node = new ModelNode();
+        node.get("name").set(name);
+        node.get("value").set(value);
+        return null;
+    }
+
+    /**
+     * Creates builder to build {@link NameValue}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static NameValue from(String name, String value) {
+        return builder().withName(name).withValue(value).build();
+    }
+
+    /**
+     * Builder to build {@link NameValue}.
+     */
+    public static final class Builder {
+        private String name;
+        private String value;
+
+        private Builder() {
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public NameValue build() {
+            return new NameValue(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an otp-credential-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class OtpCredentialMapper implements ModelNodeConvertable {
+
+    private final String algorithmFrom;
+    private final String hashFrom;
+    private final String seedFrom;
+    private final String sequenceFrom;
+
+    private OtpCredentialMapper(Builder builder) {
+        this.algorithmFrom = Objects.requireNonNull(builder.algorithmFrom);
+        this.hashFrom = Objects.requireNonNull(builder.hashFrom);
+        this.seedFrom = Objects.requireNonNull(builder.seedFrom);
+        this.sequenceFrom = Objects.requireNonNull(builder.sequenceFrom);
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "algorithm-from", algorithmFrom);
+        setIfNotNull(modelNode, "hash-from", hashFrom);
+        setIfNotNull(modelNode, "seed-from", seedFrom);
+        setIfNotNull(modelNode, "sequence-from", sequenceFrom);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link OtpCredentialMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link OtpCredentialMapper}.
+     */
+    public static final class Builder {
+        private String algorithmFrom;
+        private String hashFrom;
+        private String seedFrom;
+        private String sequenceFrom;
+
+        private Builder() {
+        }
+
+        public Builder withAlgorithmFrom(String algorithmFrom) {
+            this.algorithmFrom = algorithmFrom;
+            return this;
+        }
+
+        public Builder withHashFrom(String hashFrom) {
+            this.hashFrom = hashFrom;
+            return this;
+        }
+
+        public Builder withSeedFrom(String seedFrom) {
+            this.seedFrom = seedFrom;
+            return this;
+        }
+
+        public Builder withSequenceFrom(String sequenceFrom) {
+            this.sequenceFrom = sequenceFrom;
+            return this;
+        }
+
+        public OtpCredentialMapper build() {
+            return new OtpCredentialMapper(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/RegexPrincipalTransformer.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/RegexPrincipalTransformer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'regex-principal-transformer' configuration.
+ *
+ * @author Josef Cacek
+ */
+public class RegexPrincipalTransformer extends AbstractConfigurableElement {
+
+    private final String pattern;
+    private final String replacement;
+    private final Boolean replaceAll;
+
+    private RegexPrincipalTransformer(Builder builder) {
+        super(builder);
+        this.pattern = Objects.requireNonNull(builder.pattern, "Pattern attribute has to be provided");
+        this.replacement = Objects.requireNonNull(builder.replacement, "Replacement attribute has to be provided");
+        this.replaceAll = builder.replaceAll;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("regex-principal-transformer", name));
+        setIfNotNull(op, "pattern", pattern);
+        setIfNotNull(op, "replacement", replacement);
+        setIfNotNull(op, "replace-all", replaceAll);
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(
+                Util.createRemoveOperation(
+                        PathAddress.pathAddress().append("subsystem", "elytron").append("regex-principal-transformer", name)),
+                client);
+    }
+
+    /**
+     * Creates builder to build {@link RegexPrincipalTransformer}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link RegexPrincipalTransformer}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+
+        private String pattern;
+        private String replacement;
+        private Boolean replaceAll;
+
+        private Builder() {
+        }
+
+        public Builder withPattern(String pattern) {
+            this.pattern = pattern;
+            return this;
+        }
+
+        public Builder withReplacement(String replacement) {
+            this.replacement = replacement;
+            return this;
+        }
+
+        public Builder withReplaceAll(Boolean replaceAll) {
+            this.replaceAll = replaceAll;
+            return this;
+        }
+
+        public RegexPrincipalTransformer build() {
+            return new RegexPrincipalTransformer(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/TrustedDomainsConfigurator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/TrustedDomainsConfigurator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron configurator for trusted-domains attribute in a security-domain.
+ *
+ * @author Josef Cacek
+ */
+public class TrustedDomainsConfigurator extends AbstractConfigurableElement {
+
+    private final String[] trustedSecurityDomains;
+
+    private ModelNode originalDomains;
+
+    private TrustedDomainsConfigurator(Builder builder) {
+        super(builder);
+        this.trustedSecurityDomains = builder.trustedSecurityDomains;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        final PathAddress domainAddress = PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain",
+                name);
+        ModelNode op = Util.createEmptyOperation("read-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            result = Operations.readResult(result);
+            originalDomains = result.isDefined() ? result : null;
+        } else {
+            throw new RuntimeException("Reading existing value of trusted-security-domains attribute failed: "
+                    + Operations.getFailureDescription(result));
+        }
+
+        op = Util.createEmptyOperation("write-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        for (String domain : trustedSecurityDomains) {
+            op.get("value").add(domain);
+        }
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        final PathAddress domainAddress = PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain",
+                name);
+        ModelNode op = Util.createEmptyOperation("write-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        if (originalDomains != null) {
+            op.get("value").set(originalDomains);
+        }
+        Utils.applyUpdate(op, client);
+        originalDomains = null;
+    }
+
+    /**
+     * Creates builder to build {@link TrustedDomainsConfigurator}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link TrustedDomainsConfigurator}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String[] trustedSecurityDomains;
+
+        private Builder() {
+        }
+
+        public Builder withTrustedSecurityDomains(String... trustedSecurityDomains) {
+            this.trustedSecurityDomains = trustedSecurityDomains;
+            return this;
+        }
+
+        public TrustedDomainsConfigurator build() {
+            return new TrustedDomainsConfigurator(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of a user-password-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class UserPasswordMapper implements ModelNodeConvertable {
+
+    private final String from;
+    private final Boolean writable;
+    private final Boolean verifiable;
+
+    private UserPasswordMapper(Builder builder) {
+        this.from = Objects.requireNonNull(builder.from, "The 'from' attribute has to be provided.");
+        this.writable = builder.writable;
+        this.verifiable = builder.verifiable;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "from", from);
+        setIfNotNull(modelNode, "writable", writable);
+        setIfNotNull(modelNode, "verifiable", verifiable);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link UserPasswordMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link UserPasswordMapper}.
+     */
+    public static final class Builder {
+        private String from;
+        private Boolean writable;
+        private Boolean verifiable;
+
+        private Builder() {
+        }
+
+        public Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder withWritable(Boolean writable) {
+            this.writable = writable;
+            return this;
+        }
+
+        public Builder withVerifiable(Boolean verifiable) {
+            this.verifiable = verifiable;
+            return this;
+        }
+
+        public UserPasswordMapper build() {
+            return new UserPasswordMapper(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/X509CredentialMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/X509CredentialMapper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an x509-credential-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class X509CredentialMapper implements ModelNodeConvertable {
+
+    private final String digestFrom;
+    private final String digestAlgorithm;
+    private final String certificateFrom;
+    private final String serialNumberFrom;
+    private final String subjectDnFrom;
+
+    private X509CredentialMapper(Builder builder) {
+        this.digestFrom = builder.digestFrom;
+        this.digestAlgorithm = builder.digestAlgorithm;
+        this.certificateFrom = builder.certificateFrom;
+        this.serialNumberFrom = builder.serialNumberFrom;
+        this.subjectDnFrom = builder.subjectDnFrom;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "digest-from", digestFrom);
+        setIfNotNull(modelNode, "digest-algorithm", digestAlgorithm);
+        setIfNotNull(modelNode, "certificate-from", certificateFrom);
+        setIfNotNull(modelNode, "serial-number-from", serialNumberFrom);
+        setIfNotNull(modelNode, "subject-dn-from", subjectDnFrom);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link X509CredentialMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link X509CredentialMapper}.
+     */
+    public static final class Builder {
+        private String digestFrom;
+        private String digestAlgorithm;
+        private String certificateFrom;
+        private String serialNumberFrom;
+        private String subjectDnFrom;
+
+        private Builder() {
+        }
+
+        public Builder withDigestFrom(String digestFrom) {
+            this.digestFrom = digestFrom;
+            return this;
+        }
+
+        public Builder withDigestAlgorithm(String digestAlgorithm) {
+            this.digestAlgorithm = digestAlgorithm;
+            return this;
+        }
+
+        public Builder withCertificateFrom(String certificateFrom) {
+            this.certificateFrom = certificateFrom;
+            return this;
+        }
+
+        public Builder withSerialNumberFrom(String serialNumberFrom) {
+            this.serialNumberFrom = serialNumberFrom;
+            return this;
+        }
+
+        public Builder withSubjectDnFrom(String subjectDnFrom) {
+            this.subjectDnFrom = subjectDnFrom;
+            return this;
+        }
+
+        public X509CredentialMapper build() {
+            return new X509CredentialMapper(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/AccessIdentityConfigurator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/AccessIdentityConfigurator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.other;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+/**
+ * Configuration helper for '/core-service=management/access=identity'. It can set or remove the security-domain name.
+ *
+ * @author Josef Cacek
+ */
+public class AccessIdentityConfigurator implements ConfigurableElement {
+
+    private static final PathAddress IDENTITY_ADDR = PathAddress.pathAddress().append("core-service", "management")
+            .append("access", "identity");
+    private final String securityDomain;
+    private String originalDomain;
+
+    private AccessIdentityConfigurator(Builder builder) {
+        this.securityDomain = builder.securityDomain;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        originalDomain = setAccessIdentity(client, securityDomain);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        setAccessIdentity(client, originalDomain);
+        originalDomain = null;
+    }
+
+    @Override
+    public String getName() {
+        return "/core-service=management/access=identity";
+    }
+
+    private String setAccessIdentity(ModelControllerClient client, String domainToSet) throws Exception {
+        String origDomainValue = null;
+        ModelNode op = Util.createEmptyOperation("read-attribute", IDENTITY_ADDR);
+        op.get("name").set("security-domain");
+        ModelNode result = client.execute(op);
+        boolean identityExists = Operations.isSuccessfulOutcome(result);
+        op = null;
+        if (identityExists) {
+            result = Operations.readResult(result);
+            origDomainValue = result.isDefined() ? result.asString() : null;
+
+            if (domainToSet == null) {
+                op = Util.createRemoveOperation(IDENTITY_ADDR);
+            } else if (!domainToSet.equals(origDomainValue)) {
+                op = Util.createEmptyOperation("write-attribute", IDENTITY_ADDR);
+                op.get("name").set("security-domain");
+                op.get("value").set(domainToSet);
+            }
+        } else if (domainToSet != null) {
+            op = Util.createAddOperation(IDENTITY_ADDR);
+            op.get("security-domain").set(domainToSet);
+        }
+
+        if (op!=null) {
+            Utils.applyUpdate(op, client);
+        }
+        return origDomainValue;
+    }
+    /**
+     * Creates builder to build {@link AccessIdentityConfigurator}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link AccessIdentityConfigurator}.
+     */
+    public static final class Builder {
+        private String securityDomain;
+
+        private Builder() {
+        }
+
+        public Builder withSecurityDomain(String securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
+
+        public AccessIdentityConfigurator build() {
+            return new AccessIdentityConfigurator(this);
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/ClientMapping.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/ClientMapping.java
@@ -27,13 +27,14 @@ import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
 import java.util.Objects;
 
 import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ModelNodeConvertable;
 
 /**
  * Single item represantation of client-mappings list attribute in socket-binding configuration.
  *
  * @author Josef Cacek
  */
-public class ClientMapping {
+public class ClientMapping implements ModelNodeConvertable {
 
     private final String sourceNetwork;
     private final String destinationAddress;

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/SimpleMgmtNativeInterface.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/other/SimpleMgmtNativeInterface.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.other;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+/**
+ * Configuration for /core-service=management/management-interface=native-interface.
+ *
+ * @author Josef Cacek
+ */
+public class SimpleMgmtNativeInterface implements ConfigurableElement {
+
+    private static final PathAddress PATH_NATIVE_INTERFACE = PathAddress.pathAddress().append("core-service", "management").append("management-interface", "native-interface");
+
+    private final String saslAuthenticationFactory;
+    private final String socketBinding;
+    private final String sslContext;
+
+    private SimpleMgmtNativeInterface(Builder builder) {
+        this.saslAuthenticationFactory = builder.saslAuthenticationFactory;
+        this.socketBinding = builder.socketBinding;
+        this.sslContext = builder.sslContext;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PATH_NATIVE_INTERFACE);
+        setIfNotNull(op, "sasl-authentication-factory", saslAuthenticationFactory);
+        setIfNotNull(op, "socket-binding", socketBinding);
+        setIfNotNull(op, "ssl-context", sslContext);
+
+        Utils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        Utils.applyUpdate(Util.createRemoveOperation(PATH_NATIVE_INTERFACE), client);
+    }
+
+    @Override
+    public String getName() {
+        return "management-interface=native-interface";
+    }
+
+    /**
+     * Creates builder to build {@link SimpleMgmtNativeInterface}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+
+    /**
+     * Builder to build {@link SimpleMgmtNativeInterface}.
+     */
+    public static final class Builder {
+        private String saslAuthenticationFactory;
+        private String socketBinding;
+        private String sslContext;
+
+        private Builder() {
+        }
+
+        public Builder withSaslAuthenticationFactory(String saslAuthenticationFactory) {
+            this.saslAuthenticationFactory = saslAuthenticationFactory;
+            return this;
+        }
+
+        public Builder withSslContext(String sslContext) {
+            this.sslContext = sslContext;
+            return this;
+        }
+
+        public Builder withSocketBinding(String socketBinding) {
+            this.socketBinding = socketBinding;
+            return this;
+        }
+
+        public SimpleMgmtNativeInterface build() {
+            return new SimpleMgmtNativeInterface(this);
+        }
+    }
+
+
+}


### PR DESCRIPTION
Upstream: https://issues.jboss.org/browse/WFLY-8995
Downstream: https://issues.jboss.org/browse/JBEAP-11775

Tests for Elytron Kerberos SASL mechanisms - `GSSAPI`, `GS2-KRB5`, `GS2-KRB5-PLUS`. The tests checks access to native management interface and have similar structure as the ones in [wildfly-core (elytron module)](https://github.com/wildfly/wildfly-core/tree/master/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt).

These new tests are not placed into the core, but into the full. The reason is usage of ApacheDS as a KDC - which is already ready and used in the full testsuite.