### PR TITLE
WFLY-9221 Apache Avro version not compatible with Hibernate Search re…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>1.5.5.jbossorg-006</version.org.apache.activemq.artemis>
-        <version.org.apache.avro>1.8.1</version.org.apache.avro>
+        <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.1.12</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M20</version.org.apache.ds>


### PR DESCRIPTION
…quirements

Reverting the version of Apache Avro to the version used to compile the bundled
copy of Hibernate Search.

https://issues.jboss.org/browse/WFLY-9221

Blocker for EAP 7.1:
 - https://issues.jboss.org/browse/JBEAP-12716