### PR TITLE
[WFLY-9346] IIOP: Make ORB dependent on DefaultNamespaceContextSelect…

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.InitialContext;
+import org.jboss.as.naming.service.DefaultNamespaceContextSelectorService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -173,6 +174,7 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
         String securityDomain = props.getProperty(Constants.SECURITY_SECURITY_DOMAIN);
         if (securityDomain != null) {
             builder.addDependency(context.getCapabilityServiceName(Capabilities.CAPABILITY_LEGACY_SECURITY_DOMAIN, securityDomain, null));
+            builder.addDependency(DefaultNamespaceContextSelectorService.SERVICE_NAME);
         }
 
         // add dependencies to the ssl context services if needed.


### PR DESCRIPTION
…orService

This fix adds yet another dependency to fix the TCK JSSE security domain race condition. I have run a bunch of TCK jobs with the fix and the error hasn't occurred so hopefully this is the final fix...