### PR TITLE
Wfly 8954 from master

### DIFF
--- a/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JBossAS7TransactionController.java
+++ b/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JBossAS7TransactionController.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.eclipselink;
+
+import javax.naming.NamingException;
+import javax.transaction.Synchronization;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+import org.eclipse.persistence.transaction.AbstractSynchronizationListener;
+import org.eclipse.persistence.transaction.jboss.JBossTransactionController;
+import org.jboss.logging.Logger;
+
+/**
+ * The transaction controller overrides some of the default behavior of eclipse
+ * link under the classes
+ * {@link org.eclipse.persistence.transaction.AbstractTransactionController} and
+ * {@link org.eclipse.persistence.transaction.JTATransactionController} to
+ * ensure that the unit of work synchronization is not taking place at too-late
+ * point in time.
+ *
+ * <P>
+ * REFERENCES: <br>
+ *
+ * <a href="https://issues.jboss.org/browse/WFLY-8954">Wildfly 10 with
+ * eclipselink Onscucess observer gets stale entity</a>
+ *
+ */
+public class JBossAS7TransactionController extends JBossTransactionController {
+
+    private static final Logger LOGGER = Logger.getLogger(JBossAS7TransactionController.class);
+
+    @Override
+    protected void registerSynchronization_impl(AbstractSynchronizationListener listener, Object txn) throws Exception {
+        try {
+            // (a) Our first approach is to register the listener on the
+            // transaction registry
+            // to ensure that this listener during the oncomplete phase of a
+            // transaction the weld CDI listener
+            registerSynchronizationUsingTransactionRegistry((Synchronization) listener);
+        } catch (Exception ingnoreE) {
+            // (b) Make sure that this error is made visible - we want the
+            // default approach to work 100% of the time - not just sometimes.
+            // We know that the fallback approach will yield us the bug
+            // See, WFLY-8954
+            // eclipselink will register the listener on the Transaction instead
+            // of on the TransactionRegistry
+            String errMsg = String.format(
+                    "Unexpected error took place while attempting to register the transaction listener: %1$s "
+                            + " in the container transaction registry. %n " + " Error was: %2$s. %n "
+                            + " As a fallback approach, we shall now attempt to register the transaction manager in the JTA transaction: %3$s. %n",
+                    listener.getClass().getCanonicalName(), ingnoreE.getMessage(), txn);
+            LOGGER.warn(errMsg, ingnoreE);
+            super.registerSynchronization_impl(listener, txn);
+        }
+    }
+
+    /**
+     * Register the jta transaction synchronization listener in the container's
+     * transaction registry.
+     *
+     * <P>
+     * Motivation: <br>
+     * There may be multiple transaction listeners that have an interest in
+     * binding to the life cycle of a jta transaction. In some cases, the order
+     * by which the listeners is triggered is not arbitrary. In particular, the
+     * eclipselink synchronization listener must always be executed before the
+     * CDI EJB event listener during the oncomplete phase of a JTA transaction.
+     * Otherwise, the CDI observers may be handling stale objects.
+     *
+     * @param listener
+     *            The listener will typically be the eclipselink
+     *            {@link org.eclipse.persistence.transaction.JTASynchronizationListener}
+     * @throws Exception
+     *             Unexpected error take plade either during the process of
+     *             lookup of the {@link TransactionSynchronizationRegistry} or
+     *             in the process of registering the listener.
+     */
+    protected void registerSynchronizationUsingTransactionRegistry(Synchronization listener) throws Exception {
+        TransactionSynchronizationRegistry transactionSynchronizationRegistry = JndiUtil.SINGLETON
+                .acquireTransactionSynchronizationRegistry();
+        transactionSynchronizationRegistry.registerInterposedSynchronization(listener);
+    }
+
+    // Jndi Resource acquisiation
+    @Override
+    protected TransactionManager acquireTransactionManager() throws Exception {
+        try {
+            // (a) The transaction manager is expected to be available in the
+            // jndi tree of the container
+            return JndiUtil.SINGLETON.acquireTransactionManager();
+        } catch (NamingException ex) {
+            // (b) Give indication of error and use a fall-back approach
+            // NOTE: the fall-back approach - should never be needed
+            LOGGER.error(ex.getMessage());
+            return super.acquireTransactionManager();
+        }
+    }
+
+}

--- a/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JndiConstants.java
+++ b/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JndiConstants.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.eclipselink;
+
+/**
+ * Holder of Jndi constants.
+ */
+public interface JndiConstants {
+
+    /**
+     * Jndi name to lookup the container transaction manager (e.g.
+     * com.arjuna.ats.jbossatx.jta.TransactionManagerDelegate).
+     *
+     * <P>
+     * The outcome of this lookup is expected to be an object of
+     * {@link javax.transaction.TransactionManager}
+     *
+     * @see javax.transaction.TransactionManager
+     */
+    String JBOSS_TRANSACTION_MANAGER = "java:jboss/TransactionManager";
+
+    /**
+     * Jndi name to lookup the container transaction synchronization registry
+     * (e.g.
+     * org.jboss.as.txn.service.internal.tsr.TransactionSynchronizationRegistryWrapper).
+     *
+     * <P>
+     * Motivation: <br>
+     * Eclipselink wishes to bind to specific life cycles of a JTA transaction,
+     * e.g. it cares about the completion of a transaction to synchronize
+     * changes on a unit of work with the server session cache. There are two
+     * ways by which eclipselink can do this. One is by registering using the
+     * {@link javax.transaction.Transaction#registerSynchronization(javax.transaction.Synchronization)}.
+     * This is the traditional approach followed by eclipselink. It has the
+     * disadvantage that it cannot guarantee that its logic will take place
+     * before, for example, the CDI Synchroinizaton components. <br>
+     * Another approach, is to register itself via
+     * {@link javax.transaction.TransactionSynchronizationRegistry#registerInterposedSynchronization(javax.transaction.Synchronization)}.
+     * This latter API would allow to prioritize the logic of the eclipselink
+     * synchronization on the container.
+     *
+     *
+     *
+     *
+     * <P>
+     * The outcome of this lookup is expected to be an object of
+     * {@link javax.transaction.TransactionSynchronizationRegistry}
+     *
+     * @see javax.transaction.TransactionSynchronizationRegistry
+     */
+    String JTA_TRANSACTION_SYNCHRONIZATION_REGISTRY = "java:jboss/TransactionSynchronizationRegistry";
+}

