### PR TITLE
[WFLY-6460] and [WFLY-7185] Add JSON-P 1.1 and JSON-B 1.0 Java EE 8 tech preview support

### DIFF
--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -93,6 +93,11 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
+            <!-- This is an unusual case where we override the version only for this client. The parent pom version is
+                 using the 1.1 version for the Java EE 8 tech preview though the client still currently expects 1.0.
+                 Once we fully move to Java EE 8 this can be removed.
+            -->
+            <version>${version.org.glassfish.javax.json-1.0}</version>
         </dependency>
 
         <dependency>

--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -52,6 +52,7 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             ModuleIdentifier.create("javax.enterprise.concurrent.api"),
             ModuleIdentifier.create("javax.interceptor.api"),
             ModuleIdentifier.create("javax.json.api"),
+            ModuleIdentifier.create("javax.json.bind.api"),
             ModuleIdentifier.create("javax.resource.api"),
             ModuleIdentifier.create("javax.rmi.api"),
             ModuleIdentifier.create("javax.xml.bind.api"),

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0</version.javax.enterprise>
         <version.javax.json.api>1.1.2</version.javax.json.api>
+        <version.javax.json.bind.api>1.0</version.javax.json.bind.api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.0</version.javax.mail>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
@@ -159,6 +160,7 @@
         <version.org.codehaus.jettison>1.3.8</version.org.codehaus.jettison>
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
+        <version.org.eclipse.yasson>1.0</version.org.eclipse.yasson>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
@@ -1888,6 +1890,18 @@
                 <groupId>javax.json</groupId>
                 <artifactId>javax.json-api</artifactId>
                 <version>${version.javax.json.api}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.json.bind</groupId>
+                <artifactId>javax.json.bind-api</artifactId>
+                <version>${version.javax.json.bind.api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -5629,6 +5643,18 @@
                 <groupId>org.eclipse.jdt.core.compiler</groupId>
                 <artifactId>ecj</artifactId>
                 <version>${version.org.eclipse.jdt.core.compiler}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse</groupId>
+                <artifactId>yasson</artifactId>
+                <version>${version.org.eclipse.yasson}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0</version.javax.enterprise>
+        <version.javax.json.api>1.1.2</version.javax.json.api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.0</version.javax.mail>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
@@ -160,7 +161,8 @@
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
-        <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
+        <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
+        <version.org.glassfish.javax.json-1.0>1.0.4</version.org.glassfish.javax.json-1.0>
         <version.org.hibernate>5.1.10.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>6.0.7.Final</version.org.hibernate.validator>
@@ -1880,6 +1882,12 @@
                         <artifactId>jaxb-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${version.javax.json.api}</version>
             </dependency>
 
             <dependency>
@@ -3996,11 +4004,17 @@
                 </exclusions>
             </dependency>
 
-            <!-- JSR-353 JSONP RI implementation -->
+            <!-- JSR-374 JSON-P 1.1 RI implementation -->
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.json</artifactId>
                 <version>${version.org.glassfish.javax.json}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- EL3 RI implementation -->

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -125,6 +125,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
@@ -152,6 +157,17 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el-impl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -145,8 +145,18 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.json.bind</groupId>
+            <artifactId>javax.json.bind-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jdt.core.compiler</groupId>
             <artifactId>ecj</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.7" name="javax.json.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+    <resources>
+        <artifact name="${javax.json:javax.json-api}">
+            <conditions>
+                <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+    </resources>
+    <dependencies>
+        <!-- The 1.0 RI ships with the API bundled. We can just export the API from the 1.0 RI if it's present. -->
+        <module name="org.glassfish.javax.json" services="import">
+            <exports>
+                <include-set>
+                    <path name="javax/json"/>
+                    <path name="javax/json/spi"/>
+                    <path name="javax/json/stream"/>
+                </include-set>
+            </exports>
+        </module>
+    </dependencies>
+</module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.7" name="javax.json.bind.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+    <resources>
+        <artifact name="${javax.json.bind:javax.json.bind-api}">
+            <conditions>
+                <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+    </resources>
+    <dependencies>
+        <module name="javax.json.api"/>
+        <module name="org.eclipse.yasson" services="import"/>
+    </dependencies>
+</module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.7" name="org.eclipse.yasson">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.json.api"/>
+        <module name="javax.json.bind.api" />
+    </dependencies>
+    <resources>
+        <artifact name="${org.eclipse:yasson}">
+            <conditions>
+                <property-equal  name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+    </resources>
+</module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.7" name="org.glassfish.javax.json">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.json.api" />
+    </dependencies>
+    <resources>
+        <artifact name="org.glassfish:javax.json:1.0.4">
+            <conditions>
+                <property-not-equal  name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <artifact name="${org.glassfish:javax.json}">
+            <conditions>
+                <property-equal  name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+    </resources>
+</module>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -46,9 +46,10 @@
     <!-- Export out the EE Specs and demos -->
 
     <dependency>
-      <groupId>org.glassfish</groupId>
-      <artifactId>javax.json</artifactId>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
       <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>

--- a/testsuite/integration/ee8-temp/pom.xml
+++ b/testsuite/integration/ee8-temp/pom.xml
@@ -63,6 +63,27 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
+                    </environmentVariables>
+                    <!-- Parameters to test cases. -->
+                    <systemPropertyVariables>
+                        <jboss.inst>${wildfly.dir}</jboss.inst>
+                        <!-- TODO explicit definition of ee8.preview.mode=true is needed by JSON-P 1.1 atm, remove in future -->
+                        <server.jvm.args>-Dee8.preview.mode=true -Dmaven.repo.local=${settings.localRepository} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.other} ${jvm.args.timeouts} ${extra.server.jvm.args}</server.jvm.args>
+                        <node0>${node0}</node0>
+                    </systemPropertyVariables>
+                    <argLine>${surefire.system.args} ${jvm.args.ip.client}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>adjust-server-config</id>

