### PR TITLE
[WFLY-9205] The supports* methods should return an accurate response regardless of if the HttpScope already exists.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -667,7 +667,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
 
                 @Override
                 public boolean supportsAttachments() {
-                    return exists();
+                    return true;
                 }
 
                 @Override
@@ -684,7 +684,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
 
                 @Override
                 public boolean supportsInvalidation() {
-                    return exists();
+                    return true;
                 }
 
                 @Override
@@ -703,7 +703,7 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
 
                 @Override
                 public boolean supportsNotifications() {
-                    return exists();
+                    return true;
                 }
 
                 @Override


### PR DESCRIPTION
i.e. The caller may be calling a supports* method to determine if it is worth calling create();

https://issues.jboss.org/browse/WFLY-9205