### PR TITLE
Comment out section of RemoteStatefulEJBConcurrentFailoverTestCase failing due to EJBCLIENT-279.

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
@@ -149,6 +149,8 @@ public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends ClusterA
                 Assert.assertEquals(count++, result.getValue().intValue());
                 Assert.assertEquals(String.valueOf(i), target, result.getNode());
             }
+
+            bean.remove();
         }
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/Incrementor.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/Incrementor.java
@@ -21,6 +21,13 @@
  */
 package org.jboss.as.test.clustering.cluster.ejb.remote.bean;
 
+import javax.ejb.Remove;
+
 public interface Incrementor {
     Result<Integer> increment();
+
+    @Remove
+    default void remove() {
+        // Do nothing
+    }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/SlowStatefulIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/SlowStatefulIncrementorBean.java
@@ -23,15 +23,26 @@ package org.jboss.as.test.clustering.cluster.ejb.remote.bean;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.PreDestroy;
+import javax.annotation.PostConstruct;
 import javax.ejb.Remote;
 import javax.ejb.Stateful;
 
 @Stateful
 @Remote(Incrementor.class)
-public class SlowToDestroyStatefulIncrementorBean extends IncrementorBean {
-    @PreDestroy
-    public void preDestroy() {
+public class SlowStatefulIncrementorBean extends IncrementorBean {
+
+    @Override
+    public Result<Integer> increment() {
+        delay();
+        return super.increment();
+    }
+
+    @PostConstruct
+    public void init() {
+        delay();
+    }
+
+    private static void delay() {
         try {
             TimeUnit.SECONDS.sleep(2);
         } catch (InterruptedException e) {


### PR DESCRIPTION
I'll kick off a bunch of CI runs.  ~~Don't merge until verified.~~  Test looks stable now.
