### PR TITLE
[WFLY-9128] JAXB 2.2 / 2.3 module switch to load the API that matches…

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1283,6 +1283,11 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
             <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.xml.bind.api">
+<module xmlns="urn:jboss:module:1.7" name="javax.xml.bind.api">
 
 
     <dependencies>
@@ -33,6 +33,15 @@
     </dependencies>
 
     <resources>
-        <artifact name="${org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec}"/>
+        <artifact name="${org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.3_spec}">
+            <conditions>
+              <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <artifact name="${org.jboss.spec.javax.xml.bind:jboss-jaxb-api_2.2_spec}">
+            <conditions>
+              <property-not-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
     </resources>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,7 @@
         <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.3.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
+        <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.5.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
@@ -5462,6 +5463,12 @@
                 <groupId>org.jboss.spec.javax.ws.rs</groupId>
                 <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.xml.bind</groupId>
+                <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
… current EE version

This completes https://github.com/wildfly/wildfly/pull/10604 (https://issues.jboss.org/browse/WFLY-9128) to allow running in EE7 mode.