### PR TITLE
WFLY-9771 Ignore SingletonPartitionTestCase.testSingletonService due …

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
@@ -58,6 +58,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -73,6 +74,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("WFLY-9771")
 public class SingletonPartitionTestCase extends AbstractClusteringTestCase {
 
     private static final long TOPOLOGY_CHANGE_TIMEOUT = TimeoutUtil.adjust(120_000); // maximum time in ms to wait for cluster topology change


### PR DESCRIPTION
…to intermittent failure

https://issues.jboss.org/browse/WFLY-9771

example failure: https://ci.wildfly.org/viewLog.html?buildId=88100&buildTypeId=WF_PullRequest_LinuxElytro