### PR TITLE
[WFLY-9806] Clean up use of jboss.as.release.version

### DIFF
--- a/build/assembly.xml
+++ b/build/assembly.xml
@@ -11,7 +11,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-${version}/**</include>
+                <include>${server.output.dir.prefix}-${server.output.dir.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -53,7 +53,7 @@
     </dependencies>
 
     <build>
-        <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>
@@ -86,7 +86,7 @@
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
                             <recompressZippedFiles>true</recompressZippedFiles>
-                            <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+                            <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <workDirectory>${project.build.directory}/assembly/work</workDirectory>

--- a/dist/assembly-src.xml
+++ b/dist/assembly-src.xml
@@ -12,7 +12,7 @@
     <fileSets>
         <fileSet>
             <directory>..</directory>
-            <outputDirectory>${server.output.dir.prefix}-${jboss.as.release.version}-src</outputDirectory>
+            <outputDirectory>${server.output.dir.prefix}-${server.output.dir.version}-src</outputDirectory>
             <includes>
                 <include>**/*.xml</include>
                 <include>**/src/**</include>

--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -12,7 +12,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-${jboss.as.release.version}/**</include>
+                <include>${server.output.dir.prefix}-${server.output.dir.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -64,7 +64,7 @@
     </properties>
 
     <build>
-        <finalName>${server.output.dir.prefix}-${jboss.as.release.version}</finalName>
+        <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>
@@ -202,10 +202,10 @@
                                 <phase>prepare-package</phase>
                                 <configuration>
                                     <tasks>
-                                        <fileset id="licenses.xml.list" dir="${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses" includes="*licenses.xml"/>
+                                        <fileset id="licenses.xml.list" dir="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses" includes="*licenses.xml"/>
                                         <!--
                                         <property name="prop.licenses.xml.list" refid="licenses.xml.list"/>
-                                        <echo>List of licenses.xml in ${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses</echo>
+                                        <echo>List of licenses.xml in ${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</echo>
                                         <echo>${prop.licenses.xml.list}</echo>
                                         -->
                                         <pathconvert pathsep="&#xA;" property="license-files-list-items" refid="licenses.xml.list">
@@ -215,9 +215,9 @@
                                                 <globmapper from="*" to="*&lt;/item&gt;"/>
                                             </chainedmapper>
                                         </pathconvert>
-                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses/licenses.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#xA;&lt;list&gt;&#xA;</echo>
-                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses/licenses.xml" append="true">${license-files-list-items}&#xA;</echo>
-                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses/licenses.xml" append="true">&lt;/list&gt;</echo>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#xA;&lt;list&gt;&#xA;</echo>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml" append="true">${license-files-list-items}&#xA;</echo>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml" append="true">&lt;/list&gt;</echo>
                                     </tasks>
                                 </configuration>
                                 <goals>
@@ -241,12 +241,12 @@
                                 <configuration>
                                     <transformationSets>
                                         <transformationSet>
-                                            <dir>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses</dir>
+                                            <dir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</dir>
                                             <includes>
                                                 <include>licenses.xml</include>
                                             </includes>
-                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses/licenses-merged.xsl</stylesheet>
-                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses</outputDir>
+                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses-merged.xsl</stylesheet>
+                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</outputDir>
                                             <fileMappers>
                                                 <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
                                                     <targetExtension>.xml</targetExtension>
@@ -254,12 +254,12 @@
                                             </fileMappers>
                                         </transformationSet>
                                         <transformationSet>
-                                            <dir>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses</dir>
+                                            <dir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</dir>
                                             <includes>
                                                 <include>licenses.xml</include>
                                             </includes>
-                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses/licenses.xsl</stylesheet>
-                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${jboss.as.release.version}/docs/licenses</outputDir>
+                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xsl</stylesheet>
+                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</outputDir>
                                             <fileMappers>
                                                 <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
                                                     <targetExtension>.html</targetExtension>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -31,35 +31,35 @@ limitations under the License.
 -->
   <files>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
       <contains>slot=${verifier.slot.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/jboss-modules.jar</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/standalone/configuration/standalone.xml</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/standalone/configuration/standalone.xml</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
       <exists>true</exists>
     </file>
   </files>

--- a/feature-pack/assembly.xml
+++ b/feature-pack/assembly.xml
@@ -8,7 +8,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>target/${server.output.dir.prefix}-${version}</directory>
+            <directory>target/${server.output.dir.prefix}-${server.output.dir.version}</directory>
             <outputDirectory/>
         </fileSet>
     </fileSets>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -44,7 +44,7 @@
     </properties>
 
     <build>
-        <finalName>${server.output.dir.prefix}-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,12 @@
     </scm>
 
     <properties>
-        <!-- Release Info -->
+        <!-- Release Info. 
+             Drives properties that end up in MANIFEST.mf files produced by this build
+             and some are also used in the pom 'scm' element.
+             Do not use these properties for other purposes, e.g. jboss.as.release.version is not 
+             a general purpose release version shorthand.
+        -->
         <jboss.as.release.version>${project.version}</jboss.as.release.version>
         <jboss.as.release.codename>N/A</jboss.as.release.codename>
         <jboss.as.scm.url>https://github.com/wildfly/wildfly</jboss.as.scm.url>
@@ -254,9 +259,12 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
 
+        <!-- Properties that drive the names of various directories produced by and used in the build -->
         <server.output.dir.prefix>wildfly</server.output.dir.prefix>
-        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${jboss.as.release.version}</wildfly.build.output.dir>
-        <wildfly.web.build.output.dir>servlet-dist/target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}</wildfly.web.build.output.dir>
+        <!-- Version suffix that is appended to directories. Default is the maven GAV version but this can be edited to use a short form version -->
+        <server.output.dir.version>${project.version}</server.output.dir.version>
+        <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
+        <wildfly.web.build.output.dir>servlet-dist/target/${server.output.dir.prefix}-servlet-${server.output.dir.version}</wildfly.web.build.output.dir>
 
         <!--
             See ChildFirstClassLoaderBuilder in model-test for the explanation of the org.jboss.model.test.cache.root and org.jboss.model.test.classpath.cache properties.

--- a/servlet-build/assembly.xml
+++ b/servlet-build/assembly.xml
@@ -35,7 +35,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-servlet-${project.version}/**</include>
+                <include>${server.output.dir.prefix}-servlet-${server.output.dir.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -57,7 +57,7 @@
     </dependencies>
 
     <build>
-        <finalName>${server.output.dir.prefix}-servlet-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-servlet-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>

--- a/servlet-dist/assembly.xml
+++ b/servlet-dist/assembly.xml
@@ -34,7 +34,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-servlet-${jboss.as.release.version}/**</include>
+                <include>${server.output.dir.prefix}-servlet-${server.output.dir.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -63,7 +63,7 @@
         <verifier.product.release.version>12.0</verifier.product.release.version>
     </properties>
     <build>
-        <finalName>${server.output.dir.prefix}-servlet-${jboss.as.release.version}</finalName>
+        <finalName>${server.output.dir.prefix}-servlet-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>

--- a/servlet-dist/src/verifier/verifications.xml
+++ b/servlet-dist/src/verifier/verifications.xml
@@ -31,35 +31,35 @@ limitations under the License.
 -->
   <files>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/bin/product.conf</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/bin/product.conf</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/bin/product.conf</location>
       <contains>slot=${verifier.slot.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Name: ${verifier.product.release.name}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${verifier.slot.name}/dir/META-INF/MANIFEST.MF</location>
       <contains>JBoss-Product-Release-Version: ${verifier.product.release.version}</contains>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/jboss-modules.jar</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/jboss-modules.jar</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/standalone/configuration/standalone.xml</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/standalone/configuration/standalone.xml</location>
       <exists>true</exists>
     </file>
     <file>
-      <location>target/${server.output.dir.prefix}-servlet-${jboss.as.release.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
       <exists>true</exists>
     </file>
   </files>

--- a/servlet-feature-pack/assembly.xml
+++ b/servlet-feature-pack/assembly.xml
@@ -32,7 +32,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>target/${server.output.dir.prefix}-servlet-${project.version}</directory>
+            <directory>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}</directory>
             <outputDirectory/>
         </fileSet>
     </fileSets>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -448,7 +448,7 @@
     </dependencies>
 
     <build>
-        <finalName>${server.output.dir.prefix}-servlet-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-servlet-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -487,7 +487,7 @@
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
                             <recompressZippedFiles>true</recompressZippedFiles>
-                            <finalName>${server.output.dir.prefix}-servlet-feature-pack-${project.version}</finalName>
+                            <finalName>${server.output.dir.prefix}-servlet-feature-pack-${server.output.dir.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <workDirectory>${project.build.directory}/assembly/work</workDirectory>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9806

1) Reserves use of jboss.as.release.version for it's original purpose -- driving our MANIFEST.mf content.
2) Replaces other use with a more precisely named server.output.dir.version
3) Cleans up a few spots where other "version" properties were being used for output dir names, consolidating on "server.output.dir.version".

Besides being a good cleanup this is necessary to be able to produce clean commits moving quickly from a WF tag to an EAP branch.
