### PR TITLE
[WFLY-9800]:  ASM version divergence after org.apache.cxf:cxf-rt-bindings-xml version upgrade

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -160,7 +160,7 @@
         </dependency>
 
         <dependency>
-            <groupId>asm</groupId>
+            <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${asm:asm}"/>
+        <artifact name="${org.ow2.asm:asm}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
          -->
         <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
         <version.antlr>2.7.7</version.antlr>
-        <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.3.3</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.8.11</version.com.fasterxml.jackson>
@@ -221,6 +220,7 @@
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>
         <version.org.opensaml.opensaml>3.3.0</version.org.opensaml.opensaml>
+        <version.org.ow2.asm>6.0</version.org.ow2.asm>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.5.5.SP8</version.org.picketlink>
         <version.org.slf4j>1.7.22</version.org.slf4j>
@@ -1430,9 +1430,9 @@
             </dependency>
 
             <dependency>
-                <groupId>asm</groupId>
+                <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>${version.asm}</version>
+                <version>${version.org.ow2.asm}</version>
             </dependency>
 
             <dependency>
@@ -2344,6 +2344,10 @@
                     <exclusion>
                         <groupId>xalan</groupId>
                         <artifactId>xalan</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
                     </exclusion>
                </exclusions>
             </dependency>
@@ -5721,6 +5725,10 @@
                         <artifactId>asm</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.sun.xml.fastinfoset</groupId>
                         <artifactId>FastInfoset</artifactId>
                     </exclusion>
@@ -5964,6 +5972,10 @@
                 <exclusions>
                     <exclusion>
                         <groupId>asm</groupId>
+                        <artifactId>asm</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
                         <artifactId>asm</artifactId>
                     </exclusion>
                     <exclusion>


### PR DESCRIPTION
Excluding asm:asm and inherited dependency on org.ow2.asm:asm and defining a global dependency on org.ow2.asm:asm.

Jira: https://issues.jboss.org/browse/WFLY-9800

@asoldano please review