### PR TITLE
WFLY-9678 Expand clustering test cases to 3-node cluster

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -84,6 +84,7 @@ public abstract class AbstractClusteringTestCase {
 
     // Timeouts
     public static final int GRACE_TIME_TO_REPLICATE = TimeoutUtil.adjust(3000);
+    public static final int GRACE_TIME_TOPOLOGY_CHANGE = TimeoutUtil.adjust(3000);
     public static final int GRACEFUL_SHUTDOWN_TIMEOUT = TimeoutUtil.adjust(15);
     public static final int GRACE_TIME_TO_MEMBERSHIP_CHANGE = TimeoutUtil.adjust(10000);
     public static final int WAIT_FOR_PASSIVATION_MS = TimeoutUtil.adjust(5);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
@@ -63,6 +63,12 @@ public class CdiFailoverTestCase extends AbstractWebFailoverTestCase {
         return createDeployment();
     }
 
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
+        return createDeployment();
+    }
+
     private static Archive<?> createDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
         war.addClasses(Incrementor.class, CdiIncrementorBean.class, CdiServlet.class, SimpleServlet.class, Mutable.class, IncrementorDecorator.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
@@ -30,9 +30,10 @@ import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -49,19 +50,26 @@ import org.junit.runner.RunWith;
  * Test that HTTP session failover on shutdown and undeploy works.
  *
  * @author Radoslav Husar
- * @version Oct 2012
  */
 @RunWith(Arquillian.class)
 public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTestCase {
 
     private final String deploymentName;
-    private final Runnable nonOwnerTask;
+    private final CacheMode cacheMode;
+    private final Runnable nonTxWait;
 
-    protected AbstractWebFailoverTestCase(String deploymentName, TransactionMode mode) {
+    protected AbstractWebFailoverTestCase(String deploymentName, TransactionMode transactionMode) {
+        this(deploymentName, CacheMode.DIST_SYNC, transactionMode);
+    }
+
+    protected AbstractWebFailoverTestCase(String deploymentName, CacheMode cacheMode, TransactionMode transactionMode) {
+        super(THREE_NODES);
+
         this.deploymentName = deploymentName;
-        this.nonOwnerTask = () -> {
+        this.cacheMode = cacheMode;
+        this.nonTxWait = () -> {
             // If the cache is non-transactional, we need to wait for that replication to finish, otherwise the read can be stale
-            if (!mode.isTransactional()) {
+            if (!transactionMode.isTransactional()) {
                 try {
                     Thread.sleep(GRACE_TIME_TO_REPLICATE);
                 } catch (InterruptedException e) {
@@ -71,216 +79,272 @@ public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTest
         };
     }
 
-    /**
-     * Test simple graceful shutdown failover:
-     * <p/>
-     * 1/ Start 2 containers and deploy <distributable/> webapp.
-     * 2/ Query first container creating a web session.
-     * 3/ Shutdown first container.
-     * 4/ Query second container verifying sessions got replicated.
-     * 5/ Bring up the first container.
-     * 6/ Query first container verifying that updated sessions replicated back.
-     */
     @Test
     public void testGracefulSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws Exception {
-        testFailover(new RestartLifecycle(), baseURL1, baseURL2);
+            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
+            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_3) URL baseURL3) throws Exception {
+        this.testFailover(new RestartLifecycle(), baseURL1, baseURL2, baseURL3);
     }
 
-    /**
-     * Test simple undeploy failover:
-     * 1/ Start 2 containers and deploy <distributable/> webapp.
-     * 2/ Query first container creating a web session.
-     * 3/ Undeploy application from the first container.
-     * 4/ Query second container verifying sessions got replicated.
-     * 5/ Redeploy application to the first container.
-     * 6/ Query first container verifying that updated sessions replicated back.
-     */
     @Test
     public void testGracefulUndeployFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws Exception {
-        testFailover(new RedeployLifecycle(), baseURL1, baseURL2);
+            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
+            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_3) URL baseURL3) throws Exception {
+        this.testFailover(new RedeployLifecycle(), baseURL1, baseURL2, baseURL3);
     }
 
-    private void testFailover(Lifecycle lifecycle, URL baseURL1, URL baseURL2) throws Exception {
-        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
-
+    private void testFailover(Lifecycle lifecycle, URL baseURL1, URL baseURL2, URL baseURL3) throws Exception {
         URI uri1 = SimpleServlet.createURI(baseURL1);
         URI uri2 = SimpleServlet.createURI(baseURL2);
+        URI uri3 = SimpleServlet.createURI(baseURL3);
 
-        this.establishTopology(baseURL1, TWO_NODES);
+        this.establishTopology(baseURL1, THREE_NODES);
+        int value = 1;
+        // In case updated route information is received, it must be different from the last route
+        String lastOwner;
 
-        try {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
+                Assert.assertNotNull(entry);
                 Assert.assertEquals(NODE_1, entry.getValue());
+                lastOwner = entry.getValue();
                 Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Let's do this twice to have more debug info if failover is slow.
+            this.nonTxWait.run();
+
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_1, entry.getValue());
-                    Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
-                }
+                // Ensure routing is not changed on 2nd query
+                Assert.assertNull(entry);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Gracefully undeploy from/shutdown the 1st container.
             lifecycle.stop(NODE_1);
 
-            this.establishTopology(baseURL2, NODE_2);
+            this.establishTopology(baseURL2, NODE_2, NODE_3);
 
-            // Now check on the 2nd server
-
+            // node2
             response = client.execute(new HttpGet(uri2));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 3, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                Assert.assertEquals(NODE_2, entry.getValue());
+                // After topology change, the session will have to be re-routed to either of the 2 remaining nodes
+                Assert.assertNotNull(entry);
+                Assert.assertNotEquals(lastOwner, entry.getValue());
+                lastOwner = entry.getValue();
                 Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Let's do one more check.
+            this.nonTxWait.run();
+
             response = client.execute(new HttpGet(uri2));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(4, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_2, entry.getValue());
-                    Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+                // Ensure routing is not changed on subsequent query
+                Assert.assertNull(entry);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            this.nonTxWait.run();
+
+            // node3
+            response = client.execute(new HttpGet(uri3));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                if (cacheMode.isInvalidation()) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertEquals(NODE_3, entry.getValue());
+                } else {
+                    Assert.assertNull(entry);
                 }
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            this.nonTxWait.run();
+
+            response = client.execute(new HttpGet(uri3));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                Assert.assertNull(entry);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             lifecycle.start(NODE_1);
 
-            this.establishTopology(baseURL2, TWO_NODES);
+            this.establishTopology(baseURL2, THREE_NODES);
 
             response = client.execute(new HttpGet(uri2));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 5, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_1, entry.getValue());
+                if (cacheMode.isInvalidation()) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertEquals(NODE_2, entry.getValue());
+                } else if (entry != null) {
+                    Assert.assertNotEquals(lastOwner, entry.getValue());
+                    lastOwner = entry.getValue();
                     Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
                 }
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // The previous and next requests intentially hit the non-owning node
-            this.nonOwnerTask.run();
+            this.nonTxWait.run();
 
-            // Let's do this twice to have more debug info if failover is slow.
             response = client.execute(new HttpGet(uri2));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(6, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_1, entry.getValue());
-                    Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+                Assert.assertNull(entry);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            this.nonTxWait.run();
+
+            response = client.execute(new HttpGet(uri3));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                if (cacheMode.isInvalidation()) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertEquals(NODE_3, entry.getValue());
+                } else {
+                    Assert.assertNull(entry);
                 }
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Until graceful undeploy is supported, we need to wait for replication to complete before undeploy (WFLY-6769).
-            if (lifecycle instanceof RedeployLifecycle) {
-                Thread.sleep(GRACE_TIME_TO_REPLICATE);
-            }
-
-            // Gracefully undeploy from/shutdown the 1st container.
             lifecycle.stop(NODE_2);
 
-            this.establishTopology(baseURL1, NODE_1);
-
-            // Now check on the 2nd server
+            this.establishTopology(baseURL1, NODE_1, NODE_3);
 
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 7, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
                 if (entry != null) {
-                    Assert.assertEquals(NODE_1, entry.getValue());
+                    Assert.assertNotEquals(lastOwner, entry.getValue());
+                    lastOwner = entry.getValue();
                     Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
                 }
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Let's do one more check.
+            this.nonTxWait.run();
+
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(8, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_1, entry.getValue());
-                    Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+                Assert.assertNull(entry);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            this.nonTxWait.run();
+
+            response = client.execute(new HttpGet(uri3));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                if (cacheMode.isInvalidation()) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertEquals(NODE_3, entry.getValue());
+                } else {
+                    Assert.assertNull(entry);
                 }
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            this.nonTxWait.run();
+
+            response = client.execute(new HttpGet(uri3));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                Assert.assertNull(entry);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
             lifecycle.start(NODE_2);
 
-            this.establishTopology(baseURL1, TWO_NODES);
+            this.establishTopology(baseURL1, THREE_NODES);
+
+            this.nonTxWait.run();
 
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals("Session failed to replicate after container 1 was brought up.", 9, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value++, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_2, entry.getValue());
+                if (cacheMode.isInvalidation()) {
+                    Assert.assertNotNull(entry);
+                    Assert.assertEquals(NODE_1, entry.getValue());
+                } else if (entry != null) {
+                    Assert.assertNotEquals(lastOwner, entry.getValue());
                     Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
                 }
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
 
-            // Let's do this twice to have more debug info if failover is slow.
+            this.nonTxWait.run();
+
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
-                Assert.assertEquals(10, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Assert.assertEquals(value, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
                 Map.Entry<String, String> entry = parseSessionRoute(response);
-                if (entry != null) {
-                    Assert.assertEquals(NODE_2, entry.getValue());
-                    Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
-                }
+                Assert.assertNull(entry);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }
-        } finally {
-            HttpClientUtils.closeQuietly(client);
         }
     }
 
