### PR TITLE
[WFLY-9910] CustomUndertowFilterTestCase fails to reload server if node0!=localhost

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomUndertowFilterTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/undertow/CustomUndertowFilterTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.ModelUtil;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
@@ -123,7 +122,7 @@ public class CustomUndertowFilterTestCase {
                 ModelUtil.createCompositeNode(new ModelNode[]{addCustomFilter, addFilterRef}));
 
         // reload the server for changes to take effect
-        ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+        serverController.reload();
     }
 
     private static void resetServerConfiguration() throws Exception {
@@ -141,7 +140,7 @@ public class CustomUndertowFilterTestCase {
         // remove the custom module
         customHandlerModule.remove();
         // reload the server
-        ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+        serverController.reload();
     }
 
     private static void deploy() throws Exception {


### PR DESCRIPTION
`org.jboss.as.test.manualmode.undertow.CustomUndertowFilterTestCase` stuck on server reload if node0!=localhost. Use `org.wildfly.core.testrunner.ServerController.reload()` instead of `org.jboss.as.test.integration.management.util.ServerReload` to reload the server managed by WildflyTestRunner.

https://issues.jboss.org/browse/WFLY-9910