### PR TITLE
[WFLY-9376] Include shared keystores in .jar archive

### DIFF
--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -67,30 +67,6 @@
                     </additionalClasspathElements>
                 </configuration>
             </plugin>
-            <!-- Resources plugin. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions combine.children="append">
-                    <!-- Copy keystores from common resources. -->
-                    <execution>
-                        <id>ts.integ.web.copy-keystores</id>
-                        <phase>generate-test-resources</phase>
-                        <goals><goal>copy-resources</goal></goals>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <outputDirectory>${basedir}/target/jbossas/standalone/configuration</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>../../shared/target/shared-keystores</directory>
-                                    <includes><include>application.keystore</include></includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <!-- WFLY-5588 DefaultContextServiceServletTestCase fails on IBM jdk -->

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebTestsSecurityDomainSetup.java
@@ -34,10 +34,13 @@ import static org.jboss.as.security.Constants.LOGIN_MODULE;
 import static org.jboss.as.security.Constants.MODULE_OPTIONS;
 import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
 
+import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
@@ -78,6 +81,12 @@ public class WebTestsSecurityDomainSetup extends AbstractSecurityDomainSetup {
 
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+        // Retrieve application.keystore file from jar archive of wildfly-testsuite-shared module
+        File destFile = new File(System.getProperty("jboss.home") + File.separator + "standalone" + File.separator +
+                "configuration" + File.separatorChar + "application.keystore");
+        URL resourceUrl = this.getClass().getResource("/org/jboss/as/test/shared/shared-keystores/application.keystore");
+        FileUtils.copyInputStreamToFile(resourceUrl.openStream(), destFile);
+
         if (WebSecurityCommon.isElytron()) {
             cli = new CLIWrapper(true);
             setElytronBased();

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -140,7 +140,7 @@
                             <goal>clean</goal>
                         </goals>
                         <configuration>
-                            <keystore>${basedir}/target/tests-keystores/application.keystore</keystore>
+                            <keystore>${basedir}/target/classes/org/jboss/as/test/shared/shared-keystores/application.keystore</keystore>
                         </configuration>
                     </execution>
                     <execution>
@@ -150,7 +150,7 @@
                             <goal>generateKeyPair</goal>
                         </goals>
                         <configuration>
-                            <keystore>${basedir}/target/shared-keystores/application.keystore</keystore>
+                            <keystore>${basedir}/target/classes/org/jboss/as/test/shared/shared-keystores/application.keystore</keystore>
                             <dname>cn=server, ou=organizationUnit, o=organizationName, c=countryCode</dname>
                             <storetype>JKS</storetype>
                             <keypass>password</keypass>


### PR DESCRIPTION
- and retrieve them from there so we don't depend on the fact that
  target directory in ./testsuite/shared is present with generated
  keystores at the moment executing tests in other modules.

Project issue: https://issues.jboss.org/browse/WFLY-9376