### PR TITLE
[WFLY-9356] Remove pointless duplication execution of DomainHostExclu…

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/MixedDomain620TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/MixedDomain620TestSuite.java
@@ -34,7 +34,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain620TestCase.class, MixedDomainDeployment620TestCase.class, DomainHostExcludes620TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain620TestCase.class, MixedDomainDeployment620TestCase.class})
 @Version(AsVersion.EAP_6_2_0)
 public class MixedDomain620TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/MixedDomain630TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/MixedDomain630TestSuite.java
@@ -35,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain630TestCase.class, MixedDomainDeployment630TestCase.class, DomainHostExcludes630TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain630TestCase.class, MixedDomainDeployment630TestCase.class})
 @Version(AsVersion.EAP_6_3_0)
 public class MixedDomain630TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/MixedDomain640TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/MixedDomain640TestSuite.java
@@ -35,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain640TestCase.class, MixedDomainDeployment640TestCase.class, DomainHostExcludes640TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain640TestCase.class, MixedDomainDeployment640TestCase.class})
 @Version(AsVersion.EAP_6_4_0)
 public class MixedDomain640TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomain700TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap700/MixedDomain700TestSuite.java
@@ -35,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain700TestCase.class, MixedDomainDeployment700TestCase.class, DomainHostExcludes700TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain700TestCase.class, MixedDomainDeployment700TestCase.class})
 @Version(AsVersion.EAP_7_0_0)
 public class MixedDomain700TestSuite extends MixedDomainTestSuite {
 


### PR DESCRIPTION
…desTestCase variants

The tests I remove here are included in the @Suite.Classes annotation elsewhere. Having them here means the same tests run twice for no purpose.

https://issues.jboss.org/browse/WFLY-9356