### PR TITLE
[WFLY-9021] Mark the transaction subsystem log store child resources …

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionDefinition.java
@@ -41,8 +41,10 @@ public class LogStoreTransactionDefinition extends SimpleResourceDefinition {
 
 
     public LogStoreTransactionDefinition(final LogStoreResource resource) {
-        super(TransactionExtension.TRANSACTION_PATH,
-                TransactionExtension.getResourceDescriptionResolver(LogStoreConstants.LOG_STORE, CommonAttributes.TRANSACTION));
+        super(new Parameters(TransactionExtension.TRANSACTION_PATH,
+                TransactionExtension.getResourceDescriptionResolver(LogStoreConstants.LOG_STORE, CommonAttributes.TRANSACTION))
+                .setRuntime()
+        );
         this.resource = resource;
     }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
@@ -41,8 +41,10 @@ public class LogStoreTransactionParticipantDefinition extends SimpleResourceDefi
     static final LogStoreTransactionParticipantDefinition INSTANCE = new LogStoreTransactionParticipantDefinition();
 
     private LogStoreTransactionParticipantDefinition() {
-        super(TransactionExtension.PARTICIPANT_PATH,
-                TransactionExtension.getResourceDescriptionResolver(LogStoreConstants.LOG_STORE, CommonAttributes.TRANSACTION, CommonAttributes.PARTICIPANT));
+        super(new Parameters(TransactionExtension.PARTICIPANT_PATH,
+                TransactionExtension.getResourceDescriptionResolver(LogStoreConstants.LOG_STORE, CommonAttributes.TRANSACTION, CommonAttributes.PARTICIPANT))
+                .setRuntime()
+        );
     }
 
     @Override


### PR DESCRIPTION
…as runtime in the MRR and not just the resource

https://issues.jboss.org/browse/WFLY-9021