### PR TITLE
[WFLY-9792] Make it easier to switch the maven groupId in different branches

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -40,16 +40,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>
 
@@ -64,17 +64,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ejb3</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-webservices-server-integration</artifactId>
         </dependency>
 

--- a/batch/extension-jberet/pom.xml
+++ b/batch/extension-jberet/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-spi</artifactId>
         </dependency>
         <dependency>
@@ -65,7 +65,7 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 

--- a/batch/extension/pom.xml
+++ b/batch/extension/pom.xml
@@ -41,7 +41,7 @@
     <dependencies>
         <!-- Used to inherit some stuff from the new subsystem -->
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-batch-jberet</artifactId>
         </dependency>
         <dependency>
@@ -57,7 +57,7 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -84,7 +84,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
@@ -92,7 +92,7 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -40,7 +40,7 @@
 
 	<dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-feature-pack</artifactId>
             <type>zip</type>
             <exclusions>

--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -48,13 +48,13 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ejb-client-bom</artifactId>
             <type>pom</type>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jms-client-bom</artifactId>
             <type>pom</type>
         </dependency>

--- a/clustering/common/pom.xml
+++ b/clustering/common/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-service</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>

--- a/clustering/ee/infinispan/pom.xml
+++ b/clustering/ee/infinispan/pom.xml
@@ -39,7 +39,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-spi</artifactId>
         </dependency>
         <dependency>

--- a/clustering/ejb/infinispan/pom.xml
+++ b/clustering/ejb/infinispan/pom.xml
@@ -39,27 +39,27 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-infinispan</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ejb-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
@@ -93,14 +93,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/ejb/spi/pom.xml
+++ b/clustering/ejb/spi/pom.xml
@@ -39,15 +39,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-service</artifactId>
         </dependency>
         <dependency>

--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -39,27 +39,27 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-infinispan</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-extension</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-infinispan</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
@@ -67,7 +67,7 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>
@@ -88,21 +88,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <version>${project.version}</version><!--$NO-MVN-MAN-VER$-->
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-extension</artifactId>
             <version>${project.version}</version><!--$NO-MVN-MAN-VER$-->
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
             <version>${project.version}</version><!--$NO-MVN-MAN-VER$-->
             <scope>test</scope>

--- a/clustering/infinispan/spi/pom.xml
+++ b/clustering/infinispan/spi/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
         </dependency>
         <dependency>

--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -55,15 +55,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-spi</artifactId>
         </dependency>
         <dependency>
@@ -84,7 +84,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/jgroups/spi/pom.xml
+++ b/clustering/jgroups/spi/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
     </dependencies>

--- a/clustering/marshalling/infinispan/pom.xml
+++ b/clustering/marshalling/infinispan/pom.xml
@@ -39,7 +39,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
         </dependency>
         <dependency>

--- a/clustering/marshalling/jboss/pom.xml
+++ b/clustering/marshalling/jboss/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
         </dependency>
         <dependency>

--- a/clustering/marshalling/spi/pom.xml
+++ b/clustering/marshalling/spi/pom.xml
@@ -39,7 +39,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
         </dependency>
         <dependency>
@@ -47,7 +47,7 @@
             <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/server/pom.xml
+++ b/clustering/server/pom.xml
@@ -39,35 +39,35 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-infinispan</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
         </dependency>
         <dependency>
@@ -102,14 +102,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/singleton/api/pom.xml
+++ b/clustering/singleton/api/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-service</artifactId>
         </dependency>
     </dependencies>

--- a/clustering/singleton/extension/pom.xml
+++ b/clustering/singleton/extension/pom.xml
@@ -39,19 +39,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
@@ -75,7 +75,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/spi/pom.xml
+++ b/clustering/spi/pom.xml
@@ -43,15 +43,15 @@
             <artifactId>jboss-modules</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
         </dependency>
     </dependencies>

--- a/clustering/web/infinispan/pom.xml
+++ b/clustering/web/infinispan/pom.xml
@@ -39,27 +39,27 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-infinispan</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-spi</artifactId>
         </dependency>
         <dependency>
@@ -98,14 +98,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/web/spi/pom.xml
+++ b/clustering/web/spi/pom.xml
@@ -39,19 +39,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-api</artifactId>
         </dependency>
         <dependency>
