### PR TITLE
WFLY-8646: Use default JBOSS-LOCAL-USER mechanism user name to make test compatible with Elytron

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/CustomCallbackHandler.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/CustomCallbackHandler.java
@@ -37,7 +37,7 @@ import javax.security.sasl.RealmCallback;
  */
 public class CustomCallbackHandler implements CallbackHandler {
 
-    static final String USER_NAME = "foo-bar";
+    static final String USER_NAME = System.getProperty("elytron") == null ? "foo-bar" : "$local";
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/MapBasedInitialContextEjbClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mapbased/MapBasedInitialContextEjbClientTestCase.java
@@ -30,7 +30,6 @@ import javax.naming.InitialContext;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -64,7 +63,6 @@ public class MapBasedInitialContextEjbClientTestCase {
      */
     @Test
     public void testScopedEJBClientContexts() throws Exception {
-        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
         InitialContext ctx = new InitialContext(getEjbClientProperties(System.getProperty("node0", "127.0.0.1"), 8080));
         try {
             String lookupName = "ejb:/" + ARCHIVE_NAME + "/" + StatelessBean.class.getSimpleName() + "!" + StatelessIface.class.getCanonicalName();


### PR DESCRIPTION
Since finally there is not special handling for JBOSS-LOCAL-USER server side authentication in Elytron, see https://issues.jboss.org/browse/ELY-1103, use $local user explicitly in this test to make it compatible with Elytron profile.

Jira issues:
https://issues.jboss.org/browse/WFLY-8646
https://issues.jboss.org/browse/JBEAP-10566