### PR TITLE
[WFLY-9373] Avoid HTTPSWebConnectorTestCase removing default https listener

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -406,15 +406,11 @@ public class HTTPSWebConnectorTestCase {
         final ModelControllerClient client = managementClient.getControllerClient();
 
         // delete https web connectors
-        ModelNode operation = createOpNode("subsystem=undertow/server=default-server/https-listener=" + HTTPS,
-                ModelDescriptionConstants.REMOVE);
-        Utils.applyUpdate(operation, client);
-
         rmHttpsConnector(HTTPS_NAME_VERIFY_NOT_REQUESTED, client);
         rmHttpsConnector(HTTPS_NAME_VERIFY_REQUESTED, client);
         rmHttpsConnector(HTTPS_NAME_VERIFY_REQUIRED, client);
 
-        operation = createOpNode("core-service=management/security-realm=" + HTTPS_REALM, ModelDescriptionConstants.REMOVE);
+        ModelNode operation = createOpNode("core-service=management/security-realm=" + HTTPS_REALM, ModelDescriptionConstants.REMOVE);
         Utils.applyUpdate(operation, client);
 
         FileUtils.deleteDirectory(WORK_DIR);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9373
https://issues.jboss.org/browse/JBEAP-13220

HTTPSWebConnectorTestCase removes https web connectors in serverTearDown() method causing SSLEJBRemoteClientTestCase fail with:
    "failure-description" => "WFLYCTL0216: Management resource '[
    (\"subsystem\" => \"undertow\"),
    (\"server\" => \"default-server\"),
    (\"https-listener\" => \"https\")
]' not found",