### PR TITLE
[WFLY-9762] JMS message is not received when using a non-transactiona…

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -167,6 +167,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
     public static final String JGROUPS_CHANNEL_LOCATOR_CLASS = "jgroupsChannelLocatorClass";
     public static final String JGROUPS_CHANNEL_NAME = "jgroupsChannelName";
     public static final String JGROUPS_CHANNEL_REF_NAME = "jgroupsChannelRefName";
+    public static final String IGNORE_JTA = "ignoreJTA";
 
     private Injector<Object> transactionManager = new InjectedValue<Object>();
     private List<String> connectors;
@@ -536,7 +537,11 @@ public class PooledConnectionFactoryService implements Service<Void> {
 
     private static Activation createActivation(ConnectionDefinition common, TransactionSupportEnum transactionSupport) {
         List<ConnectionDefinition> definitions = Collections.singletonList(common);
-        return new ActivationImpl(null, null, transactionSupport, definitions, Collections.<AdminObject>emptyList(), Collections.<String, String>emptyMap(), Collections.<String>emptyList(), null, null);
+        //fix of WFLY-9762 - JMSConnectionFactoryDefinition annotation with the transactional attribute set to false results in  TransactionSupportEnum.NoTransaction -> it has to be propagated
+        boolean ignoreJTA = transactionSupport == TransactionSupportEnum.NoTransaction;
+        //attribute is propagated only if it means to ignore JTA transaction; in case of not ignoring, default behavior is used
+        Map<String, String> configProperties = ignoreJTA ? Collections.<String, String>singletonMap(IGNORE_JTA, String.valueOf(ignoreJTA)) : Collections.emptyMap();
+        return new ActivationImpl(null, null, transactionSupport, definitions, Collections.<AdminObject>emptyList(), configProperties, Collections.<String>emptyList(), null, null);
     }
 
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
@@ -28,6 +28,7 @@ public class PooledConnectionFactoryAttributesTestCase extends AttributesTestBas
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add(PooledConnectionFactoryService.JGROUPS_CHANNEL_LOCATOR_CLASS);
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add(PooledConnectionFactoryService.JGROUPS_CHANNEL_REF_NAME);
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add(PooledConnectionFactoryService.JGROUPS_CHANNEL_NAME);
+        UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add(PooledConnectionFactoryService.IGNORE_JTA);
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("jgroupsFile");
         // these 2 props will *not* be supported since AS7 relies on vaulted passwords + expressions instead
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("passwordCodec");

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueIgnoreJTATest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToQueueIgnoreJTATest.java
@@ -1,0 +1,140 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.as.test.smoke.jms.auxiliary.JMSListener;
+import org.jboss.as.test.smoke.jms.auxiliary.QueueMessageDrivenBean;
+import org.jboss.as.test.smoke.jms.auxiliary.TransactedQueueMessageSenderIgnoreJTA;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ejb.EJB;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test of fix for WFLY-9762.
+ * JMS message s send and verified if is delivered. Difference is in creation if ConectionFactory (based JMSConnectionFactoryDefinition annotation with the transactional attribute)
+ * and also tries rollback.
+ *
+ * Test is based on test from issue - https://github.com/javaee-samples/javaee7-samples/tree/master/jms/jms-xa
+ *
+ * @author <a href="jondruse@redhat.com">Jiri Ondrusek</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(CreateQueueSetupTask.class)
+public class SendToQueueIgnoreJTATest {
+
+    private static int MAX_WAIT_IN_SECONDS = 15;
+
+    @EJB
+    private TransactedQueueMessageSenderIgnoreJTA sender;
+
+    @EJB
+    private JMSListener jmsListener;
+
+    private CountDownLatch latch;
+
+    @Before
+    public void setMessageReceived() {
+        latch = new CountDownLatch(1);
+        jmsListener.setLatch(latch);
+    }
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "test.jar")
+                .addClass(TransactedQueueMessageSenderIgnoreJTA.class)
+                .addClass(JMSListener.class)
+                .addClass(QueueMessageDrivenBean.class)
+                .addClass(CreateQueueSetupTask.class)
+                .addPackage(JMSOperations.class.getPackage())
+                .addAsManifestResource(
+                        EmptyAsset.INSTANCE,
+                        ArchivePaths.create("beans.xml"));
+    }
+
+    /**
+     * JMS message is send using connection factory with transactional = false. Message should be delivered - main reason of fix.
+     */
+    @Test
+    public void sendIgnoreJTA() throws Exception {
+        sender.send(true, false);
+
+        latch.await(MAX_WAIT_IN_SECONDS, SECONDS);
+
+        assertEquals(0, latch.getCount());
+    }
+
+    /**
+     * JMS message is send using connection factory with transactional = false and with rollback of JTA transaction.
+     * Message should be still delivered as JTA transaction is ignored.
+     */
+    @Test
+    public void sendAndRollbackIgnoreJTA() throws Exception {
+        sender.send(true, true);
+
+        latch.await(MAX_WAIT_IN_SECONDS, SECONDS);
+
+        assertEquals(0, latch.getCount());
+    }
+
+    /**
+     * JMS message is send using connection factory with transactional = true.
+     * Messaging behaves as a part of JTA transaction, message should be delivered.
+     */
+    @Test
+    public void sendInJTA() throws Exception {
+        sender.send(false,false);
+
+        latch.await(MAX_WAIT_IN_SECONDS, SECONDS);
+
+        assertEquals(0, latch.getCount());
+    }
+
+    /**
+     * JMS message is send using connection factory with transactional = true and JTA rollback
+     * Messaging behaves as a part of JTA transaction, message should NOT be delivered.
+     */
+    @Test
+    public void sendAndRollbackInJTA() throws  Exception {
+        sender.send(false, true);
+
+        latch.await(MAX_WAIT_IN_SECONDS, SECONDS);
+
+        assertEquals(1, latch.getCount());
+    }
+
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/JMSListener.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/JMSListener.java
@@ -1,0 +1,48 @@
+package org.jboss.as.test.smoke.jms.auxiliary;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.SEVERE;
+
+@MessageDriven(
+    activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "java:/app/jms/nonXAQueue"),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"), }
+)
+
+/**
+ * Auxiliary class for JMS smoke tests - receives messages from a queue.
+ * Test of fix for WFLY-9762
+ *
+ * @author <a href="jondruse@redhat.com">Jiri Ondrusek</a>
+ */
+public class JMSListener implements MessageListener {
+
+
+    private static final Logger logger = Logger.getLogger(JMSListener.class.getName());
+
+    private CountDownLatch latch;
+
+
+    public void setLatch(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void onMessage(Message message) {
+        try {
+            logger.info("Message received (async): " + message.getBody(String.class));
+
+            latch.countDown();
+
+        } catch (JMSException ex) {
+            logger.log(SEVERE, null, ex);
+        }
+    }
+}

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/TransactedQueueMessageSenderIgnoreJTA.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/TransactedQueueMessageSenderIgnoreJTA.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.jms.auxiliary;
+
+import org.jboss.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.enterprise.context.RequestScoped;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSConnectionFactoryDefinitions;
+import javax.jms.JMSContext;
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.Queue;
+
+@JMSDestinationDefinition(
+        name = "java:/app/jms/nonXAQueue",
+        interfaceName = "javax.jms.Queue"
+)
+
+@JMSConnectionFactoryDefinitions(
+        value = {
+                @JMSConnectionFactoryDefinition(
+                        name = "java:/jms/nonXAcf",
+                        transactional = false,
+                        properties = {
+                                "connectors=in-vm",}
+                ),
+
+                @JMSConnectionFactoryDefinition(
+                        name = "java:/jms/XAcf",
+                        properties = {
+                                "connectors=in-vm",}
+                )
+        }
+)
+
+/**
+ * Auxiliary class for JMS smoke tests - sends messages to a queue from within a transaction with different value in JMSConnectionFactoryDefinition annotation's transactional attribute
+ * Test of fix for WFLY-9762
+ *
+ * @author <a href="jondruse@redhat.com">Jiri Ondrusek</a>
+ */
+@Stateful
+@RequestScoped
+public class TransactedQueueMessageSenderIgnoreJTA {
+
+    private static final Logger logger = Logger.getLogger(TransactedQueueMessageSenderIgnoreJTA.class);
+
+    @Resource(lookup = "java:/app/jms/nonXAQueue")
+    private Queue queue;
+
+    @Resource(lookup = "java:/ConnectionFactory")
+    private ConnectionFactory factory;
+
+    @Resource(lookup = "java:/jms/XAcf")
+    private ConnectionFactory factoryXA;
+
+    @Resource(lookup = "java:/jms/nonXAcf")
+    private ConnectionFactory factoryNonXA;
+
+    @Resource
+    private SessionContext ctx;
+
+    @TransactionAttribute(value = TransactionAttributeType.REQUIRES_NEW)
+    public void send(boolean ignoreJTA, boolean rollback) throws Exception {
+        try (JMSContext context = getFactory(ignoreJTA).createContext()) {
+            context.createProducer().send(queue, "test");
+            if (rollback) {
+                ctx.setRollbackOnly();
+            }
+        }
+    }
+
+    private ConnectionFactory getFactory(boolean ignoreJTA) {
+        return ignoreJTA ? factoryNonXA : factoryXA;
+    }
+}


### PR DESCRIPTION
…l JMSConnectionFactoryDefinition

Issue: https://issues.jboss.org/browse/WFLY-9762

Problem caused by the fact, that the value of the transactional attribute (from annotation JMSConnectionFactoryDefinition ) is ignored. If there is value false, it has to be propagated into artemis, to be used during transaction logic.

This change needs following change in ActiveMQ Artemis - https://github.com/apache/activemq-artemis/pull/1857

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.