### PR TITLE
WFLY-6456 Servlet 4.0 Support

### DIFF
--- a/clustering/web/spi/pom.xml
+++ b/clustering/web/spi/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/jsf/subsystem/pom.xml
+++ b/jsf/subsystem/pom.xml
@@ -100,7 +100,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,8 @@
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.4.7.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.metadata>10.0.2.Final</version.org.jboss.metadata>
         <version.org.jboss.narayana>5.5.31.Final</version.org.jboss.narayana>
+        <version.org.jboss.metadata>11.0.0.Beta1</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.7.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.1.0.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
@@ -189,6 +189,7 @@
         <version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>1.0.6.Final</version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
+        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>1.0.0.Alpha3</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.3.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
@@ -215,6 +216,7 @@
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.bridge.servlet-api-bridge>1.0.0.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.build-tools>1.2.6.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>4.0.0.Alpha9</version.org.wildfly.core>
@@ -4777,6 +4779,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wildfly.bridge</groupId>
+                <artifactId>servlet-api-bridge</artifactId>
+                <version>${version.org.wildfly.bridge.servlet-api-bridge}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jberet</groupId>
                 <artifactId>jberet-core</artifactId>
                 <version>${version.org.jberet}</version>
@@ -5366,6 +5374,12 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.servlet</groupId>
+                <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.servlet</groupId>
                 <artifactId>jboss-servlet-api_3.1_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec}</version>
             </dependency>
@@ -5377,7 +5391,7 @@
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.servlet</groupId>
-                        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+                        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -6022,7 +6036,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.ejb</groupId>
-                        <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+                        <artifactId>jboss-ejb-api_4.0_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <!-- superseded by org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec -->

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -105,6 +105,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.bridge</groupId>
+            <artifactId>servlet-api-bridge</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
         </dependency>
@@ -199,6 +210,11 @@
         <dependency>
             <groupId>org.jboss.spec.javax.security.auth.message</groupId>
             <artifactId>jboss-jaspi-api_1.1_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -385,7 +385,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
       <licenses>
         <license>
           <name>Common Development and Distribution License 1.1</name>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
@@ -37,5 +37,6 @@
         <module name="org.jboss.logging"/>
         <module name="io.undertow.core" />
         <module name="org.jboss.xnio"/>
+        <module name="org.wildfly.bridge.servlet-api-bridge" />
     </dependencies>
 </module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/bridge/servlet-api-bridge/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/bridge/servlet-api-bridge/main/module.xml
@@ -22,16 +22,11 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.servlet.api">
+<module xmlns="urn:jboss:module:1.7" name="org.wildfly.bridge.servlet-api-bridge">
     <resources>
-        <artifact name="${org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec}">
+        <artifact name="${org.wildfly.bridge:servlet-api-bridge}">
             <conditions>
                 <property-not-equal name="ee8.preview.mode" value="true" />
-            </conditions>
-        </artifact>
-        <artifact name="${org.jboss.spec.javax.servlet:jboss-servlet-api_4.0_spec}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true" />
             </conditions>
         </artifact>
     </resources>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -91,7 +91,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet.jsp</groupId>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/EarContextRootProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/EarContextRootProcessor.java
@@ -35,7 +35,6 @@ import org.jboss.metadata.ear.spec.EarMetaData;
 import org.jboss.metadata.ear.spec.ModuleMetaData;
 import org.jboss.metadata.ear.spec.ModulesMetaData;
 import org.jboss.metadata.ear.spec.WebModuleMetaData;
-import org.jboss.metadata.web.jboss.JBoss70WebMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 
 import static org.jboss.metadata.ear.spec.ModuleMetaData.ModuleType.Web;
