### PR TITLE
[WFLY-9339] call createAdditionalInitialization to add missing capabi…

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
@@ -130,8 +130,9 @@ public class UndertowTransformersTestCase extends AbstractSubsystemBaseTest {
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXmlResource("undertow-transformers.xml");
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, undertowVersion)
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, undertowVersion)
                 .addMavenResourceURL(String.format("%s:wildfly-undertow:%s", controllerVersion.getMavenGroupId(), controllerVersion.getMavenGavVersion()))
+                .addSingleChildFirstClass(DefaultInitialization.class)
                 .configureReverseControllerCheck(createAdditionalInitialization(), null)
                 .dontPersistXml();
 


### PR DESCRIPTION
…lities in transformer test.

As https://issues.jboss.org/browse/WFLY-9339 explained. Otherwise, I see error messages in test run:

> Jan 22, 2018 11:55:49 AM org.jboss.as.controller.OperationContextImpl validateCapabilities
ERROR: WFLYCTL0362: Capabilities required by resource '/subsystem=undertow/server=some-server/ajp-listener=ajp-connector' are not available:
    org.wildfly.network.socket-binding.ajp; There are no known registration points which can provide this capability.
    org.wildfly.io.worker.default; There are no known registration points which can provide this capability.
    org.wildfly.io.buffer-pool.default; There are no known registration points which can provide this capability.
... ...

see full errors in https://gist.github.com/soul2zimate/7033be1e7ded5b1f8f44214041aec68a