### PR TITLE
WFLY-9795 Intermittent failure in ManagementOnlyModeTestCase

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/ManagementOnlyModeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/ManagementOnlyModeTestCase.java
@@ -50,7 +50,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 @RunWith(WildflyTestRunner.class)
 public class ManagementOnlyModeTestCase {
 
-    private static final int TEST_PORT = 9091;
+    private static final int TEST_PORT = 20491;
 
     @Inject
     private ServerController container;


### PR DESCRIPTION
Port 9091 is sometimes used by teamcity
