### PR TITLE
[WFLY-9160] ChunkPartitionTestCase fails with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/ChunkPartitionTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.batch.chunk;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.net.URL;
 import java.util.Properties;
 import java.util.PropertyPermission;
@@ -73,7 +74,8 @@ public class ChunkPartitionTestCase extends AbstractBatchTestCase {
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new RemotingPermission("createEndpoint"),
                         new RemotingPermission("connect"),
-                        new PropertyPermission("ts.timeout.factor", "read")
+                        new PropertyPermission("ts.timeout.factor", "read"),
+                        new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
                 ), "permissions.xml");
 
     }


### PR DESCRIPTION
Running the test under security manager requires a FilePermission

issue: https://issues.jboss.org/browse/WFLY-9160
JBEAP issue: https://issues.jboss.org/browse/JBEAP-12499