### PR TITLE
[WFLY-9172] Add Elytron security context propagation tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -22,10 +22,12 @@
 package org.jboss.as.test.integration.ejb.security;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -253,9 +255,9 @@ public class AuthenticationTestCase {
             fail("Expected IOException");
         } catch (IOException e) {
             if (SecurityDomain.getCurrent() == null) {
-                assertTrue(e.getMessage().contains("javax.ejb.EJBAccessException"));
+                assertThat(e.getMessage(), containsString("javax.ejb.EJBAccessException"));
             } else {
-                assertTrue(e.getMessage().contains("javax.ejb.EJBException: java.lang.SecurityException: ELY01151"));
+                assertThat(e.getMessage(), containsString("javax.ejb.EJBException: java.lang.SecurityException: ELY01151"));
             }
         }
     }

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -85,6 +85,38 @@
             </configuration>
         </container>
 
+        <container qualifier="seccontext-server1" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/seccontext-server1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/seccontext-server1 -Djboss.node.name=seccontext-server1</property>
+                <property name="serverConfig">standalone.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node0:127.0.0.1}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="seccontext-server2" default="false" mode="manual">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/seccontext-server2</property>
+                <property name="javaVmArguments">${server.jvm2.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/seccontext-server2 -Djboss.node.name=seccontext-server2</property>
+                <property name="serverConfig">standalone.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="allowConnectingToRunningServer">true</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10090</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10090</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
         <container qualifier="jbossas-with-remote-outbound-connection-non-clustered" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-with-remote-outbound-connection</property>

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
@@ -1,0 +1,587 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SERVER_CONFIG;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.wildfly.test.manual.elytron.seccontext.SeccontextUtil.SERVER1;
+import static org.wildfly.test.manual.elytron.seccontext.SeccontextUtil.SERVER2;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.SocketPermission;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import javax.ejb.EJBAccessException;
+
+import org.apache.commons.io.IOUtils;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.credential.BearerTokenCredential;
+import org.wildfly.security.permission.ElytronPermission;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+
+/**
+ * Tests for testing (re)authentication and security identity propagation between 2 servers. Test scenarios use following
+ * configuration:
+ *
+ * <pre>
+ * EJB client -> Entry bean on server1 -> WhoAmI bean on server 2
+ * EJB client -> Entry bean on server1 -> WhoAmI servlet on server 2
+ * </pre>
+ *
+ * The Entry bean uses Elytron API to configure security context for outbound calls (e.g. identity forwarding, reauthentication,
+ * ...).
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class AbstractSecurityContextPropagationTestBase {
+
+    private static ServerHolder server1 = new ServerHolder(SERVER1, TestSuiteEnvironment.getServerAddress(), 0);
+    private static ServerHolder server2 = new ServerHolder(SERVER2, TestSuiteEnvironment.getServerAddressNode1(), 100);
+
+    private static final Encoder B64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final String JWT_HEADER_B64 = B64_ENCODER
+            .encodeToString("{\"alg\":\"none\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+
+    @ArquillianResource
+    private static ContainerController containerController;
+
+    @ArquillianResource
+    private static Deployer deployer;
+
+    /**
+     * Creates deployment with Entry bean - to be placed on the first server.
+     */
+    @Deployment(name = SERVER1, managed = false, testable = false)
+    @TargetsContainer(SERVER1)
+    public static Archive<?> createEntryBeanDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, SERVER1 + ".jar")
+                .addClasses(EntryBean.class, EntryBeanSFSB.class, Entry.class, WhoAmI.class, ReAuthnType.class,
+                        SeccontextUtil.class)
+                .addAsManifestResource(createPermissionsXmlAsset(new ElytronPermission("authenticate"),
+                        new ElytronPermission("getPrivateCredentials"),
+                        new ElytronPermission("getSecurityDomain"),
+                        new SocketPermission(TestSuiteEnvironment.getServerAddressNode1()+":8180", "connect,resolve")
+                        ),
+                        "permissions.xml")
+                .addAsManifestResource(Utils.getJBossEjb3XmlAsset("seccontext-entry"), "jboss-ejb3.xml");
+    }
+
+    /**
+     * Creates deployment with WhoAmI bean and servlet - to be placed on the second server.
+     */
+    @Deployment(name = SERVER2, managed = false, testable = false)
+    @TargetsContainer(SERVER2)
+    public static Archive<?> createEjbClientDeployment() {
+        return ShrinkWrap.create(WebArchive.class, SERVER2 + ".war")
+                .addClasses(WhoAmIBean.class, WhoAmIBeanSFSB.class, WhoAmI.class, WhoAmIServlet.class)
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset("seccontext-web"), "jboss-web.xml")
+                .addAsWebInfResource(new StringAsset(SecurityTestConstants.WEB_XML_BASIC_AUTHN), "web.xml")
+                .addAsWebInfResource(Utils.getJBossEjb3XmlAsset("seccontext-whoami"), "jboss-ejb3.xml");
+    }
+
+    /**
+     * Set or reset configuration of test servers.
+     */
+    @Before
+    public void before() throws CommandLineException, IOException, MgmtOperationException {
+        server1.resetContainerConfiguration();
+        server2.resetContainerConfiguration();
+    }
+
+    @AfterClass
+    public static void afterClass() throws IOException {
+        server1.shutDown();
+        server2.shutDown();
+    }
+
+    @Test
+    public void testAuthCtxPasses() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.AUTHENTICATION_CONTEXT), ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertArrayEquals("Unexpected principal names returned from doubleWhoAmI", new String[] { "entry", "whoami" },
+                doubleWhoAmI);
+    }
+
+    @Test
+    public void testClientInsufficientRoles() throws Exception {
+        try {
+            SeccontextUtil.switchIdentity("whoami", "whoami", getDoubleWhoAmICallable(ReAuthnType.AUTHENTICATION_CONTEXT),
+                    ReAuthnType.AUTHENTICATION_CONTEXT);
+            fail("Calling Entry bean must fail when user without required roles is used");
+        } catch (EJBAccessException e) {
+            // OK - expected
+        }
+    }
+
+    @Test
+    public void testAuthCtxWrongUserFail() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.AUTHENTICATION_CONTEXT, "doesntexist", "whoami"),
+                ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEjbAuthenticationError());
+    }
+
+    @Test
+    public void testAuthCtxWrongPasswdFail() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.AUTHENTICATION_CONTEXT, "whoami", "wrongpass"),
+                ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEjbAuthenticationError());
+    }
+
+    @Test
+    public void testForwardedIdentityPasses() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("admin", "admin",
+                getDoubleWhoAmICallable(ReAuthnType.FORWARDED_IDENTITY, null, null), ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertArrayEquals("Unexpected principal names returned from doubleWhoAmI", new String[] { "admin", "admin" },
+                doubleWhoAmI);
+    }
+
+    @Test
+    public void testForwardedIdentityInsufficientRolesFails() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.FORWARDED_IDENTITY, null, null), ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEjbAccessException());
+    }
+
+    @Test
+    public void testSecurityDomainAuthenticateWithoutForwarding() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.SECURITY_DOMAIN_AUTHENTICATE), ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEjbAuthenticationError());
+    }
+
+    @Test
+    public void testSecurityDomainAuthenticateWrongPassFails() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.SECURITY_DOMAIN_AUTHENTICATE, "doesntexist", "whoami"),
+                ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEvidenceVerificationError());
+    }
+
+    @Test
+    public void testSecurityDomainAuthenticateForwardedPasses() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.SECURITY_DOMAIN_AUTHENTICATE_FORWARDED),
+                ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertArrayEquals("Unexpected principal names returned from doubleWhoAmI", new String[] { "entry", "whoami" },
+                doubleWhoAmI);
+    }
+
+    @Test
+    public void testSecurityDomainAuthenticateForwardedWrongPasswordFails() throws Exception {
+        String[] doubleWhoAmI = SeccontextUtil.switchIdentity("entry", "entry",
+                getDoubleWhoAmICallable(ReAuthnType.SECURITY_DOMAIN_AUTHENTICATE_FORWARDED, "doesntexist", "whoami"),
+                ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEvidenceVerificationError());
+    }
+
+    @Test
+    public void testOauthbearerPropagationPasses() throws Exception {
+        String[] doubleWhoAmI = AuthenticationContext.empty()
+                .with(MatchRule.ALL,
+                        AuthenticationConfiguration.empty().setSaslMechanismSelector(SaslMechanismSelector.ALL)
+                                .useBearerTokenCredential(new BearerTokenCredential(createJwtToken("admin"))))
+                .runCallable(getDoubleWhoAmICallable(ReAuthnType.FORWARDED_IDENTITY, null, null));
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertArrayEquals("Unexpected principal names returned from doubleWhoAmI", new String[] { "admin", "admin" },
+                doubleWhoAmI);
+    }
+
+    @Test
+    public void testOauthbearerPropagationInsufficientRolesFails() throws Exception {
+        String[] doubleWhoAmI = AuthenticationContext.empty()
+                .with(MatchRule.ALL,
+                        AuthenticationConfiguration.empty().setSaslMechanismSelector(SaslMechanismSelector.ALL)
+                                .useBearerTokenCredential(new BearerTokenCredential(createJwtToken("entry"))))
+                .runCallable(getDoubleWhoAmICallable(ReAuthnType.FORWARDED_IDENTITY, null, null));
+        assertNotNull("The entryBean.doubleWhoAmI() should return not-null instance", doubleWhoAmI);
+        assertEquals("The result of doubleWhoAmI() has wrong lenght", 2, doubleWhoAmI.length);
+        assertEquals("entry", doubleWhoAmI[0]);
+        assertThat(doubleWhoAmI[1], isEjbAccessException());
+    }
+
+    @Test
+    public void testClientOauthbearerInsufficientRolesFails() throws Exception {
+        try {
+            AuthenticationContext.empty()
+                    .with(MatchRule.ALL,
+                            AuthenticationConfiguration.empty().setSaslMechanismSelector(SaslMechanismSelector.ALL)
+                                    .useBearerTokenCredential(new BearerTokenCredential(createJwtToken("whoami"))))
+                    .runCallable(getDoubleWhoAmICallable(ReAuthnType.FORWARDED_IDENTITY, null, null));
+            fail("Call to the protected bean should fail");
+        } catch (EJBAccessException e) {
+            // OK - expected
+        }
+    }
+
+    /**
+     * Test identity forwarding for HttpURLConnection calls.
+     */
+    @Test
+    @Ignore("JBEAP-12340 JBEAP-12341")
+    public void testHttpPropagation() throws Exception {
+        Callable<String> callable = getEjbToServletCallable(ReAuthnType.FORWARDED_IDENTITY, null, null);
+        String servletResponse = SeccontextUtil.switchIdentity("admin", "admin", callable, ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertEquals("Unexpected principal name returned from servlet call", "admin", servletResponse);
+    }
+
+    /**
+     * Tests if re-authentication works for HttpURLConnection calls.
+     */
+    @Test
+    @Ignore("JBEAP-12340 JBEAP-12341")
+    public void testHttpReauthn() throws Exception {
+        Callable<String> callable = getEjbToServletCallable(ReAuthnType.AUTHENTICATION_CONTEXT, "servlet", "servlet");
+        String servletResponse = SeccontextUtil.switchIdentity("admin", "admin", callable, ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertEquals("Unexpected principal name returned from servlet call", "servlet", servletResponse);
+    }
+
+    /**
+     * Tests propagation when user propagated to HttpURLConnection has insufficient roles.
+     */
+    @Test
+    @Ignore("JBEAP-12340 JBEAP-12341")
+    public void testHttpReauthnInsufficientRoles() throws Exception {
+        Callable<String> callable = getEjbToServletCallable(ReAuthnType.AUTHENTICATION_CONTEXT, "whoami", "whoami");
+        String servletResponse = SeccontextUtil.switchIdentity("entry", "entry", callable, ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertThat(servletResponse, allOf(startsWith("java.io.IOException"), containsString("403")));
+    }
+
+    /**
+     * Tests propagation when user propagated to HttpURLConnection has insufficient roles.
+     */
+    @Test
+    public void testHttpReauthnWrongPass() throws Exception {
+        Callable<String> callable = getEjbToServletCallable(ReAuthnType.AUTHENTICATION_CONTEXT, "servlet", "whoami");
+        String servletResponse = SeccontextUtil.switchIdentity("entry", "entry", callable, ReAuthnType.AUTHENTICATION_CONTEXT);
+        assertThat(servletResponse, allOf(startsWith("java.io.IOException"), containsString("401")));
+    }
+
+    /**
+     * Tests security context propagation behavior without isolation. This should be replaced in the future by removing reloads between the tests.
+     */
+    @Test
+    @Ignore("JBEAP-12410")
+    public void scenario1() throws Exception {
+        testOauthbearerPropagationPasses();
+        testSecurityDomainAuthenticateForwardedPasses();
+    }
+
+    /**
+     * Tests security context propagation behavior without isolation. This should be replaced in the future by removing reloads between the tests.
+     */
+    @Test
+    @Ignore("JBEAP-12410")
+    public void scenario2() throws Exception {
+        testSecurityDomainAuthenticateWithoutForwarding();
+        testOauthbearerPropagationPasses();
+        testSecurityDomainAuthenticateForwardedPasses();
+    }
+
+    /**
+     * Returns true if the stateful Entry bean variant should be used by the tests. False otherwise.
+     */
+    protected abstract boolean isEntryStateful();
+
+    /**
+     * Returns true if the stateful WhoAmI bean variant should be used by the tests. False otherwise.
+     */
+    protected abstract boolean isWhoAmIStateful();
+
+    /**
+     * Creates callable for executing {@link Entry#doubleWhoAmI(String, String, ReAuthnType, String)} as "whoami" user.
+     *
+     * @param type reauthentication reauthentication type used within the doubleWhoAmI
+     * @return Callable
+     */
+    private Callable<String[]> getDoubleWhoAmICallable(final ReAuthnType type) {
+        return getDoubleWhoAmICallable(type, "whoami", "whoami");
+    }
+
+    /**
+     * Creates callable for executing {@link Entry#doubleWhoAmI(String, String, ReAuthnType, String)} as given user.
+     *
+     * @param type reauthentication re-authentication type used within the doubleWhoAmI
+     * @param username
+     * @param password
+     * @return
+     */
+    private Callable<String[]> getDoubleWhoAmICallable(final ReAuthnType type, final String username, final String password) {
+        return () -> {
+            final Entry bean = SeccontextUtil.lookup(
+                    SeccontextUtil.getRemoteEjbName(SERVER1, "EntryBean", Entry.class.getName(), isEntryStateful()),
+                    server1.getApplicationRemotingUrl());
+            final String server2Url = server2.getApplicationRemotingUrl();
+            return bean.doubleWhoAmI(username, password, type, server2Url, isWhoAmIStateful());
+        };
+    }
+
+    private Callable<String> getEjbToServletCallable(final ReAuthnType type, final String username, final String password) {
+        return () -> {
+            final Entry bean = SeccontextUtil.lookup(
+                    SeccontextUtil.getRemoteEjbName(SERVER1, "EntryBean", Entry.class.getName(), isEntryStateful()),
+                    server1.getApplicationRemotingUrl());
+            final String servletUrl = server2.getApplicationHttpUrl() + "/" + SERVER2 + WhoAmIServlet.SERVLET_PATH;
+            return bean.readUrl(username, password, type, new URL(servletUrl));
+        };
+    }
+
+    private static org.hamcrest.Matcher<java.lang.String> isEjbAuthenticationError() {
+        // different behavior for stateless and stateful beans
+        // is reported under https://issues.jboss.org/browse/JBEAP-12439
+        return anyOf(startsWith("javax.ejb.NoSuchEJBException: EJBCLIENT000079"),
+                startsWith("javax.naming.CommunicationException: EJBCLIENT000062"));
+    }
+
+    private static org.hamcrest.Matcher<java.lang.String> isEvidenceVerificationError() {
+        return startsWith("java.lang.SecurityException: ELY01151");
+    }
+
+    private static org.hamcrest.Matcher<java.lang.String> isEjbAccessException() {
+        return startsWith("javax.ejb.EJBAccessException");
+    }
+
+    private String createJwtToken(String userName) {
+        String jwtPayload = String.format("{" //
+                + "\"iss\": \"issuer.wildfly.org\"," //
+                + "\"sub\": \"elytron@wildfly.org\"," //
+                + "\"exp\": 2051222399," //
+                + "\"aud\": \"%1$s\"," //
+                + "\"groups\": [\"%1$s\"]" //
+                + "}", userName);
+        return JWT_HEADER_B64 + "." + B64_ENCODER.encodeToString(jwtPayload.getBytes(StandardCharsets.UTF_8)) + ".";
+    }
+
+    private static class ServerHolder {
+        private String name;
+        private String host;
+        private int portOffset;
+        private ModelControllerClient client;
+        private CommandContext commandCtx;
+        private ByteArrayOutputStream consoleOut = new ByteArrayOutputStream();
+
+        private String snapshot;
+
+        public ServerHolder(String name, String host, int portOffset) {
+            this.name = name;
+            this.host = host;
+            this.portOffset = portOffset;
+        }
+
+        public void resetContainerConfiguration() throws CommandLineException, IOException, MgmtOperationException {
+            if (!containerController.isStarted(name)) {
+                containerController.start(name);
+                client = ModelControllerClient.Factory.create(host, getManagementPort());
+                commandCtx = CLITestUtil.getCommandContext(host, getManagementPort(), null, consoleOut, -1);
+                commandCtx.connectController();
+                readSnapshot();
+            }
+
+            if (snapshot == null) {
+                final File cliFIle = File.createTempFile("seccontext-", ".cli");
+                try (FileOutputStream fos = new FileOutputStream(cliFIle)) {
+                    IOUtils.copy(AbstractSecurityContextPropagationTestBase.class.getResourceAsStream("seccontext-setup.cli"),
+                            fos);
+                }
+                runBatch(cliFIle);
+                cliFIle.delete();
+                reload();
+                // deployment name is the same as the container name in this test case
+                deployer.deploy(name);
+
+                takeSnapshot();
+            } else {
+                reloadToSnapshot();
+            }
+        }
+
+        public void shutDown() throws IOException {
+            if (containerController.isStarted(name)) {
+                // deployer.undeploy(name);
+                commandCtx.terminateSession();
+                client.close();
+                containerController.stop(name);
+            }
+        }
+
+        public int getManagementPort() {
+            return 9990 + portOffset;
+        }
+
+        public int getApplicationPort() {
+            return 8080 + portOffset;
+        }
+
+        public String getApplicationHttpUrl() throws IOException {
+            return "http://" + NetworkUtils.formatPossibleIpv6Address(host) + ":" + getApplicationPort();
+        }
+
+        public String getApplicationRemotingUrl() throws IOException {
+            return "remote+" + getApplicationHttpUrl();
+        }
+
+        /**
+         * Sends command line to CLI.
+         *
+         * @param line specifies the command line.
+         * @param ignoreError if set to false, asserts that handling the line did not result in a
+         *        {@link org.jboss.as.cli.CommandLineException}.
+         *
+         * @return true if the CLI is in a non-error state following handling the line
+         */
+        public boolean sendLine(String line, boolean ignoreError) {
+            consoleOut.reset();
+            if (ignoreError) {
+                commandCtx.handleSafe(line);
+                return commandCtx.getExitCode() == 0;
+            } else {
+                try {
+                    commandCtx.handle(line);
+                } catch (CommandLineException e) {
+                    StringWriter stackTrace = new StringWriter();
+                    e.printStackTrace(new PrintWriter(stackTrace));
+                    Assert.fail(String.format("Failed to execute line '%s'%n%s", line, stackTrace.toString()));
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Runs given CLI script file as a batch.
+         *
+         * @param batchFile CLI file to run in batch
+         * @return true if CLI returns Success
+         */
+        public boolean runBatch(File batchFile) throws IOException {
+            sendLine("run-batch --file=\"" + batchFile.getAbsolutePath() + "\" -v", false);
+            if (consoleOut.size() <= 0) {
+                return false;
+            }
+            return new CLIOpResult(ModelNode.fromStream(new ByteArrayInputStream(consoleOut.toByteArray())))
+                    .isIsOutcomeSuccess();
+        }
+
+        private void takeSnapshot() throws IOException, MgmtOperationException {
+            DomainTestUtils.executeForResult(Util.createOperation("take-snapshot", null), client);
+            readSnapshot();
+        }
+
+        private void readSnapshot() throws IOException, MgmtOperationException {
+            ModelNode namesNode = DomainTestUtils.executeForResult(Util.createOperation("list-snapshots", null), client)
+                    .get("names");
+            if (namesNode == null || namesNode.getType() != ModelType.LIST) {
+                throw new IllegalStateException("Unexpected return value from :list-snaphot operation: " + namesNode);
+            }
+            List<ModelNode> snapshots = namesNode.asList();
+            if (!snapshots.isEmpty()) {
+                snapshot = namesNode.get(snapshots.size() - 1).asString();
+            }
+        }
+
+        private void reloadToSnapshot() {
+            ModelNode operation = Util.createOperation("reload", null);
+            operation.get(SERVER_CONFIG).set(snapshot);
+            ServerReload.executeReloadAndWaitForCompletion(client, operation, (int) SECONDS.toMillis(90), host,
+                    getManagementPort());
+        }
+
+        private void reload() {
+            ModelNode operation = Util.createOperation("reload", null);
+            ServerReload.executeReloadAndWaitForCompletion(client, operation, (int) SECONDS.toMillis(90), host,
+                    getManagementPort());
+        }
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/Entry.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/Entry.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import java.net.URL;
+
+import javax.ejb.Remote;
+
+/**
+ * Interface for the bean used as the entry point to verify EJB3 security behaviour.
+ */
+@Remote
+public interface Entry {
+
+    /**
+     * @return The name of the Principal obtained from a call to EJBContext.getCallerPrincipal()
+     */
+    String whoAmI();
+
+    /**
+     * Obtains the name of the Principal obtained from a call to EJBContext.getCallerPrincipal() both for the bean called and
+     * also from a call to a second bean (user may be switched before the second call - depending on arguments).
+     *
+     * @return An array containing the name from the local call first followed by the name from the second call.
+     * @throws Exception - If there is an unexpected failure establishing the security context for the second call.
+     */
+    String[] doubleWhoAmI(String username, String password, ReAuthnType type, String providerUrl, boolean statefullWhoAmI);
+
+    /**
+     * Read remote URL using simple HttpURLConnection.
+     */
+    String readUrl(String username, String password, ReAuthnType type, final URL url);
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/EntryBean.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/EntryBean.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import static org.wildfly.test.manual.elytron.seccontext.SeccontextUtil.SERVER2;
+import static org.wildfly.test.manual.elytron.seccontext.SeccontextUtil.switchIdentity;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Resource;
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.naming.NamingException;
+
+/**
+ * Stateless EJB responsible for calling remote EJB or Servlet.
+ *
+ * @author Josef Cacek
+ */
+@Stateless
+@RolesAllowed({ "entry", "admin" })
+@DeclareRoles({ "entry", "whoami", "servlet", "admin" })
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class EntryBean implements Entry {
+
+    @Resource
+    private SessionContext context;
+
+    @Override
+    public String whoAmI() {
+        return context.getCallerPrincipal().getName();
+    }
+
+    @Override
+    public String[] doubleWhoAmI(String username, String password, ReAuthnType type, final String providerUrl,
+            boolean statefullWhoAmI) {
+        String[] result = new String[2];
+        result[0] = context.getCallerPrincipal().getName();
+
+        final Callable<String> callable = () -> {
+            return getWhoAmIBean(providerUrl, statefullWhoAmI).getCallerPrincipal().getName();
+        };
+        try {
+            result[1] = switchIdentity(username, password, callable, type);
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            result[1] = sw.toString();
+        } finally {
+            String secondLocalWho = context.getCallerPrincipal().getName();
+            if (!secondLocalWho.equals(result[0])) {
+                throw new IllegalStateException(
+                        "Local getCallerPrincipal changed from '" + result[0] + "' to '" + secondLocalWho);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String readUrl(String username, String password, ReAuthnType type, final URL url) {
+        final Callable<String> callable = () -> {
+            URLConnection conn = url.openConnection();
+            conn.connect();
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                return br.readLine();
+            }
+        };
+        String result = null;
+        String firstWho = context.getCallerPrincipal().getName();
+        try {
+            result = switchIdentity(username, password, callable, type);
+        } catch (Exception e) {
+            StringWriter sw = new StringWriter();
+            e.printStackTrace(new PrintWriter(sw));
+            result = sw.toString();
+        } finally {
+            String secondLocalWho = context.getCallerPrincipal().getName();
+            if (!secondLocalWho.equals(firstWho)) {
+                throw new IllegalStateException(
+                        "Local getCallerPrincipal changed from '" + firstWho + "' to '" + secondLocalWho);
+            }
+        }
+        return result;
+    }
+
+    private WhoAmI getWhoAmIBean(String providerUrl, boolean statefullWhoAmI) throws NamingException {
+        return SeccontextUtil.lookup(
+                SeccontextUtil.getRemoteEjbName(SERVER2, "WhoAmIBean", WhoAmI.class.getName(), statefullWhoAmI), providerUrl);
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/EntryBeanSFSB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/EntryBeanSFSB.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import javax.ejb.Stateful;
+
+/**
+ * Stateful version of the {@link EntryBean}.
+ *
+ * @author Josef Cacek
+ */
+@Stateful
+public class EntryBeanSFSB extends EntryBean implements Entry {
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/ReAuthnType.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/ReAuthnType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+/**
+ * Enum of ways which can be used for (re)authentication or identity propagation in Security context propagation tests.
+ *
+ * @author Josef Cacek
+ */
+public enum ReAuthnType {
+    NO_REAUTHN, FORWARDED_IDENTITY, AUTHENTICATION_CONTEXT, SECURITY_DOMAIN_AUTHENTICATE, SECURITY_DOMAIN_AUTHENTICATE_FORWARDED
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SeccontextUtil.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SeccontextUtil.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+
+/**
+ * Util class for Elytron security context propagation tests. It helps to switch identities and lookup EJBs.
+ *
+ * @author Josef Cacek
+ */
+public class SeccontextUtil {
+
+    public static final String SERVER1 = "seccontext-server1";
+    public static final String SERVER2 = "seccontext-server2";
+
+    /**
+     * Method which handles {@link ReAuthnType} types by using Elytron API. Based on provided type new
+     * {@link AuthenticationContext} is created and given callable is called within the context.
+     *
+     * @param username login name used for reauthentication scenarios (or null)
+     * @param password password used for reauthentication scenarios (or null)
+     * @param callable logic to be executed in the requested AuthenticationContext
+     * @param type reauthentication type
+     * @return result of the callable call
+     */
+    public static <T> T switchIdentity(final String username, final String password, final Callable<T> callable,
+            ReAuthnType type) throws Exception {
+        if (type == null) {
+            type = ReAuthnType.AUTHENTICATION_CONTEXT;
+        }
+        switch (type) {
+            case FORWARDED_IDENTITY:
+                return AuthenticationContext.empty().with(MatchRule.ALL, AuthenticationConfiguration.empty()
+                        .useForwardedIdentity(SecurityDomain.getCurrent()).setSaslMechanismSelector(SaslMechanismSelector.ALL))
+                        .runCallable(callable);
+            case AUTHENTICATION_CONTEXT:
+                AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                        .setSaslMechanismSelector(SaslMechanismSelector.ALL);
+                if (username != null) {
+                    authCfg = authCfg.useName(username);
+                }
+                if (password != null) {
+                    authCfg = authCfg.usePassword(password);
+                }
+                return AuthenticationContext.empty().with(MatchRule.ALL, authCfg).runCallable(callable);
+            case SECURITY_DOMAIN_AUTHENTICATE:
+                return password == null ? null
+                        : SecurityDomain.getCurrent().authenticate(username, new PasswordGuessEvidence(password.toCharArray()))
+                                .runAs(callable);
+            case SECURITY_DOMAIN_AUTHENTICATE_FORWARDED:
+                final Callable<T> forwardIdentityCallable = () -> {
+                    return AuthenticationContext.empty()
+                            .with(MatchRule.ALL,
+                                    AuthenticationConfiguration.empty().useForwardedIdentity(SecurityDomain.getCurrent())
+                                            .setSaslMechanismSelector(SaslMechanismSelector.ALL))
+                            .runCallable(callable);
+                };
+                return password == null ? null
+                        : SecurityDomain.getCurrent().authenticate(username, new PasswordGuessEvidence(password.toCharArray()))
+                                .runAs(forwardIdentityCallable);
+            case NO_REAUTHN:
+            default:
+                return callable.call();
+        }
+    }
+
+    /**
+     * Creates "ejb:/..." name for JNDI lookup.
+     *
+     * @return name to be used for EJB lookup.
+     */
+    public static String getRemoteEjbName(String appName, String beanSimpleNameBase, String remoteInterfaceName, boolean stateful) {
+        return "ejb:/" + appName + "/" + beanSimpleNameBase + (stateful ? "SFSB!" : "!") + remoteInterfaceName
+                + (stateful ? "?stateful" : "");
+    }
+
+    /**
+     * Do JNDI lookup.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T lookup(String name, String providerUrl) throws NamingException {
+        final Properties jndiProperties = new Properties();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.wildfly.naming.client.WildFlyInitialContextFactory");
+        jndiProperties.put(Context.PROVIDER_URL, providerUrl);
+        final Context context = new InitialContext(jndiProperties);
+        return (T) context.lookup(name);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSFSFTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSFSFTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+/**
+ * Security context propagation test variant which uses both Entry and WhoAmI beans stateful.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SecurityContextPropagationSFSFTestCase extends AbstractSecurityContextPropagationTestBase {
+
+    @Override
+    protected boolean isEntryStateful() {
+        return true;
+    }
+
+    @Override
+    protected boolean isWhoAmIStateful() {
+        return true;
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSFSLTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSFSLTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+/**
+ * Security context propagation test variant which uses Entry bean stateful and WhoAmI bean stateless.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SecurityContextPropagationSFSLTestCase extends AbstractSecurityContextPropagationTestBase {
+
+    @Override
+    protected boolean isEntryStateful() {
+        return false;
+    }
+
+    @Override
+    protected boolean isWhoAmIStateful() {
+        return true;
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSLSFTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSLSFTestCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+/**
+ * Security context propagation test variant which uses Entry bean stateless and WhoAmI bean stateful.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SecurityContextPropagationSLSFTestCase extends AbstractSecurityContextPropagationTestBase {
+
+    @Override
+    protected boolean isEntryStateful() {
+        return false;
+    }
+
+    @Override
+    protected boolean isWhoAmIStateful() {
+        return true;
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSLSLTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/SecurityContextPropagationSLSLTestCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.RunWith;
+
+/**
+ * Security context propagation test variant which uses both Entry and WhoAmI beans stateless.
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SecurityContextPropagationSLSLTestCase extends AbstractSecurityContextPropagationTestBase {
+
+    @Override
+    protected boolean isEntryStateful() {
+        return false;
+    }
+
+    @Override
+    protected boolean isWhoAmIStateful() {
+        return false;
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmI.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmI.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import java.security.Principal;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface WhoAmI {
+
+    /**
+     * @return the caller principal obtained from the EJBContext.
+     */
+    Principal getCallerPrincipal();
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIBean.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIBean.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import java.security.Principal;
+
+import javax.annotation.Resource;
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+/**
+ * Stateless implementation of the {@link WhoAmI}.
+ * @author Josef Cacek
+ */
+@Stateless
+@RolesAllowed({ "whoami", "admin" })
+@DeclareRoles({ "entry", "whoami", "servlet", "admin" })
+public class WhoAmIBean implements WhoAmI {
+
+    @Resource
+    private SessionContext context;
+
+    public Principal getCallerPrincipal() {
+        return context.getCallerPrincipal();
+    }
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIBeanSFSB.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIBeanSFSB.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import javax.ejb.Stateful;
+
+/**
+ * Stateful version of the {@link WhoAmIBean}.
+ *
+ * @author Josef Cacek
+ */
+@Stateful
+public class WhoAmIBeanSFSB extends WhoAmIBean implements WhoAmI {
+
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIServlet.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/WhoAmIServlet.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.manual.elytron.seccontext;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.annotation.security.DeclareRoles;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A servlet which prints the name of the caller principal.
+ */
+@WebServlet(urlPatterns = { WhoAmIServlet.SERVLET_PATH })
+@ServletSecurity(@HttpConstraint(rolesAllowed = { "servlet", "admin" }))
+@DeclareRoles({ "entry", "whoami", "servlet", "admin" })
+public class WhoAmIServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/whoAmI";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        writer.write(req.getUserPrincipal().getName());
+        writer.close();
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/seccontext-setup.cli
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/seccontext-setup.cli
@@ -1,0 +1,59 @@
+# enable Elytron across the server
+/subsystem=undertow/server=default-server/https-listener=https:remove()
+/subsystem=undertow/application-security-domain=other:add(http-authentication-factory=application-http-authentication)
+/subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+
+/subsystem=undertow/server=default-server/host=default-host/setting=http-invoker:remove
+
+/core-service=management/security-realm=ApplicationRealm:remove
+
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add(path=seccontext-users,relative-to=jboss.server.config.dir)
+/subsystem=elytron/token-realm=JWT:add(jwt={}, principal-claim=aud)
+/subsystem=elytron/constant-realm-mapper=JWT:add(realm-name=JWT)
+
+/subsystem=elytron/security-domain=SeccontextDomain:add(realms=[ \
+    {realm=SeccontextFsRealm, role-decoder=groups-to-roles}, \
+    {realm=JWT, role-decoder=groups-to-roles} ], \
+    default-realm=SeccontextFsRealm, \
+    permission-mapper=default-permission-mapper)
+
+/subsystem=elytron/sasl-authentication-factory=seccontext-sasl-authn-factory:add( \
+    sasl-server-factory=elytron, \
+    security-domain=SeccontextDomain, \
+    mechanism-configurations=[ \
+        {mechanism-name=PLAIN}, \
+        {mechanism-name=OAUTHBEARER, realm-mapper=JWT}])
+/socket-binding-group=standard-sockets/socket-binding=seccontext-remoting-socket:add(port=16444)
+/subsystem=remoting/connector=seccontext-connector:add(socket-binding=seccontext-remoting-socket, \
+    sasl-authentication-factory=seccontext-sasl-authn-factory)
+
+/subsystem=ejb3/application-security-domain=seccontext-entry:add(security-domain=SeccontextDomain)
+/subsystem=ejb3/application-security-domain=seccontext-whoami:add(security-domain=SeccontextDomain)
+
+/subsystem=elytron/http-authentication-factory=seccontext:add(security-domain=SeccontextDomain, \ 
+    http-server-mechanism-factory=global, \
+    mechanism-configurations=[{mechanism-name=BASIC}])
+
+/subsystem=undertow/application-security-domain=seccontext-web:add(http-authentication-factory=seccontext)
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, \
+    value=seccontext-sasl-authn-factory)
+
+# add test users
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity(identity=servlet)
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:set-password(identity=servlet, clear={password=servlet})
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity-attribute(identity=servlet, name=groups, value=["servlet"])
+
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity(identity=entry)
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:set-password(identity=entry, clear={password=entry})
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity-attribute(identity=entry, name=groups, value=["entry"])
+
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity(identity=whoami)
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:set-password(identity=whoami, clear={password=whoami})
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity-attribute(identity=whoami, name=groups, value=["whoami"])
+
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity(identity=admin)
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:set-password(identity=admin, clear={password=admin})
+/subsystem=elytron/filesystem-realm=SeccontextFsRealm:add-identity-attribute(identity=admin, name=groups, value=["admin"])
+

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -54,6 +54,16 @@
             <fileset dir="target/jbossas"/>
         </copy>
 
+        <echo message="Copying and configuring instance seccontext-server1"/>
+        <copy todir="target/seccontext-server1">
+            <fileset dir="target/jbossas"/>
+        </copy>
+
+        <echo message="Copying and configuring instance seccontext-server2"/>
+        <copy todir="target/seccontext-server2">
+            <fileset dir="target/jbossas"/>
+        </copy>
+
         <echo message="Copying and configuring instance jbossas-layered"/>
         <copy todir="target/jbossas-layered">
             <fileset dir="target/jbossas"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9172
https://issues.jboss.org/browse/JBEAP-12530

Adds 2-node tests for Elytron security context propagation scenarios into manualmode TS module.