@@ -59,7 +59,7 @@
             <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-spi</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/clustering/web/undertow/pom.xml
+++ b/clustering/web/undertow/pom.xml
@@ -39,19 +39,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
         <dependency>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -42,23 +42,23 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>
@@ -66,7 +66,7 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>
         <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -38,13 +38,13 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-feature-pack</artifactId>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-feature-pack</artifactId>
             <type>zip</type>
             <exclusions>

--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -102,7 +102,7 @@
             <artifactId>jboss-invocation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -46,7 +46,7 @@ vi:ts=4:sw=4:expandtab
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
         </dependency>
         <dependency>
@@ -55,38 +55,38 @@ vi:ts=4:sw=4:expandtab
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ejb-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
  
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-iiop-openjdk</artifactId>
         </dependency>
 
@@ -106,7 +106,7 @@ vi:ts=4:sw=4:expandtab
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -98,7 +98,7 @@
         <!-- feature pack dependencies -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-servlet-feature-pack</artifactId>
             <type>zip</type>
             <exclusions>
@@ -112,7 +112,7 @@
         <!-- module and copy artifact dependencies -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-picketlink</artifactId>
             <exclusions>
                 <exclusion>
@@ -123,7 +123,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -134,7 +134,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-system-jmx</artifactId>
             <exclusions>
                 <exclusion>
@@ -797,7 +797,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-rts</artifactId>
             <exclusions>
                 <exclusion>
@@ -866,7 +866,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jpa</artifactId>
             <exclusions>
                 <exclusion>
@@ -877,7 +877,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-hibernate5</artifactId>
             <exclusions>
                 <exclusion>
@@ -888,7 +888,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-hibernate4-3</artifactId>
             <exclusions>
                 <exclusion>
@@ -899,7 +899,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-hibernate4-1</artifactId>
             <exclusions>
                 <exclusion>
@@ -910,7 +910,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-eclipselink</artifactId>
             <exclusions>
                 <exclusion>
@@ -921,12 +921,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-openjpa</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2214,7 +2214,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-appclient</artifactId>
             <exclusions>
                 <exclusion>
@@ -2248,7 +2248,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-client-all</artifactId>
             <exclusions>
                 <exclusion>
@@ -2259,7 +2259,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -2270,7 +2270,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <exclusions>
                 <exclusion>
@@ -2280,7 +2280,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-infinispan</artifactId>
             <exclusions>
                 <exclusion>
@@ -2290,7 +2290,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ee-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2301,7 +2301,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ejb-infinispan</artifactId>
             <exclusions>
                 <exclusion>
@@ -2311,7 +2311,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-ejb-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2322,7 +2322,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-extension</artifactId>
             <exclusions>
                 <exclusion>
@@ -2332,7 +2332,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2343,7 +2343,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -2353,7 +2353,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-extension</artifactId>
             <exclusions>
                 <exclusion>
@@ -2363,7 +2363,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2374,7 +2374,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -2384,7 +2384,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-infinispan</artifactId>
             <exclusions>
                 <exclusion>
@@ -2394,7 +2394,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
             <exclusions>
                 <exclusion>
@@ -2404,7 +2404,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2415,7 +2415,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-service</artifactId>
             <exclusions>
                 <exclusion>
@@ -2426,7 +2426,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-server</artifactId>
             <exclusions>
                 <exclusion>
@@ -2437,7 +2437,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -2447,7 +2447,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-singleton-extension</artifactId>
             <exclusions>
                 <exclusion>
@@ -2458,7 +2458,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2469,7 +2469,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-api</artifactId>
             <exclusions>
                 <exclusion>
@@ -2479,7 +2479,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-infinispan</artifactId>
             <exclusions>
                 <exclusion>
@@ -2489,7 +2489,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2499,7 +2499,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-web-undertow</artifactId>
             <exclusions>
                 <exclusion>
@@ -2510,7 +2510,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-cmp</artifactId>
             <exclusions>
                 <exclusion>
@@ -2521,7 +2521,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-configadmin</artifactId>
             <exclusions>
                 <exclusion>
@@ -2537,7 +2537,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-batch</artifactId>
             <exclusions>
                 <exclusion>
@@ -2548,7 +2548,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-batch-jberet</artifactId>
             <exclusions>
                 <exclusion>
