### PR TITLE
[WFLY-9277] Make SFSB's lifecycle methods transaction attribute REQUI…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
@@ -161,8 +161,8 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
                     final EEApplicationClasses applicationClasses = context.getDeploymentUnit().getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
                     InterceptorClassDescription interceptorConfig = ComponentDescription.mergeInterceptorConfig(configuration.getComponentClass(), applicationClasses.getClassByName(description.getComponentClassName()), description, MetadataCompleteMarker.isMetadataComplete(context.getDeploymentUnit()));
 
-                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), true), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
-                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy(), true), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
+                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct()), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
+                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy()), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
 
                     configuration.addTimeoutViewInterceptor(TimerCMTTxInterceptor.FACTORY, InterceptorOrder.View.CMT_TRANSACTION_INTERCEPTOR);
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -153,9 +153,9 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
                     InterceptorClassDescription interceptorConfig = ComponentDescription.mergeInterceptorConfig(configuration.getComponentClass(), applicationClasses.getClassByName(description.getComponentClassName()), description, MetadataCompleteMarker.isMetadataComplete(context.getDeploymentUnit()));
 
                     if(interceptorConfig.getPostConstruct() != null) {
-                        configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), true), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
+                        configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct()), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
                     }
-                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy() ,true), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
+                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy()), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
 
                     configuration.addTimeoutViewInterceptor(TimerCMTTxInterceptor.FACTORY, InterceptorOrder.View.CMT_TRANSACTION_INTERCEPTOR);
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulComponentDescription.java
@@ -192,12 +192,12 @@ public class StatefulComponentDescription extends SessionBeanComponentDescriptio
                     final EEApplicationClasses applicationClasses = context.getDeploymentUnit().getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
                     InterceptorClassDescription interceptorConfig = ComponentDescription.mergeInterceptorConfig(configuration.getComponentClass(), applicationClasses.getClassByName(description.getComponentClassName()), description, MetadataCompleteMarker.isMetadataComplete(context.getDeploymentUnit()));
 
-                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), false), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
-                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy(), false), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
+                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct()), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
+                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy()), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
 
                     if (description.isPassivationApplicable()) {
-                        configuration.addPrePassivateInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPrePassivate(), false), InterceptorOrder.ComponentPassivation.TRANSACTION_INTERCEPTOR);
-                        configuration.addPostActivateInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostActivate(), false), InterceptorOrder.ComponentPassivation.TRANSACTION_INTERCEPTOR);
+                        configuration.addPrePassivateInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPrePassivate()), InterceptorOrder.ComponentPassivation.TRANSACTION_INTERCEPTOR);
+                        configuration.addPostActivateInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostActivate()), InterceptorOrder.ComponentPassivation.TRANSACTION_INTERCEPTOR);
                     }
                 }
             });

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentDescription.java
@@ -112,8 +112,8 @@ public class StatelessComponentDescription extends SessionBeanComponentDescripti
                     final EEApplicationClasses applicationClasses = context.getDeploymentUnit().getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
                     InterceptorClassDescription interceptorConfig = ComponentDescription.mergeInterceptorConfig(configuration.getComponentClass(), applicationClasses.getClassByName(description.getComponentClassName()), description, MetadataCompleteMarker.isMetadataComplete(context.getDeploymentUnit()));
 
-                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), true), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
-                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy(), true), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
+                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct()), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
+                    configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy()), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
 
                     configuration.addTimeoutViewInterceptor(TimerCMTTxInterceptor.FACTORY, InterceptorOrder.View.CMT_TRANSACTION_INTERCEPTOR);
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -88,7 +88,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.ejb.client.EJBLocator;
 import org.jboss.invocation.InterceptorContext;
-import org.jboss.invocation.proxy.MethodIdentifier;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.MethodInfo;
@@ -3012,10 +3011,6 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 462, value = "Unable to detect database dialect from connection metadata or JDBC driver name. Please configure this manually using the 'datasource' property in your configuration.  Known database dialect strings are %s")
     void jdbcDatabaseDialectDetectionFailed(String validDialects);
-
-    @LogMessage(level = WARN)
-    @Message(id = 463, value = "Invalid transaction attribute type %s on SFSB lifecycle method %s of class %s, valid types are REQUIRES_NEW and NOT_SUPPORTED. Method will be treated as NOT_SUPPORTED.")
-    void invalidTransactionTypeForSfsbLifecycleMethod(TransactionAttributeType txAttr, MethodIdentifier method, Class<?> clazz);
 
     @Message(id = 464, value = "The \"" + EJB3SubsystemModel.DISABLE_DEFAULT_EJB_PERMISSIONS + "\" attribute may not be set to true")
     OperationFailedException disableDefaultEjbPermissionsCannotBeTrue();


### PR DESCRIPTION
…RED by default

The @PostConstruct and @PreDestroy methods of SFSB have been removed from unspecified transaction context (EJB 3.1 13.6.5). Instead, they are REQUIRED by default (EJB 3.2 8.3.7). As a result, we can treat the lifecycle methods in all sessions beans in the same way. What is more, the warning message that was described in the JIRA has not to be printed.