### PR TITLE
Fix failed tests with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/EEConcurrentManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/concurrent/EEConcurrentManagementTestCase.java
@@ -28,6 +28,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
+
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 
@@ -75,7 +77,8 @@ public class EEConcurrentManagementTestCase {
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller, org.jboss.as.ee, org.jboss.remoting3\n"), "MANIFEST.MF")
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new RemotingPermission("createEndpoint"),
-                        new RemotingPermission("connect")
+                        new RemotingPermission("connect"),
+                        new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
                 ), "permissions.xml");
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/flushing/FlushOperationsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/flushing/FlushOperationsTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.jca.flushing;
 
+import java.io.FilePermission;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.ReflectPermission;
@@ -95,7 +96,8 @@ public class FlushOperationsTestCase {
                 new RemotingPermission("connect"),
                 // flushInvalidConnectionsInPool needs the following
                 new RuntimePermission("accessDeclaredMembers"),
-                new ReflectPermission("suppressAccessChecks")
+                new ReflectPermission("suppressAccessChecks"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
         ), "permissions.xml");
         return archive;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -26,6 +26,7 @@ package org.jboss.as.test.integration.jca.poolattributes;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.lang.reflect.ReflectPermission;
 import java.util.List;
 
@@ -123,7 +124,8 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
                 new RemotingPermission("createEndpoint"),
                 new RemotingPermission("connect"),
                 new RuntimePermission("accessDeclaredMembers"),
-                new ReflectPermission("suppressAccessChecks")
+                new ReflectPermission("suppressAccessChecks"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
         ), "permissions.xml");
 
         rar.addAsLibrary(jar);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.messaging.jms.context.transactionscoped;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import javax.annotation.Resource;
@@ -42,6 +43,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
@@ -65,7 +67,10 @@ public class TransactionScopedJMSContextTestCase {
         return ShrinkWrap.create(JavaArchive.class, "TransactionScopedJMSContextTestCase.jar")
                 .addPackage(AppScopedBean.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE,
-                        "beans.xml");
+                        "beans.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new ElytronPermission("getSecurityDomain")
+                        ), "permissions.xml");
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -1,5 +1,6 @@
 package org.jboss.as.test.integration.naming.remote.multiple;
 
+import java.io.FilePermission;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.util.PropertyPermission;
@@ -51,7 +52,8 @@ public class MultipleClientRemoteJndiTestCase {
                         // RunRmiServlet looks up for MyObject using connection through http-remoting Endpoint
                         new RemotingPermission("connect"),
                         new SocketPermission(Utils.getDefaultHost(true), "accept,connect,listen,resolve"),
-                        new RuntimePermission("getClassLoader")),
+                        new RuntimePermission("getClassLoader"),
+                        new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")),
                         "permissions.xml");
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9184 downstream https://issues.jboss.org/browse/JBEAP-12552
https://issues.jboss.org/browse/WFLY-9165 downstream https://issues.jboss.org/browse/JBEAP-12506
https://issues.jboss.org/browse/WFLY-9164 downstream https://issues.jboss.org/browse/JBEAP-12505
https://issues.jboss.org/browse/WFLY-9163 downstream https://issues.jboss.org/browse/JBEAP-12504
https://issues.jboss.org/browse/WFLY-9162 downstream https://issues.jboss.org/browse/JBEAP-12503

WFLY-9165 adds missing ElytronPermission, the others follow same solution in 
https://issues.jboss.org/browse/WFLY-9208 to add missing FilePermission.