@@ -2559,7 +2559,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-bean-validation</artifactId>
             <exclusions>
                 <exclusion>
@@ -2570,7 +2570,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
             <exclusions>
                 <exclusion>
@@ -2594,7 +2594,7 @@
 
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ejb3</artifactId>
             <exclusions>
                 <exclusion>
@@ -2605,7 +2605,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jaxr</artifactId>
             <exclusions>
                 <exclusion>
@@ -2616,7 +2616,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
@@ -2627,7 +2627,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jdr</artifactId>
             <exclusions>
                 <exclusion>
@@ -2638,7 +2638,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jsf</artifactId>
             <exclusions>
                 <exclusion>
@@ -2649,12 +2649,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jsf-injection</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jsr77</artifactId>
             <exclusions>
                 <exclusion>
@@ -2665,7 +2665,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-iiop-openjdk</artifactId>
             <exclusions>
                 <exclusion>
@@ -2676,7 +2676,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jacorb</artifactId>
             <exclusions>
                 <exclusion>
@@ -2687,7 +2687,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mail</artifactId>
             <exclusions>
                 <exclusion>
@@ -2698,7 +2698,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging</artifactId>
             <exclusions>
                 <exclusion>
@@ -2709,7 +2709,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging-activemq</artifactId>
             <exclusions>
                 <exclusion>
@@ -2720,7 +2720,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mod_cluster-extension</artifactId>
             <exclusions>
                 <exclusion>
@@ -2731,7 +2731,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mod_cluster-undertow</artifactId>
             <exclusions>
                 <exclusion>
@@ -2753,7 +2753,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-pojo</artifactId>
             <exclusions>
                 <exclusion>
@@ -2764,7 +2764,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-sar</artifactId>
             <exclusions>
                 <exclusion>
@@ -2775,7 +2775,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
             <exclusions>
                 <exclusion>
@@ -2797,7 +2797,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web</artifactId>
             <exclusions>
                 <exclusion>
@@ -2808,7 +2808,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
             <exclusions>
                 <exclusion>
@@ -2819,7 +2819,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-spi</artifactId>
             <exclusions>
                 <exclusion>
@@ -2830,7 +2830,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
             <exclusions>
                 <exclusion>
@@ -2841,7 +2841,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-ejb</artifactId>
             <exclusions>
                 <exclusion>
@@ -2852,7 +2852,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-jpa</artifactId>
             <exclusions>
                 <exclusion>
@@ -2863,7 +2863,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-bean-validation</artifactId>
             <exclusions>
                 <exclusion>
@@ -2874,7 +2874,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-webservices</artifactId>
             <exclusions>
                 <exclusion>
@@ -2885,7 +2885,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-transactions</artifactId>
             <exclusions>
                 <exclusion>
@@ -2896,7 +2896,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-webservices-server-integration</artifactId>
             <exclusions>
                 <exclusion>
@@ -2907,7 +2907,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-xts</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -1949,7 +1949,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-eclipselink</artifactId>
       <licenses>
         <license>
@@ -1960,7 +1960,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-hibernate4-1</artifactId>
       <licenses>
         <license>
@@ -1971,7 +1971,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-hibernate4-3</artifactId>
       <licenses>
         <license>
@@ -1982,7 +1982,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-hibernate5</artifactId>
       <licenses>
         <license>
@@ -1993,7 +1993,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-openjpa</artifactId>
       <licenses>
         <license>
@@ -2004,7 +2004,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>jipijapa-spi</artifactId>
       <licenses>
         <license>
@@ -2015,7 +2015,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-appclient</artifactId>
       <licenses>
         <license>
@@ -2026,7 +2026,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-batch</artifactId>
       <licenses>
         <license>
@@ -2037,7 +2037,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-batch-jberet</artifactId>
       <licenses>
         <license>
@@ -2048,7 +2048,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-bean-validation</artifactId>
       <licenses>
         <license>
@@ -2059,7 +2059,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-client-all</artifactId>
       <licenses>
         <license>
@@ -2070,7 +2070,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-api</artifactId>
       <licenses>
         <license>
@@ -2081,7 +2081,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-common</artifactId>
       <licenses>
         <license>
@@ -2092,7 +2092,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-ee-infinispan</artifactId>
       <licenses>
         <license>
