### PR TITLE
[WFLY-3424] Correctly implement the ArtifactFactory to work better with CDI

### DIFF
--- a/batch/extension-jberet/pom.xml
+++ b/batch/extension-jberet/pom.xml
@@ -43,6 +43,15 @@
             <groupId>org.jboss.spec.javax.batch</groupId>
             <artifactId>jboss-batch-api_1.0_spec</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-weld-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchServiceNames.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchServiceNames.java
@@ -29,6 +29,17 @@ public class BatchServiceNames {
     }
 
     /**
+     * Creates a service name for the {@linkplain org.jberet.spi.ArtifactFactory artifact factory} service.
+     *
+     * @param deploymentUnit the deployment unit to create the service name for
+     *
+     * @return the service name
+     */
+    public static ServiceName batchArtifactFactoryServiceName(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.getServiceName().append("batch").append("artifact").append("factory");
+    }
+
+    /**
      * Creates the service name used for the bean manager on the deployment.
      *
      * @param deploymentUnit the deployment unit to create the service name for

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/ArtifactFactoryService.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/ArtifactFactoryService.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.jberet.creation.AbstractArtifactFactory;
+import org.jberet.spi.ArtifactFactory;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.weld.bean.builtin.BeanManagerProxy;
+import org.jboss.weld.context.RequestContext;
+import org.jboss.weld.context.unbound.UnboundLiteral;
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.wildfly.extension.batch.jberet._private.BatchLogger;
+
+/**
+ * ArtifactFactory for Java EE runtime environment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ArtifactFactoryService extends AbstractArtifactFactory implements Service<ArtifactFactory>, WildFlyArtifactFactory {
+    private final InjectedValue<BeanManager> beanManagerInjector = new InjectedValue<>();
+
+    private final Map<Object, Holder> contexts = Collections.synchronizedMap(new HashMap<>());
+    private volatile BeanManager beanManager;
+
+    @Override
+    public void destroy(final Object instance) {
+        final Holder holder = contexts.remove(instance);
+        if (holder == null) {
+            // This bean was not created via CDI, we need to invoke the JBeret cleanup
+            super.destroy(instance);
+        } else {
+            // Only release the context for @Dependent beans, Weld should take care of the other scopes
+            if (holder.isDependent()) {
+                // We're not destroying the bean here because weld should handle that for use when we release the
+                // CreationalContext
+                holder.context.release();
+            }
+        }
+    }
+
+    @Override
+    public Class<?> getArtifactClass(final String ref, final ClassLoader classLoader) {
+        final Bean<?> bean = getBean(ref, getBeanManager());
+        return bean == null ? null : bean.getBeanClass();
+    }
+
+    @Override
+    public Object create(final String ref, Class<?> cls, final ClassLoader classLoader) throws Exception {
+        final BeanManager beanManager = getBeanManager();
+        final Bean<?> bean = getBean(ref, beanManager);
+        if (bean == null) {
+            return null;
+        }
+        final CreationalContext<?> context = beanManager.createCreationalContext(bean);
+        final Object result = beanManager.getReference(bean, bean.getBeanClass(), context);
+        contexts.put(result, new Holder(bean, context));
+        return result;
+    }
+
+    @Override
+    public void start(final StartContext context) throws StartException {
+        beanManager = beanManagerInjector.getOptionalValue();
+    }
+
+    @Override
+    public void stop(final StopContext context) {
+        beanManager = null;
+        synchronized (contexts) {
+            for (Holder holder : contexts.values()) {
+                // Only release the context for @Dependent beans, Weld should take care of the other scopes
+                if (holder.isDependent()) {
+                    holder.context.release();
+                }
+            }
+            contexts.clear();
+        }
+    }
+
+    @Override
+    public ArtifactFactory getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public ContextHandle createContextHandle() {
+        final BeanManagerImpl beanManager = getBeanManager();
+        return () -> {
+            if (beanManager == null || beanManager.isContextActive(RequestScoped.class)) {
+                return () -> {
+                };
+            }
+            final RequestContext requestContext = beanManager.instance().select(RequestContext.class, UnboundLiteral.INSTANCE).get();
+            requestContext.activate();
+            return () -> {
+                requestContext.invalidate();
+                requestContext.deactivate();
+            };
+        };
+    }
+
+    public InjectedValue<BeanManager> getBeanManagerInjector() {
+        return beanManagerInjector;
+    }
+
+    private BeanManagerImpl getBeanManager() {
+        final BeanManager beanManager = this.beanManager;
+        return beanManager == null ? null : BeanManagerProxy.unwrap(beanManager);
+    }
+
+    private static Bean<?> getBean(final String ref, final BeanManager beanManager) {
+        if (beanManager == null) {
+            return null;
+        }
+        BatchLogger.LOGGER.tracef("Looking up bean reference for '%s'", ref);
+        final Set<Bean<?>> beans = beanManager.getBeans(ref);
+        final Bean<?> bean = beanManager.resolve(beans);
+        if (bean != null) {
+            BatchLogger.LOGGER.tracef("Found bean '%s' for reference '%s'", bean, ref);
+        } else {
+            BatchLogger.LOGGER.tracef("No bean found for reference '%s;'", ref);
+        }
+        return bean;
+    }
+
+    private static class Holder {
+        final Bean<?> bean;
+        final CreationalContext<?> context;
+
+        private Holder(final Bean<?> bean, final CreationalContext<?> context) {
+            this.bean = bean;
+            this.context = context;
+        }
+
+        boolean isDependent() {
+            return Dependent.class.equals(bean.getScope());
+        }
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
@@ -23,7 +23,6 @@
 package org.wildfly.extension.batch.jberet.deployment;
 
 import java.util.Properties;
-import javax.enterprise.inject.spi.BeanManager;
 import javax.transaction.TransactionManager;
 
 import org.jberet.repository.JobRepository;
@@ -52,7 +51,7 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
 
     private static final Properties PROPS = new Properties();
 
-    private final InjectedValue<BeanManager> beanManagerInjector = new InjectedValue<>();
+    private final InjectedValue<WildFlyArtifactFactory> artifactFactoryInjector = new InjectedValue<>();
     private final InjectedValue<JobExecutor> jobExecutorInjector = new InjectedValue<>();
     private final InjectedValue<TransactionManager> transactionManagerInjector = new InjectedValue<>();
     private final InjectedValue<RequestController> requestControllerInjector = new InjectedValue<>();
@@ -86,7 +85,7 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
             jobRepository = batchConfiguration.getDefaultJobRepository();
         }
 
-        this.batchEnvironment = new WildFlyBatchEnvironment(beanManagerInjector.getOptionalValue(),
+        this.batchEnvironment = new WildFlyBatchEnvironment(artifactFactoryInjector.getValue(),
                 jobExecutor, transactionManagerInjector.getValue(),
                 jobRepository, jobXmlResolver);
 
@@ -113,8 +112,8 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
         return batchEnvironment;
     }
 
-    public InjectedValue<BeanManager> getBeanManagerInjector() {
-        return beanManagerInjector;
+    public InjectedValue<WildFlyArtifactFactory> getArtifactFactoryInjector() {
+        return artifactFactoryInjector;
     }
 
     public InjectedValue<JobExecutor> getJobExecutorInjector() {
@@ -139,19 +138,19 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
 
     private class WildFlyBatchEnvironment implements BatchEnvironment, SecurityAwareBatchEnvironment {
 
-        private final ArtifactFactory artifactFactory;
+        private final WildFlyArtifactFactory artifactFactory;
         private final JobExecutor jobExecutor;
         private final TransactionManager transactionManager;
         private final JobRepository jobRepository;
         private final JobXmlResolver jobXmlResolver;
 
-        WildFlyBatchEnvironment(final BeanManager beanManager,
+        WildFlyBatchEnvironment(final WildFlyArtifactFactory artifactFactory,
                                 final JobExecutor jobExecutor,
                                 final TransactionManager transactionManager,
                                 final JobRepository jobRepository,
                                 final JobXmlResolver jobXmlResolver) {
             this.jobXmlResolver = jobXmlResolver;
-            artifactFactory = new WildFlyArtifactFactory(beanManager);
+            this.artifactFactory = artifactFactory;
             this.jobExecutor = jobExecutor;
             this.transactionManager = transactionManager;
             this.jobRepository = jobRepository;
@@ -229,7 +228,8 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
             // If the TCCL is null, use the deployments ModuleClassLoader
             final ClassLoaderContextHandle classLoaderContextHandle = (tccl == null ? new ClassLoaderContextHandle(classLoader) : new ClassLoaderContextHandle(tccl));
             // Class loader handle must be first so the TCCL is set before the other handles execute
-            return new ContextHandle.ChainedContextHandle(classLoaderContextHandle, new NamespaceContextHandle(), new SecurityContextHandle());
+            return new ContextHandle.ChainedContextHandle(classLoaderContextHandle, new NamespaceContextHandle(),
+                    new SecurityContextHandle(), artifactFactory.createContextHandle());
         }
     }
 }

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
@@ -38,6 +38,17 @@ public class BatchServiceNames {
     }
 
     /**
+     * Creates a service name for the {@linkplain org.jberet.spi.ArtifactFactory artifact factory} service.
+     *
+     * @param deploymentUnit the deployment unit to create the service name for
+     *
+     * @return the service name
+     */
+    public static ServiceName batchArtifactFactoryServiceName(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.getServiceName().append("batch").append("artifact").append("factory");
+    }
+
+    /**
      * Creates the service name used for the bean manager on the deployment.
      *
      * @param deploymentUnit the deployment unit to create the service name for

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
@@ -50,6 +50,9 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
+        <module name="org.jboss.weld.api" />
+        <module name="org.jboss.weld.core" />
+        <module name="org.jboss.weld.spi" />
         <module name="org.picketbox"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/RequestScopeCounter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/RequestScopeCounter.java
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package org.wildfly.extension.batch.jberet.deployment;
+package org.jboss.as.test.integration.batch.batchlet;
 
-import org.jberet.spi.ArtifactFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.enterprise.context.RequestScoped;
 
 /**
- * ArtifactFactory for Java EE runtime environment.
- *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public interface WildFlyArtifactFactory extends ArtifactFactory {
+@RequestScoped
+public class RequestScopeCounter {
+    private final AtomicInteger counter = new AtomicInteger();
 
-    /**
-     * Creates a {@linkplain ContextHandle context handle} required for setting up the CDI context.
-     *
-     * @return the newly create context handle
-     */
-    ContextHandle createContextHandle();
+    public int get() {
+        return counter.get();
+    }
+
+    public int incrementAndGet() {
+        return counter.incrementAndGet();
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/SimpleCounterBatchlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/SimpleCounterBatchlet.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.batch.batchlet;
+
+import javax.batch.api.AbstractBatchlet;
+import javax.batch.api.BatchProperty;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Named
+public class SimpleCounterBatchlet extends AbstractBatchlet {
+    @Inject
+    private RequestScopeCounter counter;
+
+    @Inject
+    @BatchProperty
+    private int count;
+
+    @Override
+    public String process() throws Exception {
+        final StringBuilder exitStatus = new StringBuilder();
+        int current = 0;
+        while (current < count) {
+            current = counter.incrementAndGet();
+            exitStatus.append(current);
+            if (current < count) {
+                exitStatus.append(',');
+            }
+        }
+        return exitStatus.toString();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/SimpleCounterBatchletTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/SimpleCounterBatchletTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.batch.batchlet;
+
+import java.util.List;
+import java.util.Properties;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.StepExecution;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that a {@link javax.faces.bean.RequestScoped @RequestScoped} bean will work correctly in a batch job.
+ * <p>
+ * The order of the two tests should not matter. The reason it's tested twice however is a {@code @RequestScoped} bean
+ * should create a new instance for each job executed. Executing twice ensures the scoping for batch is correct.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class SimpleCounterBatchletTestCase extends AbstractBatchTestCase {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return createDefaultWar("simple-counter-batchlet.war", SimpleCounterBatchletTestCase.class.getPackage(), "simple-counter-batchlet.xml")
+                .addPackage(SimpleCounterBatchletTestCase.class.getPackage());
+
+    }
+
+    /**
+     * Tests that a request scope bean will be injected and the counter should start with 1 and end at 10.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void testRequestScope10() throws Exception {
+        final Properties jobProperties = new Properties();
+        jobProperties.setProperty("count", "10");
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+
+        // Start the first job
+        long executionId = jobOperator.start("simple-counter-batchlet", jobProperties);
+
+        JobExecution jobExecution = jobOperator.getJobExecution(executionId);
+
+        // Wait until the job is complete for a maximum of 5 seconds
+        waitForTermination(jobExecution, 5);
+        Assert.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+
+        // Get the first step, should only be one, and get the exit status
+        Assert.assertEquals("1,2,3,4,5,6,7,8,9,10", getFirst(jobOperator, executionId).getExitStatus());
+    }
+
+
+    /**
+     * Tests that a request scope bean will be injected and the counter should start with 1 and end at 8.
+     *
+     * @throws Exception if an error occurs
+     */
+    @Test
+    public void testRequestScope8() throws Exception {
+        final Properties jobProperties = new Properties();
+        jobProperties.setProperty("count", "8");
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+
+        // Start the first job
+        long executionId = jobOperator.start("simple-counter-batchlet", jobProperties);
+
+        JobExecution jobExecution = jobOperator.getJobExecution(executionId);
+
+        // Wait until the job is complete for a maximum of 5 seconds
+        waitForTermination(jobExecution, 5);
+        Assert.assertEquals(BatchStatus.COMPLETED, jobExecution.getBatchStatus());
+
+        // Get the first step, should only be one, and get the exit status
+        Assert.assertEquals("1,2,3,4,5,6,7,8", getFirst(jobOperator, executionId).getExitStatus());
+    }
+
+    private StepExecution getFirst(final JobOperator jobOperator, final long executionId) {
+        final List<StepExecution> steps = jobOperator.getStepExecutions(executionId);
+        Assert.assertFalse(steps.isEmpty());
+        return steps.get(0);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/simple-counter-batchlet.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/batchlet/simple-counter-batchlet.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2017 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<job id="simple-counter-batchlet" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="simple-counter-batchlet.step1">
+        <batchlet ref="simpleCounterBatchlet">
+            <properties>
+                <property name="count" value="#{jobParameters['count']}"/>
+            </properties>
+        </batchlet>
+    </step>
+</job>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
@@ -22,10 +22,11 @@
 
 package org.jboss.as.test.integration.batch.chunk;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.net.URL;
 import java.util.Properties;
 import java.util.PropertyPermission;
-import java.util.concurrent.TimeUnit;
 import javax.batch.operations.JobOperator;
 import javax.batch.operations.NoSuchJobExecutionException;
 import javax.batch.runtime.BatchRuntime;
@@ -43,15 +44,12 @@ import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
 import org.jboss.as.test.integration.batch.common.CountingItemWriter;
 import org.jboss.as.test.integration.batch.common.JobExecutionMarshaller;
 import org.jboss.as.test.integration.batch.common.StartBatchServlet;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -153,31 +151,6 @@ public class ChunkPartitionTestCase extends AbstractBatchTestCase {
             Assert.assertEquals(20, countingItemWriter.getWrittenItemSize());
         } finally {
             managementClient.getControllerClient().execute(Operations.createOperation("resume"));
-        }
-    }
-
-    private static void waitForTermination(final JobExecution jobExecution, final int timeout) {
-        long waitTimeout = TimeoutUtil.adjust(timeout * 1000);
-        long sleep = 100L;
-        while (true) {
-            switch (jobExecution.getBatchStatus()) {
-                case STARTED:
-                case STARTING:
-                case STOPPING:
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(sleep);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    waitTimeout -= sleep;
-                    sleep = Math.max(sleep / 2, 100L);
-                    break;
-                default:
-                    return;
-            }
-            if (waitTimeout <= 0) {
-                throw new IllegalStateException("Batch job did not complete within allotted time.");
-            }
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -35,6 +35,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.batch.runtime.JobExecution;
+
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -122,6 +124,31 @@ public abstract class AbstractBatchTestCase {
                 "    </step>\n" +
                 "</job>";
         return new StringAsset(xml);
+    }
+
+    protected static void waitForTermination(final JobExecution jobExecution, final int timeout) {
+        long waitTimeout = TimeoutUtil.adjust(timeout * 1000);
+        long sleep = 100L;
+        while (true) {
+            switch (jobExecution.getBatchStatus()) {
+                case STARTED:
+                case STARTING:
+                case STOPPING:
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(sleep);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    waitTimeout -= sleep;
+                    sleep = Math.max(sleep / 2, 100L);
+                    break;
+                default:
+                    return;
+            }
+            if (waitTimeout <= 0) {
+                throw new IllegalStateException("Batch job did not complete within allotted time.");
+            }
+        }
     }
 
     public static class UrlBuilder {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
@@ -22,9 +22,10 @@
 
 package org.jboss.as.test.integration.batch.deployment;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 import java.io.IOException;
 import java.util.PropertyPermission;
-import java.util.concurrent.TimeUnit;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
 import javax.batch.runtime.BatchStatus;
@@ -50,8 +51,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests the start, stop and restart functionality for deployments.
@@ -283,31 +282,6 @@ public class JobControlTestCase extends AbstractBatchTestCase {
         Assert.fail(Operations.getFailureDescription(result).asString());
         // Should never be reached
         return new ModelNode();
-    }
-
-    private static void waitForTermination(final JobExecution jobExecution, final int timeout) {
-        long waitTimeout = TimeoutUtil.adjust(timeout * 1000);
-        long sleep = 100L;
-        while (true) {
-            switch (jobExecution.getBatchStatus()) {
-                case STARTED:
-                case STARTING:
-                case STOPPING:
-                    try {
-                        TimeUnit.MILLISECONDS.sleep(sleep);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    waitTimeout -= sleep;
-                    sleep = Math.max(sleep / 2, 100L);
-                    break;
-                default:
-                    return;
-            }
-            if (waitTimeout <= 0) {
-                throw new IllegalStateException("Batch job did not complete within allotted time.");
-            }
-        }
     }
 
 


### PR DESCRIPTION
[WFLY-8942] Setup the correct context for @RequestScope beans.

This contains two fixes in one commit. It didn't make sense to split the commits as they touch the same files. One would have deleted a file, the other would have added it back.

## [WFLY-3432](https://issues.jboss.org/browse/WFLY-3424)
This converts the previously named `WildFlyArtifactFactory` to an MSC service and uses the correct call to the `CreationalContext` to clean up the CDI bean rather than JBeret itself attempting to invoke the `@PostConstruct`. 

Due note while the upgrade for JBeret (https://issues.jboss.org/browse/WFLY-9051) isn't required for this change to exist, it will be required for this change to actually work properly.

## [WFLY-8942](https://issues.jboss.org/browse/WFLY-8942)
Activates and deactivates the `@RequestScope` context. Typically the request scope is a thread-local. However since batch jobs are ran in new thread(s) the context needs to be activated for all threads.