### PR TITLE
CDI 2.0 for WildFly 12

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1310,22 +1310,31 @@
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-impl</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-ejb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-jsf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-jta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-web</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.weld.probe</groupId>
             <artifactId>weld-probe-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-jsf</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -3444,8 +3444,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.weld</groupId>
-      <artifactId>weld-core-jsf</artifactId>
+      <groupId>org.jboss.weld.module</groupId>
+      <artifactId>weld-jsf</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
@@ -29,7 +29,7 @@
 
     <resources>
         <artifact name="${org.wildfly:wildfly-jsf-injection}"/>
-        <artifact name="${org.jboss.weld:weld-core-jsf}"/>
+        <artifact name="${org.jboss.weld.module:weld-jsf}"/>
     </resources>
 
     <dependencies>
@@ -42,6 +42,7 @@
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.api"/>
 
         <!-- added this for MyFacesAnnotationProvider -->
         <module name="javax.faces.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -37,6 +37,7 @@
         <module name="org.jboss.weld.core" />
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.as.weld.spi" />
+        <module name="org.picketbox" />
         <module name="org.jboss.as.weld.common" />
         <module name="org.jboss.as.weld.ejb" optional="true" services="import" />
         <module name="org.jboss.as.weld.jpa" optional="true" services="import" />

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -30,6 +30,9 @@
 
     <resources>
         <artifact name="${org.jboss.weld:weld-core-impl}"/>
+        <artifact name="${org.jboss.weld.module:weld-ejb}"/>
+        <artifact name="${org.jboss.weld.module:weld-jta}"/>
+        <artifact name="${org.jboss.weld.module:weld-web}"/>
     </resources>
 
     <dependencies>
@@ -45,8 +48,8 @@
         <module name="javax.validation.api"/>
         <module name="org.glassfish.javax.el" />
         <module name="org.jboss.classfilewriter"/>
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.spi" />
+        <module name="org.jboss.weld.api" export="true"/>
+        <module name="org.jboss.weld.spi" export="true"/>
         <module name="org.jboss.logging" />
         <module name="sun.jdk" optional="true" />
 

--- a/jsf/injection/pom.xml
+++ b/jsf/injection/pom.xml
@@ -71,8 +71,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-jsf</artifactId>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-jsf</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-web</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/weld/WeldApplication.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/weld/WeldApplication.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.as.jsf.injection.weld;
 
-import org.jboss.weld.el.WeldELContextListener;
+import org.jboss.weld.module.web.el.WeldELContextListener;
 
 import javax.el.ELResolver;
 import javax.el.ExpressionFactory;

--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/weld/WildFlyConversationAwareViewHandler.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/weld/WildFlyConversationAwareViewHandler.java
@@ -23,9 +23,10 @@ import javax.faces.application.ViewHandler;
 import javax.faces.application.ViewHandlerWrapper;
 import javax.faces.context.FacesContext;
 import javax.servlet.ServletContext;
+
 import org.jboss.as.jsf.logging.JSFLogger;
 import org.jboss.as.jsf.deployment.JSFDependencyProcessor;