@@ -2103,7 +2103,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-ee-spi</artifactId>
       <licenses>
         <license>
@@ -2114,7 +2114,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-ejb-infinispan</artifactId>
       <licenses>
         <license>
@@ -2125,7 +2125,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-ejb-spi</artifactId>
       <licenses>
         <license>
@@ -2136,7 +2136,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-infinispan-extension</artifactId>
       <licenses>
         <license>
@@ -2147,7 +2147,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-infinispan-spi</artifactId>
       <licenses>
         <license>
@@ -2158,7 +2158,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-jgroups-api</artifactId>
       <licenses>
         <license>
@@ -2169,7 +2169,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-jgroups-extension</artifactId>
       <licenses>
         <license>
@@ -2180,7 +2180,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-jgroups-spi</artifactId>
       <licenses>
         <license>
@@ -2191,7 +2191,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-marshalling-api</artifactId>
       <licenses>
         <license>
@@ -2202,7 +2202,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-marshalling-infinispan</artifactId>
       <licenses>
         <license>
@@ -2213,7 +2213,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
       <licenses>
         <license>
@@ -2224,7 +2224,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-marshalling-spi</artifactId>
       <licenses>
         <license>
@@ -2235,7 +2235,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-server</artifactId>
       <licenses>
         <license>
@@ -2246,7 +2246,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-service</artifactId>
       <licenses>
         <license>
@@ -2257,7 +2257,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-singleton-api</artifactId>
       <licenses>
         <license>
@@ -2268,7 +2268,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-singleton-extension</artifactId>
       <licenses>
         <license>
@@ -2279,7 +2279,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-spi</artifactId>
       <licenses>
         <license>
@@ -2290,7 +2290,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-web-api</artifactId>
       <licenses>
         <license>
@@ -2301,7 +2301,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-web-infinispan</artifactId>
       <licenses>
         <license>
@@ -2312,7 +2312,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-web-spi</artifactId>
       <licenses>
         <license>
@@ -2323,7 +2323,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-web-undertow</artifactId>
       <licenses>
         <license>
@@ -2334,7 +2334,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-cmp</artifactId>
       <licenses>
         <license>
@@ -2345,7 +2345,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-configadmin</artifactId>
       <licenses>
         <license>
@@ -2356,7 +2356,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-connector</artifactId>
       <licenses>
         <license>
@@ -2367,7 +2367,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-ejb3</artifactId>
       <licenses>
         <license>
@@ -2378,7 +2378,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-iiop-openjdk</artifactId>
       <licenses>
         <license>
@@ -2389,7 +2389,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jacorb</artifactId>
       <licenses>
         <license>
@@ -2400,7 +2400,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jaxr</artifactId>
       <licenses>
         <license>
@@ -2411,7 +2411,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jaxrs</artifactId>
       <licenses>
         <license>
@@ -2422,7 +2422,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jdr</artifactId>
       <licenses>
         <license>
@@ -2433,7 +2433,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jpa</artifactId>
       <licenses>
         <license>
@@ -2444,7 +2444,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jsf</artifactId>
       <licenses>
         <license>
@@ -2455,7 +2455,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jsf-injection</artifactId>
       <licenses>
         <license>
@@ -2466,7 +2466,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-jsr77</artifactId>
       <licenses>
         <license>
@@ -2477,7 +2477,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-mail</artifactId>
       <licenses>
         <license>
@@ -2488,7 +2488,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-messaging</artifactId>
       <licenses>
         <license>
@@ -2499,7 +2499,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-messaging-activemq</artifactId>
       <licenses>
         <license>
@@ -2510,7 +2510,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-mod_cluster-extension</artifactId>
       <licenses>
         <license>
@@ -2521,7 +2521,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-mod_cluster-undertow</artifactId>
       <licenses>
         <license>
@@ -2532,7 +2532,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-picketlink</artifactId>
       <licenses>
         <license>
@@ -2543,7 +2543,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-pojo</artifactId>
       <licenses>
         <license>
@@ -2554,7 +2554,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-rts</artifactId>
       <licenses>
         <license>
@@ -2565,7 +2565,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-sar</artifactId>
       <licenses>
         <license>
@@ -2576,7 +2576,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-security-api</artifactId>
       <licenses>
         <license>
