### PR TITLE
WFLY-9170 Send empty (rather than local) initial topology when server is not clustered.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -398,7 +398,7 @@ final class AssociationImpl implements Association, AutoCloseable {
             // Synchronize on the listener to ensure that the initial topology is set before processing any changes from the registry listener
             synchronized (listener) {
                 this.clusterTopologyListeners.add(listener);
-                listener.clusterTopology(Collections.singletonList(getClusterInfo(this.clientMappingRegistry.getEntries())));
+                listener.clusterTopology(!this.clientMappingRegistry.getGroup().isLocal() ? Collections.singletonList(getClusterInfo(this.clientMappingRegistry.getEntries())) : Collections.emptyList());
             }
             return () -> this.clusterTopologyListeners.remove(listener);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9170