### PR TITLE
[WFLY-9071] Remove check that journal-file-size must be multiply of 512 from messaging integration

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -275,7 +275,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setXmlName("file-size")
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalFileSize()))
             .setMeasurementUnit(BYTES)
-            .setValidator(new ModularLongRangeParameterValidator(512, 1024, Long.MAX_VALUE, true, true))
+            .setValidator(new LongRangeValidator(1024, Long.MAX_VALUE, true, true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-9071