### PR TITLE
[WFLY-9317] Fix dist and servlet-dist module to use jboss.as.release.…

### DIFF
--- a/dist/assembly-src.xml
+++ b/dist/assembly-src.xml
@@ -12,7 +12,7 @@
     <fileSets>
         <fileSet>
             <directory>..</directory>
-            <outputDirectory>${server.output.dir.prefix}-${project.version}-src</outputDirectory>
+            <outputDirectory>${server.output.dir.prefix}-${jboss.as.release.version}-src</outputDirectory>
             <includes>
                 <include>**/*.xml</include>
                 <include>**/src/**</include>

--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -12,7 +12,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-${version}/**</include>
+                <include>${server.output.dir.prefix}-${jboss.as.release.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -64,7 +64,7 @@
     </properties>
 
     <build>
-        <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-${jboss.as.release.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>
@@ -94,7 +94,7 @@
                         <phase>process-classes</phase>
                         <configuration>
                             <overwrite>true</overwrite>
-                            <outputDirectory>${basedir}/target/${server.output.dir.prefix}-${project.version}</outputDirectory>
+                            <outputDirectory>${basedir}/target/${project.build.finalName}</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/distribution/resources</directory>
@@ -155,7 +155,7 @@
                                         <descriptor>assembly.xml</descriptor>
                                     </descriptors>
                                     <recompressZippedFiles>true</recompressZippedFiles>
-                                    <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+                                    <finalName>${project.build.finalName}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <workDirectory>${project.build.directory}/assembly/work</workDirectory>
@@ -172,7 +172,7 @@
                                     <descriptors>
                                         <descriptor>assembly-src.xml</descriptor>
                                     </descriptors>
-                                    <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+                                    <finalName>${project.build.finalName}</finalName>
                                     <appendAssemblyId>true</appendAssemblyId>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <workDirectory>${project.build.directory}/assembly-src/work</workDirectory>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -28,35 +28,35 @@ limitations under the License.
 -->
   <files>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/bin/product.conf</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/bin/product.conf</location>
       <contains>slot=${verifier.slot.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/jboss-modules.jar</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/jboss-modules.jar</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/standalone/configuration/standalone.xml</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/standalone/configuration/standalone.xml</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${project.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
       <exists>true</exists>
     </file>
   </files>

--- a/servlet-dist/assembly.xml
+++ b/servlet-dist/assembly.xml
@@ -34,7 +34,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-servlet-${version}/**</include>
+                <include>${server.output.dir.prefix}-servlet-${jboss.as.release.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -63,7 +63,7 @@
         <verifier.product.release.version>11.0</verifier.product.release.version>
     </properties>
     <build>
-        <finalName>${server.output.dir.prefix}-servlet-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-servlet-${jboss.as.release.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>

--- a/servlet-dist/src/verifier/verifications.xml
+++ b/servlet-dist/src/verifier/verifications.xml
@@ -28,35 +28,35 @@ limitations under the License.
 -->
   <files>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/bin/product.conf</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/bin/product.conf</location>
       <contains>slot=${verifier.slot.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/jboss-modules.jar</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/jboss-modules.jar</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/standalone/configuration/standalone.xml</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/standalone/configuration/standalone.xml</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${project.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
       <exists>true</exists>
     </file>
   </files>


### PR DESCRIPTION
…version

Fix dist and servlet-dist module to use jboss.as.release.version so one can use `mvn clean install -DskipTests -Djboss.as.release.version=latest -Prelease` to build WF with custom name and not just `${project.version}`

JIRA: https://issues.jboss.org/browse/WFLY-9317
Discussion: 
* http://lists.jboss.org/pipermail/wildfly-dev/2017-September/006052.html 
* http://lists.jboss.org/pipermail/wildfly-dev/2017-September/006058.html