### PR TITLE
[WFLY-9662] Upgrade build tools to 1.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.build-tools>1.2.3.Final</version.org.wildfly.build-tools>
+        <version.org.wildfly.build-tools>1.2.4.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>4.0.0.Alpha5</version.org.wildfly.core>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -71,10 +71,6 @@
             <plugin>
                 <groupId>org.wildfly.build</groupId>
                 <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
-                <!--
-                This is workaround as 1.2.3.Final doesn't properly extract xsd schemas anymore
-                -->
-                <version>1.2.2.Final</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>


### PR DESCRIPTION
This solves the XSD schema extraction issue alluded to in 3c3ac91975e1a2db4ac767a8e9a043207ef03e85.