### PR TITLE
WFLY-9536 Weld: Implement BeanDeploymentArchive.getKnownClasses()

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/BeanDeploymentArchiveLookupTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/BeanDeploymentArchiveLookupTest.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.deployment.beanDeploymentArchive;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.bean.builtin.BeanManagerProxy;
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.manager.BeanManagerLookupService;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests WFLY-9536
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class BeanDeploymentArchiveLookupTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        // we are going to use WAR and one JAR, the reason is that the JAR should have different BM Impl against which we can compare
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class).addClasses(NotABean.class, SomeBean.class)
+            .addAsManifestResource(createBeansXml("annotated"), "beans.xml");
+
+        return ShrinkWrap.create(WebArchive.class).addClasses(BeanDeploymentArchiveLookupTest.class, SomeOtherBean.class)
+            .addAsWebInfResource(createBeansXml("annotated"), "beans.xml")
+            .addAsLibraries(lib);
+    }
+
+    private static StringAsset createBeansXml(String mode) {
+        return new StringAsset("<beans bean-discovery-mode=\"" + mode + "\" version=\"2.0\"/>");
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void verifyDiscoveryOfAllClasses() {
+        // BM proxy is injected, we unwrap it
+        BeanManagerImpl bmImpl = BeanManagerProxy.unwrap(bm);
+
+        // use service to lookup BM based on class
+        BeanManagerImpl bmFromSomeBean = BeanManagerLookupService.lookupBeanManager(SomeBean.class, bmImpl);
+        BeanManagerImpl bmFromNotABean = BeanManagerLookupService.lookupBeanManager(NotABean.class, bmImpl);
+        BeanManagerImpl bmFromSomeOtherBean = BeanManagerLookupService.lookupBeanManager(SomeOtherBean.class, bmImpl);
+        Assert.assertNotNull(bmFromSomeBean);
+        Assert.assertNotNull(bmFromNotABean);
+        Assert.assertNotNull(bmFromSomeOtherBean);
+        // verify that BMs from WAR and JAR differ
+        Assert.assertNotEquals(bmFromSomeBean, bmFromSomeOtherBean);
+        // Manager injected here is the same as the one for SomeOtherBean as they are in the same archive
+        Assert.assertEquals(bmImpl, bmFromSomeOtherBean);
+        // BM injected here should be different from that we get from classes in JAR lib
+        Assert.assertNotEquals(bmImpl, bmFromSomeBean);
+        Assert.assertNotEquals(bmImpl, bmFromNotABean);
+        // classes in JAR lib should have the same BM Impl
+        Assert.assertEquals(bmFromSomeBean, bmFromNotABean);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/NotABean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/NotABean.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.deployment.beanDeploymentArchive;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class NotABean {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/SomeBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/SomeBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.deployment.beanDeploymentArchive;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class SomeBean {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/SomeOtherBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/beanDeploymentArchive/SomeOtherBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.deployment.beanDeploymentArchive;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class SomeOtherBean {
+
+}

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
@@ -63,6 +63,8 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
 
     private final Set<String> beanClasses;
 
+    private final Set<String> allKnownClasses;
+
     private final Set<BeanDeploymentArchive> beanDeploymentArchives;
 
     private final BeansXml beansXml;
@@ -81,12 +83,13 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
 
     private final BeanArchiveType beanArchiveType;
 
-    public BeanDeploymentArchiveImpl(Set<String> beanClasses, BeansXml beansXml, Module module, String id, BeanArchiveType beanArchiveType) {
-        this(beanClasses, beansXml, module, id, beanArchiveType, false);
+    public BeanDeploymentArchiveImpl(Set<String> beanClasses, Set<String> allClasses, BeansXml beansXml, Module module, String id, BeanArchiveType beanArchiveType) {
+        this(beanClasses, allClasses, beansXml, module, id, beanArchiveType, false);
     }
 
-    public BeanDeploymentArchiveImpl(Set<String> beanClasses, BeansXml beansXml, Module module, String id, BeanArchiveType beanArchiveType, boolean root) {
+    public BeanDeploymentArchiveImpl(Set<String> beanClasses, Set<String> allClasses, BeansXml beansXml, Module module, String id, BeanArchiveType beanArchiveType, boolean root) {
         this.beanClasses = new ConcurrentSkipListSet<String>(beanClasses);
+        this.allKnownClasses = new ConcurrentSkipListSet<String>(allClasses);
         this.beanDeploymentArchives = new CopyOnWriteArraySet<BeanDeploymentArchive>();
         this.beansXml = beansXml;
         this.id = id;
@@ -128,6 +131,7 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
 
     public void addBeanClass(String clazz) {
         this.beanClasses.add(clazz);
+        this.allKnownClasses.add(clazz);
     }
 
     public void addBeanClass(Class<?> clazz) {
@@ -270,5 +274,10 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
         builder.append(this.id);
         builder.append(")");
         return builder.toString();
+    }
+
+    @Override
+    public Collection<String> getKnownClasses(){
+        return allKnownClasses;
     }
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldDeployment.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldDeployment.java
@@ -184,7 +184,7 @@ public class WeldDeployment implements CDI11Deployment {
             id = module.getIdentifier() + ADDITIONAL_CLASSES_BDA_SUFFIX;
         }
         BeanDeploymentArchiveImpl newBda = new BeanDeploymentArchiveImpl(Collections.singleton(beanClass.getName()),
-                BeansXml.EMPTY_BEANS_XML, module, id, BeanArchiveType.SYNTHETIC, false);
+                Collections.singleton(beanClass.getName()), BeansXml.EMPTY_BEANS_XML, module, id, BeanArchiveType.SYNTHETIC, false);
         WeldLogger.DEPLOYMENT_LOGGER.beanArchiveDiscovered(newBda);
         newBda.addBeanClass(beanClass);
         ServiceRegistry newBdaServices = newBda.getServices();
@@ -248,7 +248,8 @@ public class WeldDeployment implements CDI11Deployment {
         ClassLoader moduleClassLoader = WildFlySecurityManager.getClassLoaderPrivileged(beanClass);
         if (moduleClassLoader != null) {
             for (BeanDeploymentArchiveImpl bda : beanDeploymentArchives) {
-                if (bda.getBeanClasses().contains(beanClass.getName()) && moduleClassLoader.equals(bda.getClassLoader())) {
+                // search in all known classes in that archive
+                if (bda.getKnownClasses().contains(beanClass.getName()) && moduleClassLoader.equals(bda.getClassLoader())) {
                     return bda;
                 }
             }


### PR DESCRIPTION
WildFly issue - https://issues.jboss.org/browse/WFLY-9536

Weld 3 expanded its `BeanDeploymentArchive` SPI with `getKnownClasses` which should return all classes within that bean archive, even those which are not beans. This PR implements it for WildFly and makes use of it.

There is also a basic test included (using BDA lookup based on non-bean classes).