### PR TITLE
[WFLY-8997] Skip reauthentication if RunAs is being used to cross security domain boundaries

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -358,9 +358,11 @@ public class SimpleSecurityManager implements ServerSecurityManager {
         SecurityContext previous = contexts.peek();
 
         // skip reauthentication if the current context already has an authenticated subject (copied from the previous context
-        // upon creation - see push method) and if both contexts use the same security domain.
-        boolean skipReauthentication = current.getSubjectInfo() != null && current.getSubjectInfo().getAuthenticatedSubject() != null &&
-                previous != null && current.getSecurityDomain().equals(previous.getSecurityDomain());
+        // upon creation - see push method) and both contexts use the same security domain or there is an incoming RunAs of RunAsIdentity type
+        boolean skipReauthentication = current.getSubjectInfo() != null && current.getSubjectInfo().getAuthenticatedSubject() != null && (
+                        (previous != null && current.getSecurityDomain().equals(previous.getSecurityDomain())) ||
+                        current.getIncomingRunAs() instanceof RunAsIdentity
+                );
 
         if (!skipReauthentication) {
             SecurityContextUtil util = current.getUtil();


### PR DESCRIPTION
Before this fix, RunAs annotation required the reauthentication of the principal when a security domain boundary was crossed. This PR skip that reauthentication in that case.

Jira issue:
https://issues.jboss.org/browse/WFLY-8997

7.x: https://issues.jboss.org/browse/JBEAP-11778
7.0.z: https://issues.jboss.org/browse/JBEAP-11779