### PR TITLE
[WFLY-9789] Move to RESTEasy 3.5 in a EE7 compatible way

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -209,6 +209,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>json-patch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>jackson-coreutils</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
         </dependency>
@@ -247,6 +257,11 @@
         <dependency>
             <groupId>com.sun.istack</groupId>
             <artifactId>istack-commons-tools</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
         </dependency>
 
         <dependency>
@@ -1116,6 +1131,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>jose-jwt</artifactId>
         </dependency>
@@ -1127,7 +1147,25 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <classifier>jaxrs20</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxrs</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <classifier>jaxrs20</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -1180,18 +1218,23 @@
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-json-binding-provider</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-p-provider</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jaxb-provider</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -1248,6 +1291,11 @@
         <dependency>
             <groupId>org.jboss.spec.javax.faces</groupId>
             <artifactId>jboss-jsf-api_2.2_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
         </dependency>
 
         <dependency>
@@ -1346,6 +1394,16 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
         </dependency>
 
         <dependency>
@@ -2196,6 +2254,11 @@
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-iiop-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.reactivestreams</groupId>
+            <artifactId>reactive-streams</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/jackson-coreutils/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/jackson-coreutils/main/module.xml
@@ -22,23 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="com.github.fge.jackson-coreutils">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${com.github.fge:jackson-coreutils}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="com.google.guava"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/json-patch/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/json-patch/main/module.xml
@@ -22,23 +22,21 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="com.github.fge.json-patch">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${com.github.fge:json-patch}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="com.github.fge.jackson-coreutils"/>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
+        <module name="com.google.guava"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -22,23 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="javax.json.bind.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${javax.json.bind:javax.json.bind-api}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/restclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/restclient/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,23 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
-    <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-    </resources>
+<module xmlns="urn:jboss:module:1.5" name="org.eclipse.microprofile.restclient">
 
-    <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
-    </dependencies>
+  <resources>
+    <artifact name="${org.eclipse.microprofile.rest.client:microprofile-rest-client-api}"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.annotation.api"/>
+    <module name="javax.enterprise.api"/>
+    <module name="javax.xml.bind.api"/>
+    <module name="javax.ws.rs.api"/>
+  </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -22,23 +22,19 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="org.eclipse.yasson">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${org.eclipse:yasson}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="javax.json.bind.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,23 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
-    <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-    </resources>
+<module xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.json">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
     </dependencies>
+    <resources>
+        <artifact name="${org.glassfish:javax.json}"/>
+    </resources>
+
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
@@ -34,6 +34,7 @@
         <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" export="true"/>
         <module name="com.fasterxml.jackson.datatype.jackson-datatype-jdk8"/>
         <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310"/>
+        <module name="com.github.fge.json-patch"/>
         <module name="javax.xml.bind.api"/>
         <module name="javax.api"/>
         <module name="javax.enterprise.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -22,11 +22,29 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-jaxrs">
+<module xmlns="urn:jboss:module:1.7" name="org.jboss.resteasy.resteasy-jaxrs">
 
     <resources>
-        <artifact name="${org.jboss.resteasy:resteasy-jaxrs}"/>
-        <artifact name="${org.jboss.resteasy:resteasy-client}"/>
+        <artifact name="${org.jboss.resteasy:resteasy-jaxrs}">
+            <conditions>
+              <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <artifact name="${org.jboss.resteasy:resteasy-jaxrs::jaxrs20}">
+            <conditions>
+              <property-not-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <artifact name="${org.jboss.resteasy:resteasy-client}">
+            <conditions>
+              <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <artifact name="${org.jboss.resteasy:resteasy-client::jaxrs20}">
+            <conditions>
+              <property-not-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
     </resources>
 
     <dependencies>
@@ -37,6 +55,7 @@
         <module name="javax.enterprise.api"/>
         <module name="javax.xml.bind.api"/>
         <module name="javax.ws.rs.api"/>
+        <module name="javax.json.bind.api"/>
         <module name="org.apache.commons.io"/>
         <module name="org.apache.commons.codec" />
         <module name="org.apache.httpcomponents"/>
