### PR TITLE
WFLY-9327: Upgrade Weld to 2.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.4.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.spec.javax.websockets>1.1.1.Final</version.org.jboss.spec.javax.websockets>
-        <version.org.jboss.weld.weld>2.4.3.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>2.4.5.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.4.SP1</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>3.1.4.Final</version.org.jboss.ws.spi>


### PR DESCRIPTION
- upstream issue: https://issues.jboss.org/browse/WFLY-9327
- http://weld.cdi-spec.org/news/2017/09/11/weld-245Final/
- http://weld.cdi-spec.org/news/2017/06/14/weld-244Final/

Note that there will be no downstream issue/PR in the coming weeks.