### PR TITLE
WFLY-9796 Update OpenJPA module to public

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
@@ -25,7 +25,7 @@
 <!-- Represents the OpenJPA module  -->
 <module xmlns="urn:jboss:module:1.5" name="org.apache.openjpa">
     <properties>
-        <property name="jboss.api" value="private"/>
+        <property name="jboss.api" value="public"/>
     </properties>
 
     <resources>


### PR DESCRIPTION
https://issues.jboss.org/projects/WFLY/issues/WFLY-9796
OpenJPA module should be public, instead of private.