### PR TITLE
[master] Fix WFLY-9624

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/AsyncInvocationTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/AsyncInvocationTask.java
@@ -129,7 +129,7 @@ public abstract class AsyncInvocationTask implements Runnable, Future<Object> {
 
     @Override
     public boolean isDone() {
-        return status == ST_DONE;
+        return status != ST_RUNNING;
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/AppException.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/AppException.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -18,19 +18,20 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
  */
+
 package org.jboss.as.test.integration.ejb.remote.async;
 
-import javax.ejb.Local;
-import java.util.concurrent.Future;
+import javax.ejb.ApplicationException;
 
 /**
- * @author Stuart Douglas
+ *
  */
-@Local
-public interface LocalInterface {
-    void passByReference(String[] value);
+@ApplicationException
+public class AppException extends Exception {
 
-    Future<Void> alwaysFail() throws AppException;
-
+    public AppException(final String message) {
+        super(message);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/RemoteAsyncInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/RemoteAsyncInvocationTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ejb.remote.async;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -34,6 +35,7 @@ import org.junit.runner.RunWith;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -52,6 +54,7 @@ public class RemoteAsyncInvocationTestCase {
 
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addPackage(RemoteAsyncInvocationTestCase.class.getPackage());
+        jar.addClass(TimeoutUtil.class);
         return jar;
     }
 
@@ -108,5 +111,40 @@ public class RemoteAsyncInvocationTestCase {
         RemoteInterface remote = lookup(StatelessRemoteBean.class.getSimpleName(), RemoteInterface.class);
         Future<String> value = remote.hello();
         Assert.assertEquals("hello", value.get(5, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Tests that an exception thrown from a async EJB invocation, leads to the returned
+     * {@link Future} to be marked as {@link Future#isDone() done}
+     *
+     * @throws Exception
+     * @see <a href="https://issues.jboss.org/browse/WFLY-9624">WFLY-9624</a> for more details
+     */
+    @Test
+    public void testFutureDoneInLocalAsyncInvocation() throws Exception {
+        final LocalInterface localBean = lookup(StatelessRemoteBean.class.getSimpleName(), LocalInterface.class);
+        final Future<Void> future = localBean.alwaysFail();
+        // try a few times to make sure it's "done". it should be done immediately, so trying just
+        // a few times should be fine
+        for (int i = 0; i < 5; i++) {
+            if (future.isDone()) {
+                break;
+            }
+            // wait for a while
+            Thread.sleep(TimeoutUtil.adjust(500));
+        }
+        Assert.assertTrue("Async invocation which was expected to fail immediately, wasn't considered \"done\"", future.isDone());
+        try {
+            // once the future is marked as done, the get should immediately return, but we
+            // do send the timeouts here, just so that we don't end up blocking in this testcase
+            // due to any bugs in the implementation of the returned future
+            future.get(1, TimeUnit.SECONDS);
+            Assert.fail("Async invocation was expected to throw an application exception, but it didn't");
+        } catch (ExecutionException ee) {
+            // we expect a AppException
+            if (!(ee.getCause() instanceof AppException)) {
+                throw ee;
+            }
+        }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/StatelessRemoteBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/async/StatelessRemoteBean.java
@@ -64,6 +64,12 @@ public class StatelessRemoteBean implements RemoteInterface, LocalInterface {
 
     @Override
     @Asynchronous
+    public Future<Void> alwaysFail() throws AppException {
+        throw new AppException("Intentionally thrown");
+    }
+
+    @Override
+    @Asynchronous
     public void passByReference(final String[] array) {
         try {
             if(!startLatch.await(5, TimeUnit.SECONDS)) {


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-9624, where the `Future` returned by async invocations on local EJBs wasn't considered `done` when an exception was thrown.

The commit also includes a test case to reproduce the issue and verify the fix.