### PR TITLE
[WFLY-9066] URLBindingTestCase fails with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/URLBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/URLBindingTestCase.java
@@ -35,7 +35,9 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING_TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.SIMPLE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.VALUE;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.net.URL;
 import javax.ejb.EJB;
 
@@ -44,7 +46,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.naming.subsystem.NamingExtension;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
+import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -69,9 +73,17 @@ public class URLBindingTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
+        final String tempDir = TestSuiteEnvironment.getTmpDir();
+
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "URLBindingTestCaseBean.jar");
         jar.addClasses(URLBindingTestCase.class, BindingLookupBean.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller, org.jboss.remoting3\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new RemotingPermission("createEndpoint"),
+                new RemotingPermission("connect"),
+                new FilePermission(tempDir+"/-", "read")
+        ), "jboss-permissions.xml");
+
         return jar;
     }
 


### PR DESCRIPTION
Note: It requires minimum wildfly-core 3.0.0.Beta29 to run with security manager enabled and using -Dts.basic or -DallTests

Jira issue:
https://issues.jboss.org/browse/WFLY-9066
https://issues.jboss.org/browse/JBEAP-12024