### PR TITLE
WFLY-9648 Restore ability to disable initial state transfer for replicated/distributed caches

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -720,10 +720,10 @@ public class InfinispanSubsystemXMLReader implements XMLElementReader<List<Model
             XMLAttribute attribute = XMLAttribute.forName(reader.getAttributeLocalName(i));
             switch (attribute) {
                 case ENABLED: {
-                    if (this.schema.since(InfinispanSchema.VERSION_4_0)) {
+                    if (this.schema == InfinispanSchema.VERSION_4_0) {
                         throw ParseUtils.unexpectedAttribute(reader, i);
                     }
-                    ROOT_LOGGER.attributeDeprecated(attribute.getLocalName(), reader.getLocalName());
+                    readAttribute(reader, i, operation, StateTransferResourceDefinition.Attribute.ENABLED);
                     break;
                 }
                 case TIMEOUT: {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferBuilder.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.clustering.infinispan.subsystem.StateTransferResourceDefinition.Attribute.CHUNK_SIZE;
+import static org.jboss.as.clustering.infinispan.subsystem.StateTransferResourceDefinition.Attribute.ENABLED;
 import static org.jboss.as.clustering.infinispan.subsystem.StateTransferResourceDefinition.Attribute.TIMEOUT;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -37,7 +38,7 @@ import org.wildfly.clustering.service.Builder;
  * @author Paul Ferraro
  */
 public class StateTransferBuilder extends ComponentBuilder<StateTransferConfiguration> {
-
+    private volatile boolean enabled;
     private volatile int chunkSize;
     private volatile long timeout;
 
@@ -48,14 +49,16 @@ public class StateTransferBuilder extends ComponentBuilder<StateTransferConfigur
     @Override
     public StateTransferConfiguration getValue() {
         return new ConfigurationBuilder().clustering().stateTransfer()
+                .fetchInMemoryState(this.enabled)
+                .awaitInitialTransfer(this.timeout > 0)
                 .chunkSize(this.chunkSize)
-                .fetchInMemoryState(true)
                 .timeout(this.timeout)
                 .create();
     }
 
     @Override
     public Builder<StateTransferConfiguration> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        this.enabled = ENABLED.resolveModelAttribute(context, model).asBoolean();
         this.chunkSize = CHUNK_SIZE.resolveModelAttribute(context, model).asInt();
         this.timeout = TIMEOUT.resolveModelAttribute(context, model).asLong();
         return this;

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -159,9 +159,8 @@ infinispan.component.partition-handling.force-available=Forces a cache with degr
 infinispan.component.state-transfer=The state transfer configuration for distributed and replicated caches.
 infinispan.component.state-transfer.add=Add a state transfer configuration.
 infinispan.component.state-transfer.remove=Remove a state transfer configuration.
-infinispan.component.state-transfer.enabled=If enabled, this will cause the cache to ask neighboring caches for state when it starts up, so the cache starts 'warm', although it will impact startup time.
-infinispan.component.state-transfer.enabled.deprecated=Deprecated. Always enabled for replicated and distributed caches.
-infinispan.component.state-transfer.timeout=The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.
+infinispan.component.state-transfer.enabled=Enables initial state transfer. Disabling initial state transfer can leave cache vulnerable to data-loss, especially when using distribution mode with a minimal number of owners.
+infinispan.component.state-transfer.timeout=The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup. If timeout is less than or equal to 0, state transfer is performed asynchronously, and the cache will be immediately available.
 infinispan.component.state-transfer.chunk-size=The size, in bytes, in which to batch the transfer of cache entries.
 
 infinispan.distributed-cache=A distributed cache configuration.

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -161,7 +161,7 @@ infinispan.component.state-transfer.add=Add a state transfer configuration.
 infinispan.component.state-transfer.remove=Remove a state transfer configuration.
 infinispan.component.state-transfer.enabled=Enables initial state transfer. Disabling initial state transfer can leave cache vulnerable to data-loss, especially when using distribution mode with a minimal number of owners.
 infinispan.component.state-transfer.timeout=The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup. If timeout is less than or equal to 0, state transfer is performed asynchronously, and the cache will be immediately available.
-infinispan.component.state-transfer.chunk-size=The size, in bytes, in which to batch the transfer of cache entries.
+infinispan.component.state-transfer.chunk-size=The maximum number of cache entries in a batch of transferred state.
 
 infinispan.distributed-cache=A distributed cache configuration.
 infinispan.distributed-cache.add=Add a distributed cache to this cache container

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_5_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_5_0.xsd
@@ -735,9 +735,20 @@
     </xs:complexType>
 
     <xs:complexType name="state-transfer">
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Enables initial state transfer.
+                    Disabling initial state transfer can leave cache vulnerable to data-loss, especially when using distribution mode with a minimal number of owners.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="timeout" type="xs:long" default="240000">
             <xs:annotation>
-                <xs:documentation>The maximum amount of time (ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.</xs:documentation>
+                <xs:documentation>
+                    The maximum amount of time (in ms) to wait for state from neighboring caches, before throwing an exception and aborting startup.
+                    A timeout of 0 means the cache will be available immediately after joining, and initial state transfer is non-blocking.
+                </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="chunk-size" type="xs:integer" default="512">
@@ -1062,5 +1073,4 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
-
 </xs:schema>

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
@@ -382,6 +382,13 @@ public class InfinispanTransformersTestCase extends OperationTestCaseBase {
         PathAddress subsystemAddress = PathAddress.pathAddress(InfinispanSubsystemResourceDefinition.PATH);
         PathAddress containerAddress = subsystemAddress.append(CacheContainerResourceDefinition.WILDCARD_PATH);
 
+        if (InfinispanModel.VERSION_6_0_0.requiresTransformation(version) && !InfinispanModel.VERSION_4_0_0.requiresTransformation(version)) {
+            for (PathElement path : Arrays.asList(DistributedCacheResourceDefinition.WILDCARD_PATH, ReplicatedCacheResourceDefinition.WILDCARD_PATH)) {
+                PathAddress cacheAddress = containerAddress.append(path);
+                config.addFailedAttribute(cacheAddress.append(StateTransferResourceDefinition.PATH), new FailedOperationTransformationConfig.NewAttributesConfig(StateTransferResourceDefinition.Attribute.ENABLED.getName()));
+            }
+        }
+
         if (InfinispanModel.VERSION_2_0_0.requiresTransformation(version)) {
             for (PathElement path : Arrays.asList(DistributedCacheResourceDefinition.WILDCARD_PATH, ReplicatedCacheResourceDefinition.WILDCARD_PATH)) {
                 PathAddress cacheAddress = containerAddress.append(path);

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-reject.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-reject.xml
@@ -55,7 +55,7 @@
                 <property name="location">location</property>
                 <property name="property2">location2</property>
             </store>
-            <state-transfer timeout="60000" chunk-size="10000"/>
+            <state-transfer enabled="false" timeout="60000" chunk-size="10000"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
                 <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
@@ -79,7 +79,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </string-keyed-table>
             </mixed-keyed-jdbc-store>
-            <state-transfer timeout="60000" chunk-size="10000"/>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </distributed-cache>
         <replicated-cache name="cache-with-binary-keyed-store" statistics-enabled="true">
             <binary-keyed-jdbc-store data-source="ExampleDS">

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-5_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-5_0.xml
@@ -80,7 +80,7 @@
                 <property name="location">${java.io.tmpdir}</property>
             </store>
             <partition-handling enabled="false"/>
-            <state-transfer timeout="60000" chunk-size="10000"/>
+            <state-transfer enabled="false" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" l1-lifespan="1200000" owners="4" remote-timeout="35000" segments="2" capacity-factor="1.0" consistent-hash-strategy="INTRA_CACHE" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9648

Design: https://github.com/wildfly/wildfly-proposals/pull/11