@@ -2587,7 +2587,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-servlet-feature-pack</artifactId>
       <licenses>
         <license>
@@ -2598,7 +2598,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-system-jmx</artifactId>
       <licenses>
         <license>
@@ -2609,7 +2609,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-transactions</artifactId>
       <licenses>
         <license>
@@ -2620,7 +2620,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-web</artifactId>
       <licenses>
         <license>
@@ -2631,7 +2631,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-webservices-server-integration</artifactId>
       <licenses>
         <license>
@@ -2642,7 +2642,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld</artifactId>
       <licenses>
         <license>
@@ -2653,7 +2653,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-bean-validation</artifactId>
       <licenses>
         <license>
@@ -2664,7 +2664,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-common</artifactId>
       <licenses>
         <license>
@@ -2675,7 +2675,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-ejb</artifactId>
       <licenses>
         <license>
@@ -2686,7 +2686,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-jpa</artifactId>
       <licenses>
         <license>
@@ -2697,7 +2697,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-spi</artifactId>
       <licenses>
         <license>
@@ -2708,7 +2708,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-transactions</artifactId>
       <licenses>
         <license>
@@ -2719,7 +2719,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-weld-webservices</artifactId>
       <licenses>
         <license>
@@ -2730,7 +2730,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-xts</artifactId>
       <licenses>
         <license>

--- a/iiop-openjdk/pom.xml
+++ b/iiop-openjdk/pom.xml
@@ -97,7 +97,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -39,12 +39,12 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
 
@@ -59,12 +59,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
 

--- a/jpa/eclipselink/pom.xml
+++ b/jpa/eclipselink/pom.xml
@@ -18,7 +18,7 @@
         <!-- Internal -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
         </dependency>
 

--- a/jpa/eclipselink/pom.xml
+++ b/jpa/eclipselink/pom.xml
@@ -11,7 +11,6 @@
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-eclipselink</artifactId>
     <name>jipijapa EclipseLink integration</name>
 

--- a/jpa/hibernate4_1/pom.xml
+++ b/jpa/hibernate4_1/pom.xml
@@ -17,7 +17,6 @@
         <version.org.hibernate4_2.commons.annotations>4.0.1.Final</version.org.hibernate4_2.commons.annotations>
     </properties>    
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-hibernate4-1</artifactId>
     <name>jipijapa Hibernate 4.1.x + 4.2.x (JPA 2.0) integration</name>
 

--- a/jpa/hibernate4_1/pom.xml
+++ b/jpa/hibernate4_1/pom.xml
@@ -24,7 +24,7 @@
         <!-- Internal -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/jpa/hibernate4_3/pom.xml
+++ b/jpa/hibernate4_3/pom.xml
@@ -15,7 +15,6 @@
         <version.org.hibernate4_3>4.3.10.Final</version.org.hibernate4_3>
     </properties>    
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-hibernate4-3</artifactId>
     <name>jipijapa Hibernate 4.3.x (JPA 2.1) integration</name>
 

--- a/jpa/hibernate4_3/pom.xml
+++ b/jpa/hibernate4_3/pom.xml
@@ -39,7 +39,7 @@
         <!-- Internal -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/jpa/hibernate5/pom.xml
+++ b/jpa/hibernate5/pom.xml
@@ -28,7 +28,6 @@
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-hibernate5</artifactId>
     
     <name>jipijapa Hibernate 5.x (JPA 2.1) integration</name>

--- a/jpa/hibernate5/pom.xml
+++ b/jpa/hibernate5/pom.xml
@@ -53,7 +53,7 @@
         <!-- Internal -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
         </dependency>
 

--- a/jpa/openjpa/pom.xml
+++ b/jpa/openjpa/pom.xml
@@ -20,7 +20,7 @@
         <!-- Internal -->
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
         </dependency>
 

--- a/jpa/openjpa/pom.xml
+++ b/jpa/openjpa/pom.xml
@@ -11,7 +11,6 @@
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-openjpa</artifactId>
     
     <name>jipijapa OpenJPA integration</name>

--- a/jpa/spi/pom.xml
+++ b/jpa/spi/pom.xml
@@ -12,7 +12,6 @@
     </parent>
 
 
