### PR TITLE
[WFLY-9231] Provide more informative null variable logging

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/BindingConfiguration.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/BindingConfiguration.java
@@ -44,10 +44,10 @@ public final class BindingConfiguration {
      */
     public BindingConfiguration(final String name, final InjectionSource source) {
         if (name == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("name");
+            throw EeLogger.ROOT_LOGGER.nullName("binding");
         }
         if (source == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("source");
+            throw EeLogger.ROOT_LOGGER.nullVar("source","binding", "");
         }
         this.name = name;
         this.source = source;

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentConfiguration.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentConfiguration.java
@@ -525,7 +525,7 @@ public class ComponentConfiguration {
      */
     public void setComponentCreateServiceFactory(final ComponentCreateServiceFactory componentCreateServiceFactory) {
         if (componentCreateServiceFactory == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("componentCreateServiceFactory");
+            throw EeLogger.ROOT_LOGGER.nullVar("componentCreateServiceFactory", "component", getComponentName());
         }
         this.componentCreateServiceFactory = componentCreateServiceFactory;
     }

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentDescription.java
@@ -108,16 +108,16 @@ public class ComponentDescription implements ResourceInjectionTarget {
     public ComponentDescription(final String componentName, final String componentClassName, final EEModuleDescription moduleDescription, final ServiceName deploymentUnitServiceName) {
         this.moduleDescription = moduleDescription;
         if (componentName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("name");
+            throw EeLogger.ROOT_LOGGER.nullName("component");
         }
         if (componentClassName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("componentClassName");
+            throw EeLogger.ROOT_LOGGER.nullVar("componentClassName", "component", componentName);
         }
         if (moduleDescription == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("moduleDescription");
+            throw EeLogger.ROOT_LOGGER.nullVar("moduleDescription", "component", componentName);
         }
         if (deploymentUnitServiceName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("deploymentUnitServiceName");
+            throw EeLogger.ROOT_LOGGER.nullVar("deploymentUnitServiceName", "component", componentName);
         }
         serviceName = BasicComponent.serviceNameOf(deploymentUnitServiceName, componentName);
         this.componentName = componentName;
@@ -411,7 +411,7 @@ public class ComponentDescription implements ResourceInjectionTarget {
      */
     public void setNamingMode(final ComponentNamingMode namingMode) {
         if (namingMode == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("namingMode");
+            throw EeLogger.ROOT_LOGGER.nullVar("namingMode", "component", componentName);
         }
         this.namingMode = namingMode;
     }
@@ -432,10 +432,10 @@ public class ComponentDescription implements ResourceInjectionTarget {
      */
     public void addDependency(ServiceName serviceName, ServiceBuilder.DependencyType type) {
         if (serviceName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("serviceName");
+            throw EeLogger.ROOT_LOGGER.nullVar("serviceName", "component", componentName);
         }
         if (type == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("type");
+            throw EeLogger.ROOT_LOGGER.nullVar("type", "component", componentName);
         }
         final Map<ServiceName, ServiceBuilder.DependencyType> dependencies = this.dependencies;
         final ServiceBuilder.DependencyType dependencyType = dependencies.get(serviceName);

--- a/ee/src/main/java/org/jboss/as/ee/component/EEModuleClassDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/EEModuleClassDescription.java
@@ -71,7 +71,7 @@ public final class EEModuleClassDescription {
 
     public void setInterceptorClassDescription(final InterceptorClassDescription interceptorClassDescription) {
         if(interceptorClassDescription == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("interceptorClassDescription");
+            throw EeLogger.ROOT_LOGGER.nullVar("interceptorClassDescription", "module class", className);
         }
         this.interceptorClassDescription = interceptorClassDescription;
     }

--- a/ee/src/main/java/org/jboss/as/ee/component/EEModuleDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/EEModuleDescription.java
@@ -113,7 +113,7 @@ public final class EEModuleDescription implements ResourceInjectionTarget {
      */
     public EEModuleClassDescription addOrGetLocalClassDescription(final String className) {
         if (className == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("name");
+            throw EeLogger.ROOT_LOGGER.nullVar("className", "module", moduleName);
         }
         EEModuleClassDescription ret = classDescriptions.get(className);
         if (ret == null) {
@@ -158,10 +158,10 @@ public final class EEModuleDescription implements ResourceInjectionTarget {
         final String componentName = description.getComponentName();
         final String componentClassName = description.getComponentClassName();
         if (componentName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("componentName");
+            throw EeLogger.ROOT_LOGGER.nullVar("componentName", "module", moduleName);
         }
         if (componentClassName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("componentClassName");
+            throw EeLogger.ROOT_LOGGER.nullVar("componentClassName","module", moduleName);
         }
         if (componentsByName.containsKey(componentName)) {
             throw EeLogger.ROOT_LOGGER.componentAlreadyDefined(componentName);
@@ -242,7 +242,7 @@ public final class EEModuleDescription implements ResourceInjectionTarget {
 
     public void setDistinctName(String distinctName) {
         if (distinctName == null) {
-            throw EeLogger.ROOT_LOGGER.nullVar("distinctName");
+            throw EeLogger.ROOT_LOGGER.nullVar("distinctName", "module", moduleName);
         }
         this.distinctName = distinctName;
     }

--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -879,6 +879,7 @@ public interface EeLogger extends BasicLogger {
     @Message(id = 78, value = "%s is null")
     IllegalArgumentException nullVar(String name);
 
+
     /**
      * Creates an exception indicating the item cannot be added because the priority is already taken.
      *
@@ -1109,4 +1110,25 @@ public interface EeLogger extends BasicLogger {
     @Message(id = 114, value = "Class does not implement all of the provided interfaces")
     IllegalArgumentException classDoesNotImplementAllInterfaces();
 
+    /**
+     * Creates an exception indicating the name of the @{code objectType}, is {@code null}.
+     *
+     * @param objectType the type of the object.
+     *
+     * @return an {@link IllegalArgumentException} for the error.
+     */
+    @Message(id = 115, value = "The name of the %s is null")
+    IllegalArgumentException nullName(String objectType);
+
+    /**
+     * Creates an exception indicating the variable, represented by the {@code variable} parameter in the @{code objectType} {@code objectName}, is {@code null}.
+     *
+     * @param variable the name of the variable.
+     * @param objectType the type of the object.
+     * @param objectName the name of the object.
+     *
+     * @return an {@link IllegalArgumentException} for the error.
+     */
+    @Message(id = 116, value = "%s is null in the %s %s")
+    IllegalArgumentException nullVar(String variable, String objectType, String objectName);
 }


### PR DESCRIPTION
This is a cosmetic logging fix which overloads nullVar methods in EE subsystem in order to provide more precise information to the user about the object in which the error occurrs as asked in WFLY-9231.