### PR TITLE
[WFLY-9208] JobControlTestCase - missing permission for local auth

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.batch.deployment;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.io.IOException;
 import java.util.PropertyPermission;
 import javax.batch.operations.JobOperator;
@@ -80,7 +81,8 @@ public class JobControlTestCase extends AbstractBatchTestCase {
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new RemotingPermission("createEndpoint"),
                         new RemotingPermission("connect"),
-                        new PropertyPermission("ts.timeout.factor", "read")
+                        new PropertyPermission("ts.timeout.factor", "read"),
+                        new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
                 ), "permissions.xml");
     }
 


### PR DESCRIPTION
Added permission necessary for local auth, as discussed in JBEAP-12547.

https://issues.jboss.org/browse/JBEAP-12547
https://issues.jboss.org/browse/WFLY-9208
(no PR deps)