### PR TITLE
[WFLY-9059] add missing permissions for many org.jboss.as.test.integration.ejb.security.**.* tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MixedSecurityAnnotationAuthorizationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/MixedSecurityAnnotationAuthorizationTestCase.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.permission.ElytronPermission;
 import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
 
 import javax.ejb.EJB;
@@ -44,6 +45,7 @@ import static org.jboss.as.security.Constants.AUTHENTICATION;
 import static org.jboss.as.security.Constants.CODE;
 import static org.jboss.as.security.Constants.FLAG;
 import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -69,6 +71,10 @@ public class MixedSecurityAnnotationAuthorizationTestCase {
                 .addClasses(MixedSecurityAnnotationAuthorizationTestCase.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class, EjbElytronDomainSetup.class)
                 .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml");
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new ElytronPermission("getSecurityDomain"),
+                new ElytronPermission("authenticate")
+                ), "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/RunAsPrincipalTestCase.java
@@ -54,6 +54,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Migration of test from EJB3 testsuite [JBQA-5451] Testing calling with runasprincipal annotation (ejbthree1945)
@@ -85,7 +88,8 @@ public class RunAsPrincipalTestCase  {
                 .addClass(RunAsPrincipalTestCase.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
                 .addAsWebInfResource(RunAsPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }
@@ -102,7 +106,8 @@ public class RunAsPrincipalTestCase  {
                 .addClass(RunAsPrincipalTestCase.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
                 .addAsWebInfResource(RunAsPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/permissions.xml
@@ -8,4 +8,8 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>org.jboss.security.getSecurityContext</name>
     </permission>
+    <permission>
+        <class-name>org.wildfly.security.permission.ElytronPermission</class-name>
+        <name>getSecurityDomain</name>
+    </permission>
 </permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.ejb.security.callerprincipal;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.util.concurrent.Callable;
 
 import javax.jms.DeliveryMode;
@@ -65,6 +67,7 @@ import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 
 /**
  * The Bean Provider can invoke the getCallerPrincipal and isCallerInRole methods only
@@ -122,7 +125,8 @@ public class GetCallerPrincipalTestCase {
                 .addClass(TestResultsSingleton.class)
                 .addClass(ITestResultsSingleton.class)
                 .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-single", "MANIFEST.MF");
+                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-single", "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
     }
@@ -135,7 +139,8 @@ public class GetCallerPrincipalTestCase {
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "users.properties", "users.properties")
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "roles.properties", "roles.properties")
                 .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF");
+                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
     }
@@ -148,7 +153,8 @@ public class GetCallerPrincipalTestCase {
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "users.properties", "users.properties")
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "roles.properties", "roles.properties")
                 .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF");
+                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "jboss-permissions.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
     }
@@ -160,7 +166,8 @@ public class GetCallerPrincipalTestCase {
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "users.properties", "users.properties")
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "roles.properties", "roles.properties")
                 .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF")                ;
+                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-bean", "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
     }
@@ -178,7 +185,8 @@ public class GetCallerPrincipalTestCase {
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "users.properties", "users.properties")
                 .addAsResource(GetCallerPrincipalTestCase.class.getPackage(), "roles.properties", "roles.properties")
                 .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-test", "MANIFEST.MF");
+                .addAsManifestResource(GetCallerPrincipalTestCase.class.getPackage(), "MANIFEST.MF-test", "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("getSecurityDomain")), "permissions.xml");
         jar.addPackage(CommonCriteria.class.getPackage());
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/permissions.xml
@@ -4,4 +4,16 @@
         <class-name>javax.security.auth.AuthPermission</class-name>
         <name>modifyPrincipals</name>
     </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission>
+     <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>setContextClassLoader</name>
+    </permission>
+    <permission>
+        <class-name>org.wildfly.security.permission.ElytronPermission</class-name>
+        <name>getSecurityDomain</name>
+    </permission>
 </permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/permissions.xml
@@ -4,4 +4,8 @@
         <class-name>javax.security.auth.AuthPermission</class-name>
         <name>modifyPrincipals</name>
     </permission>
+    <permission>
+        <class-name>org.wildfly.security.permission.ElytronPermission</class-name>
+        <name>getSecurityDomain</name>
+    </permission>
 </permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/permissions.xml
@@ -4,4 +4,8 @@
         <class-name>javax.security.auth.AuthPermission</class-name>
         <name>modifyPrincipals</name>
     </permission>
+    <permission>
+        <class-name>org.wildfly.security.permission.ElytronPermission</class-name>
+        <name>getSecurityDomain</name>
+    </permission>
 </permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/permissions.xml
@@ -4,4 +4,8 @@
         <class-name>javax.security.auth.AuthPermission</class-name>
         <name>modifyPrincipals</name>
     </permission>
+    <permission>
+        <class-name>org.wildfly.security.permission.ElytronPermission</class-name>
+        <name>getSecurityDomain</name>
+    </permission>
 </permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/singleton/SingletonSecurityTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 
 /**
  * Tests that invocations on a secured singleton bean work as expected.
@@ -60,7 +61,10 @@ public class SingletonSecurityTestCase {
         jar.addPackage(SingletonSecurityTestCase.class.getPackage());
         jar.addPackage(CommonCriteria.class.getPackage());
         jar.addClass(Util.class);
-        jar.addAsResource(createPermissionsXmlAsset(new RuntimePermission("org.jboss.security.setSecurityContext")), "META-INF/jboss-permissions.xml");
+        jar.addAsResource(createPermissionsXmlAsset(
+                new RuntimePermission("org.jboss.security.setSecurityContext"),
+                new ElytronPermission("getSecurityDomain")
+                ), "META-INF/permissions.xml");
         return jar;
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9059
add missing permissions for many org.jboss.as.test.integration.ejb.security.**.* tests
missing permissions are listed in description of WFLY-9059, test fix with:
> 
> cd wildfly/testsuite/integration/basic
> mvn clean test -Dtest=org.jboss.as.test.integration.ejb.security.**.* -Dsecurity.manager

downstream issue: https://issues.jboss.org/browse/JBEAP-11990