### PR TITLE
WFLY-9567 Setting 'eclipselink.archive.factory' property should NOT depend on 'eclipselink.target-server' being set

### DIFF
--- a/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
+++ b/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/EclipseLinkPersistenceProviderAdaptor.java
@@ -44,9 +44,16 @@ public class EclipseLinkPersistenceProviderAdaptor implements
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void addProviderProperties(Map properties, PersistenceUnitMetadata pu) {
+
+        if (!pu.getProperties().containsKey(ECLIPSELINK_ARCHIVE_FACTORY)) {
+            properties.put(ECLIPSELINK_ARCHIVE_FACTORY, JBossArchiveFactoryImpl.class.getName());
+        }
+
         if (!pu.getProperties().containsKey(ECLIPSELINK_TARGET_SERVER)) {
             properties.put(ECLIPSELINK_TARGET_SERVER, WildFlyServerPlatform.class.getName());
-            properties.put(ECLIPSELINK_ARCHIVE_FACTORY, JBossArchiveFactoryImpl.class.getName());
+        }
+
+        if (!pu.getProperties().containsKey(ECLIPSELINK_LOGGING_LOGGER)) {
             properties.put(ECLIPSELINK_LOGGING_LOGGER, JBossLogger.class.getName());
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.org.apache.lucene>5.3.1</version.org.apache.lucene>
         <version.org.apache.myfaces.core>2.2.11</version.org.apache.myfaces.core>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
-        <version.org.eclipselink.version>2.6.3</version.org.eclipselink.version>
+        <version.org.eclipselink.version>2.7.1</version.org.eclipselink.version>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.16.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.1</version.org.apache.santuario>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -193,7 +193,7 @@
                     <!-- System properties passed to test cases -->
                     <systemPropertyVariables combine.children="append">
                         <node0>${node0}</node0>
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.timeouts} -Declipselink.archive.factory=org.jipijapa.eclipselink.JBossArchiveFactoryImpl ${extra.server.jvm.args}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.timeouts} ${extra.server.jvm.args}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9567
Also switched to EclipseLink 2.7.1 which has https://bugs.eclipse.org/bugs/show_bug.cgi?id=414974 merged, which goes with this fix.  We still work with older EclipseLink versions as well.
