### PR TITLE
WFLY-9680 When resolving a bean method, take also default methods imp…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ViewDescription.java
@@ -196,12 +196,9 @@ public class ViewDescription {
             final List<Method> methods = configuration.getProxyFactory().getCachedMethods();
             for (final Method method : methods) {
                 MethodIdentifier methodIdentifier = MethodIdentifier.getIdentifierForMethod(method);
-                Method componentMethod = ClassReflectionIndexUtil.findMethod(reflectionIndex, componentConfiguration.getComponentClass(), methodIdentifier);
+                //Find the method implemented in the bean class, a superclass or as a default method on any interface
+                Method componentMethod = ClassReflectionIndexUtil.findMethodIncludingSuperclassAndDefaultMethods(reflectionIndex, componentConfiguration.getComponentClass(), methodIdentifier);
 
-                if (componentMethod == null && method.getDeclaringClass().isInterface() && (method.getModifiers() & (ABSTRACT | PUBLIC | STATIC)) == PUBLIC) {
-                    // no component method and the interface method is defaulted, so we really do want to invoke on the interface method
-                    componentMethod = method;
-                }
                 if (componentMethod != null) {
 
                     if ((BRIDGE & componentMethod.getModifiers()) != 0) {


### PR DESCRIPTION
…lemented on interfaces that have not originally declared the method into account. 
Prior to this commit, if a method defined on an remote interface A is missing in a EJB class B implementing the interface A but a default method is provided the declaring interface, the method will get resolved successfully. If there is a interface C extending A and providing the default implementation and B implements C, the call fails with a message "Invocation cannot proceed (end of interceptor chain has been hit)". This is fixed by this commit. See also the pull request to wildfly core which is needed by the code commited here: https://github.com/wildfly/wildfly-core/pull/3038