### PR TITLE
[WFLY-9502] javax.naming.InvalidNameException: WFNAM00007: Invalid UR…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hornetq/client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hornetq/client/main/module.xml
@@ -40,5 +40,6 @@
         <module name="io.netty"/>
         <module name="org.jboss.logging"/>
         <module name="org.jgroups"/>
+        <module name="org.wildfly.naming-client" services="import" />
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -72,7 +72,7 @@
         <module name="org.jboss.jts"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.wildfly.naming-client"/>
+        <module name="org.wildfly.naming-client" services="import" />
         <module name="org.jboss.threads"/>
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.jboss.weld.api" />


### PR DESCRIPTION
…L scheme name null when jms bridge is trying to do remote lookup on EAP6/HornetQ

WildFly Jira: https://issues.jboss.org/browse/WFLY-9502