### PR TITLE
[WFLY-9385] DynamicJNDIContextEJBInvocationTestCase fails with security manager

### DIFF
--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -85,6 +85,8 @@
                                 <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
                                 <!-- EJB client library hack, see WFLY-4973-->
                                 <org.jboss.ejb.client.wildfly-testsuite-hack>true</org.jboss.ejb.client.wildfly-testsuite-hack>
+                                <jbossas.multinode.client>${basedir}/target/jbossas-multinode-client</jbossas.multinode.client>
+                                <jbossas.multinode.server>${basedir}/target/jbossas-multinode-server</jbossas.multinode.server>
                                 <server.jvm2.args>${surefire.system.args} ${jvm.args.ip} -Djboss.bind.address=${node1} -Djboss.bind.address.management=${node1} -Djboss.bind.address.unsecure=${node1} -Dnode0=${node0} -Dnode1=${node1}</server.jvm2.args>
                             </systemPropertyVariables>
                         </configuration>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -10,7 +10,7 @@
         <container qualifier="multinode-client" default="true">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-multinode-client</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${jbossas.multinode.client} -Djboss.node.name=multinode-client</property>
                                                                                         <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="jbossArguments">${jboss.args}</property>
@@ -27,7 +27,7 @@
         <container qualifier="multinode-server" default="false">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
-                <property name="javaVmArguments">${server.jvm2.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
+                <property name="javaVmArguments">${server.jvm2.args} -Djboss.inst=${jbossas.multinode.server} -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
@@ -36,8 +36,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.naming.InitialContext;
+import java.io.FilePermission;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * A test case for testing the feature introduced in https://issues.jboss.org/browse/EJBCLIENT-34 which
@@ -64,6 +67,10 @@ public class DynamicJNDIContextEJBInvocationTestCase {
         jar.addClasses(StatefulRemoteHomeForBeanOnOtherServer.class);
         jar.addAsManifestResource(DynamicJNDIContextEJBInvocationTestCase.class.getPackage(), "MANIFEST.MF", "MANIFEST.MF");
         jar.addAsManifestResource(DynamicJNDIContextEJBInvocationTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new FilePermission(System.getProperty("jbossas.multinode.server") + "/standalone/tmp/auth/*", "read")),
+                "permissions.xml"
+        );
         return jar;
     }
 


### PR DESCRIPTION
Running the test under security manager requires a FilePermission

issue: https://issues.jboss.org/browse/WFLY-9385
JBEAP issue: https://issues.jboss.org/browse/JBEAP-13255