### PR TITLE
[WFLY-9137] SSL tests in ElytronRemoteOutboundConnectionTestCase fails on IBM JDK

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ElytronRemoteOutboundConnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ElytronRemoteOutboundConnectionTestCase.java
@@ -1057,7 +1057,6 @@ public class ElytronRemoteOutboundConnectionTestCase {
         ModelNode credentialReference = new ModelNode();
         credentialReference.get("clear-text").set(keyPass);
         addKeyStoreOp.get("credential-reference").set(credentialReference);
-        addKeyStoreOp.get("algorithm").set("SunX509");
         return addKeyStoreOp;
     }
 
@@ -1070,7 +1069,6 @@ public class ElytronRemoteOutboundConnectionTestCase {
     private static ModelNode getAddTrustManagerOp(String trustManagerName, String keyStoreName) {
         ModelNode addKeyStoreOp = Util.createAddOperation(getTrustManagerAddress(trustManagerName));
         addKeyStoreOp.get("key-store").set(keyStoreName);
-        addKeyStoreOp.get("algorithm").set("SunX509");
         return addKeyStoreOp;
     }
 


### PR DESCRIPTION
* Fixing the setup methods not to use SunX509 algorithms for key management in ElytronRemoteOutboundConnectionTestCase.

JIRA https://issues.jboss.org/browse/WFLY-9137