### PR TITLE
[WFLY-9087] SharedSessionFailoverTestCase URLs resolving fixed

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
@@ -95,13 +95,13 @@ public class SharedSessionFailoverTestCase extends ClusterAbstractTestCase {
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURLDep1,
             @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURLDep2)
             throws URISyntaxException, IOException {
-        URL baseURL1 = new URL(baseURLDep1.toExternalForm() + "/");
-        URL baseURL2 = new URL(baseURLDep2.toExternalForm() + "/");
+        URI baseURI1 = new URI(baseURLDep1.toExternalForm() + "/");
+        URI baseURI2 = new URI(baseURLDep2.toExternalForm() + "/");
 
-        URI uri11 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_1 + "/").toURL());
-        URI uri12 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_2 + "/").toURL());
-        URI uri21 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_1 + "/").toURL());
-        URI uri22 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_2 + "/").toURL());
+        URI uri11 = SimpleServlet.createURI(baseURI1.resolve(MODULE_1 + "/"));
+        URI uri12 = SimpleServlet.createURI(baseURI1.resolve(MODULE_2 + "/"));
+        URI uri21 = SimpleServlet.createURI(baseURI2.resolve(MODULE_1 + "/"));
+        URI uri22 = SimpleServlet.createURI(baseURI2.resolve(MODULE_2 + "/"));
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri11));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
@@ -92,14 +92,16 @@ public class SharedSessionFailoverTestCase extends ClusterAbstractTestCase {
 
     @Test
     public void test(
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL baseURLDep1,
+            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL baseURLDep2)
             throws URISyntaxException, IOException {
+        URL baseURL1 = new URL(baseURLDep1.toExternalForm() + "/");
+        URL baseURL2 = new URL(baseURLDep2.toExternalForm() + "/");
 
-        URI uri11 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_1).toURL());
-        URI uri12 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_2).toURL());
-        URI uri21 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_1).toURL());
-        URI uri22 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_2).toURL());
+        URI uri11 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_1 + "/").toURL());
+        URI uri12 = SimpleServlet.createURI(baseURL1.toURI().resolve(MODULE_2 + "/").toURL());
+        URI uri21 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_1 + "/").toURL());
+        URI uri22 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_2 + "/").toURL());
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri11));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -48,11 +48,19 @@ public class SimpleServlet extends HttpServlet {
     private static final String ATTRIBUTE = "test";
 
     public static URI createURI(URL baseURL) throws URISyntaxException {
-        return baseURL.toURI().resolve(SERVLET_NAME);
+        return createURI(baseURL.toURI());
+    }
+
+    public static URI createURI(URI baseURI) throws URISyntaxException {
+        return baseURI.resolve(SERVLET_NAME);
     }
 
     public static URI createURI(URL baseURL, int requestDuration) throws URISyntaxException {
-        return baseURL.toURI().resolve(SERVLET_NAME + '?' + REQUEST_DURATION_PARAM + '=' + requestDuration);
+        return createURI(baseURL.toURI(), requestDuration);
+    }
+
+    public static URI createURI(URI baseURI, int requestDuration) throws URISyntaxException {
+        return baseURI.resolve(SERVLET_NAME + '?' + REQUEST_DURATION_PARAM + '=' + requestDuration);
     }
 
     @Override


### PR DESCRIPTION
URLs were incorrectly resolved all pointing to war2 deployment instead
of one group to war1 and second group to war2 deployment.

Fixes https://issues.jboss.org/browse/WFLY-9087