### PR TITLE
Upgrade wildfly-maven-plugin and wildfly-arquillian to final versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Final</version.org.wildfly.core>
-        <version.org.wildfly.plugin>1.2.0.Alpha5</version.org.wildfly.plugin>
+        <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.http-client>1.0.1.Final</version.org.wildfly.http-client>
         <version.org.wildfly.maven.plugins>1.0.0</version.org.wildfly.maven.plugins>
         <version.org.wildfly.naming-client>1.0.1.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.picketlink>2.5.5.SP8</version.org.picketlink>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.wildfly.arquillian>2.1.0.Beta1</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Final</version.org.wildfly.core>


### PR DESCRIPTION
I've submitted these as one PR because wildfly-arquillian uses a core plugin feature of wildfly-maven-plugin. This just allows the tests to run with the correct versions of the wildfly-maven-plugin.

wildfly-maven-plugin: https://issues.jboss.org/browse/WFLY-9253
wildfly-arquillian: https://issues.jboss.org/browse/WFLY-9254