### PR TITLE
WFLY-9866 (EE 8) JSF 2.3 api needs a dependency on websocket

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
@@ -32,6 +32,7 @@
         <module name="javax.validation.api" export="true"/>
         <module name="org.glassfish.javax.el" export="true"/>
         <module name="javax.api"/>
+        <module name="javax.websocket.api"/>
     </dependencies>
 
     <resources>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9866
This addresses a test issue, the JSF 2.3 api in WildFly is currently missing a dependency on websocket that is needed for javax.faces.event.WebsocketEvent.