### PR TITLE
[WFLY-9016] - SecurityDomain is lost when setting up remote outbound connections

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3147,5 +3147,5 @@ public interface EjbLogger extends BasicLogger {
     void suspensionComplete();
 
     @Message(id = 494, value = "Failed to obtain SSLContext")
-    StartException failedToObtainSSLContext(@Cause Exception cause);
+    RuntimeException failedToObtainSSLContext(@Cause Exception cause);
 }


### PR DESCRIPTION
### References

* https://issues.jboss.org/browse/WFLY-9016
* https://issues.jboss.org/browse/JBEAP-11377