### PR TITLE
[master] Fix WFLY-8548 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/ApplicableMethodInformation.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/ApplicableMethodInformation.java
@@ -190,17 +190,18 @@ public class ApplicableMethodInformation<T> {
                     return method.getDeclaringClass().getDeclaredMethods();
                 }
             });
+            methodLoop:
             for (Method m : declaredMethods) {
                 if (m.getName().equals(method.getName())
                         && m.getParameterTypes().length == method.getParameterTypes().length
                         && !m.isBridge()
                         && !m.isSynthetic()) {
                     if(!method.getReturnType().isAssignableFrom(m.getReturnType())) {
-                        continue;
+                        continue methodLoop;
                     }
                     for(int i = 0; i < method.getParameterTypes().length; ++i) {
                         if(!method.getParameterTypes()[i].isAssignableFrom(m.getParameterTypes()[i])) {
-                            continue;
+                            continue methodLoop;
                         }
                     }
                     return m;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/AttendanceRegistry.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/AttendanceRegistry.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.security.authorization;
+
+import javax.ejb.Remote;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Remote
+public interface AttendanceRegistry<T extends TimeProvider> {
+
+    String recordEntry(String user, T timeProvider);
+
+    String recordEntry(String user, long time);
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/AttendanceRegistrySLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/AttendanceRegistrySLSB.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.security.authorization;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateless
+@Remote(AttendanceRegistry.class)
+@SecurityDomain("ejb3-tests")
+public class AttendanceRegistrySLSB implements AttendanceRegistry<AttendanceRegistrySLSB.DefaultTimeProvider> {
+
+    @PermitAll
+    @Override
+    public String recordEntry(final String user, final DefaultTimeProvider defaultTimeProvider) {
+        return "(PermitAll) - User " + user + " logged in at " + defaultTimeProvider.getTime();
+    }
+
+    @RolesAllowed("Role2")
+    @Override
+    public String recordEntry(final String user, final long time) {
+        return "User " + user + " logged in at " + time;
+    }
+
+
+    public static final class DefaultTimeProvider implements TimeProvider, Serializable {
+        private final Date date;
+
+        public DefaultTimeProvider(final Date date) {
+            this.date = date;
+        }
+
+        @Override
+        public long getTime() {
+            return this.date.getTime();
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/TimeProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/authorization/TimeProvider.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.authorization;
+
+/**
+ * @author Jaikiran Pai
+ */
+public interface TimeProvider {
+    long getTime();
+}


### PR DESCRIPTION
@frickeo reported an issue in WildFly EJB security annotation processing and submitted a pull request a while back https://github.com/wildfly/wildfly/pull/9922. I happened to have a look at it today and what's reported in there is indeed a genuine issue, IMO. The issue can cause wrong security roles to be checked for, by the container, when dealing with invocations on EJB methods, when method level EJB security annotations are applicable.

The credit for investigating and fixing this issue should go to @frickeo. The fix provided by @frickeo has been included in this PR. The sole purpose of my PR is to add a proper testcase, to test the presence of the bug and verify the fix. The JIRA for this issue is https://issues.jboss.org/browse/WFLY-8548.

