### PR TITLE
WFLY-9771 Mark SingletonPartitionTestCase as intermittently failing (…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.clustering.cluster.singleton;
 
+import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
@@ -58,6 +59,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,6 +76,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class SingletonPartitionTestCase extends AbstractClusteringTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        thisTestIsFailingIntermittently("https://issues.jboss.org/browse/WFLY-9771");
+    }
 
     private static final long TOPOLOGY_CHANGE_TIMEOUT = TimeoutUtil.adjust(120_000); // maximum time in ms to wait for cluster topology change
     private static final int SERVICE_TIMEOUT = TimeoutUtil.adjust(5_000); // it takes a little extra time after merge for the singleton service to migrate


### PR DESCRIPTION
…essentially @Ignored by default)

Jira
https://issues.jboss.org/browse/WFLY-9771

we should ideally mark this as intermittently failing. This means that the test is essentially ignored (so no noise on PRs or running locally), but there is supposed to be a nightly job to run the intermittently failing tests. This way we have more information for debug or notice when test starts to fail consistently. This is important especially here, since we have not been able to track down the cause yet. Opened #10826 -- @jmesnil Jeff, since you introduced this, did that job ever get setup? I can't seem to find it.