### PR TITLE
WFLY-9772 Intermittent failures in EjbRemoveUnitTestCase

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/ComponentInstallProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/ComponentInstallProcessor.java
@@ -67,6 +67,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StabilityMonitor;
 
 import static org.jboss.as.ee.logging.EeLogger.ROOT_LOGGER;
 import static org.jboss.as.ee.component.Attachments.COMPONENT_REGISTRY;
@@ -262,7 +263,10 @@ public final class ComponentInstallProcessor implements DeploymentUnitProcessor 
                     ServiceBuilder<ManagedReferenceFactory> serviceBuilder = serviceTarget.addService(bindInfo.getBinderServiceName(), service);
                     bindingConfiguration.getSource().getResourceValue(resolutionContext, serviceBuilder, phaseContext, service.getManagedObjectInjector());
                     serviceBuilder.addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, service.getNamingStoreInjector());
-                    serviceBuilder.install();
+                    ServiceController<ManagedReferenceFactory> controller = serviceBuilder.install();
+                    for(StabilityMonitor monitor : phaseContext.getServiceTarget().getMonitors()) {
+                        monitor.addController(controller);
+                    }
                 } catch (DuplicateServiceException e) {
                     ServiceController<ManagedReferenceFactory> registered = (ServiceController<ManagedReferenceFactory>) CurrentServiceContainer.getServiceContainer().getService(bindInfo.getBinderServiceName());
                     if (registered == null)

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/ModuleJndiBindingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/ModuleJndiBindingProcessor.java
@@ -54,6 +54,7 @@ import org.jboss.msc.service.DuplicateServiceException;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StabilityMonitor;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -227,7 +228,10 @@ public class ModuleJndiBindingProcessor implements DeploymentUnitProcessor {
                     ServiceBuilder<ManagedReferenceFactory> serviceBuilder = CurrentServiceContainer.getServiceContainer().addService(bindInfo.getBinderServiceName(), service);
                     bindingConfiguration.getSource().getResourceValue(resolutionContext, serviceBuilder, phaseContext, service.getManagedObjectInjector());
                     serviceBuilder.addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, service.getNamingStoreInjector());
-                    serviceBuilder.install();
+                    ServiceController<ManagedReferenceFactory> controller = serviceBuilder.install();
+                    for(StabilityMonitor monitor : phaseContext.getServiceTarget().getMonitors()) {
+                        monitor.addController(controller);
+                    }
                 } catch (DuplicateServiceException e) {
                     final ServiceController<ManagedReferenceFactory> controller = (ServiceController<ManagedReferenceFactory>) CurrentServiceContainer.getServiceContainer().getService(bindInfo.getBinderServiceName());
                     if (controller == null)


### PR DESCRIPTION
This can actually affect any EJB test with remote views (e.g. ServletUnitTestCase is also affected)

The Underlying issue is that global bindings are not added to the deployments ServiceTarget, and
as such are not added to the stability monitor.

https://issues.jboss.org/browse/WFLY-9772