### PR TITLE
[WFLY-5351] allow to query cancelled persistent timer

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerResourceDefinition.java
@@ -222,6 +222,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 try {
                     final long time = timer.getTimeRemaining();
                     toSet.set(time);
@@ -238,6 +241,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 try {
                     final Date d = timer.getNextTimeout();
                     if (d != null) {
@@ -253,6 +259,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 final boolean calendarTimer = timer.isCalendarTimer();
                 toSet.set(calendarTimer);
             }
@@ -262,6 +271,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 final boolean persistent = timer.isPersistent();
                 toSet.set(persistent);
             }
@@ -280,7 +292,7 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
-                if (!timer.isCalendarTimer()) {
+                if (timer.isCanceled() || !timer.isCalendarTimer()) {
                     return;
                 }
                 ScheduleExpression sched = timer.getSchedule();
@@ -315,6 +327,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 final Object pk = timer.getPrimaryKey();
                 if (pk != null) {
                     toSet.set(pk.toString());
@@ -326,6 +341,9 @@ public class TimerResourceDefinition<T extends EJBComponent> extends SimpleResou
 
             @Override
             protected void readAttribute(TimerImpl timer, ModelNode toSet) {
+                if (timer.isCanceled()) {
+                    return;
+                }
                 if (timer.getInfo() != null) {
                     toSet.set(timer.getInfo().toString());
                 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/timers/PersistentTimerCancellationOperationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/timers/PersistentTimerCancellationOperationUnitTestCase.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.ejb3.timers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class PersistentTimerCancellationOperationUnitTestCase {
+
+    public static final String NAME = "cancelled-persistent-timer.war";
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, NAME);
+        war.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        war.addClass(TimerStartup.class);
+
+        return war;
+    }
+
+    @Test
+    public void subsystem_query_retrieves_cancelled_and_valid_timers() throws Exception {
+        final ModelNode address = new ModelNode();
+        address.add("deployment", NAME);
+        address.add("subsystem", "ejb3");
+        address.add("singleton-bean", TimerStartup.class.getSimpleName());
+        address.add("service", "timer-service");
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        operation.get(ModelDescriptionConstants.OP_ADDR).set(address);
+        operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).set(true);
+        operation.get(ModelDescriptionConstants.RECURSIVE).set(true);
+
+        ModelNode node = managementClient.getControllerClient().execute(operation);
+        assertThat(node.get(ModelDescriptionConstants.OUTCOME).asString(), is("success"));
+
+        // Let's verify timers
+        ModelNode timersNode = node.get(ModelDescriptionConstants.RESULT).get("timer");
+
+        Set<String> timerIDs = timersNode.keys();
+        assertThat(timerIDs.size(), is(2));     // 2 timers expected
+
+        List<ModelNode> timers = timerIDs.stream().map(id -> timersNode.get(id)).collect(Collectors.toList());
+
+        List<ModelNode> nonCancelledTimers = timers.stream().filter(n -> n.hasDefined("info")).collect(Collectors.toList());
+        assertThat(nonCancelledTimers.size(), is(1));   // one and only one with timer information, ie the one non cancelled
+
+        List<ModelNode> cancelledTimers = timers.stream().filter(n -> !n.hasDefined("info")).collect(Collectors.toList());
+        assertThat(cancelledTimers.size(), is(1));   // one without timer information, the one cancelled
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/timers/TimerStartup.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/timers/TimerStartup.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.ejb3.timers;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.Resource;
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.ConcurrencyManagementType;
+import javax.ejb.Lock;
+import javax.ejb.LockType;
+import javax.ejb.ScheduleExpression;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+@Startup
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
+public class TimerStartup {
+    private static final Logger LOG = LoggerFactory.getLogger(TimerStartup.class);
+    private static final String TIMER_NAME = TimerStartup.class.getName() + "-T1";
+    private static final String TIMER_CANCEL_NAME = TIMER_NAME + "-CANCEL";
+
+    @Resource
+    TimerService ts;
+
+    @Timeout
+    @Lock(LockType.READ)
+    public void timeout(Timer t) {
+        LOG.info("executing timer {}", t);
+    }
+
+    @PostConstruct
+    public void init() {
+        Timer normalTimer = createPersistenceTimer(TIMER_NAME, new ScheduleExpression().hour(1));
+        Timer cancelTimer = createPersistenceTimer(TIMER_CANCEL_NAME, new ScheduleExpression().hour(2));
+
+        // Then cancelling it
+        cancelTimer.cancel();
+    }
+
+    private Timer createPersistenceTimer(String timerName, ScheduleExpression schedule) {
+        // Let's create a persistent timer configuration
+        TimerConfig persistentTimerConfiguration = new TimerConfig(timerName, true);
+
+        // Creating it
+        return ts.createCalendarTimer(schedule, persistentTimerConfiguration);
+    }
+
+    @PreDestroy
+    public void clearTimers() {
+        for (Timer t: ts.getAllTimers()) {
+            t.cancel();
+        }
+    }
+}


### PR DESCRIPTION
allow to query wildfy model even for cancelled persistent timer (see https://issues.jboss.org/browse/WFLY-5351)

With this PR, the query ends with ModelNode _empty/undefined_ values instead of a failure.
Test included as integration/smoke test.