### PR TITLE
Update getting started with Java EE 8 tech preview and add links to JSR's

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -130,11 +130,14 @@ will remain at Java EE7 level.
 |=======================================================================
 | Name | From Version | From JSR | To Version | To JSR
 
-| Java Servlet | 3.1 | JSR-340 | 4.0 | JSR-369
-| CDI | 1.2 | JSR-346 | 2.0 | JSR-365
-| Bean Validation | 1.1 | JSR-349 | 2.0 | JSR-380
-| JavaServer Faces | 2.2 | JSR-344 | 2.3 | JSR-372
-| JavaMail | 1.5 | JSR-919 | 1.6 | JSR-919
+| Java Servlet | 3.1 | JSR-340 | 4.0 | https://jcp.org/en/jsr/detail?id=370[JSR-369]
+| Contexts and Dependency Injection for Java | 1.2 | JSR-346 | 2.0 | https://jcp.org/en/jsr/detail?id=365[JSR-365]
+| Bean Validation | 1.1 | JSR-349 | 2.0 | https://jcp.org/en/jsr/detail?id=380[JSR-380]
+| JavaServer Faces | 2.2 | JSR-344 | 2.3 | https://jcp.org/en/jsr/detail?id=372[JSR-372]
+| JavaMail | 1.5 | JSR-919 | 1.6 | https://jcp.org/en/jsr/detail?id=919[JSR-919]
+| Java API for RESTFul Web Services | 2.0 | JSR-339 | 2.1 | https://jcp.org/en/jsr/detail?id=370[JSR-370]
+| Java API for JSON Processing | 1.0 | JSR-353 | 1.1 | https://jcp.org/en/jsr/detail?id=374[JSR-374]
+| Java API for JSON Binding | - | - | 1.0 | https://jcp.org/en/jsr/detail?id=367[JSR-367]
 |=======================================================================
 
 [[download]]


### PR DESCRIPTION
Updated the getting started docs to reflect the new Java EE 8 tech preview JSR's. Also added links to the new JSR's.