### PR TITLE
[WFLY-9116] Don't rely on RuntimeCapability.Builder add[Dynamic|Optio…

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -44,7 +44,7 @@ public class Capabilities {
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/messaging/activemq/server/capability.adoc">Capability documentation</a>
      */
     static final RuntimeCapability<Void> ACTIVEMQ_SERVER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq.server", true)
-            .addOptionalRequirements(JMX_CAPABILITY)
+            //.addRuntimeOnlyRequirements(JMX_CAPABILITY) -- has no function so don't use it
             .build();
 
     /**

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -22,6 +22,9 @@
 
 package org.wildfly.extension.undertow;
 
+import static org.wildfly.extension.undertow.HostDefinition.HOST_CAPABILITY;
+import static org.wildfly.extension.undertow.ServerDefinition.SERVER_CAPABILITY;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -54,6 +57,15 @@ class HostAdd extends AbstractAddStepHandler {
 
     private HostAdd() {
         super(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE, HostDefinition.DEFAULT_RESPONSE_CODE, HostDefinition.DISABLE_CONSOLE_REDIRECT);
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+
+        String ourCap = HOST_CAPABILITY.getDynamicName(context.getCurrentAddress());
+        String serverCap = SERVER_CAPABILITY.getDynamicName(context.getCurrentAddress().getParent());
+        context.registerAdditionalCapabilityRequirement(serverCap, ourCap, null);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -51,7 +51,7 @@ class HostDefinition extends PersistentResourceDefinition {
 
     static final RuntimeCapability<Void> HOST_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HOST, true, Host.class)
             .addRequirements(Capabilities.CAPABILITY_UNDERTOW)
-            .addDynamicRequirements(Capabilities.CAPABILITY_SERVER)
+            //addDynamicRequirements(Capabilities.CAPABILITY_SERVER) -- has no function so don't use it
             .setDynamicNameMapper(pathElements -> new String[]{
                     pathElements.getParent().getLastElement().getValue(),
                     pathElements.getLastElement().getValue()})

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerAdd.java
@@ -25,6 +25,12 @@ package org.wildfly.extension.undertow;
 import static org.wildfly.extension.undertow.Capabilities.REF_BUFFER_POOL;
 import static org.wildfly.extension.undertow.Capabilities.REF_IO_WORKER;
 import static org.wildfly.extension.undertow.Capabilities.REF_SOCKET_BINDING;
+import static org.wildfly.extension.undertow.ListenerResourceDefinition.LISTENER_CAPABILITY;
+import static org.wildfly.extension.undertow.ServerDefinition.SERVER_CAPABILITY;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.undertow.server.handlers.DisallowedMethodsHandler;
 import io.undertow.server.handlers.PeerNameResolvingHandler;
@@ -35,6 +41,7 @@ import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.inject.Injector;
@@ -43,10 +50,6 @@ import org.xnio.OptionMap;
 import org.xnio.Pool;
 import org.xnio.XnioWorker;
 
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
@@ -54,6 +57,15 @@ abstract class ListenerAdd extends AbstractAddStepHandler {
 
     ListenerAdd(ListenerResourceDefinition definition) {
         super(definition.getAttributes());
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+
+        String ourCap = LISTENER_CAPABILITY.getDynamicName(context.getCurrentAddress());
+        String serverCap = SERVER_CAPABILITY.getDynamicName(context.getCurrentAddress().getParent());
+        context.registerAdditionalCapabilityRequirement(serverCap, ourCap, null);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -74,7 +74,7 @@ import org.xnio.Options;
 abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
 
     static final RuntimeCapability<Void> LISTENER_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_LISTENER, true, UndertowListener.class)
-            .addDynamicRequirements(Capabilities.CAPABILITY_SERVER)
+            //.addDynamicRequirements(Capabilities.CAPABILITY_SERVER) -- has no function so don't use it
             .setAllowMultipleRegistrations(true) //hack to support mod_cluster's legacy profiles
             .build();
     protected static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(Constants.SOCKET_BINDING, ModelType.STRING)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -75,7 +75,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
 
     static final RuntimeCapability<Void> MOD_CLUSTER_FILTER_CAPABILITY = RuntimeCapability
             .Builder.of(CAPABILITY_MOD_CLUSTER_FILTER, true, FilterService.class)
-            .addDynamicOptionalRequirements(REF_SSL_CONTEXT)
+            //.addDynamicOptionalRequirements(REF_SSL_CONTEXT) -- has no function so don't use it
             .build();
 
     public static final AttributeDefinition MANAGEMENT_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(Constants.MANAGEMENT_SOCKET_BINDING, ModelType.STRING)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/Handler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/Handler.java
@@ -48,7 +48,8 @@ import org.wildfly.extension.undertow.UndertowService;
 abstract class Handler extends PersistentResourceDefinition {
 
     static final RuntimeCapability CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HANDLER, true, HttpHandler.class)
-            .addOptionalRequirements(Capabilities.REF_REQUEST_CONTROLLER).build();
+            //.addRuntimeOnlyRequirements(Capabilities.REF_REQUEST_CONTROLLER) -- has no function so don't use it
+            .build();
 
     private static final List<AccessConstraintDefinition> CONSTRAINTS = new SensitiveTargetAccessConstraintDefinition(
             new SensitivityClassification(UndertowExtension.SUBSYSTEM_NAME, "undertow-handler", false, false, false)


### PR DESCRIPTION
…nal]Requirements to result in requirements being registered.

Don't use them at all since they currently have no function and result in deprecation warnings.

https://issues.jboss.org/browse/WFLY-9116