--- a/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JndiUtil.java
+++ b/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JndiUtil.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jipijapa.eclipselink;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+/**
+ * Helper class that centralizes the jndi lookup logic.
+ */
+public final class JndiUtil {
+
+    public static final JndiUtil SINGLETON = new JndiUtil();
+
+    /**
+     * Create a new JndiUtil.
+     */
+    private JndiUtil() {
+
+    }
+
+    /**
+     * Obtain the container transaction manager.
+     *
+     * @return The container transaction manager (e.g.
+     *         com.arjuna.ats.jbossatx.jta.TransactionManagerDelegate)
+     * @throws Exception
+     *             Unexpected error takes place during jndi lookup
+     */
+    public TransactionManager acquireTransactionManager() throws Exception {
+        try {
+            return InitialContext.doLookup(JndiConstants.JBOSS_TRANSACTION_MANAGER);
+        } catch (NamingException ex) {
+            String errMsg = createErrMsgForFailedJndiLookup(ex, JndiConstants.JBOSS_TRANSACTION_MANAGER);
+            throw new Exception(errMsg, ex);
+        }
+    }
+
+    /**
+     * Obtain the transaction synchronization registry from the container via
+     * jndi lookup.
+     *
+     * @return The transaction synchronization registry (e.g.
+     *         org.jboss.as.txn.service.internal.tsr.TransactionSynchronizationRegistryWrapper)
+     *
+     * @throws Exception
+     *             A checked exception is fired whenever an unexpected error
+     *             takes place (e.g. the jndi lookup of
+     *             {@link JndiConstants#JTA_TRANSACTION_SYNCHRONIZATION_REGISTRY}
+     *             fails)
+     */
+    public TransactionSynchronizationRegistry acquireTransactionSynchronizationRegistry() throws Exception {
+        try {
+            return InitialContext.doLookup(JndiConstants.JTA_TRANSACTION_SYNCHRONIZATION_REGISTRY);
+        } catch (NamingException ex) {
+            // (a) Build an error message
+            // note: in this case we do not log the erro - since pump up an
+            // exception
+            // there is no need to do log spamming
+            String errMsg = createErrMsgForFailedJndiLookup(ex, JndiConstants.JTA_TRANSACTION_SYNCHRONIZATION_REGISTRY);
+
+            // (b) Attempt break the execution logic accessing this resource is
+            // critical.
+            throw new Exception(errMsg, ex);
+        }
+    }
+
+    /**
+     * Build an error message giving an indication that a resource expected to
+     * exist in the container and be accessible via jndi lookup was not found.
+     *
+     * @param namingException
+     *            A jndi lookup error
+     * @param jndiLookupName
+     *            The jndi name that could not be looked up
+     * @return An indicative error message
+     */
+    private String createErrMsgForFailedJndiLookup(NamingException namingException, String jndiLookupName) {
+        return String.format(
+                "Unexpected error took place while attempting to lookup the container TransactionSynchronizationRegistry. %n"
+                        + " Jndi-lookup-name: %1$s %n" + " Error was: %2$s. ",
+                jndiLookupName, namingException.getMessage());
+
+    }
+
+}

--- a/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/WildFlyServerPlatform.java
+++ b/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/WildFlyServerPlatform.java
@@ -22,7 +22,6 @@
 
 package org.jipijapa.eclipselink;
 
-import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import javax.transaction.TransactionManager;
 
