### PR TITLE
WFLY-9054 ScheduleExpression with start and end date fail for persient timers with Oracle

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3148,4 +3148,8 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 494, value = "Failed to obtain SSLContext")
     RuntimeException failedToObtainSSLContext(@Cause Exception cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 495, value = "Ignoring the persisted start or end date for scheduled expression of timer ID:%s as it is not valid : %s.")
+    void scheduleExpressionDateFromTimerPersistenceInvalid(String timerId, String parserMessage);
 }


### PR DESCRIPTION
The SCHEDULE_EXPR_?_DATE are Date values but stored as String into the database. This lead to Exceptions as Oracle converts the toString
with NLS_TIMESTAMP_FORMAT, but this only for one direction.
The values are converted to String before adding it to the SQL Statement.

https://issues.jboss.org/browse/WFLY-9054