### PR TITLE
[WFLY-9108] Correctly register the org.wildfly.batch.job.repository capability

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/InMemoryJobRepositoryDefinition.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.batch.jberet.BatchResourceDescriptionResolver;
 import org.wildfly.extension.batch.jberet._private.Capabilities;
@@ -45,13 +44,12 @@ public class InMemoryJobRepositoryDefinition extends SimpleResourceDefinition {
     static final PathElement PATH = PathElement.pathElement(NAME);
 
     public InMemoryJobRepositoryDefinition() {
-        super(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME), new InMemoryAddHandler(),
-                ReloadRequiredRemoveStepHandler.INSTANCE);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(Capabilities.JOB_REPOSITORY_CAPABILITY);
+        super(
+                new Parameters(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME))
+                        .setAddHandler(new InMemoryAddHandler())
+                        .setRemoveHandler(new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY))
+                        .setCapabilities(Capabilities.JOB_REPOSITORY_CAPABILITY)
+        );
     }
 
     private static class InMemoryAddHandler extends AbstractAddStepHandler {

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/job/repository/JdbcJobRepositoryDefinition.java
@@ -61,8 +61,12 @@ public class JdbcJobRepositoryDefinition extends SimpleResourceDefinition {
             .build();
 
     public JdbcJobRepositoryDefinition() {
-        super(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME), new JdbcRepositoryAddHandler(),
-                new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY));
+        super(
+                new Parameters(PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME))
+                        .setAddHandler(new JdbcRepositoryAddHandler())
+                        .setRemoveHandler(new ReloadRequiredRemoveStepHandler(Capabilities.JOB_REPOSITORY_CAPABILITY))
+                        .setCapabilities(Capabilities.JOB_REPOSITORY_CAPABILITY)
+        );
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9108

The `org.wildfly.batch.job.repository` capability was not correctly registered with the `jdbc-job-repository` resource. It was also not made unavailable on the `in-memory-job-repository` resource on a removal. This simply makes a change to use the `Parameters` constructor argument to correctly register the capability and mark the capability as unavailable when removed.