### PR TITLE
[WFLY-9465] Some EJB2 clustering tests fail with security manager

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -35,6 +35,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 /**
  * Tests that invocations on a clustered stateful session EJB2 bean from a remote EJB client, failover to
  * other node(s) in cases like a node going down.
@@ -78,6 +82,9 @@ public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClient
         jar.addClass(CounterBean.class);
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: deployment." + MODULE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
+        jar.addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("jboss.node.name", "read")),
+                "META-INF/jboss-permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -36,6 +36,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 /**
  * @author Ondrej Chaloupka
  */
@@ -74,6 +78,9 @@ public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBCli
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(RemoteEJB2ClientStatefulBeanFailoverDDTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
         jar.addAsManifestResource(new StringAsset("Dependencies: deployment." + MODULE_NAME_SINGLE + ".jar\n"), "MANIFEST.MF");
+        jar.addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("jboss.node.name", "read")),
+                "META-INF/jboss-permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -23,12 +23,14 @@
 package org.jboss.as.test.clustering.cluster.ejb2.stateless;
 
 import static org.jboss.as.test.clustering.ClusteringTestConstants.*;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.PropertyPermission;
 import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
@@ -143,6 +145,9 @@ public class RemoteStatelessFailoverTestCase {
         jar.addPackage(StatelessRemote.class.getPackage());
         jar.addClass(StatelessBean.class);
         jar.addClass(NodeNameGetter.class);
+        jar.addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("jboss.node.name", "read")),
+                "META-INF/jboss-permissions.xml");
         return jar;
     }
 
@@ -152,6 +157,9 @@ public class RemoteStatelessFailoverTestCase {
         jar.addClass(StatelessBeanDD.class);
         jar.addClass(NodeNameGetter.class);
         jar.addAsManifestResource(RemoteStatelessFailoverTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        jar.addAsResource(createPermissionsXmlAsset(
+                new PropertyPermission("jboss.node.name", "read")),
+                "META-INF/jboss-permissions.xml");
         return jar;
     }
 


### PR DESCRIPTION
The execution of these tests under security manager requires a PropertyPermission

issue: https://issues.jboss.org/browse/WFLY-9465
JBEAP issue: https://issues.jboss.org/browse/JBEAP-13579