### PR TITLE
[WFLY-9358] [WFLY-9351] [WFLY-9352] [WFLY-9350] [WFLY-9349] [WFLY-9357] [WFLY-9382] Remote EJB clustered node discovery is ignored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.hal.release-stream>2.9.14.Final</version.org.jboss.hal.release-stream>
-        <version.org.jboss.ejb-client>4.0.0.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.1.Final-SNAPSHOT</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.0.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.0.Final</version.org.jboss.genericjms>
@@ -217,12 +217,12 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.core>3.0.2.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>3.0.3.Final-SNAPSHOT</version.org.wildfly.core>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.http-client>1.0.1.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.0.3.Final-SNAPSHOT</version.org.wildfly.http-client>
         <version.org.wildfly.maven.plugins>1.0.0</version.org.wildfly.maven.plugins>
-        <version.org.wildfly.naming-client>1.0.1.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.0.0.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.naming-client>1.0.2.Final-SNAPSHOT</version.org.wildfly.naming-client>
+        <version.org.wildfly.transaction.client>1.0.1.Final-SNAPSHOT</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.17</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>

--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,8 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.hal.release-stream>2.9.14.Final</version.org.jboss.hal.release-stream>
-        <version.org.jboss.ejb-client>4.0.1.Final-SNAPSHOT</version.org.jboss.ejb-client>
-        <version.org.jboss.ejb-client-legacy>3.0.0.Final</version.org.jboss.ejb-client-legacy>
+        <version.org.jboss.ejb-client>4.0.1.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client-legacy>3.0.1.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.0.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
@@ -217,12 +217,12 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.core>3.0.3.Final-SNAPSHOT</version.org.wildfly.core>
+        <version.org.wildfly.core>3.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.http-client>1.0.3.Final-SNAPSHOT</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.0.3.Final</version.org.wildfly.http-client>
         <version.org.wildfly.maven.plugins>1.0.0</version.org.wildfly.maven.plugins>
-        <version.org.wildfly.naming-client>1.0.2.Final-SNAPSHOT</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.0.1.Final-SNAPSHOT</version.org.wildfly.transaction.client>
+        <version.org.wildfly.naming-client>1.0.2.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.transaction.client>1.0.1.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.17</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/HttpRemoteIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/security/HttpRemoteIdentityTestCase.java
@@ -35,7 +35,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -107,7 +106,7 @@ public class HttpRemoteIdentityTestCase {
         env.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
         URI namingUri = getHttpUri();
         env.put(Context.PROVIDER_URL, namingUri.toString());
-        return new InitialContext(DefaultConfiguration.addSecurityProperties(env));
+        return new InitialContext(env);
     }
 
     private URI getHttpUri() throws URISyntaxException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingHTTPTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingHTTPTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.common.DefaultConfiguration;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -78,7 +77,9 @@ public class RemoteNamingHTTPTestCase {
         URI webUri = managementClient.getWebUri();
         URI namingUri = new URI("http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "/wildfly-services", "" ,"");
         env.put(Context.PROVIDER_URL, namingUri.toString());
-        return new InitialContext(DefaultConfiguration.addSecurityProperties(env));
+        env.put(Context.SECURITY_PRINCIPAL, System.getProperty("jboss.application.username", "guest"));
+        env.put(Context.SECURITY_CREDENTIALS, System.getProperty("jboss.application.username", "guest"));
+        return new InitialContext(env);
     }
 
     private static AuthenticationContext old;


### PR DESCRIPTION
[WFLY-9357] [WFLY-9382] Changes for lazy user transaction and related security enhancements

[WFLY-9358] [WFLY-9351] [WFLY-9352] [WFLY-9350] [WFLY-9349] Remote EJB clustered node discovery is ignored