### PR TITLE
WFLY-9258 Test uses JMXConnector to check the lifespan and max-idle attribute values of a specific local-cache defined for hibernate cache-container

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/EntityInvalidationCacheRefTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/EntityInvalidationCacheRefTestCase.java
@@ -1,0 +1,66 @@
+package org.jboss.as.test.integration.hibernate.cache;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.hibernate.cache.entity.Employee;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.util.logging.Logger;
+
+import static org.jboss.as.cli.Util.DEPLOYMENT_NAME;
+
+/**
+ * Test uses JMXConnector to check the lifespan and max-idle attribute values of a specific local-cache defined for hibernate cache-container
+ *
+ * Test for [ JBEAP-10453 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(EntityInvalidationServerSetupTask.class)
+public class EntityInvalidationCacheRefTestCase {
+
+    private static final Logger log = Logger.getLogger(EntityInvalidationCacheRefTestCase.class.getName());
+
+    private static final String ARCHIVE_NAME = "EntityInvalidationCacheRefTestCase";
+    private static final String OBJECT_NAME = "jboss.as.expr:subsystem=infinispan,cache-container=hibernate,local-cache=entity-invalidation,component=expiration";
+
+    @Deployment(name = DEPLOYMENT_NAME)
+    public static JavaArchive createJarArchive() {
+        return ShrinkWrap
+                .create(JavaArchive.class, ARCHIVE_NAME + ".jar")
+                .addPackage(Employee.class.getPackage())
+                .addAsResource("org/jboss/as/test/integration/hibernate/cache/persistence.xml", "META-INF/persistence.xml");
+    }
+
+    @Test
+    @RunAsClient
+    public void testReferenceEntityInvalidationCache() throws Exception {
+        JMXConnector connector = null;
+        try {
+            JMXServiceURL address = new JMXServiceURL("service:jmx:remote+http://localhost:9990");
+            connector = JMXConnectorFactory.connect(address, null);
+            MBeanServerConnection mbs = connector.getMBeanServerConnection();
+
+            // find MBean with the object name related to newly created local-cache with component=expiration
+            ObjectInstance instance = mbs.getObjectInstance(new ObjectName(OBJECT_NAME));
+            Assert.assertEquals(mbs.getAttribute(instance.getObjectName(), "lifespan").toString(), "300000");
+            Assert.assertEquals(mbs.getAttribute(instance.getObjectName(), "maxIdle").toString(), "120000");
+            return;
+        } finally {
+            connector.close();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/EntityInvalidationServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/EntityInvalidationServerSetupTask.java
@@ -1,0 +1,64 @@
+package org.jboss.as.test.integration.hibernate.cache;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.dmr.ModelNode;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.ADD;
+import static org.jboss.as.controller.client.helpers.ClientConstants.ADDRESS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+/**
+ * Creates local-cache for hibernate cache-container and sets values of the lifespan and max-idle attributes
+ *
+ * @author Daniel Cihak
+ */
+public class EntityInvalidationServerSetupTask implements ServerSetupTask {
+
+    // /subsystem=infinispan/cache-container=hibernate/local-cache=entity-invalidation
+    private static ModelNode CACHE_ADDRESS;
+    private static ModelNode EXPIRATION_ADDRESS;
+
+    static {
+        CACHE_ADDRESS = new ModelNode();
+        CACHE_ADDRESS.add("subsystem", "infinispan");
+        CACHE_ADDRESS.add("cache-container", "hibernate");
+        CACHE_ADDRESS.add("local-cache", "entity-invalidation");
+    }
+
+    @Override
+    public void setup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
+        final ModelNode cacheAddOperation = new ModelNode();
+        cacheAddOperation.get(ADDRESS).set(CACHE_ADDRESS);
+        cacheAddOperation.get(OP).set(ADD);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), cacheAddOperation);
+
+        EXPIRATION_ADDRESS = CACHE_ADDRESS.add("component", "expiration");
+        System.out.println("EXPIRATION_ADDRESS: " + EXPIRATION_ADDRESS.toJSONString(true));
+        final ModelNode lifespanWriteOperation = new ModelNode();
+        lifespanWriteOperation.get(ADDRESS).set(EXPIRATION_ADDRESS);
+        lifespanWriteOperation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        lifespanWriteOperation.get(NAME).set("lifespan");
+        lifespanWriteOperation.get(VALUE).set(300000);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), lifespanWriteOperation);
+
+        final ModelNode maxIdleWriteOperation = new ModelNode();
+        maxIdleWriteOperation.get(ADDRESS).set(EXPIRATION_ADDRESS);
+        maxIdleWriteOperation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        maxIdleWriteOperation.get(NAME).set("max-idle");
+        maxIdleWriteOperation.get(VALUE).set(120000);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), maxIdleWriteOperation);
+    }
+
+    @Override
+    public void tearDown(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
+        final ModelNode cacheRemoveOperation = new ModelNode();
+        cacheRemoveOperation.get(ADDRESS).set(CACHE_ADDRESS);
+        cacheRemoveOperation.get(OP).set(REMOVE);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), cacheRemoveOperation);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/entity/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/entity/Employee.java
@@ -1,0 +1,56 @@
+package org.jboss.as.test.integration.hibernate.cache.entity;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Version;
+
+@Entity
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.TRANSACTIONAL, region="invalidation")
+public class Employee {
+    @Id
+    private String name;
+
+    @Version
+    private long oca;
+
+    private String title;
+
+    public Employee(String name, String title) {
+        this();
+        setName(name);
+        setTitle(title);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getOca() {
+        return oca;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    protected Employee() {
+        // this form used by Hibernate
+    }
+
+    protected void setName(String name) {
+        this.name = name;
+    }
+
+    protected void setOca(long oca) {
+        this.oca = oca;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/cache/persistence.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+	        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" version="2.1">
+    <persistence-unit name="jboss-eap-hibernate" transaction-type="JTA">
+        <provider>org.hibernate.ejb.HibernatePersistence</provider>
+
+        <!-- Use the default EAP (in-memory) datasource -->
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+
+        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode> <!-- Specify ENABLE_SELECTIVE to enable L2C for @Cacheable entities -->
+
+        <properties>
+            <!-- create, create-drop, update, validate -->
+            <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+
+            <!-- provides minimal SQL logging, see also TRACE logging -->
+            <property name="hibernate.show_sql" value="false" />
+
+            <property name="hibernate.generate_statistics" value="false"/> <!-- Hibernate/JPA Statistics -->
+
+            <!-- Infinispan Configuration -->
+            <property name="hibernate.cache.use_second_level_cache" value="true"/>
+            <property name="EntityInvalidationCacheRefTestCase.jar#jboss-eap-hibernate.invalidation.cfg" value="entity-invalidation"/>
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
WFLY-9258 Test uses JMXConnector to check the lifespan and max-idle attribute values of a specific local-cache defined for hibernate cache-container