### PR TITLE
WFLY-9537 Fix ejb timer missing events during DST switch from summer to winter

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
@@ -580,12 +580,18 @@ public class CalendarBasedTimeout {
     }
 
     private void setTime(Calendar calendar, int hour, int minute, int second) {
+        int dst = calendar.get(Calendar.DST_OFFSET);
         calendar.clear(Calendar.HOUR_OF_DAY);
         calendar.set(Calendar.HOUR_OF_DAY, hour);
         calendar.clear(Calendar.MINUTE);
         calendar.set(Calendar.MINUTE, minute);
         calendar.clear(Calendar.SECOND);
         calendar.set(Calendar.SECOND, second);
+        // restore summertime offset WFLY-9537
+        // this is to avoid to have the standard time (winter) set by GregorianCalendar
+        // after clear and set the time explicit
+        // see comment for computeTime() -> http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/util/GregorianCalendar.java#2776
+        calendar.set(Calendar.DST_OFFSET, dst);
     }
 
 }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -678,6 +678,207 @@ public class CalendarBasedTimeoutTestCase {
         Assert.assertEquals(0, firstTimeout.get(Calendar.SECOND));
     }
 
+    /**
+     * Change CET winter time to CEST summer time.
+     * The timer should be fired every 15 minutes (absolutely).
+     * The calendar time will jump from 2:00CET to 3:00CEST
+     * The test should be run similar in any OS/JVM default timezone
+     * This is a test to ensure WFLY-9537 will not break this.
+     */
+    @Test
+    public void testChangeCET2CEST() {
+        Calendar start = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+        start.clear();
+        // set half an hour before the CET->CEST DST switch 2017
+        start.set(2017, Calendar.MARCH, 26, 1, 30, 0);
+
+        ScheduleExpression schedule = new ScheduleExpression();
+        schedule.hour("*")
+                .minute("0/15")
+                .second("0")
+                .timezone("Europe/Berlin")  // don't fail the check below if running in a not default TZ
+                .start(start.getTime());
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        // assert first timeout result
+        Assert.assertNotNull(firstTimeout);
+        if(firstTimeout.get(Calendar.YEAR) != 2017 ||
+                firstTimeout.get(Calendar.MONTH) != Calendar.MARCH ||
+                firstTimeout.get(Calendar.DAY_OF_MONTH) != 26 ||
+                firstTimeout.get(Calendar.HOUR_OF_DAY) != 1 ||
+                firstTimeout.get(Calendar.MINUTE) != 30 ||
+                firstTimeout.get(Calendar.SECOND) != 0 ||
+                firstTimeout.get(Calendar.DST_OFFSET) != 0) {
+            Assert.fail("Start time unexpected : " + firstTimeout.toString());
+        }
+        Calendar current = firstTimeout;
+        for(int i = 0 ; i<3 ; i++) {
+            Calendar next = calendarTimeout.getNextTimeout(current);
+            if(current.getTimeInMillis() != (next.getTimeInMillis() - 900000)) {
+                Assert.fail("Schedule is more than 15 minutes from " + current.getTime() + " to " + next.getTime());
+            }
+            current = next;
+        }
+        if(current.get(Calendar.YEAR) != 2017 ||
+                current.get(Calendar.MONTH) != Calendar.MARCH ||
+                current.get(Calendar.DAY_OF_MONTH) != 26 ||
+                current.get(Calendar.HOUR_OF_DAY) != 3 ||
+                current.get(Calendar.MINUTE) != 15 ||
+                current.get(Calendar.DST_OFFSET) != 3600000) {
+            Assert.fail("End time unexpected : " + current.toString());
+        }
+    }
+
+    /**
+     * Change CEST summer time to CEST winter time.
+     * The timer should be fired every 15 minutes (absolutely).
+     * The calendar time will jump from 3:00CEST back to 2:00CET
+     * but the timer must run within 2:00-3:00 CEST and 2:00-3:00CET!
+     * The test should be run similar in any OS/JVM default timezone
+     * This is a test for WFLY-9537
+     */
+    @Test
+    public void testChangeCEST2CET() {
+        Calendar start = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+        start.clear();
+        // set half an hour before the CEST->CET DST switch 2017
+        start.set(2017, Calendar.OCTOBER, 29, 1, 30, 0);
+
+        ScheduleExpression schedule = new ScheduleExpression();
+        schedule.hour("*")
+                .minute("5/15")
+                .second("0")
+                .timezone("Europe/Berlin")  // don't fail the check below if running in a not default TZ
+                .start(start.getTime());
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        // assert first timeout result
+        Assert.assertNotNull(firstTimeout);
+        if(firstTimeout.get(Calendar.YEAR) != 2017 ||
+                firstTimeout.get(Calendar.MONTH) != Calendar.OCTOBER ||
+                firstTimeout.get(Calendar.DAY_OF_MONTH) != 29 ||
+                firstTimeout.get(Calendar.HOUR_OF_DAY) != 1 ||
+                firstTimeout.get(Calendar.MINUTE) != 35 ||
+                firstTimeout.get(Calendar.SECOND) != 0 ||
+                firstTimeout.get(Calendar.DST_OFFSET) != 3600000) {
+            Assert.fail("Start time unexpected : " + firstTimeout.toString());
+        }
+        Calendar current = firstTimeout;
+        for(int i = 0 ; i<7 ; i++) {
+            Calendar next = calendarTimeout.getNextTimeout(current);
+            if(current.getTimeInMillis() != (next.getTimeInMillis() - 900000)) {
+                Assert.fail("Schedule is more than 15 minutes from " + current.getTime() + " to " + next.getTime());
+            }
+            current = next;
+        }
+        if(current.get(Calendar.YEAR) != 2017 ||
+                current.get(Calendar.MONTH) != Calendar.OCTOBER ||
+                current.get(Calendar.DAY_OF_MONTH) != 29 ||
+                current.get(Calendar.HOUR_OF_DAY) != 2 ||
+                current.get(Calendar.MINUTE) != 20 ||
+                current.get(Calendar.DST_OFFSET) != 0) {
+            Assert.fail("End time unexpected : " + current.toString());
+        }
+    }
+
+    /**
+     * Change PST winter time to PST summer time.
+     * The timer should be fired every 15 minutes (absolutely).
+     * This is a test to ensure WFLY-9537 will not break this.
+     */
+    @Test
+    public void testChangeUS2Summer() {
+        Calendar start = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"));
+        start.clear();
+        // set half an hour before Los Angeles summer time switch
+        start.set(2017, Calendar.MARCH, 12, 1, 30, 0);
+
+        ScheduleExpression schedule = new ScheduleExpression();
+        schedule.hour("*")
+                .minute("0/15")
+                .second("0")
+                .timezone("America/Los_Angeles")  // don't fail the check below if running in a not default TZ
+                .start(start.getTime());
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        // assert first timeout result
+        Assert.assertNotNull(firstTimeout);
+        if(firstTimeout.get(Calendar.YEAR) != 2017 ||
+                firstTimeout.get(Calendar.MONTH) != Calendar.MARCH ||
+                firstTimeout.get(Calendar.DAY_OF_MONTH) != 12 ||
+                firstTimeout.get(Calendar.HOUR_OF_DAY) != 1 ||
+                firstTimeout.get(Calendar.MINUTE) != 30 ||
+                firstTimeout.get(Calendar.SECOND) != 0 ||
+                firstTimeout.get(Calendar.DST_OFFSET) != 0) {
+            Assert.fail("Start time unexpected : " + firstTimeout.toString());
+        }
+        Calendar current = firstTimeout;
+        for(int i = 0 ; i<3 ; i++) {
+            Calendar next = calendarTimeout.getNextTimeout(current);
+            if(current.getTimeInMillis() != (next.getTimeInMillis() - 900000)) {
+                Assert.fail("Schedule is more than 15 minutes from " + current.getTime() + " to " + next.getTime());
+            }
+            current = next;
+        }
+        if(current.get(Calendar.YEAR) != 2017 ||
+                current.get(Calendar.MONTH) != Calendar.MARCH ||
+                current.get(Calendar.DAY_OF_MONTH) != 12 ||
+                current.get(Calendar.HOUR_OF_DAY) != 3 ||
+                current.get(Calendar.MINUTE) != 15 ||
+                current.get(Calendar.DST_OFFSET) != 3600000) {
+            Assert.fail("End time unexpected : " + current.toString());
+        }
+    }
+
+    /**
+     * Change PST summer time to PST winter time.
+     * The timer should be fired every 15 minutes (absolutely).
+     * This is a test for WFLY-9537
+     */
+    @Test
+    public void testChangeUS2Winter() {
+        Calendar start = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"));
+        start.clear();
+        // set half an hour before Los Angeles time switch to winter time
+        start.set(2017, Calendar.NOVEMBER, 5, 0, 30, 0);
+
+        ScheduleExpression schedule = new ScheduleExpression();
+        schedule.hour("*")
+                .minute("0/15")
+                .second("0")
+                .timezone("America/Los_Angeles")  // don't fail the check below if running in a not default TZ
+                .start(start.getTime());
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        // assert first timeout result
+        Assert.assertNotNull(firstTimeout);
+        if(firstTimeout.get(Calendar.YEAR) != 2017 ||
+                firstTimeout.get(Calendar.MONTH) != Calendar.NOVEMBER ||
+                firstTimeout.get(Calendar.DAY_OF_MONTH) != 5 ||
+                firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
+                firstTimeout.get(Calendar.MINUTE) != 30 ||
+                firstTimeout.get(Calendar.SECOND) != 0 ||
+                firstTimeout.get(Calendar.DST_OFFSET) != 3600000) {
+            Assert.fail("Start time unexpected : " + firstTimeout.toString());
+        }
+        Calendar current = firstTimeout;
+        for(int i = 0 ; i<7 ; i++) {
+            Calendar next = calendarTimeout.getNextTimeout(current);
+            if(current.getTimeInMillis() != (next.getTimeInMillis() - 900000)) {
+                Assert.fail("Schedule is more than 15 minutes from " + current.getTime() + " to " + next.getTime());
+            }
+            current = next;
+        }
+        if(current.get(Calendar.YEAR) != 2017 ||
+                current.get(Calendar.MONTH) != Calendar.NOVEMBER ||
+                current.get(Calendar.DAY_OF_MONTH) != 5 ||
+                current.get(Calendar.HOUR_OF_DAY) != 1 ||
+                current.get(Calendar.MINUTE) != 15 ||
+                current.get(Calendar.DST_OFFSET) != 0) {
+            Assert.fail("End time unexpected : " + current.toString());
+        }
+    }
+
     private ScheduleExpression getTimezoneSpecificScheduleExpression() {
         ScheduleExpression scheduleExpression = new ScheduleExpression().timezone(this.timezone.getID());
         GregorianCalendar start = new GregorianCalendar(this.timezone);


### PR DESCRIPTION
4 tests added to ensure Summer-Winter Winter-Summer switch work correct in at least two different timezones and independent from the machine timezone which run the test.

https://issues.jboss.org/browse/WFLY-9537