### PR TITLE
[WFLY-9099] Ensure an ad-hoc identity is created if a servlet run-as-principal identity doesn’t exist in the security domain

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -391,4 +391,6 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 95, value = "the path ['%s'] doesn't exist on file system")
     String unableAddHandlerForPath(String path);
 
+    @Message(id = 96, value = "Unable to obtain identity for name %s")
+    IllegalStateException unableToObtainIdentity(String name, @Cause Throwable cause);
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9099