### PR TITLE
Restore individual EJB SessionID externalizers

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
@@ -26,7 +26,10 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Base64;
 
+import org.jboss.ejb.client.BasicSessionID;
 import org.jboss.ejb.client.SessionID;
+import org.jboss.ejb.client.UUIDSessionID;
+import org.jboss.ejb.client.UnknownSessionID;
 import org.kohsuke.MetaInfServices;
 import org.wildfly.clustering.infinispan.spi.persistence.SimpleKeyFormat;
 import org.wildfly.clustering.marshalling.Externalizer;
@@ -35,11 +38,13 @@ import org.wildfly.clustering.marshalling.spi.IndexExternalizer;
 /**
  * @author Paul Ferraro
  */
-@MetaInfServices(Externalizer.class)
+
 public class SessionIDExternalizer extends SimpleKeyFormat<SessionID> implements Externalizer<SessionID> {
 
-    public SessionIDExternalizer() {
-        super(SessionID.class, value -> SessionID.createSessionID(Base64.getDecoder().decode(value)), id -> Base64.getEncoder().encodeToString(id.getEncodedForm()));
+    public static final SessionIDExternalizer INSTANCE = new SessionIDExternalizer(SessionID.class);
+
+    SessionIDExternalizer(Class<SessionID> targetClass) {
+        super(targetClass, value -> SessionID.createSessionID(Base64.getDecoder().decode(value)), id -> Base64.getEncoder().encodeToString(id.getEncodedForm()));
     }
 
     @Override
@@ -54,5 +59,29 @@ public class SessionIDExternalizer extends SimpleKeyFormat<SessionID> implements
         byte[] encoded = new byte[IndexExternalizer.UNSIGNED_BYTE.readData(input)];
         input.readFully(encoded);
         return SessionID.createSessionID(encoded);
+    }
+
+    @MetaInfServices(Externalizer.class)
+    public static class BasicSessionIDExternalizer extends SessionIDExternalizer {
+        @SuppressWarnings("unchecked")
+        public BasicSessionIDExternalizer() {
+            super((Class<SessionID>) (Class<?>) BasicSessionID.class);
+        }
+    }
+
+    @MetaInfServices(Externalizer.class)
+    public static class UnknownSessionIDExternalizer extends SessionIDExternalizer {
+        @SuppressWarnings("unchecked")
+        public UnknownSessionIDExternalizer() {
+            super((Class<SessionID>) (Class<?>) UnknownSessionID.class);
+        }
+    }
+
+    @MetaInfServices(Externalizer.class)
+    public static class UUIDSessionIDExternalizer extends SessionIDExternalizer {
+        @SuppressWarnings("unchecked")
+        public UUIDSessionIDExternalizer() {
+            super((Class<SessionID>) (Class<?>) UUIDSessionID.class);
+        }
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanEntryExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanEntryExternalizer.java
@@ -37,19 +37,17 @@ import org.wildfly.clustering.marshalling.Externalizer;
 @MetaInfServices(Externalizer.class)
 public class InfinispanBeanEntryExternalizer implements Externalizer<InfinispanBeanEntry<SessionID>> {
 
-    private static final Externalizer<SessionID> EXTERNALIZER = new SessionIDExternalizer();
-
     @Override
     public void writeObject(ObjectOutput output, InfinispanBeanEntry<SessionID> entry) throws IOException {
         output.writeUTF(entry.getBeanName());
-        EXTERNALIZER.writeObject(output, entry.getGroupId());
+        SessionIDExternalizer.INSTANCE.writeObject(output, entry.getGroupId());
         Date lastAccessedTime = entry.getLastAccessedTime();
         output.writeLong((lastAccessedTime != null) ? lastAccessedTime.getTime() : 0);
     }
 
     @Override
     public InfinispanBeanEntry<SessionID> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-        InfinispanBeanEntry<SessionID> entry = new InfinispanBeanEntry<>(input.readUTF(), EXTERNALIZER.readObject(input));
+        InfinispanBeanEntry<SessionID> entry = new InfinispanBeanEntry<>(input.readUTF(), SessionIDExternalizer.INSTANCE.readObject(input));
         long time = input.readLong();
         if (time > 0) {
             entry.setLastAccessedTime(new Date(time));

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanKeyExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanKeyExternalizer.java
@@ -38,20 +38,18 @@ import org.wildfly.clustering.marshalling.Externalizer;
 @MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class InfinispanBeanKeyExternalizer extends SimpleKeyFormat<InfinispanBeanKey<SessionID>> implements Externalizer<InfinispanBeanKey<SessionID>> {
 
-    private static final SessionIDExternalizer EXTERNALIZER = new SessionIDExternalizer();
-
     @SuppressWarnings("unchecked")
     public InfinispanBeanKeyExternalizer() {
-        super((Class<InfinispanBeanKey<SessionID>>) (Class<?>) InfinispanBeanKey.class, value -> new InfinispanBeanKey<>(EXTERNALIZER.parse(value)), key -> EXTERNALIZER.format(key.getId()));
+        super((Class<InfinispanBeanKey<SessionID>>) (Class<?>) InfinispanBeanKey.class, value -> new InfinispanBeanKey<>(SessionIDExternalizer.INSTANCE.parse(value)), key -> SessionIDExternalizer.INSTANCE.format(key.getId()));
     }
 
     @Override
     public void writeObject(ObjectOutput output, InfinispanBeanKey<SessionID> key) throws IOException {
-        EXTERNALIZER.writeObject(output, key.getId());
+        SessionIDExternalizer.INSTANCE.writeObject(output, key.getId());
     }
 
     @Override
     public InfinispanBeanKey<SessionID> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-        return new InfinispanBeanKey<>(EXTERNALIZER.readObject(input));
+        return new InfinispanBeanKey<>(SessionIDExternalizer.INSTANCE.readObject(input));
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupKeyExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupKeyExternalizer.java
@@ -39,20 +39,18 @@ import org.wildfly.clustering.marshalling.Externalizer;
 @MetaInfServices({ Externalizer.class, KeyFormat.class })
 public class InfinispanBeanGroupKeyExternalizer extends SimpleKeyFormat<InfinispanBeanGroupKey<SessionID>> implements Externalizer<InfinispanBeanGroupKey<SessionID>> {
 
-    private static final SessionIDExternalizer EXTERNALIZER = new SessionIDExternalizer();
-
     @SuppressWarnings("unchecked")
     public InfinispanBeanGroupKeyExternalizer() {
-        super((Class<InfinispanBeanGroupKey<SessionID>>) (Class<?>) InfinispanBeanGroupKey.class, value -> new InfinispanBeanGroupKey<>(EXTERNALIZER.parse(value)), key -> EXTERNALIZER.format(key.getId()));
+        super((Class<InfinispanBeanGroupKey<SessionID>>) (Class<?>) InfinispanBeanGroupKey.class, value -> new InfinispanBeanGroupKey<>(SessionIDExternalizer.INSTANCE.parse(value)), key -> SessionIDExternalizer.INSTANCE.format(key.getId()));
     }
 
     @Override
     public void writeObject(ObjectOutput output, InfinispanBeanGroupKey<SessionID> key) throws IOException {
-        EXTERNALIZER.writeObject(output, key.getId());
+        SessionIDExternalizer.INSTANCE.writeObject(output, key.getId());
     }
 
     @Override
     public InfinispanBeanGroupKey<SessionID> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
-        return new InfinispanBeanGroupKey<>(EXTERNALIZER.readObject(input));
+        return new InfinispanBeanGroupKey<>(SessionIDExternalizer.INSTANCE.readObject(input));
     }
 }


### PR DESCRIPTION
Prerequisite for Infinispan 9.1.x upgrade.

Infinispan 9.x includes some major marshalling changes.  Unfortunately, the consolidated externalizer for SessionID is not compatible with Infinispan 9.x.