### PR TITLE
WFLY-9712 Add test for WFCORE-3512

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/Airplane.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/Airplane.java
@@ -19,16 +19,18 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.ejb.java8.staticMethodInView;
+package org.jboss.as.test.integration.ejb.java8;
 
-import javax.ejb.Stateful;
+import javax.ejb.Local;
 
-@Stateful
-public class AirplaneImpl implements Airplane {
+@Local
+public interface Airplane {
 
-    @Override
-    public boolean takeOff() {
+    static boolean barrelRoll() {
         return true;
     }
 
+    boolean takeOff();
+
+    String getPlaneType();
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/AirplaneImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/AirplaneImpl.java
@@ -19,13 +19,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.ejb.java8.staticMethodInView;
+package org.jboss.as.test.integration.ejb.java8;
 
-public interface Airplane {
+import javax.ejb.Stateful;
 
-    static boolean barrelRoll() {
+@Stateful
+public class AirplaneImpl implements CargoPlane {
+
+    @Override
+    public boolean takeOff() {
         return true;
     }
 
-    boolean takeOff();
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/CargoPlane.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/CargoPlane.java
@@ -1,0 +1,8 @@
+package org.jboss.as.test.integration.ejb.java8;
+
+public interface CargoPlane extends Airplane {
+
+    default String getPlaneType() {
+        return "Cargo";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/Java8InterfacesEJBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/java8/Java8InterfacesEJBTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.ejb.java8.staticMethodInView;
+package org.jboss.as.test.integration.ejb.java8;
 
 import javax.inject.Inject;
 
@@ -38,17 +38,17 @@ import org.junit.runner.RunWith;
  * See WFLY-4316 for details.
  *
  * @author Jozef Hartinger
- *
+ * @author Stuart Douglas
  */
 @RunWith(Arquillian.class)
-public class StaticMethodOnEjbViewTestCase {
+public class Java8InterfacesEJBTestCase {
 
     @Inject
     private Airplane airplane;
 
     @Deployment
     public static Archive<?> getDeployment() {
-        return ShrinkWrap.create(WebArchive.class).addPackage(StaticMethodOnEjbViewTestCase.class.getPackage());
+        return ShrinkWrap.create(WebArchive.class).addPackage(Java8InterfacesEJBTestCase.class.getPackage());
     }
 
     @Test
@@ -57,4 +57,10 @@ public class StaticMethodOnEjbViewTestCase {
         Assert.assertTrue(airplane.takeOff());
     }
 
+
+    // See https://issues.jboss.org/browse/WFCORE-3512
+    @Test
+    public void testDefaultMethodWorks() {
+        Assert.assertEquals("Cargo", airplane.getPlaneType());
+    }
 }


### PR DESCRIPTION
Also moves the test into the correct package.

This test is expected to fail until a WFCORE release with https://github.com/wildfly/wildfly-core/pull/3040 has been merged.