### PR TITLE
WFLY-9660 upgraded FasterXML Jackson to 2.8.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.3.3</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.8.9</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>20.0</version.com.google.guava>
         <version.com.h2database>1.4.193</version.com.h2database>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9660