### PR TITLE
WFLY-9378 Attribute TransportResourceDefinition.Attribute#SOCKET_BIND…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -115,9 +115,12 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
                 .setDefaultValue(new ModelNode(false))
                 .setDeprecated(JGroupsModel.VERSION_4_0_0.getVersion())),
         SOCKET_BINDING("socket-binding", ModelType.STRING, builder -> builder
+                .setAllowExpression(false)
+                .setRequired(true)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
                 .setCapabilityReference(new CapabilityReference(Capability.TRANSPORT, CommonUnaryRequirement.SOCKET_BINDING))),
         DIAGNOSTICS_SOCKET_BINDING("diagnostics-socket-binding", ModelType.STRING, builder -> builder
+                .setAllowExpression(false)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
                 .setCapabilityReference(new CapabilityReference(Capability.TRANSPORT, CommonUnaryRequirement.SOCKET_BINDING))),
         SITE("site", ModelType.STRING),


### PR DESCRIPTION
…ING should be required and with DIAGNOSTICS_SOCKET_BINDING should not allow expressions since they are capability references.

Jira
https://issues.jboss.org/browse/WFLY-9378