### PR TITLE
WFLY-9130 Re-enable RemoteStatefulEJBConcurrentFailoverTestCase

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
@@ -37,10 +37,12 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Validates failover behavior of a remotely accessed @Stateless EJB.
@@ -65,9 +67,18 @@ public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends Cluster
     }
 
     @Test
-    public void test() throws Exception {
+    public void testJNDI() throws Exception {
+        this.test(() -> new RemoteEJBDirectory(this.module));
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        this.test(() -> new ClientEJBDirectory(this.module));
+    }
+
+    private void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
         this.configurator.apply(() -> {
-            try (EJBDirectory directory = new RemoteEJBDirectory(this.module)) {
+            try (EJBDirectory directory = directoryProvider.get()) {
                 Incrementor bean = directory.lookupStateless(this.beanClass, Incrementor.class);
 
                 // Allow sufficient time for client to receive full topology

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.InfinispanExceptionThrowingIncrementorBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
@@ -47,6 +48,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Test for WFLY-5788.
@@ -79,8 +81,17 @@ public class ClientExceptionRemoteEJBTestCase extends ClusterAbstractTestCase {
     }
 
     @Test
-    public void test() throws Exception {
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+    public void testJNDI() throws Exception {
+        test(() -> new RemoteEJBDirectory(MODULE_NAME));
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        test(() -> new ClientEJBDirectory(MODULE_NAME));
+    }
+
+    private static void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
+        try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(InfinispanExceptionThrowingIncrementorBean.class, Incrementor.class);
 
             bean.increment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -59,7 +59,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@org.junit.Ignore("WFLY-9130")
 public class RemoteStatefulEJBConcurrentFailoverTestCase extends ClusterAbstractTestCase {
     private static final String MODULE_NAME = "remote-stateful-ejb-concurrent-failover-test";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
@@ -43,6 +44,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Validates failover behavior of a remotely accessed @Stateful EJB.
@@ -77,8 +79,17 @@ public class RemoteStatefulEJBFailoverTestCase extends ClusterAbstractTestCase {
     }
 
     @Test
-    public void test() throws Exception {
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+    public void testJNDI() throws Exception {
+        this.test(() -> new RemoteEJBDirectory(MODULE_NAME));
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        this.test(() -> new ClientEJBDirectory(MODULE_NAME));
+    }
+
+    private void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
+        try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 
             Result<Integer> result = bean.increment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
@@ -46,6 +47,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Validates inhibition of failover behavior of a remotely accessed @Stateful EJB within the context of a transaction.
@@ -77,8 +79,17 @@ public class TransactionalRemoteStatefulEJBFailoverTestCase extends ClusterAbstr
     }
 
     @Test
-    public void test() throws Exception {
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+    public void testJNDI() throws Exception {
+        this.test(() -> new RemoteEJBDirectory(MODULE_NAME));
+    }
+
+    @Test
+    public void testClient() throws Exception {
+        this.test(() -> new ClientEJBDirectory(MODULE_NAME));
+    }
+
+    private void test(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) throws Exception {
+        try (EJBDirectory directory = directoryProvider.get()) {
             Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
 
             Result<Integer> result = bean.increment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/AbstractEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/AbstractEJBDirectory.java
@@ -25,7 +25,6 @@ package org.jboss.as.test.clustering.ejb;
 import java.util.Properties;
 
 import javax.ejb.EJBHome;
-import javax.ejb.SessionBean;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -59,18 +58,8 @@ public abstract class AbstractEJBDirectory implements EJBDirectory {
     }
 
     @Override
-    public <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
-        return this.lookupStateful(beanClass.getSimpleName(), beanInterface);
-    }
-
-    @Override
     public <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException {
         return this.lookup(beanName, beanInterface, Type.STATEFUL);
-    }
-
-    @Override
-    public <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
-        return this.lookupStateless(beanClass.getSimpleName(), beanInterface);
     }
 
     @Override
@@ -79,18 +68,8 @@ public abstract class AbstractEJBDirectory implements EJBDirectory {
     }
 
     @Override
-    public <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
-        return this.lookupSingleton(beanClass.getSimpleName(), beanInterface);
-    }
-
-    @Override
     public <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException {
         return this.lookup(beanName, beanInterface, Type.SINGLETON);
-    }
-
-    @Override
-    public <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException {
-        return this.lookupHome(beanClass.getSimpleName(), homeInterface);
     }
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
@@ -1,0 +1,72 @@
+package org.jboss.as.test.clustering.ejb;
+
+import javax.ejb.EJBHome;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+import org.jboss.ejb.client.ClusterAffinity;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBHomeLocator;
+import org.jboss.ejb.client.EJBLocator;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.wildfly.transaction.client.RemoteTransactionContext;
+
+public class ClientEJBDirectory implements EJBDirectory {
+
+    private final String appName;
+    private final String moduleName;
+
+    public ClientEJBDirectory(String moduleName) {
+        this("", moduleName);
+    }
+
+    public ClientEJBDirectory(String appName, String moduleName) {
+        this.appName = appName;
+        this.moduleName = moduleName;
+    }
+
+    @Override
+    public <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException {
+        try {
+            return createProxy(EJBClient.createSession(this.createStatelessLocator(beanName, beanInterface)));
+        } catch (Exception e) {
+            NamingException exception = new NamingException();
+            exception.initCause(e);
+            throw exception;
+        }
+    }
+
+    @Override
+    public <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException {
+        return createProxy(this.createStatelessLocator(beanName, beanInterface));
+    }
+
+    @Override
+    public <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException {
+        return createProxy(this.createStatelessLocator(beanName, beanInterface));
+    }
+
+    @Override
+    public <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws NamingException {
+        return createProxy(new EJBHomeLocator<>(homeInterface, this.appName, this.moduleName, beanName));
+    }
+
+    private <T> StatelessEJBLocator<T> createStatelessLocator(String beanName, Class<T> beanInterface) {
+        return new StatelessEJBLocator<>(beanInterface, this.appName, this.moduleName, beanName);
+    }
+
+    private static <T> T createProxy(EJBLocator<T> locator) {
+        T bean = EJBClient.createProxy(locator);
+        EJBClient.setStrongAffinity(bean, new ClusterAffinity("ejb"));
+        return bean;
+    }
+
+    @Override
+    public UserTransaction lookupUserTransaction() throws NamingException {
+        return RemoteTransactionContext.getInstance().getUserTransaction();
+    }
+
+    @Override
+    public void close() throws NamingException {
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/EJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/EJBDirectory.java
@@ -35,19 +35,27 @@ import javax.transaction.UserTransaction;
 public interface EJBDirectory extends AutoCloseable {
     <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException;
 
-    <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
+        return this.lookupStateful(beanClass.getSimpleName(), beanInterface);
+    }
 
     <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException;
 
-    <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
+        return this.lookupStateless(beanClass.getSimpleName(), beanInterface);
+    }
 
     <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException;
 
-    <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException {
+        return this.lookupSingleton(beanClass.getSimpleName(), beanInterface);
+    }
 
     <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws NamingException;
 
-    <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException;
+    default <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException {
+        return this.lookupHome(beanClass.getSimpleName(), homeInterface);
+    }
 
     UserTransaction lookupUserTransaction() throws NamingException;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
@@ -27,10 +27,6 @@ import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.NamingException;
 
-import org.jboss.ejb.client.Affinity;
-import org.jboss.ejb.client.ClusterAffinity;
-import org.jboss.ejb.client.EJBClient;
-
 /**
  * @author Paul Ferraro
  */
@@ -56,25 +52,5 @@ public class RemoteEJBDirectory extends AbstractEJBDirectory {
     @Override
     protected <T> String createJndiName(String beanName, Class<T> beanInterface, Type type) {
         return String.format("ejb:/%s/%s!%s%s", this.module, beanName, beanInterface.getName(), (type == Type.STATEFUL) ? "?stateful" : "");
-    }
-
-    @Override
-    protected <T> T lookup(String beanName, Class<T> beanInterface, Type type) throws NamingException {
-        T bean = super.lookup(beanName, beanInterface, type);
-        Affinity affinity = new ClusterAffinity("ejb");
-        switch (type) {
-            case STATEFUL: {
-                EJBClient.setStrongAffinity(bean, affinity);
-                break;
-            }
-            case STATELESS: {
-                EJBClient.setWeakAffinity(bean, affinity);
-                break;
-            }
-            default: {
-                // No need to set initial affinity
-            }
-        }
-        return bean;
     }
 }


### PR DESCRIPTION
Add remote ejb test variants that use the ejb client API (as opposed to JNDI).