### PR TITLE
[WFLY-9859] Add client compatibility tests using the 3.0.x client

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -232,6 +232,16 @@ public class ClientCompatibilityUnitTestCase {
     }
 
     @Test
+    public void testCore3010Final() throws Exception {
+        testWF("3.0.10.Final", 9999);
+    }
+
+    @Test
+    public void testCore3010FinalHttp() throws Exception {
+        testWF("3.0.10.Final", 9990);
+    }
+
+    @Test
     public void testCurrent() throws Exception {
         test(ModelControllerClient.Factory.create(CONTROLLER_ADDRESS, 9999));
     }
@@ -295,7 +305,6 @@ public class ClientCompatibilityUnitTestCase {
 
         final ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder(false);
         classLoaderBuilder.addRecursiveMavenResourceURL(artifact + ":" + version, excludes);
-        classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.ModelControllerClientConfiguration");
         classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.ModelControllerClient");
         classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.OperationMessageHandler");
         classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.Operation");


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9859

Updates the standard test proving that legacy clients can perform basic management ops against the current server.

It's not critical to me that this gets merged, as we are considering dropping this test class as redundant (see WFLY-9264). It was just 10 mins work to add it as I did https://issues.jboss.org/browse/WFCORE-3391 so I figured why not do it and confirm it passes. :)