### PR TITLE
[WFLY-90004] Artemis leaks JGroups channels on reload

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -36,6 +36,7 @@ import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -175,12 +176,12 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
                 .setEndpointFactory(endpointFactory);
     }
 
-    static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final String name, final BroadcastGroupConfiguration config, final JChannel channel, final String channelName) throws Exception {
+    static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final String name, final BroadcastGroupConfiguration config, ActiveMQServer server, final JChannel channel, final String channelName) throws Exception {
 
         final long broadcastPeriod = config.getBroadcastPeriod();
         final List<String> connectorRefs = config.getConnectorInfos();
 
-        final BroadcastEndpointFactory endpointFactory = new ClosingChannelBroadcastEndpointFactory(channel, channelName);
+        final BroadcastEndpointFactory endpointFactory = new ClosingChannelBroadcastEndpointFactory(channel, channelName, server);
 
         return new BroadcastGroupConfiguration()
                 .setName(name)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -148,11 +149,11 @@ public class DiscoveryGroupAdd extends AbstractAddStepHandler {
     }
 
 
-    static DiscoveryGroupConfiguration createDiscoveryGroupConfiguration(final String name, final DiscoveryGroupConfiguration config, final JChannel channel, final String channelName) throws Exception {
+    static DiscoveryGroupConfiguration createDiscoveryGroupConfiguration(final String name, final DiscoveryGroupConfiguration config, final JChannel channel, final String channelName, final ActiveMQServer server) throws Exception {
         final long refreshTimeout = config.getRefreshTimeout();
         final long initialWaitTimeout = config.getDiscoveryInitialWaitTimeout();
 
-        final BroadcastEndpointFactory endpointFactory = new ClosingChannelBroadcastEndpointFactory(channel, channelName);
+        final BroadcastEndpointFactory endpointFactory = new ClosingChannelBroadcastEndpointFactory(channel, channelName, server);
 
         return new DiscoveryGroupConfiguration()
                 .setName(name)


### PR DESCRIPTION
Artemis will close its JGroups channel when the discovery/broadcast
groups are stopped and when the server itself is stopped.
The discovery group using by a ServerLocator may be stopped when the
server is initializing.
If the inner JGroups channel is closed, any subsequent uses of the
channel will fail as it is disconnected.
The code now checks if the JGroups channel is a ForkChannel. If that's
the case, it is only closed when Artemis server is stopped.
Any other types of JGroups channel is closed whenever Artemis calls
ClosingChannelBroadcastEndpoint#internalCloseChannel()

JIRA: https://issues.jboss.org/browse/WFLY-9004