### PR TITLE
[WFLY-9897] getBytes(); calls should be replaced with getBytes(Standa…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenBuilder.java
@@ -25,6 +25,7 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import static org.jboss.as.clustering.jgroups.subsystem.CipherAuthTokenResourceDefinition.Attribute.*;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyStore;
@@ -102,7 +103,7 @@ public class CipherAuthTokenBuilder extends AuthTokenBuilder<CipherAuthToken> {
             KeyStore.PrivateKeyEntry entry = (KeyStore.PrivateKeyEntry) store.getEntry(alias, new KeyStore.PasswordProtection(password.getPassword()));
             KeyPair pair = new KeyPair(entry.getCertificate().getPublicKey(), entry.getPrivateKey());
             Cipher cipher = Cipher.getInstance(this.transformation);
-            return new CipherAuthToken(cipher, pair, authValue.getBytes());
+            return new CipherAuthToken(cipher, pair, authValue.getBytes(StandardCharsets.UTF_8));
         } catch (GeneralSecurityException | IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenBuilder.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.clustering.jgroups.subsystem.DigestAuthTokenResourceDefinition.Attribute.*;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -57,7 +58,7 @@ public class DigestAuthTokenBuilder extends AuthTokenBuilder<BinaryAuthToken> {
     public BinaryAuthToken apply(String sharedSecret) {
         try {
             MessageDigest digest = MessageDigest.getInstance(this.algorithm);
-            return new BinaryAuthToken(digest.digest(sharedSecret.getBytes()));
+            return new BinaryAuthToken(digest.digest(sharedSecret.getBytes(StandardCharsets.UTF_8)));
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalArgumentException(e);
         }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenBuilder.java
@@ -25,6 +25,8 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import org.jboss.as.clustering.jgroups.auth.BinaryAuthToken;
 import org.jboss.as.controller.PathAddress;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * @author Paul Ferraro
  */
@@ -36,6 +38,6 @@ public class PlainAuthTokenBuilder extends AuthTokenBuilder<BinaryAuthToken> {
 
     @Override
     public BinaryAuthToken apply(String sharedSecret) {
-        return new BinaryAuthToken(sharedSecret.getBytes());
+        return new BinaryAuthToken(sharedSecret.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
…rdCharsets.UTF_8);

JIRA: https://issues.jboss.org/browse/WFLY-9897

There are several calls of method getBytes(); in clustering subsystem. getBytes() depends on platform's default charset . This will cause the application behaviour to vary between platforms.