### PR TITLE
[WFLY-9389] BootstrapBeanDeploymentArchiveTestCase fails with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/weld/beanarchives/BootstrapBeanDeploymentArchiveTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.test.integration.weld.beanarchives;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
@@ -30,12 +31,10 @@ import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.shared.SecurityManagerFailure;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,12 +49,9 @@ public class BootstrapBeanDeploymentArchiveTestCase {
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(WebArchive.class).addPackage(BootstrapBeanDeploymentArchiveTestCase.class.getPackage())
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml").addAsServiceProvider(Extension.class, TestExtension.class);
-    }
-
-    @BeforeClass
-    public static void beforeClass() {
-        SecurityManagerFailure.thisTestIsFailingUnderSM("WFLY-8378");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsServiceProvider(Extension.class, TestExtension.class)
+                .addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")),"permissions.xml");
     }
 
     @Test


### PR DESCRIPTION
Running the test under security manager requires a RuntimePermission

issue: https://issues.jboss.org/browse/WFLY-9389
JBEAP issue: https://issues.jboss.org/browse/JBEAP-13269