### PR TITLE
[WFLY-9733] Correct links and misc formatting etc in the "Description…

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
@@ -1,12 +1,13 @@
 [[Description_of_the_Management_Model]]
 = Description of the Management Model
+ifdef::env-github,env-browser[:outfilesuffix: .adoc]
 
 A detailed description of the resources, attributes and operations that
 make up the management model provided by an individual WildFly instance
 or by any Domain Controller or slave Host Controller process can be
 queried using the `read-resource-description`, `read-operation-names`,
 `read-operation-description` and `read-child-types` operations described
-in the <<Global_operations,Global operations>> section. In this
+in the link:Global_operations{outfilesuffix}[Global operations] section. In this
 section we provide details on what's included in those descriptions.
 
 [[description-of-the-wildfly-managed-resources]]
@@ -14,7 +15,7 @@ section we provide details on what's included in those descriptions.
 
 All portions of the management model exposed by WildFly are addressable
 via an ordered list of key/value pairs. For each addressable
-_<<Management_resources,Management Resource>>_ , the following
+link:../Management_resources{outfilesuffix}[Management Resource], the following
 descriptive information will be available:
 
 * `description` – String – text description of this portion of the model
@@ -29,33 +30,21 @@ i.e. there is no limit. If this value is some other string, the default
 value is 1.
 * `attributes` – Map of String (the attribute name) to complex structure
 – the configuration attributes available in this portion of the model.
-See
-link:#DescriptionoftheManagementModel-attribute-description[below]
+See the <<description-of-an-attribute,Description of an Attribute>> section 
 for the representation of each attribute.
 * `operations` – Map of String (the operation name) to complex structure
-– the operations that can be targetted at this address. See
-<<description-of-an-operation,below>>
+– the operations that can be targeted at this address. See the 
+<<description-of-an-operation,Description of an Operation>> section 
 for the representation of each operation.
 * `children` – Map of String (the type of child) to complex structure –
 the relationship of this portion of the model to other addressable
-portions of the model. See
-<<description-of-parentchild-relationships,below>>
-for the representation of each child relationship.
-* `head-comment-allowed` – boolean – indicates whether this portion of
-the model can store an XML comment that would be written in the
-persistent form of the model (e.g. domain.xml) before the start of the
-XML element that represents this portion of the model. This item is
-optional, and if not present defaults to true. (Note: storing XML
-comments in the in-memory model is not currently supported. This
-description key is for future use.)
-* `tail-comment-allowed` – boolean – similar to `head-comment-allowed`,
-but indicates whether a comment just before the close of the XML element
-is supported. A tail comment can only be supported if the element has
-child elements, in which case a comment can be inserted between the
-final child element and the element's closing tag. This item is
-optional, and if not present defaults to true. (Note: storing XML
-comments in the in-memory model is not currently supported. This
-description key is for future use.)
+portions of the model. See the 
+<<description-of-parentchild-relationships,Description of Parent/Child Relationships>>
+section for the representation of each child relationship.
+* `head-comment-allowed` – boolean – This description key is for 
+possible future use.
+* `tail-comment-allowed` – boolean – This description key is for 
+possible future use.
 
 For example:
 
@@ -87,8 +76,9 @@ For example:
 
 An attribute is a portion of the management model that is not directly
 addressable. Instead, it is conceptually a property of an addressable
-<<Management_resources,management resource>>. For each attribute
-in the model, the following descriptive information will be available:
+link:../Management_resources{outfilesuffix}[management resource]. For 
+each attribute in the model, the following descriptive information will 
+be available:
 
 * `description` – String – text description of the attribute
 * `type` – `org.jboss.dmr.ModelType` – the type of the attribute value.
@@ -153,9 +143,9 @@ updating this attribute's value.
 access-type is read-write. Indicates whether execution of a
 write-attribute operation whose name parameter specifies this attribute
 requires a restart of services (or an entire JVM) in order for the
-change to take effect in the runtime . See discussion of "
+change to take effect in the runtime . See the discussion of 
 <<applying-updates-to-runtime-services,Applying
