### PR TITLE
[WFLY-8113 10.x] Upgrade netty-xnio-transport to 0.1.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <version.org.jboss.narayana>5.3.3.Final</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.3.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.0.6.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.remote-naming>2.0.4.Final</version.org.jboss.remote-naming>
         <version.org.jboss.resteasy>3.0.19.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>


### PR DESCRIPTION
Related to WFLY-7517, WFLY-8113, JBEAP-8827.