-    <groupId>org.wildfly</groupId>
     <artifactId>jipijapa-spi</artifactId>
 
     <name>jipijapa SPI</name>

--- a/jpa/subsystem/pom.xml
+++ b/jpa/subsystem/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-bean-validation</artifactId>
         </dependency>
 
@@ -80,12 +80,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ejb3</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-spi</artifactId>
         </dependency>
 
@@ -112,7 +112,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
 

--- a/jsf/injection/pom.xml
+++ b/jsf/injection/pom.xml
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jsf</artifactId>
         </dependency>
 

--- a/jsf/multi-jsf-installer/pom.xml
+++ b/jsf/multi-jsf-installer/pom.xml
@@ -48,7 +48,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jsf-injection</artifactId>
             <version>${version.jboss.as}</version>
         </dependency>

--- a/jsf/subsystem/pom.xml
+++ b/jsf/subsystem/pom.xml
@@ -44,17 +44,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-bean-validation</artifactId>
         </dependency>
 
@@ -71,7 +71,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
 

--- a/jsr77/pom.xml
+++ b/jsr77/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ejb3</artifactId>
         </dependency>
         <dependency>

--- a/legacy/jacorb/pom.xml
+++ b/legacy/jacorb/pom.xml
@@ -94,7 +94,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-iiop-openjdk</artifactId>
         </dependency>
 
@@ -104,7 +104,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 

--- a/legacy/messaging/pom.xml
+++ b/legacy/messaging/pom.xml
@@ -64,12 +64,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 
@@ -79,22 +79,22 @@
 	    </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-jgroups-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
         </dependency>
 
@@ -135,7 +135,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging-activemq</artifactId>
             <scope>test</scope>
         </dependency>

--- a/legacy/web/pom.xml
+++ b/legacy/web/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
 

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -24,8 +24,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>wildfly-parent</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 

--- a/mail/pom.xml
+++ b/mail/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>wildfly-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
@@ -49,7 +49,7 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -118,12 +118,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-connector</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 
@@ -133,27 +133,27 @@
 	    </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
         </dependency>
 

--- a/mod_cluster/extension/pom.xml
+++ b/mod_cluster/extension/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
         </dependency>
         <dependency>
@@ -94,7 +94,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/mod_cluster/undertow/pom.xml
+++ b/mod_cluster/undertow/pom.xml
@@ -39,11 +39,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mod_cluster-extension</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
         <dependency>

--- a/picketlink/pom.xml
+++ b/picketlink/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jpa</artifactId>
         </dependency>
 
@@ -37,12 +37,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
 

--- a/picketlink/pom.xml
+++ b/picketlink/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>wildfly-parent</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -887,45 +887,45 @@
             <!-- Modules in this project -->
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-appclient</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-batch</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-batch-jberet</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-build</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-bean-validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-feature-pack</artifactId>
                 <type>pom</type>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-feature-pack</artifactId>
                 <type>zip</type>
                 <version>${project.version}</version>
@@ -938,164 +938,164 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-ee-infinispan</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-ee-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-ejb-infinispan</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-ejb-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-infinispan-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-infinispan-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-jgroups-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-jgroups-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-jgroups-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-marshalling-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-marshalling-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-marshalling-infinispan</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-server</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-service</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-singleton-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-singleton-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-web-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-web-infinispan</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-web-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-clustering-web-undertow</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-cmp</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-configadmin</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-connector</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-dist</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-client-all</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -1107,13 +1107,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-ee</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-ejb3</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -1124,94 +1124,94 @@
                         <artifactId>jboss-transaction-api_1.1_spec</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.wildfly</groupId>
+                        <groupId>${project.groupId}</groupId>
                         <artifactId>wildfly-clustering-spi</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-ejb-client-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-iiop-openjdk</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jacorb</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jaxr</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jaxrs</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jdr</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jms-client-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jsr77</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-mail</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-messaging</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-messaging-activemq</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-mod_cluster-extension</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-mod_cluster-undertow</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-naming</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1229,7 +1229,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-picketlink</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -1245,49 +1245,49 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-pojo</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-security-api</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-security</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-sar</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-system-jmx</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-transactions</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-undertow</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-web</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -1299,94 +1299,94 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-web-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-servlet-dist</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-servlet-feature-pack</artifactId>
                 <type>pom</type>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-servlet-feature-pack</artifactId>
                 <type>zip</type>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-webservices-server-integration</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-spi</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-ejb</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-jpa</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-bean-validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-webservices</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-weld-transactions</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-xts</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-rts</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -1404,7 +1404,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-testsuite-shared</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>