-Updates to Runtime Services>>" below. Default value is "no-services".
+Updates to Runtime Services>> below. Default value is "no-services".
 * `default` – the default value for the attribute that will be used in
 runtime services if the attribute is not explicitly defined and no other
 attributes listed as `alternatives` are defined.
@@ -182,29 +172,13 @@ specified capability provided by another resource. This indicates the
 attribute is a reference to another area of the management model. (Note
 that at present some attributes that reference other areas of the model
 may not provide this information.)
-* `head-comment-allowed` – boolean – indicates whether the model can
-store an XML comment that would be written in the persistent form of the
-model (e.g. domain.xml) before the start of the XML element that
-represents this attribute. This item is optional, and if not present
-defaults to false. (This is a different default from what is used for an
-entire management resource, since model attributes often map to XML
-attributes, which don't allow comments.) (Note: storing XML comments in
-the in-memory model is not currently supported. This description key is
-for future use.)
-* `tail-comment-allowed` – boolean – similar to head-comment-allowed,
-but indicates whether a comment just before the close of the XML element
-is supported. A tail comment can only be supported if the element has
-child elements, in which case a comment can be inserted between the
-final child element and the element's closing tag. This item is
-optional, and if not present defaults to false. (This is a different
-default from what is used for an entire management resource, since model
-attributes often map to XML attributes, which don't allow comments.)
-(Note: storing XML comments in the in-memory model is not currently
-supported. This description key is for future use.)
+* `head-comment-allowed` – boolean – This description key is for 
+possible future use.
+* `tail-comment-allowed` – boolean – This description key is for 
+possible future use.
 * arbitrary key/value pairs that further describe the attribute value,
-e.g. "max" => 2. See "
-<<arbitrary-descriptors,Arbitrary
-Descriptors>>" below.
+e.g. "max" => 2. See the <<arbitrary-descriptors,Arbitrary
+Descriptors>> section.
 
 Some examples:
 
@@ -251,9 +225,8 @@ for details on the description of operation return value types.
 "resource-services" or "jvm". Indicates whether the operation makes a
 configuration change that requires a restart of services (or an entire
 JVM) in order for the change to take effect in the runtime. See
-discussion of "
-<<applying-updates-to-runtime-services,Applying
-Updates to Runtime Services>>" below. Default value is "no-services".
+the discussion of <<applying-updates-to-runtime-services,Applying
+Updates to Runtime Services>> below. Default value is "no-services".
 
 [[description-of-an-operation-parameter-or-return-value]]
 ==== Description of an Operation Parameter or Return Value
@@ -305,9 +278,9 @@ parameters listed as `alternatives` are defined.
 access-type is read-write. Indicates whether execution of a
 write-attribute operation whose name parameter specifies this attribute
 requires a restart of services (or an entire JVM) in order for the
-change to take effect in the runtime . See discussion of "
+change to take effect in the runtime . See the discussion of 
 <<applying-updates-to-runtime-services,Applying
-Updates to Runtime Services>>" below. Default value is "no-services".
+Updates to Runtime Services>> below. Default value is "no-services".
 * `alternatives` – List of string – Indicates an exclusive relationship
 between parameters. If this attribute is defined, the other parameters
 listed in this descriptor's value should be undefined, even if their
@@ -326,9 +299,8 @@ alternatives to each other; "c" and "d" are optional. But "b" requires
 "c" and "d", so if "b" is used, "c" and "d" must also be defined.
 Default is undefined; i.e. this does not apply to most parameters.
 * arbitrary key/value pairs that further describe the attribute value,
-e.g. "max" =>2. See "
-<<arbitrary-descriptors,Arbitrary
-Descriptors>>" below.
+e.g. "max" =>2. See the <<arbitrary-descriptors,Arbitrary Descriptors>> 
+section.
 
 [[arbitrary-descriptors]]
 === Arbitrary Descriptors
@@ -467,8 +439,8 @@ If the recursive flag was false:
 [[applying-updates-to-runtime-services]]
 === Applying Updates to Runtime Services
 
-An attribute or operation description may include a "
-`restart-required`" descriptor; this section is an explanation of the
+An attribute or operation description may include a `restart-required` 
+descriptor; this section is an explanation of the
 meaning of that descriptor.
 
 An operation that changes a management resource's persistent
@@ -484,7 +456,7 @@ reflect the new value(s).
 However, in many cases the runtime service's state cannot be updated
 without restarting the service. Restarting a service can have broad
 effects. A restart of a service A will trigger a restart of other
-services B, C and D that depend A, triggering a restart of services that
+services B, C and D that depend on A, triggering a restart of services that
 depend on B, C and D, etc. Those service restarts may very well disrupt
 handling of end-user requests.
 
@@ -497,8 +469,8 @@ restart (e.g. a `/host=master/server-config=server-one:restart`
 operation in a managed domain, or a `/:reload` operation on a standalone
 server.) For all other cases, if an operation (or attribute write)
 cannot be performed without restarting a service, the metadata
-describing the operation or attribute will include a "
-`restart-required`" descriptor whose value indicates what is necessary
+describing the operation or attribute will include a `restart-required` 
+descriptor whose value indicates what is necessary
 for the operation to affect the runtime:
 
 * `no-services` – Applying the operation to the runtime does not require
@@ -507,23 +479,23 @@ restart-required descriptor is not present.
 * `all-services` – The operation can only immediately update the
 persistent configuration; applying the operation to the runtime will
 require a subsequent restart of all services in the affected VM.
-Executing the operation will put the server into a " `reload-required`"
+Executing the operation will put the server into a `reload-required`
 state. Until a restart of all services is performed the response to this
 operation and to any subsequent operation will include a response header
-" `process-state" => "reload-required`". For a standalone server, a
-restart of all services can be accomplished by executing the `/:reload`
+`"process-state" => "reload-required"`. For a standalone server, a
+restart of all services can be accomplished by executing the `reload`
 CLI command. For a server in a managed domain, restarting all services
-currently requires a full restart of the affected server VM (e.g.
-`/host=master/server-config=server-one:restart`).
+is done via a reload operation targeting the particular server (e.g.
+`/host=master/server=server-one:reload`).
 * `jvm` --The operation can only immediately update the persistent
 configuration; applying the operation to the runtime will require a full
 process restart (i.e. stop the JVM and launch a new JVM). Executing the
-operation will put the server into a " `restart-required`" state. Until
+operation will put the server into a `restart-required` state. Until
 a restart is performed the response to this operation and to any
-subsequent operation will include a response header "
-`process-state" => "restart-required`". For a standalone server, a full
+subsequent operation will include a response header 
+`"process-state" => "restart-required"`. For a standalone server, a full
 process restart requires first stopping the server via OS-level
-operations (Ctrl-C, kill) or via the `/:shutdown` CLI command, and then
+operations (Ctrl-C, kill) or via the `shutdown` CLI command, and then
 starting the server again from the command line. For a server in a
 managed domain, restarting a server requires executing the
 `/host=<host>/server-config=<server>:restart` operation.
@@ -533,6 +505,6 @@ require a subsequent restart of some services associated with the
 resource. If the operation includes the request header
 `"allow-resource-service-restart" => true`, the handler for the
 operation will go ahead and restart the runtime service. Otherwise
-executing the operation will put the server into a " `reload-required`"
-state. (See the discussion of " `all-services`" above for more on the "
-`reload-required`" state.)
+executing the operation will put the server into a `reload-required`
+state. (See the discussion of `all-services` above for more on the 
+`reload-required` state.)


### PR DESCRIPTION
… of the Management Model" doc

https://issues.jboss.org/browse/WFLY-9733

Reviewers, please note the ifdef: on L3 of the diff. See http://asciidoctor.org/docs/faq/#how-do-i-make-relative-links-to-other-asciidoc-files-to-work-correctly-on-github. That page says that config shouldn't be needed any more but I found that when looking at the page in the source tree on github the links to other pages would not work correctly without this.