### PR TITLE
WFLY-9419 Infinispan subsystem returns wrong value for GlobalConfiguration.transport().clusterName()

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -131,7 +131,7 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
                 .addAttributes(Attribute.class)
                 .addAttributes(DeprecatedAttribute.class)
                 .addCapabilities(Capability.class)
-                .addResourceCapabilityReference(new CapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL_FACTORY), address -> address.getParent().getLastElement().getValue())
+                .addResourceCapabilityReference(new CapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL), address -> address.getParent().getLastElement().getValue())
             ), handler, registrationConfigurator.andThen(registration -> {
                 if (registration.isRuntimeOnlyRegistrationValid()) {
                     new MetricHandler<>(new ClusteredCacheMetricExecutor(), ClusteredCacheMetric.class).register(registration);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
@@ -49,7 +49,7 @@ import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.wildfly.clustering.jgroups.spi.ChannelFactory;
+import org.jgroups.Channel;
 import org.wildfly.clustering.jgroups.spi.JGroupsRequirement;
 import org.wildfly.clustering.service.UnaryRequirement;
 
@@ -66,7 +66,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
     static final PathElement PATH = pathElement("jgroups");
 
     enum Requirement implements UnaryRequirement {
-        CHANNEL_FACTORY("org.wildfly.clustering.infinispan.transport.channel-factory", ChannelFactory.class),
+        CHANNEL("org.wildfly.clustering.infinispan.transport.channel", Channel.class),
         ;
         private final String name;
         private final Class<?> type;
@@ -88,7 +88,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        TRANSPORT_CHANNEL_FACTORY(Requirement.CHANNEL_FACTORY),
+        TRANSPORT_CHANNEL(Requirement.CHANNEL),
         ;
         private final RuntimeCapability<Void> definition;
 
@@ -108,7 +108,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
     }
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
-        CHANNEL("channel", ModelType.STRING, new DefaultableCapabilityReference(Capability.TRANSPORT_CHANNEL_FACTORY, JGroupsRequirement.CHANNEL_FACTORY)),
+        CHANNEL("channel", ModelType.STRING, new DefaultableCapabilityReference(Capability.TRANSPORT_CHANNEL, JGroupsRequirement.CHANNEL_FACTORY)),
         LOCK_TIMEOUT("lock-timeout", ModelType.LONG, new ModelNode(240000L)),
         ;
         private final AttributeDefinition definition;

--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -4,7 +4,7 @@
     <extension-module>org.jboss.as.clustering.jgroups</extension-module>
     <subsystem xmlns="urn:jboss:domain:jgroups:5.0">
         <channels default="ee">
-            <channel name="ee" stack="udp"/>
+            <channel name="ee" stack="udp" cluster="ejb"/>
         </channels>
         <stacks>
             <stack name="udp">


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9419