### PR TITLE
WFLY-6464 (initial) JPA 2.2 container support

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -79,8 +79,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -116,8 +116,8 @@ vi:ts=4:sw=4:expandtab
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2092,8 +2092,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -1720,8 +1720,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
       <licenses>
         <license>
           <name>Eclipse Distribution License, Version 1.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
@@ -29,6 +29,6 @@
     </dependencies>
 
     <resources>
-        <artifact name="${org.hibernate.javax.persistence:hibernate-jpa-2.1-api}"/>
+        <artifact name="${javax.persistence:javax.persistence-api}"/>
     </resources>
 </module>

--- a/jpa/hibernate5/pom.xml
+++ b/jpa/hibernate5/pom.xml
@@ -133,8 +133,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/jpa/spi/pom.xml
+++ b/jpa/spi/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
         </dependency>
 
         <dependency>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
@@ -90,6 +90,8 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
                 version = Version.JPA_2_0;
             } else if ("2.1".equals(versionString)) {
                 version = Version.JPA_2_1;
+            } else if ("2.2".equals(versionString)) {
+                version = Version.JPA_2_2;
             } else if ("2".equals(versionString)) {
                 version = Version.JPA_2_0;
             } else {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/Version.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/Version.java
@@ -33,7 +33,8 @@ public enum Version {
     UNKNOWN(null),
     JPA_1_0("http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"),
     JPA_2_0("http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"),
-    JPA_2_1("http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd");
+    JPA_2_1("http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"),
+    JPA_2_2("http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd");
 
 
     private static final Map<String, Version> bindings = new HashMap<String, Version>();

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.org.hibernate>5.1.10.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.3.5.Final</version.org.hibernate.validator>
-        <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
+        <version.javax.persistence>2.2</version.javax.persistence>
         <version.org.hibernate.search>5.5.8.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>8.2.8.Final</version.org.infinispan>
@@ -4179,9 +4179,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.hibernate.javax.persistence</groupId>
-                <artifactId>hibernate-jpa-2.1-api</artifactId>
-                <version>${version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api}</version>
+                <groupId>javax.persistence</groupId>
+                <artifactId>javax.persistence-api</artifactId>
+                <version>${version.javax.persistence}</version>
             </dependency>
 
             <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -126,8 +126,8 @@
       <artifactId>jboss-jaxws-api_2.2_spec</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/SLSBPersistenceUnits.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/SLSBPersistenceUnits.java
@@ -28,7 +28,6 @@ import javax.ejb.EJBContext;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnit;
-import javax.persistence.PersistenceUnits;
 
 /**
  * stateless session bean
@@ -36,10 +35,9 @@ import javax.persistence.PersistenceUnits;
  * @author Scott Marlow
  */
 @Stateless
-@PersistenceUnits({
-        @PersistenceUnit(name = "pu1", unitName = "pu1"),
-        @PersistenceUnit(name = "pu2", unitName = "pu2")
-})
+@PersistenceUnit(name = "pu1", unitName = "pu1")
+@PersistenceUnit(name = "pu2", unitName = "pu2")
+
 public class SLSBPersistenceUnits {
 
     @Resource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/multiplepersistenceunittest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/multiplepersistenceunittest/persistence.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.2">
     <persistence-unit name="pu1">
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
         <properties>


### PR DESCRIPTION
We still need to add the JPA 2.2 version of Hibernate ORM (when available) and figure out how to switch between that and Hibernate ORM 5.1...