### PR TITLE
[WFLY-9725][JBTM-2983] adding test to show last resource not throwing error

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/InnerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/InnerBean.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+
+
+package org.jboss.as.test.integration.ejb.transaction.cmt.fail;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.inject.Inject;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+
+import org.jboss.as.test.integration.transactions.TestLastResource;
+import org.jboss.as.test.integration.transactions.TestXAResource;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.as.test.integration.transactions.TxTestUtil;
+
+@Stateless
+@TransactionAttribute(TransactionAttributeType.REQUIRED)
+public class InnerBean {
+
+    @Inject
+    private TransactionCheckerSingleton checker;
+
+    @Resource(name = "java:jboss/TransactionManager")
+    private TransactionManager tm;
+
+    public void innerMethodXA() {
+        try {
+            TestXAResource xaResource = new TestXAResource(TestXAResource.TestAction.COMMIT_THROW_XAER_RMFAIL, checker);
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), xaResource);
+        } catch (SystemException se) {
+            throw new IllegalStateException("Can't get transaction from transaction manager: " + tm);
+        }
+    }
+
+    public void innerMethod2pcXA() {
+        try {
+            TestXAResource xaResource1 = new TestXAResource(TestXAResource.TestAction.COMMIT_THROW_XAER_RMFAIL, checker);
+            TestXAResource xaResource2 = new TestXAResource(checker);
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), xaResource1);
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), xaResource2);
+        } catch (SystemException se) {
+            throw new IllegalStateException("Can't get transaction from transaction manager: " + tm);
+        }
+    }
+
+    public void innerMethodLocal() {
+        try {
+            TestXAResource xaResource = new TestLastResource(TestXAResource.TestAction.COMMIT_THROW_XAER_RMFAIL, checker);
+            TxTestUtil.enlistTestXAResource(tm.getTransaction(), xaResource);
+        } catch (SystemException se) {
+            throw new IllegalStateException("Can't get transaction from transaction manager: " + tm);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/OuterBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/OuterBean.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.cmt.fail;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+@Stateless
+@TransactionAttribute(TransactionAttributeType.NEVER)
+public class OuterBean {
+
+    @EJB InnerBean innerBean;
+
+    public void outerMethodXA() {
+        innerBean.innerMethodXA();
+    }
+
+    public void outerMethod2pcXA() {
+        innerBean.innerMethod2pcXA();
+    }
+
+    public void outerMethodLocal() {
+        innerBean.innerMethodLocal();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.cmt.fail;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.util.PropertyPermission;
+
+import javax.ejb.EJBException;
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.xa.XAResource;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
+import org.jboss.as.test.integration.transactions.TransactionTestLookupUtil;
+import org.jboss.as.test.integration.transactions.TxTestUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.tm.LastResource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test of behavior when one phase commit is used.
+ */
+@RunWith(Arquillian.class)
+public class TransactionFirstPhaseErrorTestCase {
+
+    @ArquillianResource
+    private InitialContext initCtx;
+
+    @Inject
+    private TransactionCheckerSingleton checker;
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test-txn-one-phase.jar")
+        .addPackage(TxTestUtil.class.getPackage())
+        .addClasses(InnerBean.class, OuterBean.class)
+        .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jboss-transaction-spi \n"), "MANIFEST.MF")
+        // grant necessary permissions for -Dsecurity.manager
+        .addAsResource(createPermissionsXmlAsset(
+            new PropertyPermission("ts.timeout.factor", "read")), "META-INF/jboss-permissions.xml");
+        return jar;
+    }
+
+    @Before
+    public void startUp() throws NamingException {
+        checker.resetAll();
+    }
+
+    /**
+     * Using {@link XAResource} which fails with <code>XAResource.XAER_RMFAIL</code>
+     * during commit.<br>
+     * Expecting the error will be propagated to the caller.
+     */
+    @Test
+    public void xaOnePhaseCommitFail() throws Exception {
+        OuterBean bean = TransactionTestLookupUtil.lookupModule(initCtx, OuterBean.class);
+        try {
+            bean.outerMethodXA();
+            Assert.fail("Expecting the one phase commit failed and exception was propagated to the caller.");
+        } catch (EJBException expected) {
+            Assert.assertTrue("Expecting on RMFAIL to get unknown state of the transaction outcome - ie. HeuristicMixedException",
+                    expected.getCause() != null && expected.getCause().getClass().equals(javax.transaction.HeuristicMixedException.class));
+        }
+    }
+
+    /**
+     * Using two {@link XAResource}s where the first one fails with <code>XAResource.XAER_RMFAIL</code>
+     * during commit.<br>
+     * Expecting the no error will be thrown as 2PC prepare phase finished and rmfail says
+     * that recovery manager should retry the commit later.
+     */
+    @Test
+    public void xaTwoPhaseCommitFail() throws Exception {
+        OuterBean bean = TransactionTestLookupUtil.lookupModule(initCtx, OuterBean.class);
+        bean.outerMethod2pcXA();
+    }
+
+    /**
+     * Using {@link XAResource} where optimization for {@link LastResource} is used.
+     * The commit call fails with <code>XAResource.XAER_RMFAIL</code><br>
+     * Expecting the error will be propagated to the caller.
+     */
+    @Test
+    public void localOnePhaseCommitFail() throws Exception {
+        OuterBean bean = TransactionTestLookupUtil.lookupModule(initCtx, OuterBean.class);
+        try {
+            bean.outerMethodLocal();
+            Assert.fail("Expecting the one phase commit failed and exception was propagated to the caller.");
+        } catch (EJBException expected) {
+            Assert.assertTrue("Expecting on RMFAIL to get unknown state of the transaction outcome - ie. HeuristicMixedException",
+                    expected.getCause() != null && expected.getCause().getClass().equals(javax.transaction.HeuristicMixedException.class));
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TestLastResource.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TestLastResource.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.transactions;
+
+import org.jboss.tm.LastResource;
+
+/**
+ * Test {@link LastResource} class which causes that <code>XAOnePhaseResource</code>
+ * will be instantiated at <code>TransactionImple#createRecord</code>.<br>
+ * The information about {@link LastResource} is taken from definition
+ * <code>jtaEnvironmentBean.setLastResourceOptimisationInterfaceClassName</code>
+ *
+ * @author Ondra Chaloupka <ochaloup@redhat.com>
+ */
+public class TestLastResource extends TestXAResource implements LastResource {
+
+    public TestLastResource(TransactionCheckerSingleton checker) {
+        super(checker);
+    }
+
+    public TestLastResource(TestAction testAction, TransactionCheckerSingleton checker) {
+        super(testAction, checker);
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -28,6 +28,8 @@ import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.xa.XAResource;
+
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.junit.Assert;
 
@@ -52,6 +54,14 @@ public final class TxTestUtil {
             throw new RuntimeException("Can't enlist test xa resource '" + xaResource + "'", e);
         }
         return xaResource;
+    }
+
+    public static void enlistTestXAResource(Transaction txn, XAResource xaResource) {
+        try {
+            txn.enlistResource(xaResource);
+        } catch (IllegalStateException | RollbackException | SystemException e) {
+            throw new RuntimeException("Can't enlist test xa resource '" + xaResource + "'", e);
+        }
     }
 
     public static void addSynchronization(Transaction txn, TransactionCheckerSingletonRemote checker) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9725
https://issues.jboss.org/browse/JBTM-2983

Adding tests of the issue JBTM-2983 where error during commit of non-XA resource (last resource commit is called inside of the Narayana) there is not thrown exception (`HeuristicMixedException`) which informs caller the commit failed.

This is fixed by Narayana 5.8.0.Final release.