### PR TITLE
WFLY-9388 - There should be replaced stacktrace loggings to stderr with usage of logging

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -906,4 +906,7 @@ public interface ConnectorLogger extends BasicLogger {
     @Message(id = 112, value = "Datasource %s is disabled")
     IllegalArgumentException datasourceIsDisabled(String jndiName);
 
+    @LogMessage(level = ERROR)
+    @Message(id =113, value = "Unexcepted error during worker execution : %s")
+    void unexceptedWorkerCompletionError(String errorMessage, @Cause Throwable t);
 }

--- a/connector/src/main/java/org/jboss/as/connector/services/workmanager/WildflyWorkWrapper.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/workmanager/WildflyWorkWrapper.java
@@ -24,6 +24,7 @@ import javax.resource.spi.work.WorkListener;
 
 import org.jboss.as.connector.security.CallbackImpl;
 import org.jboss.as.connector.security.ElytronSecurityContext;
+import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.jca.core.spi.security.SecurityIntegration;
 import org.jboss.jca.core.workmanager.WorkManagerImpl;
 
@@ -61,7 +62,7 @@ public class WildflyWorkWrapper extends org.jboss.jca.core.workmanager.WorkWrapp
                 try {
                     WildflyWorkWrapper.super.runWork();
                 } catch (WorkCompletedException e) {
-                    e.printStackTrace();
+                    ConnectorLogger.ROOT_LOGGER.unexceptedWorkerCompletionError(e.getLocalizedMessage(),e);
                 }
             });
         // delegate to super class if there is no elytron enabled

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -396,4 +396,8 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 97, value = "If http-upgrade is enabled, remoting worker and http(s) worker must be the same. Please adjust values if need be.")
     String workerValueInHTTPListenerMustMatchRemoting();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 98, value = "Unexcepted Authentification Errorr: %s")
+    void unexceptedAuthentificationError(String errorMessage, @Cause Throwable t);
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/digest/DigestAuthenticationMechanism.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/digest/DigestAuthenticationMechanism.java
@@ -53,6 +53,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.wildfly.extension.undertow.logging.UndertowLogger;
+
 /**
  * {@link io.undertow.server.HttpHandler} to handle HTTP Digest authentication, both according to RFC-2617 and draft update to allow additional
  * algorithms to be used.
@@ -164,7 +166,7 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
 
                         return handleDigestHeader(exchange, securityContext);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        UndertowLogger.ROOT_LOGGER.unexceptedAuthentificationError(e.getLocalizedMessage(), e);
                     }
                 }
 


### PR DESCRIPTION
Upstream Issue: https://issues.jboss.org/browse/WFLY-9388
Issue: https://issues.jboss.org/browse/JBEAP-12220