@@ -82,7 +81,7 @@ public class EarContextRootProcessor implements DeploymentUnitProcessor {
                 if(contextRoot != null) {
                     JBossWebMetaData jBossWebMetaData = warMetaData.getJBossWebMetaData();
                         if(jBossWebMetaData == null) {
-                            jBossWebMetaData = new JBoss70WebMetaData();
+                            jBossWebMetaData = new JBossWebMetaData();
                             warMetaData.setJBossWebMetaData(jBossWebMetaData);
                         }
                     jBossWebMetaData.setContextRoot(contextRoot);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletResourceManager.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletResourceManager.java
@@ -113,7 +113,7 @@ public class ServletResourceManager implements ResourceManager {
 
     @Override
     public void registerResourceChangeListener(ResourceChangeListener listener) {
-        if(deploymentResourceManager.isResourceChangeListenerSupported()) {
+        if(explodedDeployment && deploymentResourceManager.isResourceChangeListenerSupported()) {
             deploymentResourceManager.registerResourceChangeListener(listener);
         }
         for(ResourceManager external : externalOverlays) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -85,6 +85,7 @@ import org.jboss.metadata.web.jboss.JBossServletMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.AttributeMetaData;
 import org.jboss.metadata.web.spec.FunctionMetaData;
+import org.jboss.metadata.web.spec.ListenerMetaData;
 import org.jboss.metadata.web.spec.TagFileMetaData;
 import org.jboss.metadata.web.spec.TagMetaData;
 import org.jboss.metadata.web.spec.TldMetaData;
@@ -583,6 +584,11 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
         }
 
         TagLibraryInfo tagLibraryInfo = new TagLibraryInfo();
+        if(tldMetaData.getListeners() != null) {
+            for (ListenerMetaData l : tldMetaData.getListeners()) {
+                tagLibraryInfo.addListener(l.getListenerClass());
+            }
+        }
         tagLibraryInfo.setTlibversion(tldMetaData.getTlibVersion());
         if (tldMetaData.getJspVersion() == null) {
             tagLibraryInfo.setJspversion(tldMetaData.getVersion());

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarAnnotationDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarAnnotationDeploymentProcessor.java
@@ -82,7 +82,6 @@ import org.jboss.metadata.web.spec.ServletMetaData;
 import org.jboss.metadata.web.spec.ServletSecurityMetaData;
 import org.jboss.metadata.web.spec.ServletsMetaData;
 import org.jboss.metadata.web.spec.TransportGuaranteeType;
-import org.jboss.metadata.web.spec.Web30MetaData;
 import org.jboss.metadata.web.spec.WebMetaData;
 import org.jboss.modules.ModuleIdentifier;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
@@ -151,7 +150,7 @@ public class WarAnnotationDeploymentProcessor implements DeploymentUnitProcessor
      */
     protected WebMetaData processAnnotations(Index index)
     throws DeploymentUnitProcessingException {
-        Web30MetaData metaData = new Web30MetaData();
+        WebMetaData metaData = new WebMetaData();
         // @WebServlet
         final List<AnnotationInstance> webServletAnnotations = index.getAnnotations(webServlet);
         if (webServletAnnotations != null && webServletAnnotations.size() > 0) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
@@ -111,6 +111,8 @@ public class WebParsingDeploymentProcessor implements DeploymentUnitProcessor {
                                 validator.validate("http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd", xmlInput);
                             else if (webMetaData.is31())
                                 validator.validate("http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd", xmlInput);
+                            else if (webMetaData.getVersion() != null && webMetaData.getVersion().equals("4.0"))
+                                validator.validate("http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd", xmlInput);
                             else
                                 validator.validate("-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN", xmlInput);
                         } catch (SAXException e) {

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -88,7 +88,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -123,7 +123,7 @@
 
       <dependency>
          <groupId>org.jboss.spec.javax.servlet</groupId>
-         <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+         <artifactId>jboss-servlet-api_4.0_spec</artifactId>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This contains the non-undertow related parts of Servlet 4.0, which must be merged first before an undertow upgrade can happen.

It contains two non-final releases, however they can both be released as final at any point.