### PR TITLE
[WFLY-9055] cache-type attribute of security-domain element accepts invalid values

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadWriteHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
@@ -47,5 +48,11 @@ public class SecurityDomainReloadWriteHandler extends RestartParentWriteAttribut
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
         return SecurityDomainResourceDefinition.getSecurityDomainServiceName(parentAddress);
+    }
+
+    // TODO: Remove this method once WFCORE-3055 and WFCORE-3056 are fixed
+    @Override
+    protected void validateUpdatedModel(OperationContext context, Resource model) throws OperationFailedException {
+        SecurityDomainResourceDefinition.CACHE_TYPE.validateOperation(model.getModel());
     }
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraint
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.validation.StringAllowedValuesValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -72,7 +73,7 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
 
     public static final SimpleAttributeDefinition CACHE_TYPE = new SimpleAttributeDefinitionBuilder(Constants.CACHE_TYPE, ModelType.STRING, true)
             .setAllowExpression(true)
-            .setAllowedValues("default", INFINISPAN_CACHE_TYPE)
+            .setValidator(new StringAllowedValuesValidator("default", INFINISPAN_CACHE_TYPE))
             .build();
 
     private final boolean registerRuntimeOnly;


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-9055