### PR TITLE
[WFLY-9207] fix typo in description of enable-http2 attribute

### DIFF
--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -296,7 +296,7 @@ undertow.handler.reverse-proxy.host.remove=Removes a reverse proxy handler host
 undertow.handler.reverse-proxy.host.security-realm=The security realm that provides the SSL configuration for the connection to the host
 undertow.handler.reverse-proxy.host.ssl-context=Reference to the SSLContext to be used by this handler.
 undertow.handler.reverse-proxy.host.security-realm.deprecated=Use the ssl-context attribute to reference a configured SSLContext directly.
-undertow.handler.reverse-proxy.host.enable-http2=If this is true then the proxy will attempt to use HTTP/2 to connect to the backend. If it is not supported it will fall back to HTTP/1.1/
+undertow.handler.reverse-proxy.host.enable-http2=If this is true then the proxy will attempt to use HTTP/2 to connect to the backend. If it is not supported it will fall back to HTTP/1.1.
 undertow.handler.reverse-proxy.max-retries=The number of times to attempt to retry a request if it fails. Note that if a request is not considered idempotent then it will only be retried if the proxy can be sure it was not sent to the backend server).
 
 undertow.filter.basic-auth=Basic auth configuration


### PR DESCRIPTION
Project issue: https://issues.jboss.org/browse/WFLY-9207