### PR TITLE
WFLY-9203 Remote ejb tests fail if node0 is configured with non-localhost address.

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -346,6 +346,7 @@
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
                         <node0>${node0}</node0>
+                        <node0.escaped>${node0.escaped}</node0.escaped>
                         <node1>${node1}</node1>
                         <mcast>${mcast}</mcast>
                         <mcast.ttl>${mcast.ttl}</mcast.ttl>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9203