### PR TITLE
[WFLY-9051] Upgrade JBeret from 1.2.3.Final to 1.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <version.org.infinispan>8.2.7.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
-        <version.org.jberet>1.2.3.Final</version.org.jberet>
+        <version.org.jberet>1.2.4.Final</version.org.jberet>
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9051

This includes a fix required for https://github.com/wildfly/wildfly/pull/10297. Without the fix in the upgrade, #10297 will introduce a memory leak.

The changes are fairly minimal https://github.com/jberet/jsr352/compare/1.2.3.Final...1.2.4.Final.