### PR TITLE
WFLY-9772 Intermittent failures in EjbRemoveUnitTestCase

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/ModuleJndiBindingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/ModuleJndiBindingProcessor.java
@@ -224,7 +224,7 @@ public class ModuleJndiBindingProcessor implements DeploymentUnitProcessor {
                 BinderService service;
                 try {
                     service = new BinderService(bindInfo.getBindName(), bindingConfiguration.getSource(), true);
-                    ServiceBuilder<ManagedReferenceFactory> serviceBuilder = CurrentServiceContainer.getServiceContainer().addService(bindInfo.getBinderServiceName(), service);
+                    ServiceBuilder<ManagedReferenceFactory> serviceBuilder = phaseContext.getDeploymentUnit().getAttachment(org.jboss.as.server.deployment.Attachments.EXTERNAL_SERVICE_TARGET).addService(bindInfo.getBinderServiceName(), service);
                     bindingConfiguration.getSource().getResourceValue(resolutionContext, serviceBuilder, phaseContext, service.getManagedObjectInjector());
                     serviceBuilder.addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, service.getNamingStoreInjector());
                     serviceBuilder.install();


### PR DESCRIPTION
This can actually affect any EJB test with remote views (e.g. ServletUnitTestCase is also affected)

The Underlying issue is that global bindings are not added to the deployments ServiceTarget, and
as such are not added to the stability monitor.
