### PR TITLE
WFLY-9354 (Trivial) - Fix the error message for missing application client deployment

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
@@ -352,7 +352,7 @@ public interface AppClientLogger extends BasicLogger {
      *
      * @return a {@link RuntimeException} for the error.
      */
-    @Message(id = 23, value = "Could find application client %s")
+    @Message(id = 23, value = "Could not find application client %s")
     RuntimeException cannotFindAppClientFile(File deploymentName);
 
     @Message(id = 24, value = "Cannot specify both a host to connect to and an ejb-client.properties file. ")


### PR DESCRIPTION
JIRA https://issues.jboss.org/browse/WFLY-9354
This commit fixes the incorrect error message reported when application client deployment cannot be found.