### PR TITLE
WFLY-9768 Add smoke test verifying that CDI 2.0 cannot be used in EE …

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
@@ -32,12 +32,7 @@
         <module name="org.glassfish.javax.el"/>
         <module name="javax.inject.api" />
         <module name="javax.interceptor.api"/>
-
-        <!-- CDIProvider -->
-        <module name="org.jboss.as.weld" services="import" optional="true"/>
-        <module name="org.jboss.weld.core" optional="true"/>
-        <module name="javax.enterprise.api" />
-        <module name="javax.inject.api" />
+	<module name="javax.enterprise.api" />
     </dependencies>
 
     <resources>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
@@ -77,6 +77,12 @@ public class NoEE8InDefaultConfigurationTestCase {
         assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));
     }
 
+    @Test
+    public void unavailableCDI20() throws Exception {
+        String fqcn = "javax.enterprise.inject.spi.InterceptionFactory";
+        assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));
+    }
+
     private boolean isClassAvailable(String s) {
         boolean classAvailable = false;
         try {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9768

Adding a smoke test that makes sure you cannot load/use CDI 2.0 features in default mode.

**Note** that without the changes to bridge's `module.xml`, this test fails. Though I am unsure how those (redundant) dependencies caused that, probably some circular dep magic?

@stuartwdouglas @mkouba please review