### PR TITLE
[WFLY-9113] Fix TransactionRemoteHTTPService.stop

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/service/TransactionRemoteHTTPService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TransactionRemoteHTTPService.java
@@ -48,7 +48,7 @@ public class TransactionRemoteHTTPService implements Service<TransactionRemoteHT
 
     @Override
     public void stop(StopContext context) {
-        pathHandlerInjectedValue.getValue().removePrefixPath("/ejb");
+        pathHandlerInjectedValue.getValue().removePrefixPath("/txn");
     }
 
     @Override


### PR DESCRIPTION
Fix the prefix path to remove when the TransactionRemoteHTTPService is
stopped.

JIRA: https://issues.jboss.org/browse/WFLY-9113