### PR TITLE
Drop explanatory comment that would otherwise need to be changed in EAP

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
@@ -23,7 +23,6 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.picketlink.core.api">
-    <!-- This module is deprecated and subject to being removed in a subsequent release. -->
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>


### PR DESCRIPTION
Module is 'unsupported' in EAP so the comment talking about deprecated would be wrong. We don't have such comments in other modules; we can live without it here.