### PR TITLE
[WFLY-9817] [WFCORE-3600] ee8.preview.mode not needed in server.jvm.a…

### DIFF
--- a/testsuite/integration/ee8-temp/pom.xml
+++ b/testsuite/integration/ee8-temp/pom.xml
@@ -63,27 +63,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                        <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
-                    </environmentVariables>
-                    <!-- Parameters to test cases. -->
-                    <systemPropertyVariables>
-                        <jboss.inst>${wildfly.dir}</jboss.inst>
-                        <!-- TODO explicit definition of ee8.preview.mode=true is needed by JSON-P 1.1 atm, remove in future -->
-                        <server.jvm.args>-Dee8.preview.mode=true -Dmaven.repo.local=${settings.localRepository} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.other} ${jvm.args.timeouts} ${extra.server.jvm.args}</server.jvm.args>
-                        <node0>${node0}</node0>
-                    </systemPropertyVariables>
-                    <argLine>${surefire.system.args} ${jvm.args.ip.client}</argLine>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <profiles>
         <profile>
             <id>adjust-server-config</id>


### PR DESCRIPTION
…rgs / JAVA_OPTS

ee8.preview.mode workaround not needed in server.jvm.args / JAVA_OPTS anymore

https://issues.jboss.org/browse/WFLY-9817 / https://issues.jboss.org/browse/WFCORE-3600 

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted