### PR TITLE
WFLY-9119 Start GlobalConfiguration services ON_DEMAND when cache-container is local-only.

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoTransportBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoTransportBuilder.java
@@ -25,6 +25,9 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
 import org.infinispan.configuration.global.TransportConfiguration;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceTarget;
 
 /**
  * @author Paul Ferraro
@@ -38,5 +41,10 @@ public class NoTransportBuilder extends GlobalComponentBuilder<TransportConfigur
     @Override
     public TransportConfiguration getValue() {
         return new GlobalConfigurationBuilder().transport().transport(null).create();
+    }
+
+    @Override
+    public ServiceBuilder<TransportConfiguration> build(ServiceTarget target) {
+        return super.build(target).setInitialMode(ServiceController.Mode.ON_DEMAND);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9119

Reduces the number of classes loaded (e.g. org.wildfly.clustering.marshalling.spi classes) and number of services started during startup of standalone.xml.