### PR TITLE
[WFLY-9276] Avoid use of DefaultConsistentHashFactory for REPL caches.

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingsCacheBuilderProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingsCacheBuilderProvider.java
@@ -59,6 +59,8 @@ public class ClientMappingsCacheBuilderProvider implements CacheBuilderProvider,
             builders.add(new TemplateConfigurationBuilder(ServiceName.parse(InfinispanCacheRequirement.CONFIGURATION.resolve(containerName, cacheName)), containerName, cacheName, aliasCacheName, builder -> {
                 CacheMode mode = builder.clustering().cacheMode();
                 builder.clustering().cacheMode(mode.isClustered() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
+                // don't use DefaultConsistentHashFactory for REPL caches (WFLY-9276)
+                builder.clustering().hash().consistentHashFactory(null);
                 builder.clustering().l1().disable();
                 builder.persistence().clearStores();
             }));

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilderProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilderProvider.java
@@ -64,6 +64,8 @@ public class InfinispanRouteLocatorBuilderProvider implements RouteLocatorBuilde
         builders.add(new TemplateConfigurationBuilder(ServiceName.parse(InfinispanCacheRequirement.CONFIGURATION.resolve(containerName, serverName)), containerName, serverName, null, builder -> {
             CacheMode mode = builder.clustering().cacheMode();
             builder.clustering().cacheMode(mode.isClustered() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
+            // don't use DefaultConsistentHashFactory for REPL caches (WFLY-9276)
+            builder.clustering().hash().consistentHashFactory(null);
             builder.clustering().l1().disable();
             builder.persistence().clearStores();
         }));


### PR DESCRIPTION
This PR does the following:
* avoids use of DefaultConsistentHashFactory for a REPL cache based on a DIST cache configuration

See https://issues.jboss.org/browse/WFLY-9276 for details.