### PR TITLE
Use read-only configs in ExpressionSupportSmokeTestCase to save thous…

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
@@ -157,6 +157,8 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
     public void setUp() throws IOException {
         final WildFlyManagedConfiguration config = createConfiguration("domain.xml", "host.xml", getClass().getSimpleName());
         config.setAdminOnly(true);
+        config.setReadOnlyDomain(true);
+        config.setReadOnlyHost(true);
 
         // Trigger the servers to fail on boot if there are runtime errors
         String hostProps = config.getHostCommandLineProperties();


### PR DESCRIPTION
…ands of config copies

This test makes over 4,000 write modifications. Just store those in the .last file and not the main file and avoid copying from one to the other for each write.