### PR TITLE
[WFLY-8444] Upgrade QPid Proton to 0.1.6.0

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1844,11 +1844,6 @@
 
         <dependency>
             <groupId>org.apache.qpid</groupId>
-            <artifactId>proton-jms</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
         </dependency>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
@@ -24,7 +24,6 @@
 
 <module xmlns="urn:jboss:module:1.5" name="org.apache.qpid.proton">
     <resources>
-        <artifact name="${org.apache.qpid:proton-jms}"/>
         <artifact name="${org.apache.qpid:proton-j}"/>
     </resources>
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <version.org.apache.openjpa>2.4.1</version.org.apache.openjpa>
         <version.org.eclipselink.version>2.6.3</version.org.eclipselink.version>
         <version.org.apache.neethi>3.0.3</version.org.apache.neethi>
-        <version.org.apache.qpid.proton>0.8</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.16.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.0.8</version.org.apache.santuario>
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
         <version.org.apache.ws.security>2.1.10</version.org.apache.ws.security>
@@ -3741,12 +3741,6 @@
                         <artifactId>wsdl4j</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.qpid</groupId>
-                <artifactId>proton-jms</artifactId>
-                <version>${version.org.apache.qpid.proton}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
to align it with Artemis 1.5.5.jbossorg-007.
Remove org.apache.qpid:proton-jms dependency.

JIRA: https://issues.jboss.org/browse/WFLY-8444