### PR TITLE
[WFLY-9885] elytron security configuration is ignored in RA connectio…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
@@ -261,7 +261,7 @@ public class RaOperationUtil {
 
         boolean application = ModelNodeUtil.getBooleanIfSetOrGetDefault(context, connDefModel, APPLICATION);
         Security security = null;
-        if (securityDomain != null || securityDomainAndApplication != null || application) {
+        if (securityDomain != null || authenticationContext != null || securityDomainAndApplication != null || authenticationContextAndApplication != null || application) {
             security = new SecurityImpl(elytronEnabled? authenticationContext: securityDomain,
                     elytronEnabled? authenticationContextAndApplication: securityDomainAndApplication, application,
                     elytronEnabled);
@@ -282,10 +282,10 @@ public class RaOperationUtil {
 
 
         Recovery recovery = null;
-        if ((recoveryUsername != null && (recoveryPassword != null || recoveryCredentialSourceSupplier != null)) || recoverySecurityDomain != null || noRecovery != null) {
+        if ((recoveryUsername != null && (recoveryPassword != null || recoveryCredentialSourceSupplier != null)) || recoverySecurityDomain != null || recoveryAuthenticationContext != null || noRecovery != null) {
             Credential credential = null;
 
-            if ((recoveryUsername != null && (recoveryPassword != null || recoveryCredentialSourceSupplier != null)) || recoverySecurityDomain != null)
+            if ((recoveryUsername != null && (recoveryPassword != null || recoveryCredentialSourceSupplier != null)) || recoverySecurityDomain != null || recoveryAuthenticationContext != null)
                 credential = new CredentialImpl(recoveryUsername, recoveryPassword,
                         recoveryElytronEnabled ? recoveryAuthenticationContext : recoverySecurityDomain, recoveryElytronEnabled, recoveryCredentialSourceSupplier);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnectionFactoryWithSubjectVerification.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/rar/MultipleManagedConnectionFactoryWithSubjectVerification.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.rar;
+
+import java.security.Principal;
+import java.util.Set;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.security.PasswordCredential;
+import javax.security.auth.Subject;
+
+import org.jboss.logging.Logger;
+import org.wildfly.security.auth.principal.NamePrincipal;
+
+public class MultipleManagedConnectionFactoryWithSubjectVerification extends MultipleManagedConnectionFactory1 {
+
+    private static Logger log = Logger.getLogger(MultipleManagedConnectionFactoryWithSubjectVerification.class.getName());
+
+    @Override
+    public ManagedConnection createManagedConnection(Subject subject, ConnectionRequestInfo cxRequestInfo) throws ResourceException {
+        log.trace("createManagedConnection()");
+
+        Set<Principal> principals = subject.getPrincipals();
+        if (!principals.contains(new NamePrincipal("sa"))) {
+            throw new ResourceException("Subject should contain principal with username 'sa'");
+        }
+
+        Set<Object> privateCredentials = subject.getPrivateCredentials();
+        if (!privateCredentials.contains(new PasswordCredential("sa", "sa".toCharArray()))) {
+            throw new ResourceException("Subject should contain private credential with password 'sa'");
+        }
+
+        return new MultipleManagedConnection1(this);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
@@ -109,7 +109,7 @@ public class WildFlyActivationRaWithElytronAuthContextTestCase {
         private void addConnectionDefinition(ModelControllerClient client) throws IOException {
             PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", "Pool1");
             ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
-            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification");
             addConnectionDefinitionOperation.get("jndi-name").set(CONN_DEF_JNDI_NAME);
             addConnectionDefinitionOperation.get("elytron-enabled").set("true");
             addConnectionDefinitionOperation.get("authentication-context").set(AUTH_CONTEXT);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java
@@ -150,7 +150,7 @@ public class WildFlyActivationRaWithMixedSecurityTestCase {
         private void addConnectionDefinition(String name, String jndiName, Consumer<ModelNode> attrProvider, ModelControllerClient client) throws IOException {
             PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", name);
             ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
-            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification");
             addConnectionDefinitionOperation.get("jndi-name").set(jndiName);
 
             attrProvider.accept(addConnectionDefinitionOperation);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
@@ -111,7 +111,7 @@ public class WildFlyActivationRaWithSecurityDomainTestCase {
         private void addConnectionDefinition(ModelControllerClient client) throws IOException {
             PathAddress connectionDefinitionAddress = RA_ADDRESS.append("connection-definitions", "Pool1");
             ModelNode addConnectionDefinitionOperation = Operations.createAddOperation(connectionDefinitionAddress.toModelNode());
-            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1");
+            addConnectionDefinitionOperation.get("class-name").set("org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification");
             addConnectionDefinitionOperation.get("jndi-name").set(CONN_DEF_JNDI_NAME);
             addConnectionDefinitionOperation.get("security-domain").set("RaRealm");
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ironjacamar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ironjacamar.xml
@@ -2,7 +2,7 @@
 <ironjacamar>
     <connection-definitions>
         <connection-definition
-                class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1"
+                class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification"
                 jndi-name="java:jboss/name1" pool-name="ij_Pool1">
             <security>
                 <security-domain>RaRealm</security-domain>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ra.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/ra.xml
@@ -13,7 +13,7 @@
         <resourceadapter-class>org.jboss.as.test.integration.jca.rar.MultipleResourceAdapter</resourceadapter-class>
         <outbound-resourceadapter>
             <connection-definition>
-                <managedconnectionfactory-class>org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1</managedconnectionfactory-class>
+                <managedconnectionfactory-class>org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactoryWithSubjectVerification</managedconnectionfactory-class>
                 <connectionfactory-interface>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1</connectionfactory-interface>
                 <connectionfactory-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1Impl</connectionfactory-impl-class>
                 <connection-interface>org.jboss.as.test.integration.jca.rar.MultipleConnection1</connection-interface>


### PR DESCRIPTION
…n definition

added missing elytron configuration options to condition that determines if security is defined for connection definition + updated tests

https://issues.jboss.org/browse/WFLY-9885

@maeste  @fl4via please review