### PR TITLE
WFLY-9773 Use the custom HttpHandler's classloader as the TCCL while initializing the handler instance

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomHttpHandler.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomHttpHandler.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.manualmode.undertow;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+
+/**
+ * A custom {@link HttpHandler} which sets the response headers {@link #RESPONSE_HEADER_ONE_NAME} and
+ * {@link #RESPONSE_HEADER_TWO_NAME} with the value {@code true} if this handler was constructed using
+ * the "right" TCCL in the static and object initialization, respectively. The headers' value is set
+ * to {@code false} otherwise
+ *
+ * @author Jaikiran Pai
+ */
+public class CustomHttpHandler implements HttpHandler {
+
+    static final String RESPONSE_HEADER_ONE_NAME = "correct-tccl-during-handler-static-init";
+    static final String RESPONSE_HEADER_TWO_NAME = "correct-tccl-during-handler-init";
+
+    private final HttpHandler next;
+    private static final boolean correctTcclInStaticInit;
+    private final boolean correctTcclInInstanceConstruction;
+
+    static {
+        correctTcclInStaticInit = tryLoadClassInTCCL();
+    }
+
+    public CustomHttpHandler(final HttpHandler next) {
+        this.next = next;
+        this.correctTcclInInstanceConstruction = tryLoadClassInTCCL();
+    }
+
+    private static boolean tryLoadClassInTCCL() {
+        try {
+            Class.forName("org.jboss.as.test.manualmode.undertow.SomeClassInSameModuleAsCustomHttpHandler", true, Thread.currentThread().getContextClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        exchange.getResponseHeaders().put(new HttpString(RESPONSE_HEADER_ONE_NAME), String.valueOf(correctTcclInStaticInit));
+        exchange.getResponseHeaders().put(new HttpString(RESPONSE_HEADER_TWO_NAME), String.valueOf(this.correctTcclInInstanceConstruction));
+        next.handleRequest(exchange);
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomUndertowFilterTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomUndertowFilterTestCase.java
@@ -1,0 +1,194 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package org.jboss.as.test.manualmode.undertow;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests custom http handler(s) configured as {@code custom-filter}s in the undertow subsystem
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class CustomUndertowFilterTestCase {
+
+    private static final Logger logger = Logger.getLogger(CustomUndertowFilterTestCase.class);
+
+    private static final String CUSTOM_FILTER_MODULE_NAME = "custom-undertow-filter-module";
+    private static final String CUSTOM_FILTER_CLASSNAME = CustomHttpHandler.class.getName();
+    private static final String CUSTOM_FILTER_RESOURCE_NAME = "testcase-added-custom-undertow-filter";
+    private static final String WAR_DEPLOYMENT_NAME = "test-tccl-in-custom-undertow-handler-construction";
+
+    @Inject
+    private static ServerController serverController;
+
+    private static TestModule customHandlerModule;
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        serverController.start();
+        // setup the server with the necessary Undertow filter configurations
+        prepareServerConfiguration();
+        // deploy an web application
+        deploy();
+    }
+
+    @AfterClass
+    public static void resetServer() throws Exception {
+        try {
+            final ServerDeploymentHelper deploymentHelper = new ServerDeploymentHelper(serverController.getClient().getControllerClient());
+            deploymentHelper.undeploy(WAR_DEPLOYMENT_NAME + ".war");
+        } catch (Exception e) {
+            // ignore
+            logger.debug("Ignoring exception that occurred during un-deploying", e);
+        }
+        try {
+            // cleanup the undertow configurations we did in this test
+            resetServerConfiguration();
+        } finally {
+            serverController.stop();
+        }
+    }
+
+    private static void prepareServerConfiguration() throws Exception {
+        // create a (JBoss) module jar containing the custom http handler and a dummy class that gets used
+        // by the handler
+        customHandlerModule = createModule();
+        // create a custom-filter in the undertow subsystem and use the filter class that's
+        // present in the module that we just created
+        final ModelNode addCustomFilter = ModelUtil.createOpNode("subsystem=undertow/configuration=filter" +
+                "/custom-filter=" + CUSTOM_FILTER_RESOURCE_NAME, "add");
+        addCustomFilter.get("class-name").set(CUSTOM_FILTER_CLASSNAME);
+        addCustomFilter.get("module").set(CUSTOM_FILTER_MODULE_NAME);
+        // add a reference to this custom filter, in the default undertow host, so that it gets used
+        // for all deployed applications on this host
+        final ModelNode addFilterRef = ModelUtil.createOpNode("subsystem=undertow/server=default-server/host=default-host" +
+                "/filter-ref=" + CUSTOM_FILTER_RESOURCE_NAME, "add");
+
+        final ModelControllerClient controllerClient = serverController.getClient().getControllerClient();
+        ManagementOperations.executeOperation(controllerClient,
+                ModelUtil.createCompositeNode(new ModelNode[]{addCustomFilter, addFilterRef}));
+
+        // reload the server for changes to take effect
+        ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+    }
+
+    private static void resetServerConfiguration() throws Exception {
+        // remove the filter-ref
+        final ModelNode removeFilterRef = ModelUtil.createOpNode("subsystem=undertow/server=default-server/host=default-host" +
+                "/filter-ref=" + CUSTOM_FILTER_RESOURCE_NAME, "remove");
+        // remove the custom undertow filter
+        final ModelNode removeCustomFilter = ModelUtil.createOpNode("subsystem=undertow/configuration=filter" +
+                "/custom-filter=" + CUSTOM_FILTER_RESOURCE_NAME, "remove");
+
+        final ModelControllerClient controllerClient = serverController.getClient().getControllerClient();
+        ManagementOperations.executeOperation(controllerClient,
+                ModelUtil.createCompositeNode(new ModelNode[]{removeFilterRef, removeCustomFilter}));
+
+        // remove the custom module
+        customHandlerModule.remove();
+        // reload the server
+        ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+    }
+
+    private static void deploy() throws Exception {
+        // create a deployment
+        final WebArchive war = ShrinkWrap.create(WebArchive.class).addAsWebResource(new StringAsset("Hello world!"), "index.html");
+        // deploy it
+        try (final InputStream is = war.as(ZipExporter.class).exportAsInputStream()) {
+            final ServerDeploymentHelper deploymentHelper = new ServerDeploymentHelper(serverController.getClient().getControllerClient());
+            deploymentHelper.deploy(WAR_DEPLOYMENT_NAME + ".war", is);
+        }
+    }
+
+    /**
+     * Tests that the {@link Thread#getContextClassLoader() TCCL} that's set when a
+     * custom {@link io.undertow.server.HttpHandler}, part of a (JBoss) module, configured in the undertow subsystem
+     * is initialized/constructed, the classloader is the same as the classloader of the module to which
+     * the handler belongs
+     */
+    @Test
+    public void testTCCLInHttpHandlerInitialization() throws Exception {
+        final String url = "http://" + TestSuiteEnvironment.getHttpAddress()
+                + ":" + TestSuiteEnvironment.getHttpPort()
+                + "/" + WAR_DEPLOYMENT_NAME + "/index.html";
+        logger.debug("Invoking request at " + url);
+        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final HttpGet httpget = new HttpGet(url);
+            final HttpResponse response = httpClient.execute(httpget);
+            final StatusLine statusLine = response.getStatusLine();
+            assertEquals("Unexpected HTTP response status code for request " + url, 200, statusLine.getStatusCode());
+
+            // make sure the custom http handler was invoked and it was initialized with the right TCCL
+            final Header[] headerOneValues = response.getHeaders(CustomHttpHandler.RESPONSE_HEADER_ONE_NAME);
+            Assert.assertEquals("Unexpected number of response header value for header " + CustomHttpHandler.RESPONSE_HEADER_ONE_NAME, 1, headerOneValues.length);
+            Assert.assertEquals("Unexpected response header value for header " + CustomHttpHandler.RESPONSE_HEADER_ONE_NAME, true, Boolean.valueOf(headerOneValues[0].getValue()));
+
+            final Header[] headerTwoValues = response.getHeaders(CustomHttpHandler.RESPONSE_HEADER_TWO_NAME);
+            Assert.assertEquals("Unexpected number of response header value for header " + CustomHttpHandler.RESPONSE_HEADER_TWO_NAME, 1, headerTwoValues.length);
+            Assert.assertEquals("Unexpected response header value for header " + CustomHttpHandler.RESPONSE_HEADER_TWO_NAME, true, Boolean.valueOf(headerTwoValues[0].getValue()));
+        }
+    }
+
+
+    private static TestModule createModule() throws IOException {
+        final TestModule module = new TestModule(CUSTOM_FILTER_MODULE_NAME, "io.undertow.core");
+        module.addResource("custom-http-handler.jar").addClass(CustomHttpHandler.class)
+                .addClass(SomeClassInSameModuleAsCustomHttpHandler.class);
+        module.create(true);
+        return module;
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/SomeClassInSameModuleAsCustomHttpHandler.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/SomeClassInSameModuleAsCustomHttpHandler.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.manualmode.undertow;
+
+/**
+ * A class that's supposed to belong to the same custom (JBoss) module as {@link CustomHttpHandler}
+ *
+ * @author Jaikiran Pai
+ */
+public class SomeClassInSameModuleAsCustomHttpHandler {
+
+}


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-9773.
Related forum discussion https://developer.jboss.org/thread/277107

Undertow allows configuring custom filters (which are HttpHandler(s)) either at undertow subsystem level or through individual deployments. When a custom filter is configured at the subsystem level, it is expected to specify a classname representing the filter plus a module name which will be used to find that class.

Right now, Undertow when instantiating the instance of the handler, doesn't set any explicit thread context classloader. As a result, any code in the static initialization and the constructor of the custom HttpHandler runs in an unspecified TCCL. This can cause certain implementations of HttpHandler to fail if they rely on libraries which rely on the "right" TCCL to load other dependent classes.

I don't think/know if there's anything in Undertow docs which state any rules on the TCCL that's used in the initialization. However, for Java EE components we do make sure that the TCCL set during static/object instantiation of the component classes always happens to be the components/deployment's classloader. I think doing the same for these Undertow "components" too makes sense and will make sure that the instantiation happens in the classloader that is configured as the module of the custom handler.

The commit here includes this change to make sure that we set the TCCL to the classloader which loaded the custom filter (which actually is the module configured on that custom filter). This also includes a test case to reproduce the issue and verify the fix.