### PR TITLE
[WFLY-9118] Change default value of call-failover-timeout to 60s

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionAdd.java
@@ -104,7 +104,7 @@ public class ClusterConnectionAdd extends AbstractAddStepHandler {
         final ModelNode discoveryNode = ClusterConnectionDefinition.DISCOVERY_GROUP_NAME.resolveModelAttribute(context, model);
         final int minLargeMessageSize = CommonAttributes.MIN_LARGE_MESSAGE_SIZE.resolveModelAttribute(context, model).asInt();
         final long callTimeout = CommonAttributes.CALL_TIMEOUT.resolveModelAttribute(context, model).asLong();
-        final long callFailoverTimeout = CommonAttributes.CALL_FAILOVER_TIMEOUT.resolveModelAttribute(context, model).asLong();
+        final long callFailoverTimeout = ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT.resolveModelAttribute(context, model).asLong();
         final long clusterNotificationInterval = ClusterConnectionDefinition.NOTIFICATION_INTERVAL.resolveModelAttribute(context, model).asLong();
         final int clusterNotificationAttempts = ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS.resolveModelAttribute(context, model).asInt();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -79,6 +79,12 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    public static final SimpleAttributeDefinition CALL_FAILOVER_TIMEOUT = create(CommonAttributes.CALL_FAILOVER_TIMEOUT)
+            // cluster connection will wait forever during failover for a non-blocking call
+            .setDefaultValue(new ModelNode(-1L))
+            .setRestartAllServices()
+            .build();
+
     public static final SimpleAttributeDefinition CHECK_PERIOD = create("check-period", LONG)
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterFailureCheckPeriod()))
             .setRequired(false)
@@ -204,7 +210,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             CONNECTION_TTL,
             CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
             CommonAttributes.CALL_TIMEOUT,
-            CommonAttributes.CALL_FAILOVER_TIMEOUT,
+            CALL_FAILOVER_TIMEOUT,
             RETRY_INTERVAL, RETRY_INTERVAL_MULTIPLIER, MAX_RETRY_INTERVAL,
             INITIAL_CONNECT_ATTEMPTS,
             RECONNECT_ATTEMPTS, USE_DUPLICATE_DETECTION,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -68,7 +68,8 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition CALL_FAILOVER_TIMEOUT = create("call-failover-timeout", LONG)
             // ActiveMQClient.DEFAULT_CALL_FAILOVER_TIMEOUT was changed from -1 to 30000 in ARTEMIS-255
-            .setDefaultValue(new ModelNode(30000L))
+            // we set it to 60s to leave more time for WildFly to failover
+            .setDefaultValue(new ModelNode(60000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setMeasurementUnit(MILLISECONDS)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -350,7 +350,7 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                                 ClusterConnectionDefinition.CONNECTION_TTL,
                                                                 CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
                                                                 CommonAttributes.CALL_TIMEOUT,
-                                                                CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                                ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT,
                                                                 ClusterConnectionDefinition.RETRY_INTERVAL,
                                                                 ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
                                                                 ClusterConnectionDefinition.MAX_RETRY_INTERVAL,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
@@ -363,7 +363,7 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                         ClusterConnectionDefinition.CONNECTION_TTL,
                                                         CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
                                                         CommonAttributes.CALL_TIMEOUT,
-                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT,
                                                         ClusterConnectionDefinition.RETRY_INTERVAL,
                                                         ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
                                                         ClusterConnectionDefinition.MAX_RETRY_INTERVAL,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -144,7 +144,6 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
         ResourceTransformationDescriptionBuilder clusterConnection = server.addChildResource(MessagingExtension.CLUSTER_CONNECTION_PATH);
         // reject producer-window-size introduced in management version 2.0.0 if it is defined and different from the default value.
         rejectDefinedAttributeWithDefaultValue(clusterConnection, ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE);
-        defaultValueAttributeConverter(clusterConnection, CommonAttributes.CALL_FAILOVER_TIMEOUT);
         ResourceTransformationDescriptionBuilder connectionFactory = server.addChildResource(MessagingExtension.CONNECTION_FACTORY_PATH);
         rejectDefinedAttributeWithDefaultValue(connectionFactory, ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
                 ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST);


### PR DESCRIPTION
This new value only applies to connection-factory,
pooled-connection-factory and legacy-connection-factory resources.

Reverted the change to cluster-connection resource so that it uses again
a default value of -1 (i.e. for ever).

JIRA: https://issues.jboss.org/browse/WFLY-9118