### PR TITLE
Add mixed domain tests

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
@@ -49,6 +49,7 @@ import org.jboss.as.security.SecurityExtension;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
 import org.jboss.as.test.integration.domain.mixed.eap640.DomainAdjuster640;
 import org.jboss.as.test.integration.domain.mixed.eap700.DomainAdjuster700;
+import org.jboss.as.test.integration.domain.mixed.eap710.DomainAdjuster710;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.junit.Assert;
@@ -88,6 +89,9 @@ public class DomainAdjuster {
                 break;
             case EAP_7_0_0:
                 adjuster = new DomainAdjuster700();
+                break;
+            case EAP_7_1_0:
+                adjuster = new DomainAdjuster710();
                 break;
             default:
                 adjuster = new DomainAdjuster();

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDeploymentOverlayTestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDeploymentOverlayTestCase.java
@@ -365,6 +365,10 @@ public class MixedDeploymentOverlayTestCase {
     }
 
     protected String getUnknowOperationErrorCode() {
-        return "WFLYCTL0031";
+        Version version = this.getClass().getAnnotation(Version.class);
+        if (version.value().compare(7, 1) < 0) {
+            return "WFLYCTL0031";
+        }
+        return "WFLYDC0032";
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
@@ -68,6 +68,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -234,6 +235,9 @@ public abstract class MixedDomainDeploymentTest {
 
     @Test
     public void testExplodedDeployment() throws Exception {
+        // TODO WFLY-9634
+        Assume.assumeFalse(supportManagedExplodedDeployment());
+
         ModelNode composite = createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
         ModelNode steps = composite.get(STEPS);
         ModelNode op = createAddOperation(ROOT_DEPLOYMENT_ADDRESS);

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
@@ -105,9 +105,12 @@ class OldVersionCopier {
         String entryName = path.toString();
         if (entryName.endsWith("/docs/") || entryName.endsWith("/bundles/")) {
             return true;
-        } else if (entryName.endsWith("/bin/") || entryName.endsWith("/welcome-content/")) {
+        } else if (entryName.endsWith("/bin/")) {
             return true;
         } else if (entryName.endsWith("/eap/dir/")) { //console files
+            return true;
+        } else if (entryName.contains("/welcome-content/") && !entryName.endsWith("/welcome-content/")) {
+            //Create the directory but don't include any files
             return true;
         }
         return false;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -44,7 +44,8 @@ public @interface Version {
         EAP_6_2_0(EAP, 6, 2, 0),
         EAP_6_3_0(EAP, 6, 3, 0),
         EAP_6_4_0(EAP, 6, 4, 0),
-        EAP_7_0_0(EAP, 7, 0, 0);
+        EAP_7_0_0(EAP, 7, 0, 0),
+        EAP_7_1_0(EAP, 7, 1, 0);
 
 
         final String basename;
@@ -91,6 +92,19 @@ public @interface Version {
 
         public int getMicro() {
             return micro;
+        }
+
+        int compare(int major, int minor) {
+            if (this.major < major) {
+                return -1;
+            }
+            if (this.major > major) {
+                return  1;
+            }
+            if (this.minor == minor) {
+                return 0;
+            }
+            return this.minor < minor ? -1 : 1;
         }
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.mixed.DomainAdjuster;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Does adjustments to the domain model for 7.1.0 legacy slaves.
+ *
+ * @author <a href="mailto:kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class DomainAdjuster710 extends DomainAdjuster {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress, boolean withMasterServers) throws Exception {
+        final List<ModelNode> list = new ArrayList<>();
+
+        adjustUndertow(profileAddress.append(SUBSYSTEM, "undertow"), list);
+
+        if (withMasterServers) {
+            list.addAll(reconfigureServers());
+        }
+
+        return list;
+    }
+
+    private void adjustUndertow(PathAddress undertow, List<ModelNode> ops) {
+        // EAP 7.0 and earlier required explicit SSL configuration. Wildfly 10.1 added support
+        // for SSL by default, which automatically generates certs.
+        // This could be removed if all hosts were configured to contain a security domain with SSL
+        // enabled.
+        final PathAddress httpsListener = undertow
+                .append("server", "default-server")
+                .append("https-listener", "https");
+        ops.add(Util.getEmptyOperation(ModelDescriptionConstants.REMOVE, httpsListener.toModelNode()));
+    }
+
+    private Collection<? extends ModelNode> reconfigureServers() {
+        final List<ModelNode> list = new ArrayList<>();
+        //Reconfigure master servers
+        final PathAddress masterHostAddress = PathAddress.pathAddress(HOST, "master");
+        list.add(Util.getWriteAttributeOperation(masterHostAddress.append(SERVER_CONFIG, "server-one"), AUTO_START, true));
+        list.add(Util.getWriteAttributeOperation(masterHostAddress.append(SERVER_CONFIG, "server-one"), ModelDescriptionConstants.GROUP, "main-server-group"));
+        list.add(Util.getUndefineAttributeOperation(masterHostAddress.append(SERVER_CONFIG, "server-one"), ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET));
+        list.add(Util.getWriteAttributeOperation(masterHostAddress.append(SERVER_CONFIG, "server-two"), AUTO_START, true));
+        list.add(Util.getWriteAttributeOperation(masterHostAddress.append(SERVER_CONFIG, "server-two"), ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET, 100));
+        return list;
+    }
+
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainHostExcludes710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainHostExcludes710TestCase.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.test.integration.domain.mixed.DomainHostExcludesTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.junit.BeforeClass;
+
+/**
+ * Tests of the ability of a DC to exclude resources from visibility to an EAP 7.1.0 slave.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_1_0)
+public class DomainHostExcludes710TestCase extends DomainHostExcludesTest {
+
+    @BeforeClass
+    public static void beforeClass() throws InterruptedException, TimeoutException, MgmtOperationException, IOException {
+        LegacyConfig710TestSuite.initializeDomain();
+        setup(DomainHostExcludes710TestCase.class,"EAP7.1", ModelVersion.create(5, 0));
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/ElytronOnlyMaster710TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/ElytronOnlyMaster710TestSuite.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.ElytronOnlyMasterTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * @author Martin Simka
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {ElytronOnlyMasterSmoke710TestCase.class})
+@Version(Version.AsVersion.EAP_7_1_0)
+@Ignore("Ignore until WFCORE-2882 is integrated")
+public class ElytronOnlyMaster710TestSuite extends ElytronOnlyMasterTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        ElytronOnlyMasterTestSuite.getSupport(ElytronOnlyMaster710TestSuite.class);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/ElytronOnlyMasterSmoke710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/ElytronOnlyMasterSmoke710TestCase.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.ElytronOnlyMasterSmokeTestCase;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * @author Martin Simka
+ */
+@Version(Version.AsVersion.EAP_7_1_0)
+public class ElytronOnlyMasterSmoke710TestCase extends ElytronOnlyMasterSmokeTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        ElytronOnlyMaster710TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/KernelBehavior710TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/KernelBehavior710TestSuite.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.KernelBehaviorTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {RBACConfig710TestCase.class, WildcardReads710TestCase.class})
+@Version(Version.AsVersion.EAP_7_1_0)
+public class KernelBehavior710TestSuite extends KernelBehaviorTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        KernelBehaviorTestSuite.getSupport(KernelBehavior710TestSuite.class);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfig710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfig710TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 7.0 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_0_0)
+public class LegacyConfig710TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig710TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfig710TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfig710TestSuite.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 7.1 domain.xml with a current DC and a 6.4 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig710TestCase.class, DomainHostExcludes710TestCase.class})
+@Version(Version.AsVersion.EAP_7_1_0)
+public class LegacyConfig710TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig710TestSuite.class, Version.AsVersion.EAP_7_1_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfigAdjuster710.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/LegacyConfigAdjuster710.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigAdjuster;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 7.0 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster710 extends LegacyConfigAdjuster {
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomain710TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomain710TestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@RunWith(Suite.class)
+@SuiteClasses(value= {SimpleMixedDomain710TestCase.class, MixedDomainDeployment710TestCase.class})
+@Version(AsVersion.EAP_7_1_0)
+public class MixedDomain710TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupport(MixedDomain710TestSuite.class);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainDeployment710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainDeployment710TestCase.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainDeploymentTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Version(AsVersion.EAP_7_1_0)
+public class MixedDomainDeployment710TestCase extends MixedDomainDeploymentTest {
+    @BeforeClass
+    public static void beforeClass() {
+        MixedDomain710TestSuite.initializeDomain();
+    }
+
+    @Override
+    protected boolean supportManagedExplodedDeployment() {
+        return true;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainDeploymentOverlay710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainDeploymentOverlay710TestCase.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDeploymentOverlayTestCase;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+
+/**
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+@Version(AsVersion.EAP_7_1_0)
+public class MixedDomainDeploymentOverlay710TestCase extends MixedDeploymentOverlayTestCase {
+    @BeforeClass
+    public static void beforeClass() {
+        MixedDomainOverlay710TestSuite.initializeDomain();
+        MixedDeploymentOverlayTestCase.setupDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainOverlay710TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/MixedDomainOverlay710TestSuite.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+@RunWith(Suite.class)
+@SuiteClasses(value= {MixedDomainDeploymentOverlay710TestCase.class})
+@Version(AsVersion.EAP_7_1_0)
+public class MixedDomainOverlay710TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupport(MixedDomainOverlay710TestSuite.class, "master-config/host.xml", "slave-config/host-slave-overlay.xml", Profile.DEFAULT, true, false, true);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/RBACConfig710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/RBACConfig710TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.RBACConfigTestCase;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 7.0 variant of RBACConfigTestCase.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_1_0)
+public class RBACConfig710TestCase extends RBACConfigTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        KernelBehavior710TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/SimpleMixedDomain710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/SimpleMixedDomain710TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.SimpleMixedDomainTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+@Version(AsVersion.EAP_7_1_0)
+public class SimpleMixedDomain710TestCase extends SimpleMixedDomainTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        MixedDomain710TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/WildcardReads710TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/WildcardReads710TestCase.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap710;
+
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.WildcardReadsTestCase;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_7_1_0)
+public class WildcardReads710TestCase extends WildcardReadsTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        KernelBehavior710TestSuite.initializeDomain();
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9633

This needs https://github.com/wildfly/wildfly-core/pull/3008 (https://issues.jboss.org/browse/WFCORE-3472) merged and released before it will pass.

testExplodedDeployment() can not  pass on 7.1.0 due to https://issues.jboss.org/browse/WFCORE-3479. and has been conditionally ignored. https://issues.jboss.org/browse/WFLY-9634 has been opened to reenable it.