### PR TITLE
[WFLY-9292] TimerServiceSuspendTestCase and DatasourceNonCcmTestCase …

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/suspend/TimerServiceSuspendTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/suspend/TimerServiceSuspendTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.ejb.timerservice.suspend;
 
+import java.io.FilePermission;
 import java.io.IOException;
 import javax.ejb.Timer;
 import javax.ejb.TimerConfig;
@@ -61,7 +62,8 @@ public class TimerServiceSuspendTestCase {
         war.addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller-client, org.jboss.remoting3\n"), "MANIFEST.MF");
         war.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),
-                new RemotingPermission("connect")
+                new RemotingPermission("connect"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
         ), "permissions.xml");
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
@@ -28,6 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.sql.Connection;
 
 import javax.annotation.Resource;
@@ -189,7 +190,8 @@ public class DatasourceNonCcmTestCase extends JcaMgmtBase {
 
         jar.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),
-                new RemotingPermission("connect")
+                new RemotingPermission("connect"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
         ), "permissions.xml");
 
         return jar;


### PR DESCRIPTION
…fail with security manager

WFLY: https://issues.jboss.org/browse/WFLY-9292