### PR TITLE
Fix WFLY-9884

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldResourceInjectionServices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldResourceInjectionServices.java
@@ -25,6 +25,10 @@ import static org.jboss.as.weld.util.ResourceInjectionUtilities.getResourceAnnot
 
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
 
 import javax.annotation.Resource;
@@ -81,7 +85,7 @@ public class WeldResourceInjectionServices extends AbstractResourceInjectionServ
 
     private final boolean warModule;
 
-    private final Iterable<ResourceInjectionResolver> resourceResolvers;
+    private final List<ResourceInjectionResolver> resourceResolvers;
 
     public WeldResourceInjectionServices(final ServiceRegistry serviceRegistry, final EEModuleDescription moduleDescription, Module module, boolean warModule) {
         super(serviceRegistry, moduleDescription, module);
@@ -91,8 +95,18 @@ public class WeldResourceInjectionServices extends AbstractResourceInjectionServ
         } catch (NamingException e) {
             throw new RuntimeException(e);
         }
-        this.resourceResolvers = ServiceLoader.load(ResourceInjectionResolver.class,
-                WildFlySecurityManager.getClassLoaderPrivileged(WeldResourceInjectionServices.class));
+
+        final Iterator<ResourceInjectionResolver> resolvers = ServiceLoader.load(ResourceInjectionResolver.class,
+                WildFlySecurityManager.getClassLoaderPrivileged(WeldResourceInjectionServices.class)).iterator();
+        if (!resolvers.hasNext()) {
+            this.resourceResolvers = Collections.emptyList();
+        } else {
+            this.resourceResolvers = new ArrayList<>();
+            while (resolvers.hasNext()) {
+                this.resourceResolvers.add(resolvers.next());
+            }
+        }
+
     }
 
     protected String getEJBResourceName(InjectionPoint injectionPoint, String proposedName) {


### PR DESCRIPTION
The commit here has a potential fix for the issue reported in https://issues.jboss.org/browse/WFLY-9884. The change makes sure the access to the `ServiceLoader` is synchronized since instances of this class aren't expected to be thread-safe (as noted in the javadoc of that class).

Given the nature of the issue, I don't have a way to add a test case which can consistently reproduce this, but based on what the user is noting in that JIRA, what I suspect is happening is that multiple `component start` threads, for the same deployment, are running and triggering field injections through this per-deployment `WeldResourceInjectionServices` instance.  The user notes that they have multiple `@Singleton` `@Startup` beans which makes this theory, of race condition, a valid possibility. However, I don't have much knowledge of this Weld integration code and there might be more that might need to be handled. So this change will need an approval from @mkouba 

P.S: I did consider an alternate way to handle this by instantiating the `ServiceLoader` as a method variable instead of a instance member of that class. But I think that just might lead to unnecessary performance impact with the `ServiceLoader` looking up the services every time this method gets called. So I decided to instead add a `synchronized` block.