-    private void establishTopology(URL baseURL, String... nodes) throws URISyntaxException, IOException {
+    private void establishTopology(URL baseURL, String... nodes) throws URISyntaxException, IOException, InterruptedException {
         ClusterHttpClientUtil.establishTopology(baseURL, "web", this.deploymentName, nodes);
+
+        // TODO we should be able to speed this up by observing changes in the routing registry
+        // prevents failing assertions when topology information is expected, e.g.:
+        //java.lang.AssertionError: expected null, but was:<bpAmUlICzeXMtFiOJvTiOCASbXNivRdHTIlQC00c=node-2>
+        Thread.sleep(GRACE_TIME_TOPOLOGY_CHANGE);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
@@ -80,18 +80,19 @@ public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTest
     }
 
     @Test
-    public void testGracefulSimpleFailover(
+    public void test(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_3) URL baseURL3) throws Exception {
+        this.testGracefulUndeployFailover(baseURL1, baseURL2, baseURL3);
+        this.testGracefulSimpleFailover(baseURL1, baseURL2, baseURL3);
+    }
+
+    protected void testGracefulSimpleFailover(URL baseURL1, URL baseURL2, URL baseURL3) throws Exception {
         this.testFailover(new RestartLifecycle(), baseURL1, baseURL2, baseURL3);
     }
 
-    @Test
-    public void testGracefulUndeployFailover(
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2,
-            @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_3) URL baseURL3) throws Exception {
+    protected void testGracefulUndeployFailover(URL baseURL1, URL baseURL2, URL baseURL3) throws Exception {
         this.testFailover(new RedeployLifecycle(), baseURL1, baseURL2, baseURL3);
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
@@ -40,13 +40,19 @@ public class CoarseWebFailoverTestCase extends AbstractWebFailoverTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
         return getDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentCoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentCoarseWebFailoverTestCase.java
@@ -42,13 +42,19 @@ public class ConcurrentCoarseWebFailoverTestCase extends AbstractWebFailoverTest
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
         return getDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
@@ -34,7 +34,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
  * @author Radoslav Husar
- * @version April 2012
  */
 @ServerSetup(ConcurrentWebFailoverServerSetup.class)
 public class ConcurrentFineWebFailoverTestCase extends AbstractWebFailoverTestCase {
@@ -46,13 +45,19 @@ public class ConcurrentFineWebFailoverTestCase extends AbstractWebFailoverTestCa
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
         return createDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
@@ -33,7 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
  * @author Radoslav Husar
- * @version April 2012
  */
 public class FineWebFailoverTestCase extends AbstractWebFailoverTestCase {
     private static final String DEPLOYMENT_NAME = "fine-distributable.war";
@@ -44,13 +43,19 @@ public class FineWebFailoverTestCase extends AbstractWebFailoverTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
         return createDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
@@ -57,16 +57,21 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends AbstractWebF
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return getDeployment();
     }
 
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
+        return getDeployment();
+    }
     private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
         war.addClasses(SimpleServlet.class, Mutable.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/DatabasePersistenceWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/DatabasePersistenceWebFailoverTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.clustering.cluster.web.persistence;
 
 import java.net.URL;
 
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -40,6 +41,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 /**
+ * Tests session failover where sessions are stored in a shared database (H2 database in AUTO_SERVER mode) using invalidation cache mode.
+ *
  * @author Tomas Remes
  * @author Radoslav Husar
  */
@@ -49,18 +52,24 @@ public class DatabasePersistenceWebFailoverTestCase extends AbstractWebFailoverT
     private static final String DEPLOYMENT_NAME = DatabasePersistenceWebFailoverTestCase.class.getSimpleName() + ".war";
 
     public DatabasePersistenceWebFailoverTestCase() {
-        super(DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);
+        super(DEPLOYMENT_NAME, CacheMode.INVALIDATION_SYNC, TransactionMode.NON_TRANSACTIONAL);
     }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
         return getDeployment();
     }
 
@@ -74,17 +83,18 @@ public class DatabasePersistenceWebFailoverTestCase extends AbstractWebFailoverT
     }
 
     @Override
-    public void testGracefulSimpleFailover(URL baseURL1, URL baseURL2) {
+    public void testGracefulSimpleFailover(URL baseURL1, URL baseURL2, URL baseURL3) {
         // TODO rework to use external database process since H2's AUTO_SERVER doesn't handle server restarts reliably
     }
 
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
-            builder.node(TWO_NODES)
+            builder.node(THREE_NODES)
                     .setup("/subsystem=datasources/data-source=web-sessions-ds:add(jndi-name=\"java:jboss/datasources/web-sessions-ds\",enabled=true,use-java-context=true,connection-url=\"jdbc:h2:file:./target/h2/web-sessions;AUTO_SERVER=true;DB_CLOSE_ON_EXIT=FALSE;DB_CLOSE_DELAY=-1;\",driver-name=h2")
                     .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence:add")
-                    .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/store=jdbc:add(data-source=web-sessions-ds,fetch-state=false,purge=false,shared=true")
-                    .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/store=jdbc/write=through:add")
+                    .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/store=jdbc:add(data-source=web-sessions-ds,fetch-state=false,purge=false,passivation=false,shared=true")
+                    .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/component=transaction:add(mode=BATCH)")
+                    .setup("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence/component=locking:add(isolation=REPEATABLE_READ)")
                     .teardown("/subsystem=infinispan/cache-container=web/invalidation-cache=database-persistence:remove")
                     .teardown("/subsystem=datasources/data-source=web-sessions-ds:remove");
         }


### PR DESCRIPTION
The core of the problem is that since all cases run against 2-node cluster a get(..) going remote is never being tested given that numOwners defaults to 2 so both nodes are always an owner.

Jira
https://issues.jboss.org/browse/WFLY-9678

~~~Requires #10746~~~
