### PR TITLE
[i18n] Allow obsolete Zanata modules to be removed on the server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,7 @@
                  <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
                  <!-- In previous versions, 3.8.0 and lower, this defaulted to true -->
                  <copyTrans>true</copyTrans>
+                 <deleteObsoleteModules>true</deleteObsoleteModules>
               </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This is a changed that was applied in EAP that was not applied in master.