@@ -46,5 +65,7 @@
         <module name="javax.servlet.api"/>
         <module name="org.jboss.resteasy.resteasy-validator-provider-11" optional="true" services="export" export="true"/>
         <module name="org.jboss.logging"/>
+        <module name="org.reactivestreams" export="true"/>
+        <module name="org.eclipse.microprofile.restclient" export="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -22,23 +22,27 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="org.jboss.resteasy.resteasy-json-binding-provider">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${org.jboss.resteasy:resteasy-json-binding-provider}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
+        <module name="org.glassfish.javax.json"/>
+        <module name="javax.json.bind.api" export="true"/>
+        <module name="org.eclipse.yasson"/>
+        <module name="javax.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.ws.rs.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.jboss.resteasy.resteasy-jaxrs"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/reactivestreams/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/reactivestreams/main/module.xml
@@ -22,23 +22,12 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.5" name="org.reactivestreams">
+
     <resources>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}">
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.1_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${org.reactivestreams:reactive-streams}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.resteasy.resteasy-jaxrs" services="export"/>
-        <module name="javax.xml.bind.api" />
-        <module name="javax.api" />
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,10 @@
         <version.antlr>2.7.7</version.antlr>
         <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
-        <version.com.fasterxml.classmate>1.3.3</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
+        <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
+        <version.com.fasterxml.jackson>2.9.2</version.com.fasterxml.jackson>
+        <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>
+        <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>20.0</version.com.google.guava>
         <version.com.h2database>1.4.193</version.com.h2database>
@@ -107,6 +109,7 @@
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0</version.javax.enterprise>
+        <version.javax.json.bind-api>1.0</version.javax.json.bind-api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.0</version.javax.mail>
         <version.javax.validation>1.1.0.Final</version.javax.validation>
@@ -121,13 +124,14 @@
         <version.org.apache.cxf>3.2.2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.1.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M20</version.org.apache.ds>
-        <version.org.apache.httpcomponents.httpasyncclient>4.1.2</version.org.apache.httpcomponents.httpasyncclient>
+        <version.org.apache.httpcomponents.httpasyncclient>4.1.3</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.lucene>5.3.1</version.org.apache.lucene>
         <version.org.apache.myfaces.core>2.2.11</version.org.apache.myfaces.core>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
         <version.org.eclipselink.version>2.6.3</version.org.eclipselink.version>
+        <version.org.eclipse.yasson>1.0</version.org.eclipse.yasson>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.16.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.1</version.org.apache.santuario>
@@ -140,6 +144,7 @@
         <version.org.codehaus.jettison>1.3.8</version.org.codehaus.jettison>
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
+        <version.org.eclipse.microprofile.rest.client.api>1.0</version.org.eclipse.microprofile.rest.client.api>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
@@ -169,7 +174,7 @@
         <version.org.jboss.mod_cluster>1.3.7.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.1.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
-        <version.org.jboss.resteasy>3.0.24.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.5.0.CR1</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.4.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
@@ -192,6 +197,7 @@
         <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.3.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
+        <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
@@ -212,6 +218,7 @@
         <version.org.opensaml.opensaml>3.3.0</version.org.opensaml.opensaml>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.5.5.SP8</version.org.picketlink>
+        <version.org.reactivestreams>1.0.1</version.org.reactivestreams>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
@@ -1480,6 +1487,18 @@
                 <version>${version.com.github.relaxng}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.github.fge</groupId>
+                <artifactId>json-patch</artifactId>
+                <version>${version.com.github.fge.json-patch}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.fge</groupId>
+                <artifactId>jackson-coreutils</artifactId>
+                <version>${version.com.github.fge.jackson-coreutils}</version>
+            </dependency>
+
 
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
@@ -1906,6 +1925,12 @@
             <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
                 <version>${version.jsoup}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.reactivestreams</groupId>
+                <artifactId>reactive-streams</artifactId>
+                <version>${version.org.reactivestreams}</version>
             </dependency>
 
             <dependency>