@@ -31,10 +30,11 @@ import org.eclipse.persistence.sessions.DatabaseSession;
 import org.eclipse.persistence.transaction.jboss.JBossTransactionController;
 
 /**
- * The fully qualified name of WildFlyServerPlatform must be set as the value
- * of the eclipselink.target-server property on EclipseLink version 2.3.2 and
- * older. In newer versions where bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=365704
- * has been fixed, setting eclipselink.target-server to "jboss" is sufficient.
+ * The fully qualified name of WildFlyServerPlatform must be set as the value of
+ * the eclipselink.target-server property on EclipseLink version 2.3.2 and
+ * older. In newer versions where bug
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=365704 has been fixed, setting
+ * eclipselink.target-server to "jboss" is sufficient.
  *
  * @author Craig Ringer <ringerc@ringerc.id.au>
  *
@@ -47,17 +47,27 @@ public class WildFlyServerPlatform extends JBossPlatform {
 
     @Override
     public Class<?> getExternalTransactionControllerClass() {
-        return JBossAS7TransactionController.class;
+        return org.jipijapa.eclipselink.JBossAS7TransactionController.class;
     }
 
+    /**
+     * This class is not to be used because it will register the eclipselink
+     * transaction listener using the wrong approach for wildfly.
+     *
+     * @deprecated See
+     *             <a href="https://issues.jboss.org/browse/WFLY-8954">Wildfly
+     *             10 with eclipselink Onscucess observer gets stale entity</a>
+     *             The
+     *             {@link org.jipijapa.eclipselink.JBossAS7TransactionController}
+     *             should be used instead
+     */
+    @Deprecated
     public static class JBossAS7TransactionController extends JBossTransactionController {
-
-        private static final String JBOSS_TRANSACTION_MANAGER = "java:jboss/TransactionManager";
 
         @Override
         protected TransactionManager acquireTransactionManager() throws Exception {
             try {
-                return InitialContext.doLookup(JBOSS_TRANSACTION_MANAGER);
+                return JndiUtil.SINGLETON.acquireTransactionManager();
             } catch (NamingException ex) {
                 return super.acquireTransactionManager();
             }

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -59,6 +59,17 @@
     	Compile-time dependencies upon anything in the WildFly runtime are allowed in this section.
     -->
     <dependencies>
+            
+         <dependency>
+            <!-- FIXME: 
+                This library is added to give access to import javax.enterprise.event.Event
+                The appropriate dependency to use for this that is already managed in a parent pom is no known so for now we put this.
+               -->
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <scope>provided</scope>
+            <version>7.0</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/DeleteMeTest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/DeleteMeTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+import org.jboss.as.test.compat.jpa.eclipselink.EclipseLinkSharedModuleProviderTestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This base class is based on the {@link EclipseLinkSharedModuleProviderTestCase}
+ *
+ */
+public class DeleteMeTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteMeTest.class);
+
+    @Test
+    public void dummyTest() throws Exception {
+        String persistenceXml = PersistenceXmlHelper.SINGLETON.getWFLY8954BaseTestPersistenceXml();
+        LOGGER.info(persistenceXml);
+
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/EjbThatModifiesEntityAndFiresEventLocalFacade.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/EjbThatModifiesEntityAndFiresEventLocalFacade.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+import static java.lang.String.format;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.jboss.as.test.compat.jpa.eclipselink.Employee;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An ejb whose pupose is to modify a value on an existing entity and fire out an event that this action has been done.
+ */
+@LocalBean
+@Stateful
+public class EjbThatModifiesEntityAndFiresEventLocalFacade {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EjbThatModifiesEntityAndFiresEventLocalFacade.class);
+
+    /**
+     * Each time we modify an address we will build an incrementing address number. This will make it very obvious if we are
+     * dealing with a stale value or not.
+     */
+    private static final AtomicInteger CURRENT_ADDRESS_MODIFICATION_NUMBER = new AtomicInteger(0);
+
+    @PersistenceContext(unitName = "hibernate3_pc")
+    EntityManager em;
+
+    @Inject
+    Event<SomeEntityChangeEvent> someEntityChangeEvent;
+
+    /**
+     * Opens a new jta transaction, modifies an entity by increasing its address and finally fires an event.
+     *
+     * @param employeePrimaryKey
+     *
+     *        the primary key of the entity to be updated.
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void modifyEmployeedAddressAndFireAChangeEvent(int employeePrimaryKey) {
+        // (a) load the entity we want to update
+        Employee entityToUpdate = em.find(Employee.class, Integer.valueOf(employeePrimaryKey));
+        if (entityToUpdate == null) {
+            throw new RuntimeException(format("No employee etity could be found with id: %1$s", employeePrimaryKey));
+        }
+
+        // (b) Before we update the entity we prepare the state variables that will go into the update event
+        // and make some noise on the log
+        String oldAddress = entityToUpdate.getAddress();
+        String newAddress = getIncrementedAddressNumber();
+        LOGGER.info("Going to update employee: {} to have its address change from: {} -> to:  {}", employeePrimaryKey, oldAddress, newAddress);
+
+        // (c) So now we do our change
+        entityToUpdate.setAddress(newAddress);
+
+        // (f) We inform the interested parties that this employeed just got its address updated to some new incremented address
+        SomeEntityChangeEvent eventToFire = new SomeEntityChangeEvent(oldAddress, newAddress, Integer.valueOf(employeePrimaryKey));
+        someEntityChangeEvent.fire(eventToFire);
+    }
+
+    /**
+     *
+     * @return a string of the form "IncrementAddressNumber: 1"
+     */
+    protected String getIncrementedAddressNumber() {
+        return format("IncrementAddressNumber: %1$s ", CURRENT_ADDRESS_MODIFICATION_NUMBER.incrementAndGet());
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/PersistenceXmlHelper.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/PersistenceXmlHelper.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.jboss.as.test.compat.util.SystemTestStringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This factory allows us to build strings representing the persistence.xml files.
+ */
+public class PersistenceXmlHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceXmlHelper.class);
+
+    public static PersistenceXmlHelper SINGLETON = new PersistenceXmlHelper();
+
+    private PersistenceXmlHelper() {
+
+    }
+
+    /**
+     * Reurn a persistence xml as string.
+     *
+     * <P>
+     * NOTE: <br>
+     * The persistence.xml is to be found src/test/resources under the appropriate package.
+     *
+     *
+     * @return A string that can conveniently be wrapped into a String resource to be assembled into a progrmatic war file.
+     */
+    public String getWFLY8954BaseTestPersistenceXml() {
+        // (a) Build up a folder classpath - path
+        String packageWithFowardSlashes = WFLY8954BaseTest.class.getPackage().getName().replaceAll("[.]", "/");
+        // (b) Build up a classpath search expression
+        String clasppathSearchPath = String.format("/%1$s/persistence.xml", packageWithFowardSlashes);
+        // (c) Search the classpath for the persistence xml we want to use in our test
+        URL pathToPersistenceXml = WFLY8954BaseTest.class.getResource(clasppathSearchPath);
+        if (pathToPersistenceXml == null) {
+            String errMsg = String.format("Could not find classpath resource: %1$s", pathToPersistenceXml);
+            throw new RuntimeException(errMsg);
+        }
+        LOGGER.info("Going to use the persistence.xml located at {} for system test. ", pathToPersistenceXml);
+
+        // (d) trivially read the file into a string
+        File fileToRead = new File(mapUrlToTuri(pathToPersistenceXml));
+        return SystemTestStringUtil.SINGLETON.getFileAsString(fileToRead);
+    }
+
+    /**
+     * Wrapper method to save us from anoying try catch blocks.
+     *
+     * @param url url to convert to uri
+     * @return uri associated to url
+     */
+    private URI mapUrlToTuri(URL url) {
+        try {
+            return url.toURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/PersistenceXmlHelperTest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/PersistenceXmlHelperTest.java
@@ -31,9 +31,9 @@ import org.slf4j.LoggerFactory;
  * This base class is based on the {@link EclipseLinkSharedModuleProviderTestCase}
  *
  */
-public class DeleteMeTest {
+public class PersistenceXmlHelperTest {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteMeTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceXmlHelperTest.class);
 
     @Test
     public void dummyTest() throws Exception {

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/SomeEntityChangeEvent.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/SomeEntityChangeEvent.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+/**
+ * This event here is interesting because it will be reporting the old value that existed on an entity and the new value that
+ * should have been committed. With this information we can determine if we are dealing with a stale entity. A stale entity will
+ * show us the old value.
+ */
+class SomeEntityChangeEvent {
+
+    final String oldValue;
+    final String newValue;
+    final Integer someEntityId;
+
+    /**
+     * Create a new SomeEntityChangeEvent.
+     *
+     * @param oldValue
+     * @param newValue
+     * @param someEntityId
+     */
+    public SomeEntityChangeEvent(String oldValue, String newValue, Integer someEntityId) {
+        super();
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+        this.someEntityId = someEntityId;
+    }
+
+    public String getOldValue() {
+        return oldValue;
+    }
+
+    public String getNewValue() {
+        return newValue;
+    }
+
+    public Integer getSomeEntityId() {
+        return someEntityId;
+    }
+
+    /**
+     * Check if we are being given a stale value.
+     *
+     * <P>
+     * NOTE: <br>
+     * To ensure the value passed is read from the shared cache, ensure that the business transaction that is observing the
+     * event is behind a transaction requires new. This will ensure that eclipselink first level cache must be empty an when an
+     * entity is fetched by its primary key the entiy is coming from the shared/session cache.
+     *
+     * @param valueReadFromSharedCache an arbitrary value we want to compare to the "new value" that should be found on the
+     *        entity.
+     *
+     * @return TRUE - if the value given is not the same as the new value on the event. This would most likely be an indication
+     *         that the value in hand is stale.
+     *
+     */
+    public boolean isValueReadFromSharedCacheStale(String valueReadFromSharedCache) {
+        return !newValue.equals(valueReadFromSharedCache);
+    }
+
+    @Override
+    public String toString() {
+        return "SomeEntityChangeEvent [oldValue=" + oldValue + ", newValue=" + newValue + ", someEntityId=" + someEntityId + "]";
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/SomeEntityChangeEventObserverFacade.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/SomeEntityChangeEventObserverFacade.java
@@ -1,0 +1,114 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+import javax.ejb.Singleton;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.event.Observes;
+import javax.enterprise.event.TransactionPhase;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.jboss.as.test.compat.jpa.eclipselink.Employee;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observe the event and report
+ */
+@Singleton
+public class SomeEntityChangeEventObserverFacade {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SomeEntityChangeEventObserverFacade.class);
+
+    // state that will be updated once the on success transaction is obseved
+    /**
+     * Intialize the bean state to bug not detected. Once the system tests fires the event this value might change to true if
+     * the bug gets detected.
+     */
+    private boolean bugDetected = false;
+    private SomeEntityChangeEvent lastProcessedSomeEntityChangeEvent = null;
+    private String lastProcessedEntityAddressBeforeExecutingRefresh = null;
+    private String lastProcessedEntityAddressAfterExecutingRefresh = null;
+
+    @PersistenceContext(unitName = "hibernate3_pc")
+    EntityManager em;
+
+    /**
+     * In this test we check if the requires new annotation in the observer is effective. in our application this is not the
+     * case, and we were forced into using the executor facade to be able to open a new transaction context.
+     *
+     * Here it seems to be effective.
+     *
+     */
+    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
+    public void observeEvent(
+        @Observes(during = TransactionPhase.AFTER_SUCCESS) SomeEntityChangeEvent someEntityChangeEvent) {
+
+        // (a) we start by fetching the entity that should be found on the eclipse link shared cache (no db access needed)
+        Integer employeePrimaryKey = someEntityChangeEvent.getSomeEntityId();
+        Employee entity = em.find(Employee.class, employeePrimaryKey);
+
+        // (b) Now we see what value we have to the address
+        String entityAddressBeforeExecutingRefresh = entity.getAddress();
+        boolean eventBelieveWeHaveStaleData = someEntityChangeEvent.isValueReadFromSharedCacheStale(entityAddressBeforeExecutingRefresh);
+        if (eventBelieveWeHaveStaleData) {
+            LOGGER.error("According to event: {}  we are currently holding stale data. address value on enitity fetached from shared cache was: {}. This value is stale. ",
+                someEntityChangeEvent, entityAddressBeforeExecutingRefresh);
+        }
+
+        // (c) Now we refresh the entity - which should force querying the DB to get fresh new data
+        em.refresh(entity);
+        String entityAddressAfterExecutingRefresh = entity.getAddress();
+
+        LOGGER.info(
+            "Before Refresh value was: {}, After Refresh: {}. The NEW Value on entity passed by event object - which must be the accurate value - was: {} ",
+            entityAddressBeforeExecutingRefresh, entityAddressAfterExecutingRefresh, someEntityChangeEvent.getNewValue());
+        if (!entityAddressAfterExecutingRefresh.equals(entityAddressBeforeExecutingRefresh)) {
+            LOGGER.error(
+                "NOT OK - BUG DETECTED - Wildfly ON_SUCCESS handling observing stale entity that does not match what transaction persisted."
+                    + " Entity Address before refresh: {} And After Refresh: {} For Employee: {} ",
+                entityAddressBeforeExecutingRefresh, entityAddressAfterExecutingRefresh, employeePrimaryKey);
+            bugDetected = true;
+        } else {
+            LOGGER.info(
+                " OK - The entity remained unchanged before and after refresh. Before Refresh value was: {}, After Refresh: {} ",
+                entityAddressBeforeExecutingRefresh, entityAddressAfterExecutingRefresh);
+            bugDetected = false;
+        }
+
+        // (d) Update the state of the singleton with the metadata about the last processed event
+        // can be useful for the test fire an assertion erro
+        lastProcessedSomeEntityChangeEvent = someEntityChangeEvent;
+        lastProcessedEntityAddressBeforeExecutingRefresh = entityAddressBeforeExecutingRefresh;
+        lastProcessedEntityAddressAfterExecutingRefresh = entityAddressAfterExecutingRefresh;
+    }
+
+    /**
+     * @return TRUE if the bug has been detected.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public boolean isBugDetected() {
+        return bugDetected;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public SomeEntityChangeEvent getLastProcessedSomeEntityChangeEvent() {
+        return lastProcessedSomeEntityChangeEvent;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public String getLastProcessedEntityAddressBeforeExecutingRefresh() {
+        return lastProcessedEntityAddressBeforeExecutingRefresh;
+    }
+
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public String getLastProcessedEntityAddressAfterExecutingRefresh() {
+        return lastProcessedEntityAddressAfterExecutingRefresh;
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/WFLY8954BaseTest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/WFLY8954BaseTest.java
@@ -54,21 +54,6 @@ public class WFLY8954BaseTest {
 
     private static final String ARCHIVE_NAME = "toplink_module_test";
 
-    private static final String persistence_xml =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
-            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
-            "  <persistence-unit name=\"hibernate3_pc\">" +
-            "<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>" +
-            "    <description>TopLink Persistence Unit." +
-            "    </description>" +
-            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
-            "  <properties>" +
-            "  <property name=\"jboss.as.jpa.providerModule\" value=\"org.eclipse.persistence:test\"/>" +
-            "  <property name=\"eclipselink.ddl-generation\" value=\"drop-and-create-tables\"/>" +
-            "  </properties>" +
-            "  </persistence-unit>" +
-            "</persistence>";
-
     @ArquillianResource
     private static InitialContext iniCtx;
 
@@ -84,7 +69,8 @@ public class WFLY8954BaseTest {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
 
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
-        // NOTE: PersistenceXmlHelper - should not beed be deployed - but it is a test class dependency for test preparation
+        // NOTE: PersistenceXmlHelper - should not beed be deployed - but it is a test class dependency for test
+        // preparation
         lib.addClass(PersistenceXmlHelper.class);
         lib.addClasses(BasicJndiUtil.class);
 
@@ -104,7 +90,8 @@ public class WFLY8954BaseTest {
         lib.addClasses(Employee.class);
 
         // lib.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
-        lib.addAsManifestResource(new StringAsset(PersistenceXmlHelper.SINGLETON.getWFLY8954BaseTestPersistenceXml()), "persistence.xml");
+        lib.addAsManifestResource(new StringAsset(PersistenceXmlHelper.SINGLETON.getWFLY8954BaseTestPersistenceXml()),
+                "persistence.xml");
         ear.addAsLibraries(lib);
 
         final WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
@@ -124,7 +111,8 @@ public class WFLY8954BaseTest {
         sfsb1.createEmployee("Kelly Smith", "Initial Address Value. ", employeePrimaryKey);
 
         // (b) Execute the bug step
-        // This consists on modifying an entity, making it be observed, and verify if the enityt on th observes reflects the
+        // This consists on modifying an entity, making it be observed, and verify if the enityt on th observes reflects
+        // the
         // committed state
         EjbThatModifiesEntityAndFiresEventLocalFacade ejbThatWillModifyAndFireEvent = jndiLookupEjbThatModifiesEntityAndFiresEventLocalFacade();
         ejbThatWillModifyAndFireEvent.modifyEmployeedAddressAndFireAChangeEvent(employeePrimaryKey);
@@ -132,16 +120,22 @@ public class WFLY8954BaseTest {
         // (c) Now we check the results of the test
         // either the observer get a stale entity or an entity that reflects the db changes
         SomeEntityChangeEventObserverFacade singletonObserver = jndiLookupSomeEntityChangeEventObserverFacade();
-        String lastProcessedEntityAddressBeforeExecutingRefresh = singletonObserver.getLastProcessedEntityAddressBeforeExecutingRefresh();
-        String lastProcessedEntityAddressAfterExecutingRefresh = singletonObserver.getLastProcessedEntityAddressAfterExecutingRefresh();
+        String lastProcessedEntityAddressBeforeExecutingRefresh = singletonObserver
+                .getLastProcessedEntityAddressBeforeExecutingRefresh();
+        String lastProcessedEntityAddressAfterExecutingRefresh = singletonObserver
+                .getLastProcessedEntityAddressAfterExecutingRefresh();
         SomeEntityChangeEvent changeEvent = singletonObserver.getLastProcessedSomeEntityChangeEvent();
         boolean isBugDetected = singletonObserver.isBugDetected();
         if (isBugDetected) {
-            String arrsetionError = String.format("The observer bug has been tected. The context is: %n "
-                + "EVENT OBSERVED: %1$s %n"
-                + "lastProcessedEntityAddressBeforeExecutingRefresh: %2$s "
-                + "lastProcessedEntityAddressAfterExecutingRefresh: %3$s ", changeEvent, lastProcessedEntityAddressBeforeExecutingRefresh,
-                lastProcessedEntityAddressAfterExecutingRefresh);
+            String arrsetionError = String.format(
+                    "The observer bug has been detected.%n" + "The context is: %n " + "EVENT OBSERVED: %1$s %n"
+                            + "lastProcessedEntityAddressBeforeExecutingRefresh: %2$s %n"
+                            + "lastProcessedEntityAddressAfterExecutingRefresh: %3$s %n"
+                            + " If the bug was not present, we would expect that refreshing the entity would have no effect. %n"
+                            + " When the bug is present, refreshing the entity has an effect because the unit of work cache has not yet been merged to the session cache"
+                            + " but the changes have already been committed to the database. ",
+                    changeEvent, lastProcessedEntityAddressBeforeExecutingRefresh,
+                    lastProcessedEntityAddressAfterExecutingRefresh);
             Assert.fail(arrsetionError);
         }
     }
@@ -151,7 +145,8 @@ public class WFLY8954BaseTest {
      * @return A stateless ejb that can help us create entities
      */
     protected SFSB1 jndiLookupSFB1() {
-        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, SFSB1.class.getSimpleName(), SFSB1.class);
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, SFSB1.class.getSimpleName(),
+                SFSB1.class);
     }
 
     /**
@@ -159,13 +154,14 @@ public class WFLY8954BaseTest {
      * @return A stateless ejb that can help us reproduce the issue of we are trying to validate
      */
     protected EjbThatModifiesEntityAndFiresEventLocalFacade jndiLookupEjbThatModifiesEntityAndFiresEventLocalFacade() {
-        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, EjbThatModifiesEntityAndFiresEventLocalFacade.class.getSimpleName(),
-            EjbThatModifiesEntityAndFiresEventLocalFacade.class);
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME,
+                EjbThatModifiesEntityAndFiresEventLocalFacade.class.getSimpleName(),
+                EjbThatModifiesEntityAndFiresEventLocalFacade.class);
     }
 
     protected SomeEntityChangeEventObserverFacade jndiLookupSomeEntityChangeEventObserverFacade() {
-        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, SomeEntityChangeEventObserverFacade.class.getSimpleName(),
-            SomeEntityChangeEventObserverFacade.class);
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME,
+                SomeEntityChangeEventObserverFacade.class.getSimpleName(), SomeEntityChangeEventObserverFacade.class);
     }
 
 }

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/WFLY8954BaseTest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/WFLY8954BaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.eclipselink.wildfly8954;
+
+import static org.junit.Assume.assumeTrue;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.compat.jpa.eclipselink.EclipseLinkSharedModuleProviderTestCase;
+import org.jboss.as.test.compat.jpa.eclipselink.Employee;
+import org.jboss.as.test.compat.jpa.eclipselink.SFSB1;
+import org.jboss.as.test.compat.util.BasicJndiUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This base class is based on the {@link EclipseLinkSharedModuleProviderTestCase}
+ *
+ */
+@RunWith(Arquillian.class)
+public class WFLY8954BaseTest {
+
+    private static final String ARCHIVE_NAME = "toplink_module_test";
+
+    private static final String persistence_xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " +
+            "<persistence xmlns=\"http://java.sun.com/xml/ns/persistence\" version=\"1.0\">" +
+            "  <persistence-unit name=\"hibernate3_pc\">" +
+            "<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>" +
+            "    <description>TopLink Persistence Unit." +
+            "    </description>" +
+            "  <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>" +
+            "  <properties>" +
+            "  <property name=\"jboss.as.jpa.providerModule\" value=\"org.eclipse.persistence:test\"/>" +
+            "  <property name=\"eclipselink.ddl-generation\" value=\"drop-and-create-tables\"/>" +
+            "  </properties>" +
+            "  </persistence-unit>" +
+            "</persistence>";
+
+    @ArquillianResource
+    private static InitialContext iniCtx;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        iniCtx = new InitialContext();
+    }
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        // (a) Create an .ear file
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
+        // NOTE: PersistenceXmlHelper - should not beed be deployed - but it is a test class dependency for test preparation
+        lib.addClass(PersistenceXmlHelper.class);
+        lib.addClasses(BasicJndiUtil.class);
+
+        // Add ejbs:
+        // 1. An ejb that allows us to create employees
+        lib.addClasses(SFSB1.class);
+        // 2. An ejb that will modify and fire an event
+        lib.addClass(EjbThatModifiesEntityAndFiresEventLocalFacade.class);
+        // 3. Add the event to be fired
+        lib.addClass(SomeEntityChangeEvent.class);
+        // 4. Add the observer of the event that will get a stale entity
+        lib.addClass(SomeEntityChangeEventObserverFacade.class);
+        // Pump the jar file into the EAR/lib
+        ear.addAsModule(lib);
+
+        lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
+        lib.addClasses(Employee.class);
+
+        // lib.addAsManifestResource(new StringAsset(persistence_xml), "persistence.xml");
+        lib.addAsManifestResource(new StringAsset(PersistenceXmlHelper.SINGLETON.getWFLY8954BaseTestPersistenceXml()), "persistence.xml");
+        ear.addAsLibraries(lib);
+
+        final WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
+        main.addClasses(WFLY8954BaseTest.class);
+        ear.addAsModule(main);
+
+        return ear;
+    }
+
+    @Test
+    public void testSimpleCreateAndLoadEntities() throws Exception {
+        assumeTrue(System.getSecurityManager() == null); // ignore test if System.getSecurityManager() returns non-null
+
+        // (a) Start by creating an employeed entity
+        SFSB1 sfsb1 = jndiLookupSFB1();
+        final Integer employeePrimaryKey = 10;
+        sfsb1.createEmployee("Kelly Smith", "Initial Address Value. ", employeePrimaryKey);
+
+        // (b) Execute the bug step
+        // This consists on modifying an entity, making it be observed, and verify if the enityt on th observes reflects the
+        // committed state
+        EjbThatModifiesEntityAndFiresEventLocalFacade ejbThatWillModifyAndFireEvent = jndiLookupEjbThatModifiesEntityAndFiresEventLocalFacade();
+        ejbThatWillModifyAndFireEvent.modifyEmployeedAddressAndFireAChangeEvent(employeePrimaryKey);
+
+        // (c) Now we check the results of the test
+        // either the observer get a stale entity or an entity that reflects the db changes
+        SomeEntityChangeEventObserverFacade singletonObserver = jndiLookupSomeEntityChangeEventObserverFacade();
+        String lastProcessedEntityAddressBeforeExecutingRefresh = singletonObserver.getLastProcessedEntityAddressBeforeExecutingRefresh();
+        String lastProcessedEntityAddressAfterExecutingRefresh = singletonObserver.getLastProcessedEntityAddressAfterExecutingRefresh();
+        SomeEntityChangeEvent changeEvent = singletonObserver.getLastProcessedSomeEntityChangeEvent();
+        boolean isBugDetected = singletonObserver.isBugDetected();
+        if (isBugDetected) {
+            String arrsetionError = String.format("The observer bug has been tected. The context is: %n "
+                + "EVENT OBSERVED: %1$s %n"
+                + "lastProcessedEntityAddressBeforeExecutingRefresh: %2$s "
+                + "lastProcessedEntityAddressAfterExecutingRefresh: %3$s ", changeEvent, lastProcessedEntityAddressBeforeExecutingRefresh,
+                lastProcessedEntityAddressAfterExecutingRefresh);
+            Assert.fail(arrsetionError);
+        }
+    }
+
+    /**
+     *
+     * @return A stateless ejb that can help us create entities
+     */
+    protected SFSB1 jndiLookupSFB1() {
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, SFSB1.class.getSimpleName(), SFSB1.class);
+    }
+
+    /**
+     *
+     * @return A stateless ejb that can help us reproduce the issue of we are trying to validate
+     */
+    protected EjbThatModifiesEntityAndFiresEventLocalFacade jndiLookupEjbThatModifiesEntityAndFiresEventLocalFacade() {
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, EjbThatModifiesEntityAndFiresEventLocalFacade.class.getSimpleName(),
+            EjbThatModifiesEntityAndFiresEventLocalFacade.class);
+    }
+
+    protected SomeEntityChangeEventObserverFacade jndiLookupSomeEntityChangeEventObserverFacade() {
+        return BasicJndiUtil.SINGLETON.lookupEjbWithinEar(iniCtx, ARCHIVE_NAME, SomeEntityChangeEventObserverFacade.class.getSimpleName(),
+            SomeEntityChangeEventObserverFacade.class);
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/util/BasicJndiUtil.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/util/BasicJndiUtil.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.util;
+
+import static java.lang.String.format;
+
+import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+
+import org.jboss.as.test.compat.jpa.eclipselink.wildfly8954.PersistenceXmlHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class that allows us to interact with the wildfly jndi registered objects.
+ */
+public class BasicJndiUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceXmlHelper.class);
+
+    public static BasicJndiUtil SINGLETON = new BasicJndiUtil();
+
+    private static final String JNDI_ROOT_NAME = "";
+    private static final int ROOT_DEPTH_ZERO = 0;
+    private static final String FOUR_SPACES_STR = "    ";
+
+    private BasicJndiUtil() {
+    }
+
+    /**
+     * Lookup an EJB deployed with an EAR.
+     *
+     * @param initialContext the initial context of the container where we can hunt for our deployed ejbs
+     * @param earName the name of the enterprise application archieve containing the ejbs
+     * @param beanName the jndi bean name (e.g. SFSB1)
+     * @param interfaceType the business interface (e.g. the local or remote interface) offered by the ejb
+     * @return The desired ejb if it can be found, otherwise a runtime excpetion shall be fired up
+     */
+    public <T> T lookupEjbWithinEar(InitialContext initialContext, String earName, String beanName, Class<T> interfaceType) {
+        // (a) Setup a jndi portable name to find the deployed component
+        String ejbJndiPortableName = String.format("java:global/%1$s/beans/%2$s!%3$s",
+            // 1, 2, 3
+            earName, beanName, interfaceType.getCanonicalName());
+        try {
+            // (b) Execute the jndi lookup and cast it out to the expected bean type
+            return interfaceType.cast(initialContext.lookup(ejbJndiPortableName));
+        } catch (Exception e) {
+            // (c) Jndi has gone wrong - safely dump the jndi tree
+            dumpFullJndiTree(initialContext);
+
+            // (d) ensure that the excpetion that caused us to come here gets reported
+            String errMsg = String.format("Unexpected error took place while attempting to lookup deployed ejb: %1$s. %n%n"
+                + "Error was: %2$s.", ejbJndiPortableName, e.getMessage());
+            throw new RuntimeException(errMsg, e);
+        }
+    }
+
+    /**
+     * Dumps the full jndi tree, starting from the root element.
+     *
+     * <P>
+     * For example: <br>
+     * {@code
+     *  depth: [0]  jndiName: []
+            depth: [1]  jndiName: [TransactionManager]
+     * }
+     */
+    public void dumpFullJndiTree(InitialContext initialContext) {
+        StringBuilder stringBuilder = new StringBuilder();
+        try {
+            dumpTreeEntryListRecursive(stringBuilder, initialContext, JNDI_ROOT_NAME, ROOT_DEPTH_ZERO);
+            LOGGER.info("JNDI DUMP: {} ", stringBuilder.toString());
+        } catch (Exception ignoreE) {
+            LOGGER.error("Unexpected error took place while attempting to dump out the jndi tree: {} ", ignoreE.getMessage(), ignoreE);
+        }
+    }
+
+    /**
+     * Prints the current element to expand, and recursively expands all of the child jndi element names.
+     *
+     * @param sbuild The string builder object that is being pumped with jndi name print statements - shall be logged in the end
+     * @param initialContext The initial jndi context that we use to do our jndi lookups / listings
+     * @param list The list of jndi names to be expanded on the current iteration
+     * @param jndiName The current jndi name to expand
+     * @param currentDepth A value ranging from 0 to N, where 0 is for the root name "" and the rest N is equal to the name of /
+     *        slashes in the jndi name + 1. It creases each time we go depper in the recursion.
+     * @throws NamingException a jndi lookup error
+     */
+    private void dumpTreeEntryListRecursive(StringBuilder sbuild, InitialContext initialContext, String jndiName, int currentDepth) throws NamingException {
+        // (a) Start by printing out the current jndi name being exapnded
+        sbuild.append(format("%n"));
+        sbuild.append(createStringWithSpaces(currentDepth));
+        String currentNode = String.format("depth: [%1$s]  jndiName: [%2$s] ", currentDepth, jndiName);
+        sbuild.append(currentNode);
+
+        // (b) Load all of the child jndi names
+        NamingEnumeration<NameClassPair> childJndiNames = safelyGetChildElements(initialContext, jndiName);
+        if (childJndiNames == null) {
+            // we have reach a leaf element, we cannot co any deeper with this name
+            return;
+        }
+
+        // (c) Loop over each of the jndi child elements for the current name
+        while (childJndiNames.hasMore()) {
+            // (i) load the current child element
+            NameClassPair currentChildJndiName = childJndiNames.next();
+
+            // (ii) Determine what the next jndi name should be like
+            String nextJndiName = JNDI_ROOT_NAME.equals(jndiName) ?
+            // - This is the very first iteration when we are deling with ""
+                currentChildJndiName.getName()
+                // - This is the default cause when we are going deeper and deep
+                : String.format("%1$s/%2$s", jndiName, currentChildJndiName.getName());
+
+            // (iii) Go deeper with the recursion and attempt to exapnd the next jndi name
+            int nextDepth = currentDepth + 1;
+            dumpTreeEntryListRecursive(sbuild, initialContext, nextJndiName, nextDepth);
+        }
+    }
+
+    /**
+     * Not every jndi name can be listed, because not every jndi name represents a naming context. Some will correspond to non
+     * listable objects. In case of for example, javax.naming.NotContextException: TransactionManager, we want to return an
+     * empty list (the node is a leaf).
+     *
+     * @param initialContext the initial context to help us list the name
+     * @param jndiNameToExpand the name we shall attempt to list
+     * @return Null when the name cannot be exapnded, otherwise the leaf elements
+     */
+    private NamingEnumeration<NameClassPair> safelyGetChildElements(InitialContext initialContext, String jndiNameToExpand) {
+        try {
+            return initialContext.list(jndiNameToExpand);
+        } catch (NamingException ignoreE) {
+            // we do not care - most likely we are dealing with a leaf element
+            return null;
+        }
+    }
+
+    /**
+     * Create a string that serves as identation. The string shall hold 4 * depth spaces within it.
+     *
+     * @param depth the depth of our recursion
+     * @return a string with an appropriate number of spaces for our current recursion depth.
+     */
+    private String createStringWithSpaces(int depth) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < depth; i++) {
+            stringBuilder.append(FOUR_SPACES_STR);
+        }
+        return stringBuilder.toString();
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/util/SystemTestStringUtil.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/util/SystemTestStringUtil.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.util;
+
+import static java.lang.String.format;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+/**
+ * This factory allows us to build strings representing the persistence.xml files.
+ */
+public class SystemTestStringUtil {
+
+    private static final String SCANNER_DELIMITER = "\\A";
+    public static SystemTestStringUtil SINGLETON = new SystemTestStringUtil();
+
+    private SystemTestStringUtil() {
+    }
+
+    /**
+     * Trivially read a file into string.
+     *
+     * @param file file to read
+     * @return The corresponding file contents
+     */
+    public String getFileAsString(File file) {
+        if (!file.exists()) {
+            throw new RuntimeException(format("The file %1$s does not exist", file));
+        }
+        try {
+            try (InputStream inputStream = new BufferedInputStream(new FileInputStream(file))) {
+                return convertStreamToStringUntilFirstDelimiter(inputStream);
+            }
+        } catch (Exception e) {
+            String errMsg = String.format("Unexpected error while attempting to read file: %1$s", file);
+            throw new RuntimeException(errMsg);
+        }
+
+    }
+
+    /**
+     * Read an input stream expected to contain UTF-8 text into a string. The caller is responsible for closing the input sream.
+     *
+     * @param inputStream data to read
+     * @return the corresponding string.
+     */
+    public String convertStreamToStringUntilFirstDelimiter(InputStream inputStream) {
+        try (java.util.Scanner scanner = new java.util.Scanner(inputStream, java.nio.charset.StandardCharsets.UTF_8.toString())) {
+            // (a) set delimiter that shall not be found on the stream
+            scanner.useDelimiter(SCANNER_DELIMITER);
+            // (b) read file until EOF
+            return scanner.hasNext() ? scanner.next() : "";
+        }
+    }
+}

