### PR TITLE
WFLY-9775 Clustering testsuite: cleanup @RunAsClient and "testable = …

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.jboss.arquillian.container.test.api.Deployer;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.test.clustering.NodeUtil;
@@ -144,7 +143,6 @@ public abstract class AbstractClusteringTestCase {
      * Guarantees that prior to test method execution both containers are running and both deployments are deployed.
      */
     @Before
-    @RunAsClient // Does not work, see https://issues.jboss.org/browse/ARQ-351
     public void beforeTestMethod() throws Exception {
         NodeUtil.start(this.controller, nodes);
         NodeUtil.deploy(this.deployer, deployments);
@@ -154,7 +152,6 @@ public abstract class AbstractClusteringTestCase {
      * Guarantees that all deployments are undeployed after the test method has been executed.
      */
     @After
-    @RunAsClient // Does not work, see https://issues.jboss.org/browse/ARQ-351
     public void afterTestMethod() throws Exception {
         NodeUtil.start(this.controller, nodes);
         NodeUtil.undeploy(this.deployer, deployments);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.test.clustering.cluster.cdi;
 
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.ClusterTestUtil;
@@ -43,7 +42,6 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class CdiFailoverTestCase extends AbstractWebFailoverTestCase {
 
     private static final String MODULE_NAME = CdiFailoverTestCase.class.getSimpleName();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -25,7 +25,6 @@ package org.jboss.as.test.clustering.cluster.dispatcher;
 import static org.junit.Assert.*;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -42,7 +41,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class CommandDispatcherTestCase extends AbstractClusteringTestCase {
     private static final long VIEW_CHANGE_WAIT = TimeoutUtil.adjust(2000);
     private static final String MODULE_NAME = "command-dispatcher";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
@@ -32,15 +32,14 @@ import java.util.concurrent.TimeUnit;
 import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.CLIServerSetupTask;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.stateful.RemoteStatefulSB;
 import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.common.CommonStatefulSB;
 import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.AbstractForwardingStatefulSBImpl;
+import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.stateful.RemoteStatefulSB;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.logging.Logger;
@@ -69,7 +68,6 @@ import org.wildfly.common.function.ExceptionSupplier;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 @ServerSetup(AbstractRemoteEJBForwardingTestCase.ServerSetupTask.class)
 public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractClusteringTestCase {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatefulEJBFailoverTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.clustering.cluster.ejb.remote;
 
 import java.util.PropertyPermission;
 
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
@@ -47,7 +46,6 @@ import org.wildfly.common.function.ExceptionSupplier;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public abstract class AbstractRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
     private static final int COUNT = 20;
     private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AbstractRemoteStatelessEJBFailoverTestCase.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.remote;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,7 +31,6 @@ import java.util.PropertyPermission;
 import java.util.concurrent.Callable;
 import java.util.function.UnaryOperator;
 
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
@@ -55,7 +54,6 @@ import org.wildfly.common.function.ExceptionSupplier;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public abstract class AbstractRemoteStatelessEJBFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final int COUNT = 20;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
@@ -29,7 +29,6 @@ import java.util.PropertyPermission;
 import javax.ejb.EJBException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ClientExceptionRemoteEJBTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = "client-exception-remote-ejb-test";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -56,7 +55,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RemoteStatefulEJBConcurrentFailoverTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = "remote-stateful-ejb-concurrent-failover-test";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
@@ -28,7 +28,6 @@ import javax.ejb.NoSuchEJBException;
 import javax.transaction.UserTransaction;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -52,7 +51,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class TransactionalRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = "transactional-remote-stateful-ejb-failover-test";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
@@ -37,7 +37,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -66,7 +65,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class StatefulFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final String MODULE_NAME = "stateful-failover";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
@@ -37,7 +37,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -59,7 +58,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class StatefulTimeoutTestCase extends AbstractClusteringTestCase {
     private static final long WAIT_FOR_TIMEOUT = TimeoutUtil.adjust(5000);
     private static final String MODULE_NAME = "stateful-timeout";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/xpc/StatefulWithXPCFailoverTestCase.java
@@ -40,7 +40,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -62,7 +61,6 @@ import org.junit.runner.RunWith;
  * @author Scott Marlow
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class StatefulWithXPCFailoverTestCase extends AbstractClusteringTestCase {
 
     private static final String persistence_xml =

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulBeanFailoverTestCase.java
@@ -27,7 +27,6 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.NodeNameGetter;
@@ -49,7 +48,6 @@ import org.junit.runner.RunWith;
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RemoteEJBClientStatefulBeanFailoverTestCase extends RemoteEJBClientStatefulFailoverTestBase {
 
     @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/dd/RemoteEJB2ClientStatefulBeanFailoverDDTestCase.java
@@ -27,7 +27,6 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.NodeNameGetter;
@@ -44,7 +43,6 @@ import org.junit.runner.RunWith;
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RemoteEJB2ClientStatefulBeanFailoverDDTestCase extends RemoteEJBClientStatefulFailoverTestBase {
 
     @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -55,7 +54,6 @@ import org.junit.runner.RunWith;
  */
 @Ignore("Uses legacy client hack")
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestCase.class);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -59,7 +58,6 @@ import org.junit.runner.RunWith;
  */
 @Ignore("Uses legacy client hack")
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationDDTestCase.class);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -37,7 +37,6 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -63,7 +62,6 @@ import org.junit.runner.RunWith;
  * @author Ondrej Chaloupka
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RemoteStatelessFailoverTestCase {
     private static final Logger log = Logger.getLogger(RemoteStatelessFailoverTestCase.class);
     private static EJBDirectory directoryAnnotation;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
@@ -39,7 +39,6 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -61,7 +60,6 @@ import org.wildfly.test.api.Authentication;
  * @author Jan Martiska
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ClusteredJPA2LCTestCase {
 
     private static final String MODULE_NAME = "clustered2lc";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -47,7 +47,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -68,7 +67,6 @@ import org.junit.runner.RunWith;
  * @author Stuart Douglas
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class JSFFailoverTestCase extends AbstractClusteringTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import java.util.Collection;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -20,7 +19,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ServiceProviderRegistrationTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = "service-provider-registration";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -7,7 +7,6 @@ import java.util.Collection;
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
@@ -22,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RegistryTestCase extends AbstractClusteringTestCase {
     private static final String MODULE_NAME = "registry";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
@@ -35,7 +35,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -53,7 +52,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SingletonBackupServiceTestCase extends AbstractClusteringTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
@@ -36,7 +36,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -56,7 +55,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public abstract class SingletonDeploymentTestCase extends AbstractClusteringTestCase {
 
     private static final String DEPLOYMENT_NAME = "singleton-deployment-helper.war";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPartitionTestCase.java
@@ -39,7 +39,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -74,7 +73,6 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SingletonPartitionTestCase extends AbstractClusteringTestCase {
 
     @BeforeClass

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPolicyServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPolicyServiceTestCase.java
@@ -35,7 +35,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -54,7 +53,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SingletonPolicyServiceTestCase extends AbstractClusteringTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
@@ -35,7 +35,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -54,7 +53,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SingletonServiceTestCase extends AbstractClusteringTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/ClusteredSingleSignOnTestCase.java
@@ -25,7 +25,6 @@ import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -43,7 +42,6 @@ import org.junit.runner.RunWith;
  * @author <a href="mailto:dpospisi@redhat.com">Dominik Pospisil</a>
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ClusteredSingleSignOnTestCase extends AbstractClusteringTestCase {
 
     private static Logger log = Logger.getLogger(ClusteredSingleSignOnTestCase.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
@@ -35,7 +35,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusterHttpClientUtil;
@@ -53,7 +52,6 @@ import org.junit.runner.RunWith;
  * @version Oct 2012
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTestCase {
 
     private final String deploymentName;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
@@ -40,7 +40,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -62,18 +61,17 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class DistributableTestCase extends AbstractClusteringTestCase {
 
     private static final int REQUEST_DURATION = 10000;
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
@@ -36,7 +36,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -56,7 +55,6 @@ import org.wildfly.clustering.marshalling.Externalizer;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ExternalizerTestCase extends AbstractClusteringTestCase {
     private static final String DEPLOYMENT_NAME = "externalizer.war";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
@@ -59,13 +59,13 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class NonDistributableTestCase extends AbstractClusteringTestCase {
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -33,7 +33,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -54,7 +53,6 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class NonHaWebSessionPersistenceTestCase extends AbstractClusteringTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
@@ -34,7 +34,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -55,7 +54,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class AsyncServletTestCase extends AbstractClusteringTestCase {
     private static final String DEPLOYMENT_NAME = "async.war";
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/BasicAuthenticationWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/BasicAuthenticationWebFailoverTestCase.java
@@ -39,7 +39,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClients;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -57,17 +56,16 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 @ServerSetup(WebSecurityDomainSetup.class)
 public class BasicAuthenticationWebFailoverTestCase extends AbstractClusteringTestCase {
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
@@ -40,7 +40,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -59,17 +58,16 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 @ServerSetup(WebSecurityDomainSetup.class)
 public class FormAuthenticationWebFailoverTestCase extends AbstractClusteringTestCase {
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
@@ -36,7 +36,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -56,18 +55,17 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class InvalidateConversationTestCase extends AbstractClusteringTestCase {
 
     private static final String DEPLOYMENT_NAME = "conversation.war";
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/CoarseSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/CoarseSessionExpirationTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.clustering.cluster.web.expiration;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.clustering.cluster.web.expiration;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/CoarseSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/CoarseSessionPassivationTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.clustering.cluster.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class CoarseSessionPassivationTestCase extends SessionPassivationTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.clustering.cluster.web.passivation;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@RunAsClient
 public class FineSessionPassivationTestCase extends SessionPassivationTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/DatabasePersistenceWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/persistence/DatabasePersistenceWebFailoverTestCase.java
@@ -26,7 +26,6 @@ import java.net.URL;
 
 import org.infinispan.transaction.TransactionMode;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
@@ -45,7 +44,6 @@ import org.junit.runner.RunWith;
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 @ServerSetup(DatabasePersistenceWebFailoverTestCase.ServerSetupTask.class)
 public class DatabasePersistenceWebFailoverTestCase extends AbstractWebFailoverTestCase {
     private static final String DEPLOYMENT_NAME = DatabasePersistenceWebFailoverTestCase.class.getSimpleName() + ".war";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionTestCase.java
@@ -33,7 +33,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -56,7 +55,6 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SharedSessionTestCase extends AbstractClusteringTestCase {
 
     private static final String MODULE = "shared";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
@@ -35,7 +35,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -76,7 +75,6 @@ import org.junit.runner.RunWith;
  * @author Richard Achmatowicz
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 @ServerSetup({XSiteSimpleTestCase.ServerSetupTask.class})
 public class XSiteSimpleTestCase extends AbstractClusteringTestCase {
 
@@ -84,25 +82,25 @@ public class XSiteSimpleTestCase extends AbstractClusteringTestCase {
         super(FOUR_NODES, FOUR_DEPLOYMENTS);
     }
 
-    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment1() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment2() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_3, managed = false)
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
     @TargetsContainer(NODE_3)
     public static Archive<?> deployment3() {
         return getDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_4, managed = false)
+    @Deployment(name = DEPLOYMENT_4, managed = false, testable = false)
     @TargetsContainer(NODE_4)
     public static Archive<?> deployment4() {
         return getDeployment();

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
@@ -25,7 +25,6 @@ import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.NO
 import static org.junit.Assert.*;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopology;
 import org.jboss.as.test.clustering.cluster.dispatcher.bean.ClusterTopologyRetriever;
@@ -43,11 +42,10 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class CommandDispatcherTestCase {
     private static final String MODULE_NAME = "command-dispatcher";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> createDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejbJar.addPackage(ClusterTopologyRetriever.class.getPackage());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriever;
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
@@ -46,11 +45,10 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class ServiceProviderRegistrationTestCase {
     private static final String MODULE_NAME = "service-provider-registration";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> createDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejbJar.addPackage(ServiceProviderRetriever.class.getPackage());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetriever;
 import org.jboss.as.test.clustering.cluster.registry.bean.RegistryRetrieverBean;
@@ -46,11 +45,10 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class RegistryTestCase {
     private static final String MODULE_NAME = "registry";
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> createDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         jar.addPackage(RegistryRetriever.class.getPackage());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
@@ -36,7 +36,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.server.security.ServerPermission;
@@ -57,10 +56,9 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SingletonServiceTestCase {
 
-    @Deployment
+    @Deployment(testable = false)
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
         war.addPackage(NodeService.class.getPackage());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.clustering.single.web;
 
+import static org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase.DEPLOYMENT_1;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -34,7 +36,6 @@ import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
@@ -51,10 +52,9 @@ import org.junit.runner.RunWith;
  * @author Paul Ferraro
  */
 @RunWith(Arquillian.class)
-@RunAsClient
 public class SimpleWebTestCase {
 
-    @Deployment(name = "deployment-single")
+    @Deployment(name = DEPLOYMENT_1, testable = false)
     public static Archive<?> deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
         war.addClasses(SimpleServlet.class, Mutable.class);
@@ -63,7 +63,7 @@ public class SimpleWebTestCase {
     }
 
     @Test
-    @OperateOnDeployment("deployment-single")
+    @OperateOnDeployment(DEPLOYMENT_1)
     public void test(@ArquillianResource(SimpleServlet.class) URL baseURL) throws IOException, URISyntaxException {
 
         URI uri = SimpleServlet.createURI(baseURL);


### PR DESCRIPTION
…false"

None of the deployments used in the clustering tests are tested in container thus all should be marked as testable = false defining that deployment should not be wrapped up based on the protocol so the testcase can be executed incontainer. This means, there is no reason to explicitly label the test classes as @RunAsClient since that behavior is driven by specified @ Deployments. Saves 100 LOC.

Jira
https://issues.jboss.org/browse/WFLY-9775