@@ -4868,8 +4893,25 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
+                <classifier>jaxrs20</classifier>
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-client</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>
@@ -4880,6 +4922,51 @@
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-jaxrs</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.resteasy</groupId>
+                        <artifactId>jaxrs-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-httpclient</groupId>
+                        <artifactId>commons-httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.jcip</groupId>
+                        <artifactId>jcip</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.jcip</groupId>
+                        <artifactId>jcip-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.annotation</groupId>
+                        <artifactId>jsr250-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jaxrs</artifactId>
+                <classifier>jaxrs20</classifier>
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
@@ -4979,6 +5066,10 @@
                         <artifactId>resteasy-client</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>
                     </exclusion>
@@ -4991,24 +5082,8 @@
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>org.jboss.resteasy</groupId>
-                        <artifactId>jaxrs-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.xml.stream</groupId>
-                        <artifactId>sjsxp</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>servlet-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-impl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.jboss.logging</groupId>
-                        <artifactId>jboss-logging</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -5074,6 +5149,22 @@
                         <groupId>com.fasterxml.jackson.jaxrs</groupId>
                         <artifactId>jackson-jaxrs-json-provider</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.github.fge</groupId>
+                        <artifactId>json-patch</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-json-binding-provider</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -5083,8 +5174,8 @@
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.json</groupId>
-                        <artifactId>javax.json-api</artifactId>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -5106,6 +5197,10 @@
                 <artifactId>resteasy-jsapi</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.jboss.resteasy</groupId>
                         <artifactId>jaxrs-api</artifactId>
@@ -5341,6 +5436,12 @@
             </dependency>
 
             <dependency>
+                <groupId>javax.json.bind</groupId>
+                <artifactId>javax.json.bind-api</artifactId>
+                <version>${version.javax.json.bind-api}</version>
+            </dependency>
+
+            <dependency>
               <groupId>org.jboss.spec.javax.management.j2ee</groupId>
               <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
               <version>${version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec}</version>
@@ -5392,6 +5493,12 @@
                 <groupId>org.jboss.spec.javax.ws.rs</groupId>
                 <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec}</version>
             </dependency>
 
             <dependency>
@@ -5482,9 +5589,33 @@
             </dependency>
 
             <dependency>
+                <groupId>org.eclipse</groupId>
+                <artifactId>yasson</artifactId>
+                <version>${version.org.eclipse.yasson}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.eclipse.jdt.core.compiler</groupId>
                 <artifactId>ecj</artifactId>
                 <version>${version.org.eclipse.jdt.core.compiler}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.rest.client</groupId>
+                <artifactId>microprofile-rest-client-api</artifactId>
+                <version>${version.org.eclipse.microprofile.rest.client.api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.9.2</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.9.4</version.com.fasterxml.jackson>
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.org.jboss.mod_cluster>1.3.7.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.1.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
-        <version.org.jboss.resteasy>3.5.0.CR1</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.5.0.CR2</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.4.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
This is a preview of the upgrade that I'm soon submitting for bringing JAX-RS 2.1 RESTEasy implementation in WildFly. I'd like the reviewers to start having a look and letting me know of any additional requirements / changes needed for merging before I tag 3.5.0.Final.
I'm dealing with the needed analysis / test plan in the mean time; besides JSR 370 (JAX-RS 2.1), the RESTEasy component upgrade also pulls few other planned new features.

Few JIRA links:
https://issues.jboss.org/browse/WFLY-9789
https://issues.jboss.org/browse/WFLY-6459
https://issues.jboss.org/browse/WFLY-9786
https://issues.jboss.org/browse/WFLY-9787

Dev analysis:
https://github.com/wildfly/wildfly-proposals/pull/16
https://github.com/wildfly/wildfly-proposals/pull/18
https://github.com/wildfly/wildfly-proposals/pull/19

Note this is related to WFLY-6460 and WFLY-7185 too.

@jamezp @n1hility @bstansberry @kabir @rsvoboda @stuartwdouglas @kanovotn 