### PR TITLE
[WFLY-9323] TimerManagementTestCase fail with non-en_US.UTF-8 locale

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/TimerManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/TimerManagementTestCase.java
@@ -17,6 +17,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  *
  * Test non persistent interval timer.
@@ -69,7 +71,7 @@ public class TimerManagementTestCase extends AbstractTimerManagementTestCase {
             getTimerDetails();
         } catch (OperationFailedException ofe) {
             final ModelNode failureDescription = ofe.getFailureDescription();
-            Assert.assertTrue(failureDescription.toString(), failureDescription.toString().contains("not found"));
+            Assert.assertThat("Wrong failure description", failureDescription.toString(), containsString("WFLYCTL0216"));
         }
     }
 
@@ -82,7 +84,7 @@ public class TimerManagementTestCase extends AbstractTimerManagementTestCase {
             getTimerDetails();
         } catch (OperationFailedException ofe) {
             final ModelNode failureDescription = ofe.getFailureDescription();
-            Assert.assertTrue(failureDescription.toString(), failureDescription.toString().contains("not found"));
+            Assert.assertThat("Wrong failure description", failureDescription.toString(), containsString("WFLYCTL0216"));
         }
     }
 


### PR DESCRIPTION
TimerManagementTestCase fail with non-en_US.UTF-8 locale settings

JBEAP jira: https://issues.jboss.org/browse/JBEAP-13082
WFLY jira: https://issues.jboss.org/browse/WFLY-9323
EAP PR: https://github.com/jbossas/jboss-eap7/pull/2376