### PR TITLE
WFLY-9768 Upgrade to Weld 3.0.3.Final and support CDI API multiversion

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -131,6 +131,7 @@ will remain at Java EE7 level.
 | Name | From Version | From JSR | To Version | To JSR
 
 |Java Servlet | 3.1 | JSR-340 | 4.0 | JSR-369
+| CDI | 1.2 | JSR-346 | 2.0 | JSR-365
 
 |=======================================================================
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2218,6 +2218,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.bridge</groupId>
+            <artifactId>cdi-api-bridge</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-appclient</artifactId>
             <exclusions>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
@@ -46,6 +46,7 @@
         <module name="org.wildfly.extension.bean-validation"/>
         <module name="org.hibernate.validator.cdi" />
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.validation.api"/>
     </dependencies>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
@@ -47,6 +47,7 @@
         <module name="org.jboss.as.security"/>
         <module name="org.jboss.invocation"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.annotation.api"/>
     </dependencies>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
@@ -49,6 +49,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.api"/>
         <module name="javax.ejb.api" />
         <module name="org.jboss.as.ejb3"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
@@ -44,6 +44,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -47,6 +47,7 @@
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.enterprise.concurrent.api"/>
         <module name="javax.interceptor.api"/>
         <module name="javax.servlet.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
@@ -46,6 +46,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
@@ -31,6 +31,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.interceptor.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -40,6 +40,7 @@
         <module name="javax.annotation.api"/>
         <module name="javax.ejb.api" />
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>
         <module name="javax.interceptor.api"/>
         <module name="javax.persistence.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
@@ -36,6 +36,7 @@
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>
         <module name="javax.interceptor.api"/>
         <module name="javax.servlet.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
@@ -36,6 +36,7 @@
         <module name="javax.annotation.api"/>
         <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.servlet.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2016, Red Hat, Inc., and individual contributors
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,23 +22,29 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.spi">
+<module xmlns="urn:jboss:module:1.7" name="org.wildfly.cdi-api-bridge">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <resources>
-        <artifact name="${org.wildfly:wildfly-weld-spi}"/>
-    </resources>
-
     <dependencies>
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.spi" />
-        <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.server"/>
-        <module name="javax.enterprise.api"/>
-        <module name="org.wildfly.cdi-api-bridge"/>
+        <module name="org.glassfish.javax.el"/>
+        <module name="javax.inject.api" />
+        <module name="javax.interceptor.api"/>
+
+        <!-- CDIProvider -->
+        <module name="org.jboss.as.weld" services="import" optional="true"/>
+        <module name="org.jboss.weld.core" optional="true"/>
+        <module name="javax.enterprise.api" />
+        <module name="javax.inject.api" />
     </dependencies>
 
+    <resources>
+        <artifact name="${org.wildfly.bridge:cdi-api-bridge}">
+            <conditions>
+                <property-not-equal name="ee8.preview.mode" value="true" />
+            </conditions>
+        </artifact>
+    </resources>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.5.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.spec.javax.websockets>1.1.3.Final</version.org.jboss.spec.javax.websockets>
-        <version.org.jboss.weld.weld>3.0.2.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>3.0.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>3.0.SP2</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.0.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>3.2.0.Final</version.org.jboss.ws.spi>
@@ -228,6 +228,7 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.0.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.build-tools>1.2.6.Final</version.org.wildfly.build-tools>
+        <version.org.wildfly.cdi-api-bridge>1.0.0.Final</version.org.wildfly.cdi-api-bridge>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>4.0.0.Alpha10</version.org.wildfly.core>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
@@ -4657,6 +4658,26 @@
                 <groupId>org.jboss.ironjacamar</groupId>
                 <artifactId>ironjacamar-validator</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.bridge</groupId>
+                <artifactId>cdi-api-bridge</artifactId>
+                <version>${version.org.wildfly.cdi-api-bridge}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>javax.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.interceptor</groupId>
+                        <artifactId>javax.interceptor-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.enterprise.api">
+<module xmlns="urn:jboss:module:1.7" name="javax.enterprise.api">
     <dependencies>
         <module name="org.glassfish.javax.el" export="true"/>
         <module name="javax.inject.api" export="true"/>
@@ -34,6 +34,16 @@
     </dependencies>
 
     <resources>
