### PR TITLE
[WFLY-9159] AuthenticationTestCase fails when server IP address is not bound to loopback in Elytron profile

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/WhoAmIServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/WhoAmIServlet.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Callable;
 
 import javax.annotation.security.DeclareRoles;
 import javax.ejb.EJB;
-import javax.ejb.EJBAccessException;
+import javax.ejb.EJBException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HttpConstraint;
 import javax.servlet.annotation.ServletSecurity;
@@ -76,7 +76,7 @@ public class WhoAmIServlet extends HttpServlet {
                 } else {
                     response = bean.doubleWhoAmI();
                 }
-            } catch (EJBAccessException e) {
+            } catch (EJBException e) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN, e.toString());
                 return;
             } catch (Exception e) {


### PR DESCRIPTION
* Fixing WhoAmIServlet to propagate authentication exception for Elytron (which is ancestor of one produced by legacy security).

JIRA https://issues.jboss.org/browse/WFLY-9159