### PR TITLE
WFLY-9814 use release=8 when building on JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6587,8 +6587,7 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${version.compiler.plugin}</version>
                         <configuration>
-                            <!-- jdk.unsupported is needed for security subsystem FastConcurrentDirectDeque-->
-                            <compilerArgument>-J--add-modules=java.xml.ws.annotation,jdk.unsupported</compilerArgument>
+                            <release>8</release>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/security/subsystem/pom.xml
+++ b/security/subsystem/pom.xml
@@ -175,4 +175,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <profiles>
+        <!-- this is a "hack" to be able to build with release=8 on JDK9 where you cannot access sun.misc package anymore
+        FastConcurrentDirectDeque relies heavily on Unsafe class.
+        Classes in this dependancy are there just for compiling noting else.
+        -->
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss</groupId>
+                    <artifactId>jdk-misc</artifactId>
+                    <version>2.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -44,9 +44,8 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.LdapContext;
 
-import com.sun.jndi.ldap.LdapCtx;
-import com.sun.jndi.ldap.LdapCtxFactory;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
@@ -136,7 +135,7 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(CLASS).set(InitialDirContext.class.getName());
             bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
                     ExternalContextBindingTestCase.LDAP_PORT);
-            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
             bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
             bindingAdd.get(ENVIRONMENT)
                     .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
@@ -155,7 +154,7 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(CACHE).set(true);
             bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
                     ExternalContextBindingTestCase.LDAP_PORT);
-            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
             bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
             bindingAdd.get(ENVIRONMENT)
                     .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
@@ -373,8 +372,8 @@ public class ExternalContextBindingTestCase {
                 Assert.assertNotSame(ldapContext1, ldapContext2);
             }
             LOGGER.debug("acquired external LDAP context: " + ldapContext1.toString());
-            LdapCtx c = (LdapCtx)ldapContext1.lookup("dc=jboss,dc=org");
-            c = (LdapCtx)c.lookup("ou=People");
+            LdapContext c = (LdapContext)ldapContext1.lookup("dc=jboss,dc=org");
+            c = (LdapContext)c.lookup("ou=People");
             Attributes attributes = c.getAttributes("uid=jduke");
             Assert.assertTrue(attributes.get("description").contains("awesome"));
             // resource injection
@@ -382,7 +381,7 @@ public class ExternalContextBindingTestCase {
             Assert.assertNotNull(ejb);
             c = ejb.getLdapCtx();
             Assert.assertNotNull(c);
-            c = (LdapCtx)c.lookup("ou=People");
+            c = (LdapContext)c.lookup("ou=People");
             attributes = c.getAttributes("uid=jduke");
             Assert.assertTrue(attributes.get("description").contains("awesome"));
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/LookupEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/LookupEjb.java
@@ -2,8 +2,7 @@ package org.jboss.as.test.integration.naming;
 
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
-
-import com.sun.jndi.ldap.LdapCtx;
+import javax.naming.ldap.LdapContext;
 
 /**
  * @author Stuart Douglas
@@ -12,9 +11,9 @@ import com.sun.jndi.ldap.LdapCtx;
 public class LookupEjb {
 
     @Resource(lookup = "java:global/ldap/dc=jboss,dc=org")
-    private LdapCtx ldapCtx;
+    private LdapContext ldapCtx;
 
-    public LdapCtx getLdapCtx() {
+    public LdapContext getLdapCtx() {
         return ldapCtx;
     }
 }


### PR DESCRIPTION
- do a workaround for using Unsafe in security subsystem
- sync FastConcurrentDirectDeque with changes from ConcurrentLinkedDeque
- fix code to not use private packages

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
