### PR TITLE
Drop unnecessary Supplier wrapper when configuring web session routing.

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilderProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilderProvider.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.function.Supplier;
 
 import org.infinispan.configuration.cache.CacheMode;
 import org.jboss.as.clustering.controller.CapabilityServiceBuilder;
@@ -55,12 +54,12 @@ public class InfinispanRouteLocatorBuilderProvider implements RouteLocatorBuilde
     }
 
     @Override
-    public Collection<CapabilityServiceBuilder<?>> getRouteLocatorConfigurationBuilders(String serverName, Supplier<ValueDependency<String>> routeDependencyProvider) {
+    public Collection<CapabilityServiceBuilder<?>> getRouteLocatorConfigurationBuilders(String serverName, ValueDependency<String> routeDependency) {
         String containerName = InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER;
 
         List<CapabilityServiceBuilder<?>> builders = new LinkedList<>();
 
-        builders.add(new RouteRegistryEntryProviderBuilder(serverName, routeDependencyProvider.get()));
+        builders.add(new RouteRegistryEntryProviderBuilder(serverName, routeDependency));
         builders.add(new TemplateConfigurationBuilder(ServiceName.parse(InfinispanCacheRequirement.CONFIGURATION.resolve(containerName, serverName)), containerName, serverName, null, builder -> {
             CacheMode mode = builder.clustering().cacheMode();
             builder.clustering().cacheMode(mode.isClustered() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilderProvider.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilderProvider.java
@@ -22,7 +22,6 @@
 package org.wildfly.clustering.web.session;
 
 import java.util.Collection;
-import java.util.function.Supplier;
 
 import org.jboss.as.clustering.controller.CapabilityServiceBuilder;
 import org.wildfly.clustering.service.ValueDependency;
@@ -44,5 +43,5 @@ public interface RouteLocatorBuilderProvider {
      * @param route the injected route source
      * @return a service builder
      */
-    Collection<CapabilityServiceBuilder<?>> getRouteLocatorConfigurationBuilders(String serverName, Supplier<ValueDependency<String>> routeDependencyProvider);
+    Collection<CapabilityServiceBuilder<?>> getRouteLocatorConfigurationBuilders(String serverName, ValueDependency<String> routeDependencyProvider);
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecBuilderProvider.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecBuilderProvider.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
 import org.jboss.as.clustering.controller.CapabilityServiceBuilder;
@@ -57,8 +56,8 @@ public class DistributableSessionIdentifierCodecBuilderProvider implements org.w
         Collection<CapabilityServiceBuilder<?>> builders = new LinkedList<>();
         CapabilityServiceBuilder<String> routeBuilder = new RouteBuilder(serverName);
         builders.add(routeBuilder);
-        Supplier<ValueDependency<String>> routeDependencyProvider = () -> new InjectedValueDependency<>(routeBuilder, String.class);
-        PROVIDER.ifPresent(provider -> builders.addAll(provider.getRouteLocatorConfigurationBuilders(serverName, routeDependencyProvider)));
+        ValueDependency<String> routeDependency = new InjectedValueDependency<>(routeBuilder, String.class);
+        PROVIDER.ifPresent(provider -> builders.addAll(provider.getRouteLocatorConfigurationBuilders(serverName, routeDependency)));
         return builders;
     }
 }


### PR DESCRIPTION
This exists to allow mod_cluster to update the route, but this is no longer used.