### PR TITLE
[WFLY-9065] DatasourcePoolAttributesTestCase fails with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaTestsUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaTestsUtil.java
@@ -176,7 +176,7 @@ public class JcaTestsUtil {
             delegate.setAccessible(true);
             return (WrapperDataSource) delegate.get(wfds);
         } catch (Throwable t) {
-            //
+            fail(t.getMessage());
         }
         return null;
     }
@@ -194,7 +194,7 @@ public class JcaTestsUtil {
             delegate.setAccessible(true);
             return (BlockingExecutor) delegate.get(sei);
         } catch (Throwable t) {
-            //
+            fail(t.getMessage());
         }
         return null;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
@@ -28,7 +28,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
+import java.lang.reflect.ReflectPermission;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 
@@ -55,6 +58,7 @@ import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.adapters.jdbc.WrapperDataSource;
 import org.jboss.jca.core.api.connectionmanager.pool.PoolConfiguration;
+import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -105,10 +109,19 @@ public class DatasourcePoolAttributesTestCase extends JcaMgmtBase {
                 "org.jboss.as.controller," +
                 "org.jboss.dmr," +
                 "org.jboss.as.cli," +
+                "org.jboss.remoting3," +
                 "org.jboss.staxmapper," +
                 "org.jboss.ironjacamar.api," +
                 "org.jboss.ironjacamar.impl," +
                 "org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
+
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new RemotingPermission("connect"),
+                new RemotingPermission("createEndpoint"),
+                new RuntimePermission("accessDeclaredMembers"),
+                new ReflectPermission("suppressAccessChecks"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")),
+                "permissions.xml");
 
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
@@ -153,7 +153,9 @@ public class LongRunningThreadsCheckTestCase extends JcaMgmtBase {
                 MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, JcaMgmtServerSetupTask.class,
                 JcaMgmtBase.class, JcaTestsUtil.class);
         ja.addPackage(AbstractMgmtTestBase.class.getPackage());
-        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller-client, org.jboss.as.cli, org.jboss.as.connector"),
+        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, " +
+                        "org.jboss.as.controller-client, org.jboss.as.cli, " +
+                        "org.jboss.as.connector, org.jboss.threads"),
                 "MANIFEST.MF");
 
         ResourceAdapterArchive ra1 = ShrinkWrap.create(ResourceAdapterArchive.class, "wm1.rar");


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9065