### PR TITLE
[WFLY-9246]: discovery-group does not work for pooled-connection-factory because of NPE

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/JGroupsChannelLocator.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/JGroupsChannelLocator.java
@@ -1,12 +1,12 @@
 package org.wildfly.extension.messaging.activemq;
 
 import java.security.AccessController;
+import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
-import org.jgroups.JChannel;
 
 
 public class JGroupsChannelLocator {
@@ -14,13 +14,14 @@ public class JGroupsChannelLocator {
      * Callback used by ActiveMQ to locate a JChannel instance corresponding to the channel name
      * passed through the ActiveMQ RA property {@code channelRefName}
      */
-    public JChannel locateChannel(String channelRefName) {
+    public BroadcastEndpointFactory locateBroadcastEndpointFactory(String channelRefName) throws Exception {
         String[] split = channelRefName.split("/");
         String activeMQServerName = split[0];
         String channelName = split[1];
+        @SuppressWarnings("unchecked")
         ServiceController<ActiveMQServer> controller = (ServiceController<ActiveMQServer>) currentServiceContainer().getService(MessagingServices.getActiveMQServiceName(activeMQServerName));
         ActiveMQServerService service = (ActiveMQServerService) controller.getService();
-        return service.getChannels().get(channelName);
+        return service.getBroadcastEndpointFactory(channelName);
     }
 
     private static ServiceContainer currentServiceContainer() {


### PR DESCRIPTION
Creating a JChannel if it is configured but not already created when the locator is looking for it.

Jira: https://issues.jboss.org/browse/WFLY-9246
JBEAP: https://issues.jboss.org/browse/JBEAP-12778