### PR TITLE
WFLY-9097 Comment-out non-default cache configurations from default config files

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -18,14 +18,17 @@
                     <transaction mode="BATCH"/>
                     <file-store passivation="true" purge="false"/>
                 </local-cache>
-                <local-cache name="persistent">
+                <!-- Alternate configuration which always persists HttpSession state to disk -->
+                <!--local-cache name="persistent">
                     <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store passivation="false" purge="false"/>
-                </local-cache>
-                <local-cache name="concurrent">
+                </local-cache-->
+                <!-- Alternate configuration to reduce lock contention for applications that make use of concurrent access to a web session -->
+                <!-- Web sessions will be locked more frequently, but for shorter periods of time -->
+                <!--local-cache name="concurrent">
                     <file-store passivation="true" purge="false"/>
-                </local-cache>
+                </local-cache-->
             </cache-container>
             <cache-container name="ejb" aliases="sfsb" default-cache="passivation" module="org.wildfly.clustering.ejb.infinispan">
                 <local-cache name="passivation">
@@ -33,11 +36,12 @@
                     <transaction mode="BATCH"/>
                     <file-store passivation="true" purge="false"/>
                 </local-cache>
-                <local-cache name="persistent">
+                <!-- Alternate configuration which always persists SFSB state to disk -->
+                <!--local-cache name="persistent">
                     <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store passivation="false" purge="false"/>
-                </local-cache>
+                </local-cache-->
             </cache-container>
             <cache-container name="hibernate" module="org.hibernate.infinispan">
                 <local-cache name="entity">
@@ -68,9 +72,11 @@
                     <transaction mode="BATCH"/>
                     <file-store/>
                 </distributed-cache>
-                <distributed-cache name="concurrent">
+                <!-- Alternate configuration to reduce lock contention for applications that make use of concurrent access to a web session -->
+                <!-- Web sessions will be locked more frequently, but for shorter periods of time -->
+                <!--distributed-cache name="concurrent">
                     <file-store/>
-                </distributed-cache>
+                </distributed-cache-->
             </cache-container>
             <cache-container name="ejb" aliases="sfsb" default-cache="dist" module="org.wildfly.clustering.ejb.infinispan">
                 <transport lock-timeout="60000"/>


### PR DESCRIPTION
Reduces the number of MSC services installed by the Infinispan subsystem by almost a third.

https://issues.jboss.org/browse/WFLY-9097