### PR TITLE
[WFLY-9433] apply InfiniteOrPositiveValidators to messaging attributes allow valid value -1

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -77,6 +77,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts()))
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -90,6 +91,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -130,6 +132,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts()))
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -98,6 +98,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -133,6 +134,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -172,6 +174,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -187,6 +190,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -80,6 +80,7 @@ public interface CommonAttributes {
             .setRequired(false)
             .setAllowExpression(true)
             .setMeasurementUnit(MILLISECONDS)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setFlags(RESTART_ALL_SERVICES)
             .build();
 
@@ -98,6 +99,7 @@ public interface CommonAttributes {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -105,6 +107,7 @@ public interface CommonAttributes {
             .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONNECTION_TTL))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setMeasurementUnit(MILLISECONDS)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -67,6 +67,7 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InfiniteOrPositiveValidators.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InfiniteOrPositiveValidators.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.messaging.activemq.jms.bridge;
+package org.wildfly.extension.messaging.activemq;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -109,6 +109,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition SECURITY_DOMAIN = create("security-domain", ModelType.STRING)
@@ -137,6 +138,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition OVERRIDE_IN_VM_SECURITY = create("override-in-vm-security", BOOLEAN)
@@ -303,6 +305,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalPoolFiles()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition JOURNAL_SYNC_NON_TRANSACTIONAL = create("journal-sync-non-transactional", BOOLEAN)
@@ -344,6 +347,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition ASYNC_CONNECTION_EXECUTION_ENABLED = create("async-connection-execution-enabled", BOOLEAN)
@@ -407,6 +411,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalPerfBlastPages()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition RUN_SYNC_SPEED_TEST = create("run-sync-speed-test", BOOLEAN)
@@ -422,6 +427,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition MEMORY_MEASURE_INTERVAL = create("memory-measure-interval", LONG)
@@ -430,6 +436,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition MEMORY_WARNING_THRESHOLD = create("memory-warning-threshold", INT)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
@@ -38,6 +38,7 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
+import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
@@ -62,6 +63,7 @@ public class HAAttributes {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetries()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -50,6 +50,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
+import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
 
 public interface ConnectionFactoryAttributes {
 
@@ -89,6 +90,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(MILLISECONDS)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
                 .build();
 
         AttributeDefinition COMPRESS_LARGE_MESSAGES = SimpleAttributeDefinitionBuilder.create("compress-large-messages", BOOLEAN)
@@ -102,6 +104,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
         AttributeDefinition CONNECTION_LOAD_BALANCING_CLASS_NAME = SimpleAttributeDefinitionBuilder.create("connection-load-balancing-policy-class-name", STRING)
@@ -114,6 +117,7 @@ public interface ConnectionFactoryAttributes {
                 .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONNECTION_TTL))
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
                 .setMeasurementUnit(MILLISECONDS)
                 .build();
 
@@ -130,6 +134,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
         AttributeDefinition CONSUMER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("consumer-window-size", INT)
@@ -214,6 +219,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
         AttributeDefinition PRODUCER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("producer-window-size", INT)
@@ -250,12 +256,14 @@ public interface ConnectionFactoryAttributes {
                 .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
         AttributeDefinition THREAD_POOL_MAX_SIZE = SimpleAttributeDefinitionBuilder.create("thread-pool-max-size", INT)
                 .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
         AttributeDefinition TRANSACTION_BATCH_SIZE = SimpleAttributeDefinitionBuilder.create("transaction-batch-size", INT)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -57,6 +57,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
+import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
 /**

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
@@ -58,6 +58,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
+import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 import org.wildfly.extension.messaging.activemq.jms.Validators;
 
@@ -106,6 +107,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -121,6 +123,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -135,6 +138,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CONNECTION_TTL))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setMeasurementUnit(MILLISECONDS)
             .setRestartAllServices()
             .build();
@@ -144,6 +148,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -241,6 +246,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -279,6 +285,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
@@ -286,6 +293,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9433
applied for configuration parameters in:

ActiveMQClient.java
public static final long DEFAULT_CLIENT_FAILURE_CHECK_PERIOD_INVM = -1;
public static final long DEFAULT_CONNECTION_TTL_INVM = -1;
public static final int DEFAULT_CONSUMER_MAX_RATE = -1;
public static final int DEFAULT_CONFIRMATION_WINDOW_SIZE = -1;
public static final int DEFAULT_PRODUCER_MAX_RATE = -1;
public static final int DEFAULT_THREAD_POOL_MAX_SIZE = -1;

ActiveMQDefaultConfiguration.java
private static long DEFAULT_CONNECTION_TTL_OVERRIDE = -1;
private static int DEFAULT_JOURNAL_POOL_FILES = -1;
private static long DEFAULT_CONNECTION_TTL_OVERRIDE = -1;
private static int DEFAULT_JOURNAL_PERF_BLAST_PAGES = -1;
private static long DEFAULT_SERVER_DUMP_INTERVAL = -1;
private static long DEFAULT_MEMORY_MEASURE_INTERVAL = -1;
private static int DEFAULT_BRIDGE_INITIAL_CONNECT_ATTEMPTS = -1;
private static int DEFAULT_BRIDGE_RECONNECT_ATTEMPTS = -1;
private static int DEFAULT_BRIDGE_PRODUCER_WINDOW_SIZE = -1;
private static int DEFAULT_CLUSTER_INITIAL_CONNECT_ATTEMPTS = -1;
private static int DEFAULT_CLUSTER_RECONNECT_ATTEMPTS = -1;
private static int DEFAULT_HAPOLICY_BACKUP_REQUEST_RETRIES = -1;
private static int DEFAULT_GROUPING_HANDLER_GROUP_TIMEOUT = -1;