### PR TITLE
[WFLY-9808] Restore support for configuring surefire forkedProcessTimeoutInSecond…

### DIFF
--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -182,6 +182,8 @@
                 <configuration>
                     <workingDirectory>${basedir}/target/workdir</workingDirectory> <!-- Work in submodule's own dir. -->
 
+                    <!-- Forked process timeout -->
+                    <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>
                     <!-- System properties passed to test cases -->

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -325,6 +325,8 @@
                     <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
                     <enableAssertions>true</enableAssertions>
                  
+                    <!-- Forked process timeout -->
+                    <forkedProcessTimeoutInSeconds>${surefire.forked.process.timeout}</forkedProcessTimeoutInSeconds>
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${surefire.system.args} ${surefire.memory.args} ${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -153,6 +153,8 @@
         <modular.jdk.testsuite.args />
         <surefire.system.args>${modular.jdk.testsuite.args} -Dorg.jboss.ejb.client.wildfly-testsuite-hack=true ${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist} ${surefire.jacoco.args} -Dmaven.repo.local=${settings.localRepository}</surefire.system.args>
         <extra.server.jvm.args />
+        <!-- Hook to control forked process timeout via -D. Default value of 0 means no timeout -->
+        <surefire.forked.process.timeout>0</surefire.forked.process.timeout>
 
         <!-- If servers should be killed before the test suite is run-->
         <org.wildfly.test.kill-servers-before-test>false</org.wildfly.test.kill-servers-before-test>


### PR DESCRIPTION
…s via -D

https://issues.jboss.org/browse/WFLY-9808

Alternatively we can remove all uses of this property from poms and docs. Now we have some testsuite poms setting it but none using it.


This is another in the many PRs I've been sending up aiming at eliminating minor diffs between WF and what was in EAP.  EAP had the testsuite/pom.xml setting of the timeout at 1500 seconds, but I think 0 is better, as that is the effective value WF has been using. The point of this is to resolve the WF vs EAP diff by providing the hook to set the timeout externally via -D, not to change the default WF behavior.