### PR TITLE
WFLY-9731 The fix for WFLY-4625 breaks PolicyContext(javax.security.auth.subject.container) in CXF web service with STS

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -359,7 +359,8 @@ public class SimpleSecurityManager implements ServerSecurityManager {
 
         // skip reauthentication if the current context already has an authenticated subject (copied from the previous context
         // upon creation - see push method) and both contexts use the same security domain or there is an incoming RunAs of RunAsIdentity type
-        boolean skipReauthentication = current.getSubjectInfo() != null && current.getSubjectInfo().getAuthenticatedSubject() != null && (
+        boolean skipReauthentication = current.getSubjectInfo() != null && current.getSubjectInfo().getAuthenticatedSubject() != null &&
+                   !current.getSubjectInfo().getAuthenticatedSubject().getPrincipals().isEmpty() && (
                         (previous != null && current.getSecurityDomain().equals(previous.getSecurityDomain())) ||
                         current.getIncomingRunAs() instanceof RunAsIdentity
                 );


### PR DESCRIPTION
Fix for skipping reauthentication in case of empty principal list.

Jira: https://issues.jboss.org/browse/WFLY-9731