-import org.jboss.weld.jsf.ConversationAwareViewHandler;
+import org.jboss.weld.module.jsf.ConversationAwareViewHandler;
 
 /**
  * If this is a CDI-enabled app, then delegate to a wrapped Weld ViewHandler.

--- a/jsf/multi-jsf-installer/pom.xml
+++ b/jsf/multi-jsf-installer/pom.xml
@@ -53,8 +53,8 @@
             <version>${version.jboss.as}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-jsf</artifactId>
+            <groupId>org.jboss.weld.module</groupId>
+            <artifactId>weld-jsf</artifactId>
             <version>${version.weld.core}</version>
         </dependency>
     </dependencies>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
@@ -1,3 +1,3 @@
 module add --name=javax.faces.api --slot=mojarra-${jsf-version} --resources=jsf-api-${jsf-version}.jar --module-xml=mojarra-api-module.xml
 module add --name=com.sun.jsf-impl --slot=mojarra-${jsf-version} --resources=jsf-impl-${jsf-version}.jar --module-xml=mojarra-impl-module.xml
-module add --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version} --resources=weld-core-jsf-${version.weld.core}.jar:wildfly-jsf-injection-${version.jboss.as}.jar --resource-delimiter=: --module-xml=mojarra-injection-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version} --resources=weld-jsf-${version.weld.core}.jar:wildfly-jsf-injection-${version.jboss.as}.jar --resource-delimiter=: --module-xml=mojarra-injection-module.xml

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-injection-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-injection-module.xml
@@ -29,7 +29,7 @@
 
     <resources>
         <resource-root path="wildfly-jsf-injection-${version.jboss.as}.jar"/>
-        <resource-root path="weld-core-jsf-${version.weld.core}.jar"/>
+        <resource-root path="weld-jsf-${version.weld.core}.jar"/>
         <!-- Insert resources here -->
     </resources>
 

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
@@ -1,4 +1,4 @@
 module add --name=javax.faces.api --slot=myfaces-${jsf-version} --resources=myfaces-api-${jsf-version}.jar --module-xml=myfaces-api-module.xml
 module add --name=com.sun.jsf-impl --slot=myfaces-${jsf-version} --resources=myfaces-impl-${jsf-version}.jar --module-xml=myfaces-impl-module.xml
-module add --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version} --resources=weld-core-jsf-${version.weld.core}.jar:wildfly-jsf-injection-${version.jboss.as}.jar --resource-delimiter=: --module-xml=myfaces-injection-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version} --resources=weld-jsf-${version.weld.core}.jar:wildfly-jsf-injection-${version.jboss.as}.jar --resource-delimiter=: --module-xml=myfaces-injection-module.xml
 module add --name=org.apache.commons.digester --slot=main --resources=commons-digester-1.8.jar --module-xml=myfaces-digester-module.xml

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <version.io.undertow.jastow>2.0.2.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
-        <version.javax.enterprise>1.2</version.javax.enterprise>
+        <version.javax.enterprise>2.0</version.javax.enterprise>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.5.6</version.javax.mail>
         <version.javax.validation>1.1.0.Final</version.javax.validation>
@@ -197,8 +197,8 @@
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.4.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.spec.javax.websockets>1.1.2.Final</version.org.jboss.spec.javax.websockets>
-        <version.org.jboss.weld.weld>2.4.5.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>2.4.SP1</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>3.0.1.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>3.0.SP1</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>3.1.4.Final</version.org.jboss.ws.spi>
         <version.org.jboss.ws.common>3.1.5.Final</version.org.jboss.ws.common>
@@ -5472,68 +5472,56 @@
                 <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.enterprise</groupId>
-                        <artifactId>cdi-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.interceptor</groupId>
-                        <artifactId>jboss-interceptor-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.interceptor</groupId>
-                        <artifactId>jboss-interceptor-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.annotation</groupId>
-                        <artifactId>jsr250-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-ext</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ch.qos.cal10n</groupId>
-                        <artifactId>cal10n-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-spi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.spec.javax.el</groupId>
-                        <artifactId>jboss-el-api_3.0_spec</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-core-jsf</artifactId>
+                <groupId>org.jboss.weld.module</groupId>
+                <artifactId>weld-ejb</artifactId>
                 <version>${version.org.jboss.weld.weld}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.enterprise</groupId>
-                        <artifactId>cdi-api</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.module</groupId>
+                <artifactId>weld-jsf</artifactId>
+                <version>${version.org.jboss.weld.weld}</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-api</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.module</groupId>
+                <artifactId>weld-jta</artifactId>
+                <version>${version.org.jboss.weld.weld}</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-spi</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld.module</groupId>
+                <artifactId>weld-web</artifactId>
+                <version>${version.org.jboss.weld.weld}</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>org.jboss.weld</groupId>
-                        <artifactId>weld-core-impl</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/weld/common/pom.xml
+++ b/weld/common/pom.xml
@@ -25,6 +25,11 @@
       </dependency>
 
       <dependency>
+          <groupId>org.jboss.weld.module</groupId>
+          <artifactId>weld-ejb</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.logging</groupId>
          <artifactId>jboss-logging</artifactId>
       </dependency>

--- a/weld/common/src/main/java/org/jboss/as/weld/ejb/EjbRequestScopeActivationInterceptor.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/ejb/EjbRequestScopeActivationInterceptor.java
@@ -37,8 +37,8 @@ import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;
 import org.jboss.weld.context.ejb.EjbRequestContext;
-import org.jboss.weld.ejb.AbstractEJBRequestScopeActivationInterceptor;
 import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.module.ejb.AbstractEJBRequestScopeActivationInterceptor;
 
 /**
  * Interceptor for activating the CDI request scope on some EJB invocations.

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -142,6 +142,21 @@
       </dependency>
 
       <dependency>
+         <groupId>org.jboss.weld.module</groupId>
+         <artifactId>weld-ejb</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.weld.module</groupId>
+         <artifactId>weld-web</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.weld.module</groupId>
+         <artifactId>weld-jta</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.weld</groupId>
          <artifactId>weld-spi</artifactId>
       </dependency>

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/CdiAnnotations.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/CdiAnnotations.java
@@ -25,9 +25,7 @@ import java.util.Set;
 
 import org.jboss.as.weld.discovery.AnnotationType;
 import org.jboss.jandex.DotName;
-import org.jboss.weld.util.Function;
 import org.jboss.weld.util.collections.ImmutableSet;
-import org.jboss.weld.util.collections.Iterables;
 
 /**
  * Class that stores the {@link DotName}s of CDI annotations.
@@ -199,12 +197,7 @@ public enum CdiAnnotations {
 
     public static final Set<DotName> BUILT_IN_SCOPE_NAMES = ImmutableSet.<DotName>of(DEPENDENT.getDotName(), REQ_SCOPED.getDotName(), CONV_SCOPED.getDotName(), SESS_SCOPED.getDotName(), APP_SCOPED.getDotName(), SINGLETON.getDotName());
 
-    public static final Set<AnnotationType> BUILT_IN_SCOPES = ImmutableSet
-            .copyOf(Iterables.transform(BUILT_IN_SCOPE_NAMES, new Function<DotName, AnnotationType>() {
-                public AnnotationType apply(DotName input) {
-                    return new AnnotationType(input, true);
-                }
-            }));
+    public static final Set<AnnotationType> BUILT_IN_SCOPES = BUILT_IN_SCOPE_NAMES.stream().map(dotName -> new AnnotationType(dotName, true)).collect(ImmutableSet.collector());
 
     public static final Set<AnnotationType> BEAN_DEFINING_ANNOTATIONS = ImmutableSet.of(
             new AnnotationType(DotName.createComponentized(Constants.JAVAX_INTERCEPTOR, "Interceptor"), false), asAnnotationType(DECORATOR, false),

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
@@ -29,9 +29,9 @@ import javax.enterprise.inject.spi.CDIProvider;
 
 import org.jboss.as.weld.deployment.WeldDeployment;
 import org.jboss.as.weld.util.Reflections;
+import org.jboss.weld.AbstractCDI;
 import org.jboss.weld.Container;
 import org.jboss.weld.ContainerState;
-import org.jboss.weld.AbstractCDI;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
 import org.jboss.weld.logging.BeanManagerLogger;
@@ -103,5 +103,7 @@ public class WeldProvider implements CDIProvider {
         public String toString() {
             return "Weld instance for deployment " + BeanManagerProxy.unwrap(rootBeanManager).getContextId();
         }
+
     }
+
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
@@ -27,7 +28,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;
-import org.jboss.weld.literal.AnyLiteral;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 /**
@@ -77,7 +77,7 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service<EECla
         }
         final BeanManagerImpl beanManager = BeanManagerProxy.unwrap(this.beanManager.getValue());
         Bean<?> bean = null;
-        Set<Bean<?>> beans = new HashSet<>(beanManager.getBeans(clazz, AnyLiteral.INSTANCE));
+        Set<Bean<?>> beans = new HashSet<>(beanManager.getBeans(clazz, Any.Literal.INSTANCE));
         Iterator<Bean<?>> it = beans.iterator();
         //we may have resolved some sub-classes
         //go through and remove them from the bean set

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
@@ -49,9 +49,9 @@ import org.jboss.metadata.web.spec.FilterMetaData;
 import org.jboss.metadata.web.spec.FiltersMetaData;
 import org.jboss.metadata.web.spec.ListenerMetaData;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.weld.servlet.ConversationFilter;
-import org.jboss.weld.servlet.WeldInitialListener;
-import org.jboss.weld.servlet.WeldTerminalListener;
+import org.jboss.weld.module.web.servlet.ConversationFilter;
+import org.jboss.weld.module.web.servlet.WeldInitialListener;
+import org.jboss.weld.module.web.servlet.WeldTerminalListener;
 import org.jboss.weld.servlet.api.InitParameters;
 
 /**

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/AnnotationType.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/AnnotationType.java
@@ -23,11 +23,11 @@ package org.jboss.as.weld.discovery;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
+import java.util.function.Function;
 
 import org.jboss.as.weld.util.Indices;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
-import org.jboss.weld.util.Function;
 
 public class AnnotationType {
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/WeldClassFileServices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/discovery/WeldClassFileServices.java
@@ -23,6 +23,7 @@ package org.jboss.as.weld.discovery;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.jboss.as.server.deployment.annotation.CompositeIndex;
 import org.jboss.as.weld.logging.WeldLogger;
@@ -30,7 +31,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.weld.resources.spi.ClassFileInfo;
 import org.jboss.weld.resources.spi.ClassFileServices;
-import org.jboss.weld.util.Function;
 import org.jboss.weld.util.cache.ComputingCache;
 import org.jboss.weld.util.cache.ComputingCacheBuilder;
 import org.jboss.weld.util.collections.ImmutableSet;

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/injection/WeldComponentService.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/injection/WeldComponentService.java
@@ -113,7 +113,7 @@ public class WeldComponentService implements Service<WeldComponentService> {
 
             if (bean instanceof SessionBean<?>) {
                 SessionBean<?> sessionBean = (SessionBean<?>) bean;
-                this.injectionTarget = sessionBean.getInjectionTarget();
+                this.injectionTarget = sessionBean.getProducer();
                 return;
             }
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldExecutorServices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldExecutorServices.java
@@ -89,7 +89,7 @@ public class WeldExecutorServices extends AbstractExecutorServices implements Se
         if (executor != null) {
             context.asynchronous();
             new Thread(() -> {
-                super.cleanup();
+                super.shutdown();
                 executor = null;
                 context.complete();
             }).start();

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/util/Indices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/util/Indices.java
@@ -24,13 +24,13 @@ package org.jboss.as.weld.util;
 import java.lang.annotation.Inherited;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
-import org.jboss.weld.util.Function;
-import org.jboss.weld.util.Predicate;
 
 /**
  * Utilities for working with Jandex indices.

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/webtier/jsp/WeldJspExpressionFactoryWrapper.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/webtier/jsp/WeldJspExpressionFactoryWrapper.java
@@ -55,7 +55,7 @@ public class WeldJspExpressionFactoryWrapper implements ExpressionFactoryWrapper
 
         // register compositeELResolver with JSP
         jspAppContext.addELResolver(beanManager.getELResolver());
-        jspAppContext.addELContextListener(Reflections.<ELContextListener>newInstance("org.jboss.weld.el.WeldELContextListener", getClass().getClassLoader()));
+        jspAppContext.addELContextListener(Reflections.<ELContextListener>newInstance("org.jboss.weld.module.web.el.WeldELContextListener", getClass().getClassLoader()));
 
         return beanManager.wrapExpressionFactory(expressionFactory);
     }


### PR DESCRIPTION
Adapt Wildfly 12 for Weld 3.
Implement new method in WeldSecurityServices. Enable Elytron, use PrivilegedActions.
As per WELD-1914, we need other modules to be able to use Weld API module. Hence we export it from the core module.