### PR TITLE
[JBEAP-12622][WFLY-9210] XSiteSimpleTestCase do not work with node0 a…

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -523,6 +523,94 @@
             </build>
         </profile>
 
+        <!-- If 4 different IP addresses for node0-4 are not available, only two IPs can be used.
+             Set node0/1 to one address and node2/3 to the other one.
+
+             You can ensure to execute this profile by:
+               Linux: -P \!ts.clustering.xsite.profile,ts.clustering.xsite.profile.simple.xsite
+               Windows: -P !ts.clustering.xsite.profile,ts.clustering.xsite.profile.simple.xsite
+        -->
+        <profile>
+            <id>ts.clustering.xsite.profile.simple.xsite</id>
+
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>ts.config-as.clustering.xsite</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <echo>Creating x-site configurations</echo>
+                                        <!-- Build the UDP server configs in target/ . -->
+                                        <!-- this configuration uses one interface and port offsets -->
+                                        <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <property name="node0" value="${node0}"/>
+                                            <property name="node1" value="${node0}"></property>
+                                            <property name="node2" value="${node1}"></property>
+                                            <property name="node3" value="${node1}"></property>
+                                            <property name="mcast-lon" value="${mcast}"/>
+                                            <property name="mcast-nyc" value="${mcast1}"/>
+                                            <property name="mcast-sfo" value="${mcast2}"/>
+                                            <property name="mcast-mping" value="${mcast3}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
+                                            <target name="build-clustering-xsite"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                       Surefire test executions.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+
+                            <!-- Single node clustering tests. -->
+                            <execution>
+                                <id>ts.surefire.clustering.xsite</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables combine.children="append">
+                                        <arquillian.launch>clustering-xsite-simple</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <!--bit of a workaround, we don't include ${jvm.args.ip.server} as clustering does custom binding-->
+                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>ts.clustering.two.clusters.profile</id>
             <activation><property><name>extendedTests</name></property></activation>

--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -200,6 +200,69 @@
 
     </group>
 
+    <group qualifier="clustering-xsite-simple">
+        <container qualifier="container-0" mode="custom" managed="false" default="true">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-0</property>
+                <!-- AS7-2493 different jboss.node.name must be specified -->
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-0 -Djboss.node.name=LON-0</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-1" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">10090</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node0} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-2" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-xsite-NYC-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10190</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10199</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-3" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-xsite-SFO-0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-SFO-0 -Djboss.node.name=SFO-0 -Djboss.port.offset=300</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10290</property>
+
+                <!-- AS7-4070 -->
+                <property name="waitForPorts">${as.debug.port.node1} 10299</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
+
     <group qualifier="clustering-xsite-backupFor">
 
         <container qualifier="container-0" mode="custom" managed="false" default="true">


### PR DESCRIPTION
Testsuite issue. This PR adds new profile to TS, current default behaviour is not changed.

==========================================================

XSiteSimpleTestCase is design to use node0, node1, node2 and node3. If all these node addresses are set to the same real address (like 127.0.0.1), test pass. Test pass also if these 4 addresses are different. But test fail, if only two addresses are set.

* Test fail if node0==node2 && node1==node3 && node0!= node1
* Test pass if node0==node1 && node2==node3 && node0!=node2. But all other tests in TS needs to have different node0 and node1. And XSiteSimpleTestCase is the only one testcase in EAP TS, that needs 4 addresses. So there is no way to run TS with two different IP addresses with passing XSiteSimpleTestCase.


This is explained by @rhusar : https://issues.jboss.org/browse/WFLY-5239?focusedCommentId=13304413&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13304413

I suggest to
* keep current default behaviour
* add new profile, that allows to run XSiteSimpleTestCase with two different IP addresses.

==========================================================

JBEAP jira: https://issues.jboss.org/browse/JBEAP-12622
WF jira: https://issues.jboss.org/browse/WFLY-9210
EAP PR: https://github.com/jbossas/jboss-eap7/pull/2292