### PR TITLE
WFLY-9130 Re-enable RemoteStatefulEJBConcurrentFailoverTestCase

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.test.clustering;
 
-import javax.naming.NamingException;
-
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.server.security.ServerPermission;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
@@ -69,7 +67,7 @@ public class ClusterTestUtil {
         return archive;
     }
 
-    public static void establishTopology(EJBDirectory directory, String container, String cache, String... nodes) throws NamingException, InterruptedException {
+    public static void establishTopology(EJBDirectory directory, String container, String cache, String... nodes) throws Exception {
         TopologyChangeListener listener = directory.lookupStateless(TopologyChangeListenerBean.class, TopologyChangeListener.class);
         listener.establishTopology(container, cache, TopologyChangeListener.DEFAULT_TIMEOUT, nodes);
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import java.util.PropertyPermission;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.common.function.ExceptionSupplier;
+
+/**
+ * Validates failover behavior of a remotely accessed @Stateful EJB.
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends ClusterAbstractTestCase {
+    private static final int COUNT = 20;
+    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+
+    static Archive<?> createDeployment(String moduleName) {
+        return ShrinkWrap.create(JavaArchive.class, moduleName + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, StatefulIncrementorBean.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    private final ExceptionSupplier<EJBDirectory, Exception> directoryProvider;
+
+    protected AbstractRemoteStatefulEJBFailoverTestCase(ExceptionSupplier<EJBDirectory, Exception> directoryProvider) {
+        this.directoryProvider = directoryProvider;
+    }
+
+    @Test
+    public void test() throws Exception {
+        try (EJBDirectory directory = this.directoryProvider.get()) {
+            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
+
+            Result<Integer> result = bean.increment();
+            String target = result.getNode();
+            int count = 1;
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            undeploy(this.findDeployment(target));
+
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            // Bean should failover to other node
+            String failoverTarget = result.getNode();
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+            Assert.assertNotEquals(target, failoverTarget);
+
+            deploy(this.findDeployment(target));
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            String failbackTarget = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            Assert.assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+
+            stop(this.findContainer(target));
+
+            result = bean.increment();
+            // Bean should failover to other node
+            failoverTarget = result.getNode();
+
+            Assert.assertEquals(count++, result.getValue().intValue());
+            Assert.assertNotEquals(target, failoverTarget);
+
+            start(this.findContainer(target));
+
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+            result = bean.increment();
+            failbackTarget = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+            // Bean should retain weak affinity for this node
+            Assert.assertEquals(failoverTarget, failbackTarget);
+
+            result = bean.increment();
+            // Bean may have acquired new weak affinity
+            target = result.getNode();
+            Assert.assertEquals(count++, result.getValue().intValue());
+
+            // Bean should retain weak affinity for this node
+            for (int i = 0; i < COUNT; ++i) {
+                result = bean.increment();
+                Assert.assertEquals(count++, result.getValue().intValue());
+                Assert.assertEquals(String.valueOf(i), target, result.getNode());
+            }
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AuthContextRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AuthContextRemoteStatelessEJBFailoverTestCase.java
@@ -22,21 +22,14 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.remote;
 
-import java.util.PropertyPermission;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
-import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
-import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.SecureStatelessIncrementorBean;
-import org.jboss.as.test.clustering.ejb.EJBDirectory;
-import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
@@ -56,25 +49,17 @@ public abstract class AuthContextRemoteStatelessEJBFailoverTestCase extends Abst
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
     public static Archive<?> createDeploymentForContainer1() {
-        return createDeployment();
+        return createDeployment(MODULE_NAME);
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(CONTAINER_2)
     public static Archive<?> createDeploymentForContainer2() {
-        return createDeployment();
-    }
-
-    private static Archive<?> createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
-                .addPackage(EJBDirectory.class.getPackage())
-                .addClasses(Result.class, Incrementor.class, IncrementorBean.class, SecureStatelessIncrementorBean.class)
-                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
-                ;
+        return createDeployment(MODULE_NAME);
     }
 
     public AuthContextRemoteStatelessEJBFailoverTestCase(UnaryOperator<Callable<Void>> configurator) {
-        super(MODULE_NAME, SecureStatelessIncrementorBean.class, configurator);
+        super(() -> new RemoteEJBDirectory(MODULE_NAME), SecureStatelessIncrementorBean.class, configurator);
     }
 }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatefulEJBFailoverTestCase.java
@@ -22,20 +22,13 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.remote;
 
-import java.util.function.UnaryOperator;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementorBean;
-import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
 
-/**
- * Validates failover behavior of a remotely accessed @Stateless EJB.
- * @author Paul Ferraro
- */
-public class RemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
-    private static final String MODULE_NAME = "remote-stateless-ejb-failover-test";
+public class ClientRemoteStatefulEJBFailoverTestCase extends AbstractRemoteStatefulEJBFailoverTestCase {
+    private static final String MODULE_NAME = "client-remote-stateful-ejb-failover-test";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -49,7 +42,7 @@ public class RemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessE
         return createDeployment(MODULE_NAME);
     }
 
-    public RemoteStatelessEJBFailoverTestCase() {
-        super(() -> new RemoteEJBDirectory(MODULE_NAME), StatelessIncrementorBean.class, UnaryOperator.identity());
+    public ClientRemoteStatefulEJBFailoverTestCase() {
+        super(() -> new ClientEJBDirectory(MODULE_NAME));
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatelessEJBFailoverTestCase.java
@@ -27,15 +27,14 @@ import java.util.function.UnaryOperator;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatelessIncrementorBean;
-import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
 
 /**
- * Validates failover behavior of a remotely accessed @Stateless EJB.
  * @author Paul Ferraro
  */
-public class RemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
-    private static final String MODULE_NAME = "remote-stateless-ejb-failover-test";
+public class ClientRemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
+    private static final String MODULE_NAME = "client-remote-stateless-ejb-failover-test";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -49,7 +48,7 @@ public class RemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessE
         return createDeployment(MODULE_NAME);
     }
 
-    public RemoteStatelessEJBFailoverTestCase() {
-        super(() -> new RemoteEJBDirectory(MODULE_NAME), StatelessIncrementorBean.class, UnaryOperator.identity());
+    public ClientRemoteStatelessEJBFailoverTestCase() {
+        super(() -> new ClientEJBDirectory(MODULE_NAME), StatelessIncrementorBean.class, UnaryOperator.identity());
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -31,8 +31,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.naming.NamingException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -175,7 +173,7 @@ public class RemoteStatefulEJBConcurrentFailoverTestCase extends ClusterAbstract
         public void run() {
             try {
                 this.directory.lookupStateful(this.beanClass, Incrementor.class);
-            } catch (NamingException e) {
+            } catch (Exception e) {
                 throw new IllegalStateException(e);
             } finally {
                 this.latch.countDown();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -59,7 +59,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@org.junit.Ignore("WFLY-9130")
 public class RemoteStatefulEJBConcurrentFailoverTestCase extends ClusterAbstractTestCase {
     private static final String MODULE_NAME = "remote-stateful-ejb-concurrent-failover-test";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
@@ -25,36 +25,23 @@ package org.jboss.as.test.clustering.cluster.ejb.remote;
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.IncrementorBean;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.StatefulIncrementorBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
- * Validates failover behavior of a remotely accessed @Stateful EJB.
  * @author Paul Ferraro
  */
-@RunWith(Arquillian.class)
-@RunAsClient
-public class RemoteStatefulEJBFailoverTestCase extends ClusterAbstractTestCase {
+public class RemoteStatefulEJBFailoverTestCase extends AbstractRemoteStatefulEJBFailoverTestCase {
     private static final String MODULE_NAME = "remote-stateful-ejb-failover-test";
-
-    private static final int COUNT = 20;
-    private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -76,89 +63,7 @@ public class RemoteStatefulEJBFailoverTestCase extends ClusterAbstractTestCase {
                 ;
     }
 
-    @Test
-    public void test() throws Exception {
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
-            Incrementor bean = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
-
-            Result<Integer> result = bean.increment();
-            String target = result.getNode();
-            int count = 1;
-
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
-                Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
-
-            undeploy(this.findDeployment(target));
-
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            // Bean should failover to other node
-            String failoverTarget = result.getNode();
-
-            Assert.assertEquals(count++, result.getValue().intValue());
-            Assert.assertNotEquals(target, failoverTarget);
-
-            deploy(this.findDeployment(target));
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            String failbackTarget = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-            // Bean should retain weak affinity for this node
-            Assert.assertEquals(failoverTarget, failbackTarget);
-
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
-                Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
-
-            stop(this.findContainer(target));
-
-            result = bean.increment();
-            // Bean should failover to other node
-            failoverTarget = result.getNode();
-
-            Assert.assertEquals(count++, result.getValue().intValue());
-            Assert.assertNotEquals(target, failoverTarget);
-
-            start(this.findContainer(target));
-
-            // Allow sufficient time for client to receive new topology
-            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
-
-            result = bean.increment();
-            failbackTarget = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-            // Bean should retain weak affinity for this node
-            Assert.assertEquals(failoverTarget, failbackTarget);
-
-            result = bean.increment();
-            // Bean may have acquired new weak affinity
-            target = result.getNode();
-            Assert.assertEquals(count++, result.getValue().intValue());
-
-            // Bean should retain weak affinity for this node
-            for (int i = 0; i < COUNT; ++i) {
-                result = bean.increment();
-                Assert.assertEquals(count++, result.getValue().intValue());
-                Assert.assertEquals(String.valueOf(i), target, result.getNode());
-            }
-        }
+    public RemoteStatefulEJBFailoverTestCase() {
+        super(() -> new RemoteEJBDirectory(MODULE_NAME));
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/ClientIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/ClientIncrementorBean.java
@@ -26,7 +26,6 @@ import javax.ejb.Remote;
 import javax.ejb.Stateful;
 import javax.naming.NamingException;
 
-import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 
 @Stateful(passivationCapable = false)
@@ -38,7 +37,7 @@ public class ClientIncrementorBean implements Incrementor {
 
     @PostConstruct
     public void postConstruct() {
-        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE)) {
+        try (RemoteEJBDirectory directory = new RemoteEJBDirectory(MODULE)) {
             this.locator = directory.lookupStateful(StatefulIncrementorBean.class, Incrementor.class);
         } catch (NamingException e) {
             throw new IllegalStateException(e);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.ejb;
+
+import javax.ejb.EJBHome;
+import javax.transaction.UserTransaction;
+
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBHomeLocator;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.wildfly.transaction.client.RemoteTransactionContext;
+
+/**
+ * {@link EJBDirectory} that uses the EJB client API.
+ * @author Paul Ferraro
+ */
+public class ClientEJBDirectory implements EJBDirectory {
+
+    private final String appName;
+    private final String moduleName;
+
+    public ClientEJBDirectory(String moduleName) {
+        this("", moduleName);
+    }
+
+    public ClientEJBDirectory(String appName, String moduleName) {
+        this.appName = appName;
+        this.moduleName = moduleName;
+    }
+
+    @Override
+    public <T> T lookupStateful(String beanName, Class<T> beanInterface) throws Exception {
+        return EJBClient.createSessionProxy(this.createStatelessLocator(beanName, beanInterface));
+    }
+
+    @Override
+    public <T> T lookupStateless(String beanName, Class<T> beanInterface) throws Exception {
+        return EJBClient.createProxy(this.createStatelessLocator(beanName, beanInterface));
+    }
+
+    @Override
+    public <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws Exception {
+        return EJBClient.createProxy(this.createStatelessLocator(beanName, beanInterface));
+    }
+
+    private <T> StatelessEJBLocator<T> createStatelessLocator(String beanName, Class<T> beanInterface) {
+        return new StatelessEJBLocator<>(beanInterface, this.appName, this.moduleName, beanName);
+    }
+
+    @Override
+    public <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) {
+        return EJBClient.createProxy(new EJBHomeLocator<>(homeInterface, this.appName, this.moduleName, beanName));
+    }
+
+    @Override
+    public UserTransaction lookupUserTransaction() {
+        return RemoteTransactionContext.getInstance().getUserTransaction();
+    }
+
+    @Override
+    public void close() {
+        // Do nothing
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/ClientEJBDirectory.java
@@ -53,12 +53,12 @@ public class ClientEJBDirectory implements EJBDirectory {
     }
 
     @Override
-    public <T> T lookupStateless(String beanName, Class<T> beanInterface) throws Exception {
+    public <T> T lookupStateless(String beanName, Class<T> beanInterface) {
         return EJBClient.createProxy(this.createStatelessLocator(beanName, beanInterface));
     }
 
     @Override
-    public <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws Exception {
+    public <T> T lookupSingleton(String beanName, Class<T> beanInterface) {
         return EJBClient.createProxy(this.createStatelessLocator(beanName, beanInterface));
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/EJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/EJBDirectory.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.clustering.ejb;
 
 import javax.ejb.EJBHome;
 import javax.ejb.SessionBean;
-import javax.naming.NamingException;
 import javax.transaction.UserTransaction;
 
 /**
@@ -33,24 +32,32 @@ import javax.transaction.UserTransaction;
  * @author Paul Ferraro
  */
 public interface EJBDirectory extends AutoCloseable {
-    <T> T lookupStateful(String beanName, Class<T> beanInterface) throws NamingException;
+    <T> T lookupStateful(String beanName, Class<T> beanInterface) throws Exception;
 
-    <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupStateful(Class<? extends T> beanClass, Class<T> beanInterface) throws Exception {
+        return this.lookupStateful(beanClass.getSimpleName(), beanInterface);
+    }
 
-    <T> T lookupStateless(String beanName, Class<T> beanInterface) throws NamingException;
+    <T> T lookupStateless(String beanName, Class<T> beanInterface) throws Exception;
 
-    <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupStateless(Class<? extends T> beanClass, Class<T> beanInterface) throws Exception {
+        return this.lookupStateless(beanClass.getSimpleName(), beanInterface);
+    }
 
-    <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws NamingException;
+    <T> T lookupSingleton(String beanName, Class<T> beanInterface) throws Exception;
 
-    <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws NamingException;
+    default <T> T lookupSingleton(Class<? extends T> beanClass, Class<T> beanInterface) throws Exception {
+        return this.lookupSingleton(beanClass.getSimpleName(), beanInterface);
+    }
 
-    <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws NamingException;
+    <T extends EJBHome> T lookupHome(String beanName, Class<T> homeInterface) throws Exception;
 
-    <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws NamingException;
+    default <T extends EJBHome> T lookupHome(Class<? extends SessionBean> beanClass, Class<T> homeInterface) throws Exception {
+        return this.lookupHome(beanClass.getSimpleName(), homeInterface);
+    }
 
-    UserTransaction lookupUserTransaction() throws NamingException;
+    UserTransaction lookupUserTransaction() throws Exception;
 
     @Override
-    void close() throws NamingException;
+    void close() throws Exception;
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/LocalEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/LocalEJBDirectory.java
@@ -23,42 +23,32 @@
 package org.jboss.as.test.clustering.ejb;
 
 import java.util.Properties;
-import javax.naming.InitialContext;
 
 import javax.naming.NamingException;
 
 /**
+ * {@link EJBDirectory} that uses local JNDI.
  * @author Paul Ferraro
  */
-public class LocalEJBDirectory extends AbstractEJBDirectory {
-    private static final String TX_CONTEXT_NAME = "java:comp/UserTransaction";
-
-    private final String module;
+public class LocalEJBDirectory extends NamingEJBDirectory {
 
     public LocalEJBDirectory(String module) throws NamingException {
-        super(TX_CONTEXT_NAME, new Properties());
-        this.module = module;
+        this(module, new Properties());
     }
 
-    public LocalEJBDirectory(String module, InitialContext context) {
-        super(TX_CONTEXT_NAME, context);
-        this.module = module;
+    public LocalEJBDirectory(String module, Properties properties) throws NamingException {
+        super(properties, "java:app", module, "java:comp/UserTransaction");
     }
 
-    public <T> T lookupStateful(Class<T> beanClass) throws NamingException {
+    public <T> T lookupStateful(Class<T> beanClass) throws Exception {
         return this.lookupStateful(beanClass, beanClass);
     }
 
-    public <T> T lookupStateless(Class<T> beanClass) throws NamingException {
+    public <T> T lookupStateless(Class<T> beanClass) throws Exception {
         return this.lookupStateless(beanClass, beanClass);
     }
 
-    public <T> T lookupSingleton(Class<T> beanClass) throws NamingException {
+    public <T> T lookupSingleton(Class<T> beanClass) throws Exception {
         return this.lookupSingleton(beanClass, beanClass);
-    }
-
-    @Override
-    protected <T> String createJndiName(String beanName, Class<T> beanInterface, Type type) {
-        return String.format("java:app/%s/%s!%s", this.module, beanName, beanInterface.getName());
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
@@ -27,10 +27,6 @@ import java.util.Properties;
 import javax.naming.Context;
 import javax.naming.NamingException;
 
-import org.jboss.ejb.client.Affinity;
-import org.jboss.ejb.client.ClusterAffinity;
-import org.jboss.ejb.client.EJBClient;
-
 /**
  * @author Paul Ferraro
  */
@@ -56,25 +52,5 @@ public class RemoteEJBDirectory extends AbstractEJBDirectory {
     @Override
     protected <T> String createJndiName(String beanName, Class<T> beanInterface, Type type) {
         return String.format("ejb:/%s/%s!%s%s", this.module, beanName, beanInterface.getName(), (type == Type.STATEFUL) ? "?stateful" : "");
-    }
-
-    @Override
-    protected <T> T lookup(String beanName, Class<T> beanInterface, Type type) throws NamingException {
-        T bean = super.lookup(beanName, beanInterface, type);
-        Affinity affinity = new ClusterAffinity("ejb");
-        switch (type) {
-            case STATEFUL: {
-                EJBClient.setStrongAffinity(bean, affinity);
-                break;
-            }
-            case STATELESS: {
-                EJBClient.setWeakAffinity(bean, affinity);
-                break;
-            }
-            default: {
-                // No need to set initial affinity
-            }
-        }
-        return bean;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -61,7 +61,7 @@ public abstract class ClusterPassivationTestBase {
     }
 
     @AfterClass
-    public static void destroy() throws NamingException {
+    public static void destroy() throws Exception {
         directory.close();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/remote/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -62,7 +62,7 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends ClusterAbs
     }
 
     @AfterClass
-    public static void destroy() throws NamingException {
+    public static void destroy() throws Exception {
         directory.close();
         singletonDirectory.close();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -112,7 +112,7 @@ public class RemoteStatelessFailoverTestCase {
     }
 
     @AfterClass
-    public static void destroy() throws NamingException {
+    public static void destroy() throws Exception {
         directoryAnnotation.close();
         directoryDD.close();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
@@ -159,7 +159,7 @@ public class RemoteEJBTwoClusterTestCase extends ExtendedClusterAbstractTestCase
     }
 
     @AfterClass
-    public static void destroy() throws NamingException {
+    public static void destroy() throws Exception {
         beanDirectory.close();
         txnBeanDirectory.close();
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9130

Add remote EJB test case variants that use EJB client API.