### PR TITLE
[WFLY-9127] Add failover test for modcluster.

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -698,6 +698,92 @@
             </build>
         </profile>
 
+        <profile>
+            <id>clustering.integration.tests.modcluster</id>
+            <activation><property><name>!ts.noClustering</name></property></activation>
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>ts.config-as.clustering.balancer</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <echo>In Maven: node0: ${node0}</echo>
+                                        <echo>In Maven: node1: ${node1}</echo>
+                                        <echo>In Maven: node0: ${node2}</echo>
+                                        <echo>In Maven: mcast: ${mcast}</echo>
+                                        <echo>In Maven: mcast.ttl: ${mcast.ttl}</echo>
+                                        <!-- Build the TCP server configs in target/ . -->
+                                        <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="node1" value="${node1}"/>
+                                            <property name="node2" value="${node2}"/> <!-- balancer -->
+                                            <property name="mcast" value="${mcast}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
+                                            <property name="cacheLoader" value="binary-keyed" />
+                                            <property name="cacheType" value="replicated" />
+                                            <property name="mode" value="${cacheMode}" />
+                                            <target name="build-clustering-balancer"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                       Surefire test executions.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.surefire.plugin}</version>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+
+                            <!-- Worker failover test with custom containers with manual deployments. -->
+                            <execution>
+                                <id>ts.surefire.clustering.balancer</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/modcluster/WorkerFailoverTestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables combine.children="append">
+                                        <arquillian.launch>clustering-balancer</arquillian.launch>
+                                        <!-- <arquillian.launch>clustering-all</arquillian.launch> -->
+                                        <!-- Use combine.children="append" to pick up parent properties automatically. -->
+                                        <jboss.server.config.file.standalone>standalone.xml</jboss.server.config.file.standalone>
+                                        <jboss.server.config.file.standalone-ha>standalone-ha.xml</jboss.server.config.file.standalone-ha>
+                                        <cacheMode>SYNC</cacheMode>
+                                        <stack>tcp</stack>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Enable using -Dts.noClustering. -->
         <profile>
             <id>ts.clustering.do-nothing.profile</id>

--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -38,6 +38,55 @@
         </configuration>
     </container>
 
