### PR TITLE
WFLY-9827 Upgrade Hibernate Commons Annotations to 5.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.glassfish.javax.json-1.0>1.0.4</version.org.glassfish.javax.json-1.0>
         <version.org.hibernate>5.1.10.Final</version.org.hibernate>
-        <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
+        <version.org.hibernate.commons.annotations>5.0.2.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>6.0.7.Final</version.org.hibernate.validator>
         <version.org.hibernate.validator.ee7>5.3.6.Final</version.org.hibernate.validator.ee7>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>


### PR DESCRIPTION
 - https://issues.jboss.org/browse/WFLY-9827

A trivial upgrade; this has been tested with all Hibernate projects already.

Most notable changes:
 - automatic module name has been defined
 - updated JBoss Logging during our build to match WildFly
 - reduced amount of runtime object allocations to workaround for https://bugs.openjdk.java.net/browse/JDK-5043030
