### PR TITLE
Testcase for WFLY-9573

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/EchoBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/EchoBean.java
@@ -29,11 +29,20 @@ import javax.ejb.Stateless;
  * @author Jaikiran Pai
  */
 @Stateless
-@Remote (RemoteEcho.class)
+@Remote(RemoteEcho.class)
 public class EchoBean implements RemoteEcho {
 
     @Override
     public String echo(String msg) {
         return msg;
+    }
+
+    @Override
+    public EchoMessage echo(final EchoMessage message) {
+        final EchoMessage echo = new EchoMessage();
+        if (message != null) {
+            echo.setMessage(message.getMessage());
+        }
+        return echo;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/EchoMessage.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/EchoMessage.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -18,16 +18,26 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
  */
 
 package org.jboss.as.test.integration.ejb.remote.jndi;
 
+import java.io.Serializable;
+
 /**
- * @author Jaikiran Pai
+ *
  */
-public interface RemoteEcho {
+public class EchoMessage implements Serializable {
 
-    String echo(String msg);
+    private String message;
 
-    EchoMessage echo(EchoMessage message);
+    public void setMessage(final String msg) {
+        this.message = msg;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/HttpRemoteEJBJndiBasedInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/jndi/HttpRemoteEJBJndiBasedInvocationTestCase.java
@@ -102,6 +102,13 @@ public class HttpRemoteEJBJndiBasedInvocationTestCase {
         final String msg = "Hello world from a really remote client!!!";
         final String echo = remoteEcho.echo(msg);
         Assert.assertEquals("Unexpected echo returned from remote bean", msg, echo);
+
+        // invoke a method which uses application specific type instead of primitives
+        final EchoMessage message = new EchoMessage();
+        message.setMessage("Hello");
+        final EchoMessage echoResponse = remoteEcho.echo(message);
+        Assert.assertNotNull("Echo response was null", echoResponse);
+        Assert.assertEquals("Unexpected echo returned from the bean", message.getMessage(), echoResponse.getMessage());
     }
 
     @Test


### PR DESCRIPTION
The commit here contains a testcase to reproduce the issue reported in https://issues.jboss.org/browse/WFLY-9573. The actual fix for the issue has been submitted as a PR to the wildfly-http-client project here https://github.com/wildfly/wildfly-http-client/pull/14. 

**Note that this PR is meant to be merged after the fix in the other PR is approved and the wildfly-http-client library itself it upgraded in WidlFly. Until then, this testcase will continue to fail.**ir

Kabir: This will need https://github.com/wildfly/wildfly/pull/10806 which upgrades it to 1.0.9 (or we need a later version)