+    <group qualifier="clustering-balancer">
+        <container qualifier="balancer" mode="custom" managed="false" default="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-${cacheMode}-${stack}-0</property>
+                <!-- AS7-2493 different jboss.node.name must be specified -->
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-0 -Djboss.node.name=balancer</property>
+                <property name="serverConfig">${jboss.server.config.file.standalone}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">9990</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">9990</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="con-1" mode="custom" managed="false" default="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-${cacheMode}-${stack}-1</property>
+                <!-- AS7-2493 different jboss.node.name must be specified -->
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.mod_cluster.jvmRoute=worker-1 -Djboss.port.offset=100</property>
+                <property name="serverConfig">${jboss.server.config.file.standalone-ha}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10090</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">10090</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="con-2" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-${cacheMode}-${stack}-2</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-2 -Djboss.node.name=node-2 -Djboss.mod_cluster.jvmRoute=worker-2 -Djboss.port.offset=200</property>
+                <property name="serverConfig">${jboss.server.config.file.standalone-ha}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node2}</property>
+                <property name="managementPort">10190</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">10190</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
+
     <group qualifier="clustering-all">
 
         <container qualifier="container-0" mode="custom" managed="false" default="true">

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/modcluster/WorkerFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/modcluster/WorkerFailoverTestCase.java
@@ -1,0 +1,343 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.modcluster;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.WildFlyContainerController;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.clustering.NodeUtil;
+import org.jboss.as.test.clustering.single.web.CommonJvmRoute;
+import org.jboss.as.test.clustering.single.web.JvmRouteServlet;
+import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ * Worker failover test for modcluster. Creates basic scenario (one balancer and two workers) and sends a request when both
+ * workers are alive, then it undeploys worker which responded and sends the request again.
+ *
+ * @author Matus Madzin
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class WorkerFailoverTestCase {
+
+    private static final String MODULE = "jvmroute";
+    private static final String DEPLOYMENT_1 = "deployment-1";
+    private static final String DEPLOYMENT_2 = "deployment-2";
+    private static final String CONTAINER_1 = "con-1";
+    private static final String CONTAINER_2 = "con-2";
+    private static final String BALANCER = "balancer";
+    private static final int TIMEOUT = 90;
+
+    private static final Logger LOGGER = Logger.getLogger(WorkerFailoverTestCase.class);
+
+    @ArquillianResource
+    protected WildFlyContainerController controller;
+    @ArquillianResource
+    protected Deployer deployer;
+
+    private String balancerConfigFile;
+    private String worker1ConfigFile;
+    private String worker2ConfigFile;
+    private String undeployedApp;
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> deployment0() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_2)
+    public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE + ".war");
+        war.addClasses(JvmRouteServlet.class, CommonJvmRoute.class);
+
+        return war;
+    }
+
+    @Before
+    public void startAndSetupContainers() throws Exception {
+
+        LOGGER.trace("*** starting balancer");
+        controller.start(BALANCER);
+
+        LOGGER.trace("*** will configure server now");
+        balancerSetup();
+
+        LOGGER.trace("*** starting worker1");
+        controller.start(CONTAINER_1);
+
+        LOGGER.trace("*** will configure worker1 now");
+        workerSetup("node1", 10090);
+
+        LOGGER.trace("*** starting worker2");
+        controller.start(CONTAINER_2);
+
+        LOGGER.trace("*** will configure worker2 now");
+        workerSetup("node2", 10190);
+
+        LOGGER.trace("*** will deploy " + DEPLOYMENT_1 + " and " + DEPLOYMENT_2);
+        deployer.deploy(DEPLOYMENT_1);
+        deployer.deploy(DEPLOYMENT_2);
+    }
+
+    /*
+        Configures EAP on node "node0" as a load balancer (undertow filter).
+     */
+    private void balancerSetup() throws Exception {
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient(null, TestSuiteEnvironment.getServerAddress("node0"), 9990)) {
+
+            /* Configuration backup */
+            ModelNode op = createOpNode("path=jboss.server.config.dir", "read-attribute");
+            op.get("name").set("path");
+            ModelNode response = client.execute(op);
+            Assert.assertEquals("Server's configuration file not found!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            balancerConfigFile = response.get("result").asString() + File.separator + System.getProperty("jboss.server.config.file.standalone", "standalone.xml");
+            Files.copy(Paths.get(balancerConfigFile), Paths.get(balancerConfigFile + ".WorkerFailoverTestCase.backup"), REPLACE_EXISTING);
+
+            /* Server configuration */
+            op = createOpNode("subsystem=undertow/configuration=filter/mod-cluster=modcluster", "add");
+            op.get("management-socket-binding").set("http");
+            response = client.execute(op);
+            Assert.assertEquals("Server's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            op = createOpNode("subsystem=undertow/server=default-server/host=default-host/filter-ref=modcluster", "add");
+            response = client.execute(op);
+            Assert.assertEquals("Server's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+        }
+
+    }
+
+    /*
+        Configures EAP as worker with proxies
+
+        @param cliAddress - name of node where EAP will be configured e.g. node1.
+        @param port - management port of the node.
+     */
+    private void workerSetup(String cliAddress, int port) throws Exception {
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient(null, TestSuiteEnvironment.getServerAddress(cliAddress), port)) {
+
+            /* Configuration backup */
+            ModelNode op = createOpNode("path=jboss.server.config.dir", "read-attribute");
+            op.get("name").set("path");
+            ModelNode response = client.execute(op);
+            Assert.assertEquals("Workers's configuration file not found!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+
+            String workerConfigFile = response.get("result").asString() + File.separator + System.getProperty("jboss.server.config.file.standalone-ha","/standalone-ha.xml");
+            Files.copy(Paths.get(workerConfigFile), Paths.get(workerConfigFile + ".WorkerFailoverTestCase.backup"), REPLACE_EXISTING);
+
+            if (port == 10090) worker1ConfigFile = workerConfigFile;
+            else worker2ConfigFile = workerConfigFile;
+
+            /* Server configuration */
+            op = createOpNode("subsystem=modcluster/mod-cluster-config=configuration/", "write-attribute");
+            op.get("name").set("advertise");
+            op.get("value").set("false");
+            response = client.execute(op);
+            Assert.assertEquals("Worker's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            op = createOpNode("socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=proxy1", "add");
+            op.get("host").set(TestSuiteEnvironment.getServerAddress(cliAddress));
+            op.get("port").set("8080");
+            response = client.execute(op);
+            Assert.assertEquals("Worker's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            op = createOpNode("subsystem=modcluster/mod-cluster-config=configuration", "list-add");
+            op.get("name").set("proxies");
+            op.get("value").set("proxy1");
+            response = client.execute(op);
+            Assert.assertEquals("Worker's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            op = createOpNode("subsystem=modcluster/mod-cluster-config=configuration", "write-attribute");
+            op.get("name").set("status-interval");
+            op.get("value").set("1");
+            response = client.execute(op);
+            Assert.assertEquals("Worker's configuration failed!\n" + response.toString(), SUCCESS, response.get("outcome").asString());
+
+            ServerReload.executeReloadAndWaitForCompletion(client, ServerReload.TIMEOUT, false, TestSuiteEnvironment.getServerAddress(cliAddress), port);
+        }
+    }
+
+    @After
+    public void stopContainers() throws Exception {
+        LOGGER.trace("*** undeploy applications");
+
+        if (undeployedApp == null || !undeployedApp.equals(DEPLOYMENT_1)) deployer.undeploy(DEPLOYMENT_1);
+
+        if (undeployedApp == null || !undeployedApp.equals(DEPLOYMENT_2)) deployer.undeploy(DEPLOYMENT_2);
+
+        LOGGER.trace("*** stopping container");
+        controller.stop(CONTAINER_1);
+        controller.stop(CONTAINER_2);
+        controller.stop(BALANCER);
+
+        LOGGER.trace("*** reseting test configuration");
+        Files.move(Paths.get(worker1ConfigFile + ".WorkerFailoverTestCase.backup"), Paths.get(worker1ConfigFile), REPLACE_EXISTING);
+        Files.move(Paths.get(worker2ConfigFile + ".WorkerFailoverTestCase.backup"), Paths.get(worker2ConfigFile), REPLACE_EXISTING);
+        Files.move(Paths.get(balancerConfigFile + ".WorkerFailoverTestCase.backup"), Paths.get(balancerConfigFile), REPLACE_EXISTING);
+    }
+
+    /*
+        Checks that both workers are visible for balancer before the test.
+     */
+    private void infrastructureCheck() {
+        /* Connects to the balancer */
+        try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient(null, TestSuiteEnvironment.getServerAddress("node0"), 9990)) {
+
+            ModelNode checkWorker1 = null, checkWorker2 = null;
+
+            /* Prepare opperations for retriving info about workers from the balancer*/
+            try {
+                checkWorker1 = createOpNode("subsystem=undertow/configuration=filter/mod-cluster=modcluster/balancer=mycluster/node=node-1", "read-children-names");
+                checkWorker1.get("child-type").set("context");
+
+                checkWorker2 = createOpNode("subsystem=undertow/configuration=filter/mod-cluster=modcluster/balancer=mycluster/node=node-2", "read-children-names");
+                checkWorker2.get("child-type").set("context");
+            } catch (Exception e) {
+                Assert.assertTrue(false);
+            }
+
+            int iteration = 0;
+            ModelNode response1 = null, response2 = null;
+            boolean result1 = false, result2 = false;
+
+            /* Periodically checks whether both workers are registered to the balancer in TIMEOUT */
+            do {
+                try {
+                    response1 = client.execute(checkWorker1);
+                    response2 = client.execute(checkWorker2);
+                    iteration++;
+
+                    result1 = response1.get("result").asString().contains("jvmroute");
+                    result2 = response2.get("result").asString().contains("jvmroute");
+
+                    if (result1 && result2) break;
+
+                    TimeUnit.SECONDS.sleep(1);
+                } catch (Exception e) {
+                    Assert.assertTrue(false);
+                }
+            } while (iteration < TIMEOUT);
+
+            /* In case any worker is not ready (after timeout) then test fails */
+            Assert.assertEquals("TIMEOUT ELAPSED: Balancer didn't see both workers!\n", SUCCESS, response1.get("outcome").asString());
+            Assert.assertEquals("TIMEOUT ELAPSED: Balancer didn't see both workers!\n", SUCCESS, response2.get("outcome").asString());
+
+        } catch (IOException e) {
+            Assert.assertTrue(false);
+        }
+    }
+
+    @Test
+    public void workerFailoverTest() throws URISyntaxException, IOException {
+        String address = TestSuiteEnvironment.getServerAddress("node0");
+        URL url = new URL("http", address, 8080, "/jvmroute/jvmroute");
+        URI uri = url.toURI();
+
+        /* Checks whether all servers are set as expected */
+        infrastructureCheck();
+
+        try (CloseableHttpClient httpClient = TestHttpClientUtils.promiscuousCookieHttpClient()) {
+            HttpResponse response = null;
+            String worker1, worker2;
+
+            try {
+                /* The first HTTP request */
+                response = httpClient.execute(new HttpGet(uri));
+
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                HttpEntity entity = response.getEntity();
+                Assert.assertNotNull(entity);
+                worker1 = EntityUtils.toString(entity);
+
+                if (!worker1.equals("worker-1")) Assert.assertEquals("worker-2", worker1);
+
+                /* Undeploy worker which responsed the first HTTP request */
+                if (worker1.equals("worker-1")) {
+                    NodeUtil.undeploy(this.deployer, DEPLOYMENT_1);
+                    undeployedApp = DEPLOYMENT_1;
+                } else {
+                    NodeUtil.undeploy(this.deployer, DEPLOYMENT_2);
+                    undeployedApp = DEPLOYMENT_2;
+                }
+
+                /* The second HTTP request */
+                response = httpClient.execute(new HttpGet(uri));
+
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                entity = response.getEntity();
+                Assert.assertNotNull(entity);
+                worker2 = EntityUtils.toString(entity);
+
+                /* Checks that the second node responded the second request */
+                if (worker1.equals("worker-1")) Assert.assertEquals("worker-2", worker2);
+                else Assert.assertEquals("worker-1", worker2);
+
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/CommonJvmRoute.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/CommonJvmRoute.java
@@ -1,0 +1,99 @@
+package org.jboss.as.test.clustering.single.web;
+
+import java.lang.management.ManagementFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+/**
+ * Created by mmadzin on 7/14/17.
+ */
+public class CommonJvmRoute {
+  private static final long serialVersionUID = 3691025554701624250L;
+  private static final Logger log = Logger.getLogger(CommonJvmRoute.class.getName());
+  private static final String[] properties = new String[] { "jvmRoute", "jboss.mod_cluster.jvmRoute", "instance-id", "jboss.domain.web.instance-id", "jboss.jvmRoute" };
+  private static final String UNKNOWN = "unknown";
+
+  public String jvmRoute() {
+    // This should work for both AS5 and AS7 with reasonable set jvmRoute property.
+    String jvmRoute1 = UNKNOWN;
+    String jvmRoute2 = UNKNOWN;
+    String jvmRoute3 = UNKNOWN;
+    String jvmRoute4 = UNKNOWN;
+    for (String property : properties) {
+      String value = System.getProperty(property, UNKNOWN);
+      if (!value.equals(UNKNOWN) && value.length() > 0) {
+        jvmRoute1 = value;
+        break;
+      }
+    }
+
+    // Hmm, maybe, we are deployed into Tomcat?
+    if (jvmRoute1.equals(UNKNOWN)) {
+      try {
+        MBeanServer mbsc = ManagementFactory.getPlatformMBeanServer();
+        ObjectName on = null;
+        try {
+          on = new ObjectName("Catalina:type=Engine");
+          jvmRoute2 = (String) mbsc.getAttribute(on, "jvmRoute");
+        } catch (InstanceNotFoundException ex1) {
+          try {
+
+            // Crap. It was not Catalina..., let's try jboss.web:
+            on = new ObjectName("jboss.web:type=Engine");
+            jvmRoute3 = (String) mbsc.getAttribute(on, "jvmRoute");
+
+            // Well, it looks like AS7 with no jvmRoute set, let's try to retrieve instance-id...
+          } catch (InstanceNotFoundException ex2) {
+            try {
+              on = new ObjectName("jboss.as:subsystem=web");
+              jvmRoute4 = (String) mbsc.getAttribute(on, "instance-id");
+            } catch (InstanceNotFoundException ex3) {
+              jvmRoute4 = UNKNOWN;
+              log.log(Level.WARNING, "We have failed to determine the jvmRoute.");
+            } catch (NullPointerException e) {
+              jvmRoute4 = UNKNOWN;
+              log.log(Level.WARNING, "We have failed to determine the jvmRoute.");
+            }
+          }
+        }
+
+      } catch (AttributeNotFoundException e) {
+        log.log(Level.SEVERE, ":-(");
+        e.printStackTrace();
+      } catch (MalformedObjectNameException e) {
+        log.log(Level.SEVERE, ":-(");
+        e.printStackTrace();
+      } catch (MBeanException e) {
+        log.log(Level.SEVERE, ":-(");
+        e.printStackTrace();
+      } catch (ReflectionException e) {
+        log.log(Level.SEVERE, ":-(");
+        e.printStackTrace();
+      } catch (NullPointerException e) {
+        log.log(Level.SEVERE, ":-(");
+        e.printStackTrace();
+      }
+    }
+    String jvmRoute = UNKNOWN;
+    if (jvmRoute1 != null && !jvmRoute1.equals(UNKNOWN)) {
+      jvmRoute = jvmRoute1;
+    } else if (jvmRoute2 != null && !jvmRoute2.equals(UNKNOWN)) {
+      jvmRoute = jvmRoute2;
+    } else if (jvmRoute3 != null && !jvmRoute3.equals(UNKNOWN)) {
+      jvmRoute = jvmRoute3;
+    } else if (jvmRoute4 != null && !jvmRoute4.equals(UNKNOWN)) {
+      jvmRoute = jvmRoute4;
+    } else {
+      log.log(Level.WARNING, "We have failed to determine the jvmRoute.");
+    }
+    return jvmRoute;
+  }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/JvmRouteServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/JvmRouteServlet.java
@@ -1,0 +1,32 @@
+package org.jboss.as.test.clustering.single.web;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Created by mmadzin on 7/14/17.
+ */
+@WebServlet(name = "JvmRouteServlet", urlPatterns = {"/jvmroute"})
+public class JvmRouteServlet extends HttpServlet {
+    private static final long serialVersionUID = 1855772223216460567L;
+
+    private CommonJvmRoute commonJvmRoute = new CommonJvmRoute();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        // Gives it a JSESSIONID
+        request.getSession();
+        response.setContentType("text/plain");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().print(commonJvmRoute.jvmRoute());
+    }
+
+    @Override
+    public String getServletInfo() {
+        return "By invoking JvmRouteServlet, you get the node's JvmRoute.";
+    }
+}

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -67,9 +67,45 @@
                                              stack="${stack}"/>
     </target>
 
+    <target name="build-balancer" description="Builds two server configuration for given JGroups stack and cache mode">
+
+        <echo>clustering-${cacheMode}-${stack}-2 node2: ${node2}</echo>
+        <echo>clustering-${cacheMode}-${stack}-0 mcast: ${mcast}</echo>
+
+        <echo message="  =========  Building config clustering-${cacheMode}-${stack}-2  =========  "/>
+        <copy todir="target/wildfly-${cacheMode}-${stack}-2" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast name="wildfly-${cacheMode}-${stack}-2"
+                                        node="${node2}"
+                                        mcast="${mcast}"
+                />
+        <ts.config-as.add-port-offset name="wildfly-${cacheMode}-${stack}-2" offset="200" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.change-transport-stack name="wildfly-${cacheMode}-${stack}-2"
+                                             stack="${stack}"/>
+        <ts.config-as.change-cache-mode name="wildfly-${cacheMode}-${stack}-2"
+                                        cacheMode="${cacheMode}"
+                />
+        <ts.config-as.configure-multicast-ttl name="wildfly-${cacheMode}-${stack}-2" mcast.ttl="${mcast.ttl}"/>
+        <ts.config-as.add-interface name="wildfly-${cacheMode}-${stack}-2"
+                                    interface="multicast"
+                                    inet-address="${node0}"/>
+        <ts.config-as.change-jgroups-multicast-interface name="wildfly-${cacheMode}-${stack}-2"
+                                                         interface="multicast"/>
+    </target>
+
     <!-- Build SYNC-tcp stack configs -->
     <target name="build-clustering" description="Builds server configuration for SYNC-tcp tests">
         <antcall target="abstract-build-clustering">
+            <param name="cacheMode" value="SYNC"/>
+            <param name="stack" value="tcp"/>
+        </antcall>
+    </target>
+
+    <!-- Build SYNC-tcp stack configs -->
+    <target name="build-clustering-balancer" description="Builds server configuration for SYNC-tcp tests">
+        <antcall target="build-clustering"/>
+        <antcall target="build-balancer">
             <param name="cacheMode" value="SYNC"/>
             <param name="stack" value="tcp"/>
         </antcall>


### PR DESCRIPTION
Worker failover test for modcluster. Creates basic scenario (one balancer and two workers) and sends a request when both workers are alive, then it undeploys worker which responded and sends the request again.

https://issues.jboss.org/browse/WFLY-9127