### PR TITLE
[WFLY-7185] Add missing CDI dependency on the JSON-P implementation module

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -23,8 +23,10 @@
     </properties>
 
     <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
         <module name="javax.json.api"/>
-        <module name="javax.json.bind.api" />
+        <module name="javax.json.bind.api"/>
     </dependencies>
     <resources>
         <artifact name="${org.eclipse:yasson}">


### PR DESCRIPTION
This follows up on [WFLY-7185](https://issues.jboss.org/browse/WFLY-7185) which adds missing dependencies on the `org.eclipse.yasson` module. This should have been done in the original PR, but it may have gotten lost in some rebase I did.