### PR TITLE
[WFLY-9679] removing duplication in implementation of test XAResources

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
@@ -42,6 +42,7 @@ import javax.transaction.UserTransaction;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.as.test.integration.transactions.TestXAResource;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -68,6 +69,7 @@ public abstract class TxExceptionBaseTestCase {
         final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         jar.addPackages(true, TxExceptionBaseTestCase.class.getPackage());
+        jar.addPackage(TestXAResource.class.getPackage());
         jar.addPackages(true, "javassist");
         // this test needs to create a new public class thru javassist so AllPermission is needed here
         ear.addAsManifestResource(createPermissionsXmlAsset(new AllPermission()), "permissions.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/CmtEjb3.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/CmtEjb3.java
@@ -30,10 +30,9 @@ import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
-import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource;
-import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource.CommitOperation;
-import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource.PrepareOperation;
+import org.jboss.as.test.integration.ejb.transaction.exception.TimeoutTestXAResource;
 import org.jboss.as.test.integration.ejb.transaction.exception.bean.TestBean;
+import org.jboss.as.test.integration.transactions.TestXAResource.TestAction;
 
 @LocalBean
 @Remote
@@ -53,20 +52,20 @@ public class CmtEjb3 implements TestBean {
         Transaction txn = tm.getTransaction();
         switch (txManagerException) {
         case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
-            txn.enlistResource(new TestXAResource(CommitOperation.NONE));
-            txn.enlistResource(new TestXAResource(CommitOperation.THROW_KNOWN_XA_EXCEPTION));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.NONE));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.COMMIT_THROW_XAER_RMERR));
             break;
         case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
-            txn.enlistResource(new TestXAResource(CommitOperation.NONE));
-            txn.enlistResource(new TestXAResource(CommitOperation.THROW_UNKNOWN_XA_EXCEPTION));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.NONE));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.COMMIT_THROW_UNKNOWN_XA_EXCEPTION));
             break;
         case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
-            txn.enlistResource(new TestXAResource(PrepareOperation.NONE));
-            txn.enlistResource(new TestXAResource(PrepareOperation.THROW_KNOWN_XA_EXCEPTION));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.NONE));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.PREPARE_THROW_XAER_RMERR));
             break;
         case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
-            txn.enlistResource(new TestXAResource(PrepareOperation.NONE));
-            txn.enlistResource(new TestXAResource(PrepareOperation.THROW_UNKNOWN_XA_EXCEPTION));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.NONE));
+            txn.enlistResource(new TimeoutTestXAResource(TestAction.PREPARE_THROW_UNKNOWN_XA_EXCEPTION));
             break;
         default:
             throw new IllegalArgumentException("Unknown type " + txManagerException);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9679

Removing duplication of code having in the two implementations of `XAResource` in testsuite for transaction testing.