### PR TITLE
[WFLY-9471] Export org.apache.activemq.artemis.addons module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -43,5 +43,10 @@
         <module name="io.netty"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
         <module name="sun.jdk"/>
+
+        <!-- WFLY-6301 This module can be used to load user-created classes that are
+             used by Artemis resources (e.g. connector-service, transformers, etc.)
+        -->
+        <module name="org.apache.activemq.artemis.addons" optional="true" />
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -63,12 +63,5 @@
         <module name="org.apache.activemq.artemis.protocol.amqp" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.hornetq" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.stomp" services="import" optional="true"/>
-
-        <!--
-          WFLY-6301 This module can be used to load user-created classes that are
-          used by Artemis resources (e.g. connector-service, transformers, etc.)
-        -->
-        <module name="org.apache.activemq.artemis.addons" slot="main" optional="true"/>
-
     </dependencies>
 </module>


### PR DESCRIPTION
Export org.apache.activemq.artemis.addons from
org.apache.activemq.artemis as the code that is responsible for
instantiating classes in Artemis are defined in
org.apache.activemq.artemis.journal sinrce WFLY-5522.

JIRA: https://issues.jboss.org/browse/WFLY-9471