### PR TITLE
WFLY-9813 lower test logging levels

### DIFF
--- a/legacy/configadmin/src/test/resources/logging.properties
+++ b/legacy/configadmin/src/test/resources/logging.properties
@@ -24,7 +24,7 @@
 #loggers=org.jboss.whatever,org.jboss.foo
 
 # Root logger level
-logger.level=DEBUG
+logger.level=OFF
 
 # Root logger handlers
 logger.handlers=FILE

--- a/testsuite/compat/src/test/resources/logging.properties
+++ b/testsuite/compat/src/test/resources/logging.properties
@@ -26,10 +26,10 @@ logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=INFO
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
@@ -40,7 +40,7 @@ handler.CONSOLE.formatter=PATTERN
 
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
+handler.FILE.level=INFO
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log

--- a/testsuite/integration/clustering/src/test/resources/logging.properties
+++ b/testsuite/integration/clustering/src/test/resources/logging.properties
@@ -31,7 +31,7 @@ logger.sun.rmi.level=WARNING
 logger.level=INFO
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/elytron/src/test/resources/logging.properties
+++ b/testsuite/integration/elytron/src/test/resources/logging.properties
@@ -35,9 +35,6 @@ logger.jacorb.useParentHandlers=true
 logger.org.jboss.as.config.level=DEBUG
 logger.org.jboss.as.config.useParentHandlers=true
 
-logger.org.apache.tomcat.util.modeler.level=WARN
-logger.org.apache.tomcat.util.modeler.useParentHandlers=true
-
 logger.org.apache.directory.level=WARN
 logger.org.apache.directory.useParentHandlers=true
 

--- a/testsuite/integration/iiop/src/test/resources/logging.properties
+++ b/testsuite/integration/iiop/src/test/resources/logging.properties
@@ -26,10 +26,10 @@ logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/legacy-ejb-client/src/test/resources/logging.properties
+++ b/testsuite/integration/legacy-ejb-client/src/test/resources/logging.properties
@@ -28,7 +28,7 @@ logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=INFO
+logger.level=WARN
 
 # Root logger handlers
 #logger.handlers=FILE, CONSOLE

--- a/testsuite/integration/manualmode/src/test/resources/logging.properties
+++ b/testsuite/integration/manualmode/src/test/resources/logging.properties
@@ -21,17 +21,18 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory,org.jboss.as.cli
 logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=DEBUG
+#logger.org.jboss.as.test.level=DEBUG
 logger.org.apache.directory.level=WARNING
+logger.org.jboss.as.cli.level=WARNING
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=INFO
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/picketlink/src/test/resources/logging.properties
+++ b/testsuite/integration/picketlink/src/test/resources/logging.properties
@@ -26,7 +26,7 @@ logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=OFF
 
 # Root logger handlers
 logger.handlers=FILE, CONSOLE

--- a/testsuite/integration/rts/src/test/resources/logging.properties
+++ b/testsuite/integration/rts/src/test/resources/logging.properties
@@ -26,10 +26,10 @@ logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/smoke/src/test/resources/logging.properties
+++ b/testsuite/integration/smoke/src/test/resources/logging.properties
@@ -27,10 +27,10 @@ logger.sun.rmi.level=WARNING
 logger.org.apache.http.wire.level=WARN
 
 # Root logger level
-logger.level=DEBUG
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/web/src/test/resources/logging.properties
+++ b/testsuite/integration/web/src/test/resources/logging.properties
@@ -28,10 +28,10 @@ logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=INFO
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/ws/src/test/resources/logging.properties
+++ b/testsuite/integration/ws/src/test/resources/logging.properties
@@ -28,10 +28,10 @@ logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=INFO
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler

--- a/testsuite/integration/xts/src/test/resources/logging.properties
+++ b/testsuite/integration/xts/src/test/resources/logging.properties
@@ -26,10 +26,10 @@ logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=DEBUG
+logger.level=WARN
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler


### PR DESCRIPTION
changed client logging in testuite to log to console so output can be seen in surefire results.
as well as lower the total logging to warn or even OFF in some cases where it makes sense.

This logs are something that is not commonly looked at, they can only come in handy when you are debugging testsuite issues but not at regular runs.

https://issues.jboss.org/browse/WFLY-9813

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