--- a/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONBServlet.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONBServlet.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.json;
+
+import javax.json.bind.JsonbBuilder;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * JSON-B 1.0 sample servlet - using JsonbBuilder
+ *
+ * @author Rostislav Svoboda
+ */
+@WebServlet("/jsonb")
+public class JSONBServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("application/json");
+        PrintWriter out = response.getWriter();
+
+        out.print(JsonbBuilder.create().toJson(new Person("foo", "bar")));
+        out.flush();
+    }
+
+    public static class Person {
+        public String name;
+        public String surname;
+
+        public Person(String name, String surname) {
+            this.name = name;
+            this.surname = surname;
+        }
+    }
+}

--- a/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.json;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * JSON-B 1.0 smoke test
+ *
+ * @author Rostislav Svoboda
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JSONBTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "jsonb10-test.war").addClasses(JSONBServlet.class);
+    }
+
+    @Test
+    public void testJsonbServlet() throws Exception {
+        final String result = HttpRequest.get(url + "jsonb", 5, TimeUnit.SECONDS);
+
+        assertEquals("{\"name\":\"foo\",\"surname\":\"bar\"}", result);
+    }
+}

--- a/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONPServlet.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONPServlet.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.json;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.stream.JsonCollectors;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * JSON-P 1.1 sample servlet - using JsonCollectors.toJsonArray()
+ *
+ * @author Rostislav Svoboda
+ */
+@WebServlet("/json")
+public class JSONPServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        response.setContentType("application/json");
+
+        JsonArray array = this.list.
+                stream().
+                collect(JsonCollectors.toJsonArray());
+
+        PrintWriter out = response.getWriter();
+        out.print(array);
+        out.flush();
+    }
+    private List<JsonObject> list;
+
+    @Override
+    public void init() throws ServletException {
+        this.list = Arrays.asList(next(), next());
+    }
+
+    private JsonObject next() {
+        return Json.createObjectBuilder().
+                add("number", System.currentTimeMillis()).
+                build();
+    }
+}

--- a/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONPTestCase.java
+++ b/testsuite/integration/ee8-temp/src/test/java/org/jboss/as/test/integration/json/JSONPTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.json;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonReader;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * JSON-P 1.1 smoke test
+ *
+ * @author Rostislav Svoboda
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JSONPTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, "jsonp11-test.war").addClasses(JSONPServlet.class);
+    }
+
+    @Test
+    public void testJsonServlet() throws Exception {
+        final String result = HttpRequest.get(url + "json", 5, TimeUnit.SECONDS);
+
+        JsonReader jsonReader = Json.createReader(new StringReader(result));
+        JsonArray array = jsonReader.readArray();
+        jsonReader.close();
+
+        assertEquals(2, array.size());
+    }
+}

--- a/webservices/tests-integration/pom.xml
+++ b/webservices/tests-integration/pom.xml
@@ -42,6 +42,10 @@
     <name>WildFly: Web Services Tests Integration Subsystem</name>
 
     <dependencies>
+        <dependency> <!-- Required by activemq... -->
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jboss.ws</groupId>
             <artifactId>jbossws-spi</artifactId>
@@ -124,10 +128,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-commons</artifactId>
-        </dependency>
-        <dependency> <!-- Required by activemq... -->
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
         </dependency>
         <dependency> <!-- Required for activemq compatibility -->
             <groupId>io.netty</groupId>


### PR DESCRIPTION
# Overview
This PR includes changes for JSON-P and JSON-B with the Java EE 8 tech preview. 

## JSON-P 1.1 [WFLY-6460](https://issues.jboss.org/browse/WFLY-6460)
This replaces JSON-P 1.0 with JSON-P 1.1 when the `ee8.preview.mode` system property is set to `true`. Note that in the JMS client we hard-code the version to 1.0.4 since client itself still relies on JSON-P 1.0. This library is shaded into the client which is the reason for doing this.

Also note that JSON-P 1.0 implementation library includes both the API and the implementation which is my the `module.xml` exports only the `javax.json.*` packages.

## JSON-B 1.0 [WFLY-7185](https://issues.jboss.org/browse/WFLY-7185)
This introduces the new JSON-B 1.0 API. The module itself will be added to all deployments however the resource will only be added if the `ee8.preview.mode` system property is set to `true`.

## Tests
Currently the tests will require the `ee8.preview.mode` to be set in the `JAVA_OPTS`, or in the case of Arquillian in the `javaVmArguments`. This requirement should go away once https://github.com/wildfly/wildfly-core/pull/3100 is merged and a new version of WildFly Core is introduced.