### PR TITLE
[WFLY-8817] The jboss.dist system property is not used in testsuite/integration/elytron module

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -43,8 +43,8 @@
 
     <properties>
         <wildfly.instance.name>wildfly</wildfly.instance.name>
-        <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
-        <jboss.dist>${wildfly.dir}</jboss.dist>
+        <jboss.dist>${basedir}/target/${wildfly.instance.name}</jboss.dist>
+        <wildfly.dir>${jboss.dist}</wildfly.dir>
 
         <enforcer.skip>true</enforcer.skip>
     </properties>


### PR DESCRIPTION
jboss.dist system property is not taken into account when Elytron tests are being executed. Elytron tests are using wildfly.dir, so overriding its value with the one in jboss.dist fixes the issue.

Issue: https://issues.jboss.org/browse/WFLY-8817
JBEAP Issue: https://issues.jboss.org/browse/JBEAP-11054