### PR TITLE
[WFLY-9174] Fix discovery-group with pooled-connection-factory

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -284,7 +284,7 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
                     if (jgroupFactories.containsKey(key)) {
                         ChannelFactory channelFactory = jgroupFactories.get(key);
                         String channelName = jgroupsChannels.get(key);
-                        newConfigs.add(BroadcastGroupAdd.createBroadcastGroupConfiguration(name, config, channelFactory, channelName));
+                        newConfigs.add(BroadcastGroupAdd.createBroadcastGroupConfiguration(name, config, channelFactory, channelName, channels));
                     } else {
                         final SocketBinding binding = groupBindings.get(key);
                         if (binding == null) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -30,6 +30,7 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
@@ -51,6 +52,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
+import org.jgroups.JChannel;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.JGroupsDefaultRequirement;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
@@ -175,12 +177,12 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
                 .setEndpointFactory(endpointFactory);
     }
 
-    static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final String name, final BroadcastGroupConfiguration config, final ChannelFactory channelFactory, final String channelName) throws Exception {
+    static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final String name, final BroadcastGroupConfiguration config, final ChannelFactory channelFactory, final String channelName, Map<String, JChannel> channels) throws Exception {
 
         final long broadcastPeriod = config.getBroadcastPeriod();
         final List<String> connectorRefs = config.getConnectorInfos();
 
-        final BroadcastEndpointFactory endpointFactory = new JGroupsBroadcastEndpointFactory(channelName, channelFactory);
+        final BroadcastEndpointFactory endpointFactory = new JGroupsBroadcastEndpointFactory(channelName, channelFactory, channels);
 
         return new BroadcastGroupConfiguration()
                 .setName(name)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/JGroupsBroadcastEndpointFactory.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/JGroupsBroadcastEndpointFactory.java
@@ -35,7 +35,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
-class JGroupsBroadcastEndpointFactory implements BroadcastEndpointFactory {
+public class JGroupsBroadcastEndpointFactory implements BroadcastEndpointFactory {
     private final String channelName;
     private final ChannelFactory channelFactory;
     // can be null
@@ -48,10 +48,6 @@ class JGroupsBroadcastEndpointFactory implements BroadcastEndpointFactory {
         this.channelName = channelName;
         this.channelFactory = channelFactory;
         this.channels = channels;
-    }
-
-    public JGroupsBroadcastEndpointFactory(String channelName, ChannelFactory channelFactory) {
-        this(channelName, channelFactory, null);
     }
 
     @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
-import org.apache.activemq.artemis.api.core.ChannelBroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
@@ -121,6 +120,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.extension.messaging.activemq.ActiveMQActivationService;
+import org.wildfly.extension.messaging.activemq.JGroupsBroadcastEndpointFactory;
 import org.wildfly.extension.messaging.activemq.JGroupsChannelLocator;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
@@ -396,7 +396,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                     properties.add(simpleProperty15(GROUP_ADDRESS, STRING_TYPE, udpCfg.getGroupAddress()));
                     properties.add(simpleProperty15(GROUP_PORT, INTEGER_TYPE, "" + udpCfg.getGroupPort()));
                     properties.add(simpleProperty15(DISCOVERY_LOCAL_BIND_ADDRESS, STRING_TYPE, "" + udpCfg.getLocalBindAddress()));
-                } else if (bgCfg instanceof ChannelBroadcastEndpointFactory) {
+                } else if (bgCfg instanceof JGroupsBroadcastEndpointFactory) {
                     properties.add(simpleProperty15(JGROUPS_CHANNEL_LOCATOR_CLASS, STRING_TYPE, JGroupsChannelLocator.class.getName()));
                     properties.add(simpleProperty15(JGROUPS_CHANNEL_NAME, STRING_TYPE, jgroupsChannelName));
                     properties.add(simpleProperty15(JGROUPS_CHANNEL_REF_NAME, STRING_TYPE, serverName + '/' + jgroupsChannelName));


### PR DESCRIPTION
* In PooledConnectionFactoryService, fix the check on the
  BroadcastEndpointFactory type to take into account the
  JGroupsBroadcastEndpointFactory introduced in WFLY-9004.
* In ServerAdd, keep track of channels created by both broadcast-group
  and discovery-group as Artemis as its own JChannelManager that keeps
  only 1 channel for a given channelName.

JIRA: https://issues.jboss.org/browse/WFLY-9174