-        <artifact name="${javax.enterprise:cdi-api}"/>
+        <artifact name="javax.enterprise:cdi-api:1.2">
+            <conditions>
+                <property-not-equal name="ee8.preview.mode" value="true" />
+            </conditions>
+        </artifact>
+        <artifact name="${javax.enterprise:cdi-api}">
+            <conditions>
+                <property-equal name="ee8.preview.mode" value="true" />
+            </conditions>
+        </artifact>
     </resources>
+
 </module>

--- a/testsuite/integration/ee8-temp/src/test/java/org/wildfly/test/integration/ee8/temp/cdi20/CDI20SanityTest.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/wildfly/test/integration/ee8/temp/cdi20/CDI20SanityTest.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.ee8.temp.cdi20;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test to verify that using EE8 switch, one can use CDI 2.0 feature. Here we use async events as that feature.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class CDI20SanityTest {
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "sanity-cdi20-ee8-test-case.war")
+            .addClasses(ObservingBean.class, CDI20SanityTest.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void testCDI20FeatureCanBeUsed() throws Exception {
+        // we assume EE 8 switch was set at this point
+        Assert.assertNotNull(bm);
+        CountDownLatch latch = new CountDownLatch(1);
+        // use BM to fire async event, use latch to synchronize async operation
+        bm.getEvent().fireAsync(latch);
+
+        // assert that it was observed
+        latch.await(5, TimeUnit.SECONDS);
+        Assert.assertTrue(ObservingBean.EVENT_OBSERVED);
+    }
+}

--- a/testsuite/integration/ee8-temp/src/test/java/org/wildfly/test/integration/ee8/temp/cdi20/ObservingBean.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/wildfly/test/integration/ee8/temp/cdi20/ObservingBean.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.integration.ee8.temp.cdi20;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class ObservingBean {
+
+    public static boolean EVENT_OBSERVED = false;
+
+    public void observeIt(@ObservesAsync CountDownLatch latch) {
+        EVENT_OBSERVED = true;
+        latch.countDown();
+    }
+}

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -77,6 +77,11 @@
       </dependency>
 
       <dependency>
+         <groupId>org.wildfly.bridge</groupId>
+         <artifactId>cdi-api-bridge</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>org.jboss.metadata</groupId>
          <artifactId>jboss-metadata-web</artifactId>
       </dependency>

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.InjectionTarget;
@@ -28,6 +27,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;
+import org.jboss.weld.literal.AnyLiteral;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 /**
@@ -77,7 +77,7 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service<EECla
         }
         final BeanManagerImpl beanManager = BeanManagerProxy.unwrap(this.beanManager.getValue());
         Bean<?> bean = null;
-        Set<Bean<?>> beans = new HashSet<>(beanManager.getBeans(clazz, Any.Literal.INSTANCE));
+        Set<Bean<?>> beans = new HashSet<>(beanManager.getBeans(clazz, AnyLiteral.INSTANCE));
         Iterator<Bean<?>> it = beans.iterator();
         //we may have resolved some sub-classes
         //go through and remove them from the bean set

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -322,6 +322,7 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         final boolean nonPortableMode = parentDeploymentUnit.getAttachment(WeldConfiguration.ATTACHMENT_KEY).isNonPortableMode();
         final ExternalConfiguration configuration = new ExternalConfigurationBuilder()
             .add(ConfigurationKey.NON_PORTABLE_MODE.get(), nonPortableMode)
+            .add(ConfigurationKey.ALLOW_OPTIMIZED_CLEANUP.get(), true)
             .build();
         deployment.getServices().add(ExternalConfiguration.class, configuration);
     }


### PR DESCRIPTION
WFLY-9768 - https://issues.jboss.org/browse/WFLY-9768

This should be the last piece of puzzle to enable EE 8 preview for Weld/CDI.
It switches default behaviour to CDI 1.2 and adds dependency on CDI-API bridge (https://github.com/wildfly/cdi-api-bridge; already released) which can bring in missing CDI 2.0 bits needed by Weld.

If user enabled EE 8 preview, CDI 2.0 jar is used and bridge module is empty. If running in EE 7 mode, CDI 1.2 jar is used and bridge contains a jar with missing pieces of CDI 2.0 api.

As for testing, I verified full Weld TS in EE 8 mode with patched WFLY as well as CDI TCK 1.2 (default mode) and CDI TCK 2.0 (ee 8 mode). I haven't executed full WFLY TS, that I am leaving to this PR.