### PR TITLE
[WFLY-9628] Follow up to fix the way the module resources are applied

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,6 @@
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.0</version.javax.mail>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
-        <!-- Be careful, this version is hardcoded in the javax.validation.api module.xml -->
-        <version.javax.validation.ee7>1.1.0.Final</version.javax.validation.ee7>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.joda-time>2.9.7</version.joda-time>

--- a/servlet-feature-pack/feature-pack-build.xml
+++ b/servlet-feature-pack/feature-pack-build.xml
@@ -45,9 +45,6 @@
                 subsystems="configuration/host/subsystems.xml"
                 output-file="domain/configuration/host-slave.xml" />
     </config>
-    <copy-artifacts>
-        <copy-artifact artifact="javax.validation:validation-api:::${version.javax.validation.ee7}" to-location="modules/system/layers/base/javax/validation/api/main/"/>
-    </copy-artifacts>
     <file-permissions>
         <permission value="755">
             <filter pattern="*.sh" include="true"/>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -34,11 +34,11 @@
           when building feature packs. It is not a big issue as this will
           be removed once we fully support EE 8.
         -->
-        <resource-root path="validation-api-1.1.0.Final.jar">
+        <artifact name="javax.validation:validation-api:1.1.0.Final">
             <conditions>
                 <property-not-equal name="ee8.preview.mode" value="true"/>
             </conditions>
-        </resource-root>
+        </artifact>
     </resources>
 
     <dependencies>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -23,25 +23,25 @@
   -->
 
 <module xmlns="urn:jboss:module:1.7" name="javax.validation.api">
-  <resources>
-    <artifact name="${javax.validation:validation-api}">
-      <conditions>
-        <property-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </artifact>
-    <!--
-      The version is hardcoded as property resolution is not supported
-      when building feature packs. It is not a big issue as this will
-      be removed once we fully support EE 8.
-    -->
-    <resource-root path="validation-api-1.1.0.Final.jar">
-      <conditions>
-        <property-not-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </resource-root>
-  </resources>
+    <resources>
+        <artifact name="${javax.validation:validation-api}">
+            <conditions>
+                <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
+        <!--
+          The version is hardcoded as property resolution is not supported
+          when building feature packs. It is not a big issue as this will
+          be removed once we fully support EE 8.
+        -->
+        <resource-root path="validation-api-1.1.0.Final.jar">
+            <conditions>
+                <property-not-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </resource-root>
+    </resources>
 
-  <dependencies>
-    <module name="org.jboss.logging"/>
-  </dependencies>
+    <dependencies>
+        <module name="org.jboss.logging"/>
+    </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9628

The first commit is not necessary, but for consistency sake I formatted the `module.xml` from using 2 space indentation to 4 space indentation.

The second commit follows up on #10725 to hard-code the version in the `module.xml` instead of the feature-pack. This allows thin servers to still use a maven repository instead of copying the JAR into the provisioned server. 