### PR TITLE
Split variable assignment and export into 2 lines

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -206,7 +206,8 @@ concat_lines() {
   fi
 }
 
-export MAVEN_PROJECTBASEDIR="${MAVEN_BASEDIR:-`find_maven_basedir`}"
+MAVEN_PROJECTBASEDIR="${MAVEN_BASEDIR:-`find_maven_basedir`}"
+export MAVEN_PROJECTBASEDIR
 MAVEN_OPTS="`(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config")` $MAVEN_OPTS"
 
 # For Cygwin, switch paths to Windows format before running java


### PR DESCRIPTION
Replaces #9924, which I screwed up by trying to use the github UI to resolve a conflict.