### PR TITLE
[WFLY-8984] Removing -Dwildfly.tmp.enable.elytron.profile.tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultManagedThreadFactoryTestCase.java
@@ -29,10 +29,8 @@ import javax.naming.InitialContext;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,11 +41,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class DefaultManagedThreadFactoryTestCase {
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @Deployment
     public static WebArchive getDeployment() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/SwitchIdentityTestCase.java
@@ -45,14 +45,12 @@ import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.security.SecurityContextAssociation;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
@@ -93,11 +91,6 @@ public class SwitchIdentityTestCase {
     }
 
     // Public methods --------------------------------------------------------
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     /**
      * Creates a deployment application for this test.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
@@ -49,7 +49,6 @@ import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.resteasy.plugins.server.embedded.SimplePrincipal;
 import org.jboss.security.ClientLoginModule;
@@ -57,7 +56,6 @@ import org.jboss.security.SecurityContextAssociation;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
@@ -117,11 +115,6 @@ public class SwitchIdentityTestCase {
     };
 
     // Public methods --------------------------------------------------------
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     /**
      * Creates a deployment application for this test.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/MapBasedInitialContextEjbClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/MapBasedInitialContextEjbClientTestCase.java
@@ -30,7 +30,6 @@ import javax.naming.InitialContext;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -64,7 +63,6 @@ public class MapBasedInitialContextEjbClientTestCase {
      */
     @Test
     public void testScopedEJBClientContexts() throws Exception {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
         InitialContext ctx = new InitialContext(getEjbClientProperties(System.getProperty("node0", "127.0.0.1"), 8080));
         try {
             String lookupName = "ejb:/" + ARCHIVE_NAME + "/" + StatelessBean.class.getSimpleName() + "!" + StatelessIface.class.getCanonicalName();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -51,7 +51,6 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -64,7 +63,6 @@ import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -103,11 +101,6 @@ public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestB
                 jmsAdminOperations.close();
             }
         }
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     @Before

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnSBTest.java
@@ -37,13 +37,11 @@ import org.jboss.as.test.integration.ejb.security.authorization.AnnOnlyCheckSLSB
 import org.jboss.as.test.integration.ejb.security.authorization.ParentAnnOnlyCheck;
 import org.jboss.as.test.integration.ejb.security.authorization.SimpleAuthorizationRemote;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -63,11 +61,6 @@ public abstract class AnnSBTest {
 
     @ContainerResource
     private ManagementClient managementClient;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     public static Archive<JavaArchive> testAppDeployment(final Logger LOG, final String MODULE, final Class SB_TO_TEST) {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE + ".jar")

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -57,17 +57,16 @@ import org.jboss.as.test.integration.ejb.security.base.WhoAmIBean;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.wildfly.security.permission.ElytronPermission;
+import org.wildfly.security.auth.server.SecurityDomain;
 
 /**
  * Test case to hold the authentication scenarios, these range from calling a servlet which calls a bean to calling a bean which
@@ -86,12 +85,6 @@ public class AuthenticationTestCase {
 
     private static final Logger log = Logger.getLogger(AuthenticationTestCase.class.getName());
 
-    @BeforeClass
-    public static void beforeClass() {
-        //Conditionally ignore all the tests, although only testICIR_TwoBeans_ViaServlet() needs this treatment.
-        //There seems to be an issue with the system property not getting propagated to the server
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
     /*
      * Authentication Scenarios
      *
@@ -259,7 +252,11 @@ public class AuthenticationTestCase {
             getWhoAmI("?method=doubleWhoAmI&username=user2&password=bad_password");
             fail("Expected IOException");
         } catch (IOException e) {
-            assertTrue(e.getMessage().contains("javax.ejb.EJBAccessException"));
+            if (SecurityDomain.getCurrent() == null) {
+                assertTrue(e.getMessage().contains("javax.ejb.EJBAccessException"));
+            } else {
+                assertTrue(e.getMessage().contains("javax.ejb.EJBException: java.lang.SecurityException: ELY01151"));
+            }
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -45,14 +45,12 @@ import org.jboss.as.test.integration.ejb.security.runasprincipal.transitive.Sing
 import org.jboss.as.test.integration.ejb.security.runasprincipal.transitive.StatelessSingletonUseBean;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -74,11 +72,6 @@ public class RunAsPrincipalTestCase  {
     @ArquillianResource
     public Deployer deployer;
 
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
-
     @Deployment(name = STARTUP_SINGLETON_DEPLOYMENT, managed = false, testable = false)
     public static Archive<?> runAsStartupTransitiveDeployment() {
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
@@ -99,12 +92,6 @@ public class RunAsPrincipalTestCase  {
 
     @Deployment
     public static Archive<?> runAsDeployment() {
-        //XXX This is hack related to Elytron profile assumption in beforeClass() method.
-        // Arquillian does deploy before executing @BeforeClass annotated methods. So let's create a dummy deployment
-        if (! AssumeTestGroupUtil.CONDITION_SKIP_ELYTRON_PROFILE.get()) {
-            return ShrinkWrap.create(WebArchive.class).addAsWebResource(new StringAsset(""), "index.html");
-        }
-
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war")
                 .addPackage(WhoAmI.class.getPackage())

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/AsynchronousSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/AsynchronousSecurityTestCase.java
@@ -41,14 +41,12 @@ import org.jboss.as.test.integration.ejb.security.AnnotationAuthorizationTestCas
 import org.jboss.as.test.integration.ejb.security.EjbSecurityDomainSetup;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -80,11 +78,6 @@ public class AsynchronousSecurityTestCase {
         protected String getGroupsFile() {
             return new File(AsynchronousSecurityTestCase.class.getResource("roles.properties").getFile()).getAbsolutePath();
         }
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     @ArquillianResource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -40,7 +40,6 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
 import org.jboss.as.test.shared.integration.ejb.security.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.junit.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -63,7 +62,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -96,11 +94,6 @@ public class GetCallerPrincipalTestCase {
     private static final String OK = "OK";
 
     public static final String LOCAL_USER = "$local";
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @ArquillianResource
     Deployer deployer;
@@ -224,7 +217,11 @@ public class GetCallerPrincipalTestCase {
 
             bean.remove();
 
-            Assert.assertEquals(LOCAL_USER +  "stop", results.getSfsb("predestroy"));
+            if (System.getProperty("elytron") == null) {
+                Assert.assertEquals(LOCAL_USER + "stop", results.getSfsb("predestroy"));
+            } else {
+                Assert.assertEquals(ANONYMOUS + "stop", results.getSfsb("predestroy"));
+            }
             return null;
         };
         try {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -208,6 +208,7 @@ public class GetCallerPrincipalTestCase {
     @Test
     public void testStatefulLifecycle() throws Exception {
         deployer.deploy("sfsb");
+        final boolean elytronProfile = System.getProperty("elytron") != null;
         final Callable<Void> callable = () -> {
             ITestResultsSingleton results = this.getResultsSingleton();
             IBeanLifecycleCallback bean = (IBeanLifecycleCallback) initialContext.lookup("ejb:/sfsb//" + SFSBLifecycleCallback.class.getSimpleName() + "!" + IBeanLifecycleCallback.class.getName() + "?stateful");
@@ -217,7 +218,7 @@ public class GetCallerPrincipalTestCase {
 
             bean.remove();
 
-            if (System.getProperty("elytron") == null) {
+            if (! elytronProfile) {
                 Assert.assertEquals(LOCAL_USER + "stop", results.getSfsb("predestroy"));
             } else {
                 Assert.assertEquals(ANONYMOUS + "stop", results.getSfsb("predestroy"));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -45,7 +45,6 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.ChildFirstClassLoaderBuilder;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.test.integration.management.ManagementOperations;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -54,7 +53,6 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -104,11 +102,6 @@ public class ClientCompatibilityUnitTestCase {
                     .append(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT)
                     .append(ModelDescriptionConstants.MANAGEMENT_INTERFACE, ModelDescriptionConstants.NATIVE_INTERFACE).toModelNode();
         }
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
     }
 
     // Arquillian requires a deployment to trigger @ServerSetup handling

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/TimerEJBRuntimeNameTestCase.java
@@ -17,7 +17,6 @@ import org.jboss.as.test.integration.management.deploy.runtime.ejb.singleton.tim
 import org.jboss.as.test.integration.management.deploy.runtime.ejb.singleton.timer.PointlessInterface;
 import org.jboss.as.test.integration.management.util.ModelUtil;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -47,11 +46,6 @@ public class TimerEJBRuntimeNameTestCase extends AbstractRuntimeTestCase {
     private static final String SUB_DEPLOYMENT_MODULE_NAME = "ejb";
     private static final String SUB_DEPLOYMENT_NAME = SUB_DEPLOYMENT_MODULE_NAME + ".jar";
     private static ModelControllerClient controllerClient = TestSuiteEnvironment.getModelControllerClient();
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @BeforeClass
     public static void setup() throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -12,12 +12,10 @@ import org.wildfly.naming.java.permission.JndiPermission;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import org.jboss.as.test.integration.security.common.Utils;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import org.jboss.remoting3.security.RemotingPermission;
@@ -40,12 +38,6 @@ public class MultipleClientRemoteJndiTestCase {
     private URL urlTwo;
 
     private static final Package thisPackage = MultipleClientRemoteJndiTestCase.class.getPackage();
-
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @Deployment(name="one")
     public static WebArchive deploymentOne() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -12,12 +12,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.java.permission.JndiPermission;
@@ -34,11 +32,6 @@ public class NestedRemoteContextTestCase {
     private URL callEjbUrl;
 
     private static final Package thisPackage = NestedRemoteContextTestCase.class.getPackage();
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @Deployment
     public static EnterpriseArchive deploymentTwo() {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
@@ -37,7 +37,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.manualmode.ejb.Util;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -45,7 +44,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -78,12 +76,6 @@ public class RemoteOutboundConnectionReconnectTestCase {
     private Deployer deployer;
 
     private Context context;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
-
 
     @Before
     public void before() throws Exception {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
@@ -31,10 +31,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,11 +45,6 @@ public class DefaultContextServiceServletTestCase {
 
     @ArquillianResource
     private URL url;
-
-    @BeforeClass
-    public static void beforeClass() {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
-    }
 
     @Deployment
     public static WebArchive deployment() {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
@@ -289,7 +289,7 @@ public class FormAuthUnitTestCase {
      */
     @Test
     public void testFlushOnSessionInvalidation() throws Exception {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+        AssumeTestGroupUtil.assumeElytronProfileEnabled();
 
         log.trace("+++ testFlushOnSessionInvalidation");
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -15,9 +15,6 @@ import org.junit.Assume;
  */
 public class AssumeTestGroupUtil {
 
-    public static final Supplier<Boolean> CONDITION_SKIP_ELYTRON_PROFILE = () -> (System.getProperty("elytron") == null
-            || Boolean.getBoolean("wildfly.tmp.enable.elytron.profile.tests"));
-
     /**
      * Assume for invocation-related test failures. It skips test in case the system property
      * {@codewildfly.tmp.enable.invocation.tests} hasn't value {@code 'true'}.
@@ -29,11 +26,10 @@ public class AssumeTestGroupUtil {
 
     /**
      * Assume for test failures when running with Elytron profile enabled. It skips test in case the {@code '-Delytron'} Maven
-     * argument is used (for Elytron profile activation) and system property {@code wildfly.tmp.enable.elytron.profile.tests}
-     * hasn't value {@code 'true'}.
+     * argument is used (for Elytron profile activation). For legacy-security only tests.
      */
-    public static void assumeElytronProfileTestsEnabled() {
-        assumeCondition("Tests failing in Elytron profile are disabled", CONDITION_SKIP_ELYTRON_PROFILE);
+    public static void assumeElytronProfileEnabled() {
+        assumeCondition("Tests failing in Elytron profile are disabled", () -> System.getProperty("elytron") == null);
     }
 
     private static void assumeCondition(final String message, final Supplier<Boolean> assumeTrueCondition) {


### PR DESCRIPTION
* removed unnecessary assumeElytronProfileTestsEnabled()
* only remaining renamed to non-temp assumeElytronProfileEnabled() (renamed to be sure not kept on other places)
* first commit is unreverting of https://github.com/wildfly/wildfly/pull/10190 revert (by @fjuma 's comment original PR can be resent, but not resent by original author yet)

https://issues.jboss.org/browse/WFLY-8984
https://issues.jboss.org/browse/JBEAP-11560