### PR TITLE
WFLY-9767 Clustering testsuite trimming - redundant testsuite/integra…

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -39,7 +39,7 @@
                         <version>${version.org.wildfly.plugin}</version>
                         <executions>
                             <execution>
-                                <phase>process-test-resources</phase>
+                                <phase>generate-test-resources</phase>
                                 <goals>
                                     <goal>execute-commands</goal>
                                 </goals>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -1,17 +1,39 @@
 <?xml version="1.0"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
 <project>
     <target name="build-clustering">
-        <copy todir="target/wildfly-1" overwrite="true">
+        <move todir="target/wildfly-1" overwrite="true">
             <fileset dir="${basedir}/target/wildfly"/>
-        </copy>
+        </move>
         <copy todir="target/wildfly-2" overwrite="true">
-            <fileset dir="${basedir}/target/wildfly"/>
+            <fileset dir="${basedir}/target/wildfly-1"/>
         </copy>
         <copy todir="target/wildfly-3" overwrite="true">
-            <fileset dir="${basedir}/target/wildfly"/>
+            <fileset dir="${basedir}/target/wildfly-1"/>
         </copy>
         <copy todir="target/wildfly-4" overwrite="true">
-            <fileset dir="${basedir}/target/wildfly"/>
+            <fileset dir="${basedir}/target/wildfly-1"/>
         </copy>
     </target>
 </project>


### PR DESCRIPTION
…tion/clustering/target/wildfly

Jira
https://issues.jboss.org/browse/WFLY-9767

The testsuite/integration/clustering/target/wildfly is copied by an inherited execution from testsuite/pom.xml, which is then used for templating but remains untouched for the testsuite run. That is not necessary. This saves another ~30 MB.

