### PR TITLE
[WFLY-9845] Add always a post construct transaction interceptor to Singleton Component

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -151,9 +151,7 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
                     final EEApplicationClasses applicationClasses = context.getDeploymentUnit().getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
                     InterceptorClassDescription interceptorConfig = ComponentDescription.mergeInterceptorConfig(configuration.getComponentClass(), applicationClasses.getClassByName(description.getComponentClassName()), description, MetadataCompleteMarker.isMetadataComplete(context.getDeploymentUnit()));
 
-                    if(interceptorConfig.getPostConstruct() != null) {
-                        configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), true), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
-                    }
+                    configuration.addPostConstructInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPostConstruct(), true), InterceptorOrder.ComponentPostConstruct.TRANSACTION_INTERCEPTOR);
                     configuration.addPreDestroyInterceptor(new LifecycleCMTTxInterceptor.Factory(interceptorConfig.getPreDestroy() ,true), InterceptorOrder.ComponentPreDestroy.TRANSACTION_INTERCEPTOR);
 
                     configuration.addTimeoutViewInterceptor(TimerCMTTxInterceptor.FACTORY, InterceptorOrder.View.CMT_TRANSACTION_INTERCEPTOR);


### PR DESCRIPTION
Given an abstract base class B with an @PostConstruct annotated method and a derived class D with the annotations @Singleton and @Startup. When the @PostConstruct method is called, no transaction is started. 

This change allows the execution of a transaction interceptor for post construct methods inherited from a superclass

Jira issue: https://issues.jboss.org/browse/WFLY-9845