@@ -4648,13 +4648,13 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jpa</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-spi</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -4668,7 +4668,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-hibernate5</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -4692,7 +4692,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-hibernate4-3</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -4712,7 +4712,7 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-hibernate4-1</artifactId>
                 <version>${project.version}</version>
                 <exclusions>
@@ -4732,25 +4732,25 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-eclipselink</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-openjpa</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jsf</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-jsf-injection</artifactId>
                 <version>${project.version}</version>
                 <exclusions>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
 
@@ -106,7 +106,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-jaxrs</artifactId>
         </dependency>
 

--- a/sar/pom.xml
+++ b/sar/pom.xml
@@ -74,7 +74,7 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>

--- a/security/api/pom.xml
+++ b/security/api/pom.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>
     </dependencies>

--- a/security/subsystem/pom.xml
+++ b/security/subsystem/pom.xml
@@ -87,17 +87,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -44,7 +44,7 @@
             <artifactId>wildfly-request-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-servlet-feature-pack</artifactId>
             <type>zip</type>
             <exclusions>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -38,13 +38,13 @@
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-servlet-feature-pack</artifactId>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-servlet-feature-pack</artifactId>
             <type>zip</type>
             <exclusions>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -348,7 +348,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-common</artifactId>
             <exclusions>
                 <exclusion>
@@ -359,7 +359,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-service</artifactId>
             <exclusions>
                 <exclusion>
@@ -370,7 +370,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
             <exclusions>
                 <exclusion>
@@ -381,7 +381,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
             <exclusions>
                 <exclusion>
@@ -403,7 +403,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <exclusions>
                 <exclusion>
@@ -414,7 +414,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-undertow</artifactId>
             <exclusions>
                 <exclusion>
@@ -425,7 +425,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -171,7 +171,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-common</artifactId>
       <licenses>
         <license>
@@ -182,7 +182,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-clustering-service</artifactId>
       <licenses>
         <license>
@@ -193,7 +193,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-ee</artifactId>
       <licenses>
         <license>
@@ -204,7 +204,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-naming</artifactId>
       <licenses>
         <license>
@@ -215,7 +215,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-security</artifactId>
       <licenses>
         <license>
@@ -226,7 +226,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-undertow</artifactId>
       <licenses>
         <license>
@@ -237,7 +237,7 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.wildfly</groupId>
+      <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-web-common</artifactId>
       <licenses>
         <license>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -27,8 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>wildfly-testsuite</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-testsuite</artifactId>
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -107,7 +107,7 @@
             <artifactId>hibernate-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-hibernate5</artifactId>
         </dependency>
         <dependency>
@@ -115,11 +115,11 @@
             <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-eclipselink</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-openjpa</artifactId>
         </dependency>
         <dependency>
@@ -131,7 +131,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-eclipselink</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -27,8 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>wildfly-testsuite</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-testsuite</artifactId>
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -68,7 +68,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>compile</scope>
             <exclusions>
@@ -105,7 +105,7 @@
             <artifactId>wildfly-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging-activemq</artifactId>
             <exclusions>
                 <exclusion>
@@ -151,7 +151,7 @@
             <artifactId>wildfly-network</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <exclusions>
                 <exclusion>

--- a/testsuite/integration/ee8-temp/pom.xml
+++ b/testsuite/integration/ee8-temp/pom.xml
@@ -42,7 +42,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -56,7 +56,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testsuite/integration/legacy-ejb-client/pom.xml
+++ b/testsuite/integration/legacy-ejb-client/pom.xml
@@ -55,7 +55,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-webservices-tests-integration</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -67,7 +67,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <version>${project.version}</version>
             <exclusions>

--- a/testsuite/integration/picketlink/pom.xml
+++ b/testsuite/integration/picketlink/pom.xml
@@ -5,8 +5,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>wildfly-ts-integ</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ts-integ</artifactId>
         <version>12.0.0.Alpha1-SNAPSHOT</version>
     </parent>
 

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -384,7 +384,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-webservices-tests-integration</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
@@ -406,7 +406,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
         </dependency>
 

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -34,7 +34,7 @@
     </properties>
         <dependencies>
             <dependency>