--- a/testsuite/compat/src/test/resources/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/persistence.xml
+++ b/testsuite/compat/src/test/resources/org/jboss/as/test/compat/jpa/eclipselink/wildfly8954/persistence.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="1.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd">
+    
+    <persistence-unit name="hibernate3_pc" transaction-type="JTA">
+        <!-- (a) Tell wildfly we want to use eclipselink and not hibernat -->
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        
+        <!-- (b) java:jboss/datasources/ExampleDS in defined in the standalone.xml it is the only type of datasource available -->
+        <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        <class>db.model.SomeEntity</class>
+
+        <properties>
+            <!-- (c) Tell eclipselink to create the DB schema - this should not be done with a JTA data source -->
+            <property name="eclipselink.ddl-generation" value="drop-and-create-tables"/>
+            
+            <!-- (d) Set eclipse link with fine logging -->
+            <property name="eclipselink.logging.logger" value="JavaLogger" />
+            <property name="eclipselink.logging.level" value="FINE" />
+            <property name="eclipselink.logging.level.sql" value="FINE" />
+            <property name="eclipselink.logging.parameters" value="true" />
+
+            <!-- (e) Tune eclipse sequence generation to run on small self managed independent non jta transactions. We cannot do this here. -->
+            <!--   We do not have any non jta data source available in the standalone.xml so we leave this configuration out - which would be critical to use in any productive scenario-->
+            <!--  property name="eclipselink.jdbc.sequence-connection-pool" value="true" />
+            <property name="eclipselink.jdbc.sequence-connection-pool.non-jta-data-source" value="jdbc/SAMPLE_NON_JTA_DS" / -->
+                                   
+            <property name="javax.persistence.lock.timeout" value="2000" />
+            
+            <!-- (f) Have wildfly boot up the eclipselink module. Seems to be using 2.6.3 version - we are already at 2.6.4  
+                This is wildfly specific propery and it will cause the eclipse link module to be required during deploymnet.
+                NOTE: This module is being placed dynamic in the target/modules folder.
+              -->
+            <property name="jboss.as.jpa.providerModule" value="org.eclipse.persistence:test" />                                               
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
Please consider the following pull request, that aims at correcting the issue https://issues.jboss.org/browse/WFLY-8954 . The pull request consists of:

(a) An arquillian based system test,  that was originally able to reproduce this issue and which now serves the purpose of validating that this issue no longer takes place
(b) a small set of changes recommended by the red hat team to improve the process followed by eclipselink to register a transaction listener on a jta transaction, to ensure that during an oncomplete event, the eclipselink synchronization will be executed before any CDI oncomplete observers.

Please feel free to discard, modify or improve any aspect of the suggested changes. I would be happy if the changes could be cherry picked onto the next 10.2.0.Final branch. So that I could keep my options open as to whether upgrade to an 11 release or be conservative an keep working with the 10.X patch fix releases.

Kindest regards.