### PR TITLE
[WFLY-9464] Some XACML tests fail with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/EjbXACMLAuthorizationModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/EjbXACMLAuthorizationModuleTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.security.xacml;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -45,6 +46,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.security.permission.ElytronPermission;
 
 /**
  * Arquillian JUnit testcase for testing XACML based authorization of EJBs.
@@ -160,7 +162,10 @@ public class EjbXACMLAuthorizationModuleTestCase {
                 .addAsResource(EjbXACMLAuthorizationModuleTestCase.class.getPackage(),
                         XACMLTestUtils.TESTOBJECTS_POLICIES + "/ejb-xacml-policy.xml", "xacml-policy.xml")
                 .addAsManifestResource(EjbXACMLAuthorizationModuleTestCase.class.getPackage(),
-                        XACMLTestUtils.TESTOBJECTS_CONFIG + "/jboss-ejb3.xml", "jboss-ejb3.xml");
+                        XACMLTestUtils.TESTOBJECTS_CONFIG + "/jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsResource(createPermissionsXmlAsset(
+                        new ElytronPermission("getSecurityDomain")
+                ), "META-INF/permissions.xml");
         XACMLTestUtils.addJBossDeploymentStructureToArchive(jar);
         jar.addClasses(AbstractSecurityDomainsServerSetupTask.class);
         return jar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPServletInitializationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPServletInitializationTestCase.java
@@ -22,8 +22,10 @@
 package org.jboss.as.test.integration.security.xacml;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
+import java.io.FilePermission;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -33,6 +35,7 @@ import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.asset.AssetUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,6 +63,11 @@ public class JBossPDPServletInitializationTestCase {
         XACMLTestUtils.addCommonClassesToArchive(war);
         XACMLTestUtils.addJBossDeploymentStructureToArchive(war);
         XACMLTestUtils.addXACMLPoliciesToArchive(war);
+
+        final String testObjectsPolicies = AssetUtil.getClassLoaderResourceName(JBossPDPServletInitializationTestCase.class.getPackage(), XACMLTestUtils.TESTOBJECTS_POLICIES);
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new FilePermission(testObjectsPolicies + "/-", "read")
+                ), "permissions.xml");
         return war;
     }
 


### PR DESCRIPTION
This issue cannot be merged directly. It depends on some changes in two libraries `jboss-jaxb-api_spec` and `security-xacml`

Apart from the two privileged blocks in the libraries, there are some additional permissions required at the application level.

Issue: https://issues.jboss.org/browse/WFLY-9464
JBEAP Issue: https://issues.jboss.org/browse/JBEAP-13576

It depends on: 
https://github.com/picketbox/security-xacml/pull/9
https://github.com/jboss/jboss-jaxb-api_spec/pull/9