### PR TITLE
WFLY-9215 Upgrade to Hibernate Search 5.5.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.3.5.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hibernate.search>5.5.5.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>5.5.8.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>8.2.8.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9215

Two most important reasons to upgrade:
 - previous version wasn't tested to work with the matching version of Hibernate ORM included in WildFly; also I doubt the tests where run as the testing utilities needed patching to compile with ORM 5.1.x (see [HSEARCH-2851](https://hibernate.atlassian.net/browse/HSEARCH-2851) ).
 - a significant bug in spatial queries causes exceptions under load: (see [HSEARCH-2691](https://hibernate.atlassian.net/browse/HSEARCH-2691) ).


Full details:

- Changelog for [5.5.6.Final](https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%205.5.6.Final)
 - Changelog for [5.5.7.Final](https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%205.5.7.Final)
 - Changelog for [5.5.8.Final](https://hibernate.atlassian.net/issues/?jql=project%20%3D%20HSEARCH%20AND%20fixVersion%20%3D%205.5.8.Final)

