### PR TITLE
[WFLY-9531] Workaround WFCORE-3410. Improve handling of dynamic management model registration by resource adapter services.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
@@ -29,12 +29,14 @@ import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
 more  * @author <a href="mailto:stefano.maestri@redhat.com">Stefano Maestri</a>
@@ -70,6 +72,14 @@ public class ResourceAdaptersExtension implements Extension {
 
         // Remoting subsystem description and operation handlers
         registration.registerSubsystemModel(new ResourceAdaptersRootResourceDefinition(context.isRuntimeOnlyRegistrationValid()));
+
+        if (context.isRuntimeOnlyRegistrationValid()) {
+            ManagementResourceRegistration deployments = registration.registerDeploymentModel(new SimpleResourceDefinition(
+                    new SimpleResourceDefinition.Parameters(SUBSYSTEM_PATH,
+                            new StandardResourceDescriptionResolver(Constants.STATISTICS_NAME,
+                                    CommonAttributes.RESOURCE_NAME, CommonAttributes.class.getClassLoader()))));
+            deployments.registerSubModel(new IronJacamarResourceDefinition());
+        }
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9531

1) Work around WFCORE-3410. Change MRR cleanup in IronJacamarActivationResourceService to avoid having different service instances racing to remove different bits of the MRR tree.

2) Register the fixed parts of the r-a subsystem deployment model in the Extension; only deal with the overrides in service start/stop. This prevents cases where undeploying deployment 1 results in the MRR tree being removed for deployment 2, thus resulting in loss of the ability to read stats from deployment 2.

Also includes a second commit that does a general code cleanup of the IronJacamarActivationResourceService class.

I very much recommend reviewing the commits separately as the code cleanup obscures the main fix quite a lot.