-                <groupId>org.wildfly</groupId>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-feature-pack</artifactId>
                 <type>pom</type>
             </dependency>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -72,7 +72,7 @@
             <artifactId>wildfly-core-testsuite-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-messaging</artifactId>
             <exclusions>
                 <exclusion>
@@ -82,7 +82,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <exclusions>
                 <exclusion>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -44,12 +44,12 @@
     <dependencies>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-feature-pack</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-servlet-feature-pack</artifactId>
             <type>pom</type>
         </dependency>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -40,11 +40,11 @@
             <artifactId>wildfly-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-iiop-openjdk</artifactId>
         </dependency>
         <dependency>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>wildfly-request-controller</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
@@ -63,11 +63,11 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
         </dependency>
         <dependency>

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
 

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -65,22 +65,22 @@
     </dependency>
 
     <dependency>
-       <groupId>org.wildfly</groupId>
+       <groupId>${project.groupId}</groupId>
        <artifactId>wildfly-ee</artifactId>
     </dependency>
 
     <dependency>
-       <groupId>org.wildfly</groupId>
+       <groupId>${project.groupId}</groupId>
        <artifactId>wildfly-ejb3</artifactId>
     </dependency>
     
     <dependency>
-       <groupId>org.wildfly</groupId>
+       <groupId>${project.groupId}</groupId>
        <artifactId>wildfly-undertow</artifactId>
     </dependency>
 
     <dependency>
-        <groupId>org.wildfly</groupId>
+        <groupId>${project.groupId}</groupId>
         <artifactId>wildfly-web-common</artifactId>
     </dependency>
 

--- a/webservices/tests-integration/pom.xml
+++ b/webservices/tests-integration/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>wildfly-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
             <exclusions>
                 <exclusion>

--- a/weld/bean-validation/pom.xml
+++ b/weld/bean-validation/pom.xml
@@ -15,17 +15,17 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
      <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-bean-validation</artifactId>
       </dependency>
 

--- a/weld/common/pom.xml
+++ b/weld/common/pom.xml
@@ -15,7 +15,7 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 

--- a/weld/ejb/pom.xml
+++ b/weld/ejb/pom.xml
@@ -15,17 +15,17 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-ejb3</artifactId>
       </dependency>
 

--- a/weld/jpa/pom.xml
+++ b/weld/jpa/pom.xml
@@ -15,17 +15,17 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-jpa</artifactId>
       </dependency>
 

--- a/weld/spi/pom.xml
+++ b/weld/spi/pom.xml
@@ -20,7 +20,7 @@
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-ee</artifactId>
       </dependency>
 

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -43,12 +43,12 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-ee</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-naming</artifactId>
       </dependency>
 
@@ -63,12 +63,12 @@
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-web-common</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-security</artifactId>
       </dependency>
 
@@ -162,12 +162,12 @@
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 

--- a/weld/transactions/pom.xml
+++ b/weld/transactions/pom.xml
@@ -15,17 +15,17 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-transactions</artifactId>
       </dependency>
 

--- a/weld/webservices/pom.xml
+++ b/weld/webservices/pom.xml
@@ -15,12 +15,12 @@
    <dependencies>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-spi</artifactId>
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-weld-common</artifactId>
       </dependency>
 
@@ -31,12 +31,12 @@
       </dependency>
 
       <dependency>
-         <groupId>org.wildfly</groupId>
+         <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-webservices-server-integration</artifactId>
          <exclusions>
             <exclusion>
                <artifactId>wildfly-ejb3</artifactId>
-               <groupId>org.wildfly</groupId>
+               <groupId>${project.groupId}</groupId>
             </exclusion>
          </exclusions>
       </dependency>

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -38,7 +38,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
@@ -46,15 +46,15 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-webservices-server-integration</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>
         <dependency>
@@ -117,7 +117,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
         </dependency>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9792

Makes it as easy as possible to change the maven groupId. Limits occurrences of ```<groupId>org.wildfly</groupId>``` to one per pom, except for poms that declare a dependency on the external artifact org.wildfly:wildfly-naming-client. 