### PR TITLE
[WFLY-9706] Correct negative values to -1 for messaging attributes

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -77,6 +77,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts()))
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -91,6 +92,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -132,6 +134,7 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts()))
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -134,6 +134,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -174,6 +175,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -190,6 +192,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -99,6 +99,7 @@ public interface CommonAttributes {
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InfiniteOrPositiveValidators.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InfiniteOrPositiveValidators.java
@@ -23,13 +23,22 @@
 package org.wildfly.extension.messaging.activemq;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
-import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
- * Validates a given parameter is a legal value (-1 or > 0) where -1 means "forever"
+ * Validates a given parameter is a legal value (-1 or > 0) where -1 means "forever".
+ *
+ * The validation is done in 2 steps:
+ * 1. a ParameterCorrector will correct any negative value to -1
+ * 2. a ParameterValidator will check that negative values and > 0 are valid.
+ *
+ * Note that the ParameterValidator will validate any negative value until WFCORE-3651 is fixed to preserve
+ * backwards compatibility (as the parameter correction is not apply before the validator is called during
+ * XML parsing).
  *
  * @author Jeff Mesnil (c) 2012 Red Hat Inc.
  */
@@ -40,7 +49,7 @@ public interface InfiniteOrPositiveValidators {
         public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
             super.validateParameter(parameterName, value);
             long val = value.asLong();
-            if (!(val == -1 || (val > 0 && val < Long.MAX_VALUE))) {
+            if (!(val <= -1 || (val > 0 && val < Long.MAX_VALUE))) {
                 throw new OperationFailedException(MessagingLogger.ROOT_LOGGER.illegalValue(value, parameterName));
             }
         }
@@ -51,10 +60,28 @@ public interface InfiniteOrPositiveValidators {
         public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
             super.validateParameter(parameterName, value);
             int val = value.asInt();
-            if (!(val == -1 || (val > 0 && val < Integer.MAX_VALUE))) {
+            if (!(val <= -1 || (val > 0 && val < Integer.MAX_VALUE))) {
                 throw new OperationFailedException(MessagingLogger.ROOT_LOGGER.illegalValue(value, parameterName));
             }
         }
     };
 
+    /**
+     * Correct any negative value to use -1 (interpreted by Artemis as infinite).
+     */
+    ParameterCorrector NEGATIVE_VALUE_CORRECTOR = new ParameterCorrector() {
+        @Override
+        public ModelNode correct(ModelNode newValue, ModelNode currentValue) {
+            if (newValue.isDefined() && newValue.getType() != ModelType.EXPRESSION) {
+                try {
+                    if (newValue.asLong() < -1) {
+                        return new ModelNode(-1);
+                    }
+                } catch (Exception e) {
+                    // not convertible; let the validator that the caller will invoke later deal with this
+                }
+            }
+            return newValue;
+        }
+    };
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -109,6 +109,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -138,6 +139,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -305,6 +307,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalPoolFiles()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -411,6 +414,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalPerfBlastPages()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
@@ -63,6 +63,7 @@ public class HAAttributes {
             .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetries()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -104,6 +104,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
                 .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
@@ -134,6 +135,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
                 .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
@@ -219,6 +221,7 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
                 .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
@@ -256,6 +259,7 @@ public interface ConnectionFactoryAttributes {
                 .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
                 .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 
@@ -263,6 +267,7 @@ public interface ConnectionFactoryAttributes {
                 .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
                 .setRequired(false)
                 .setAllowExpression(true)
+                .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
                 .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
                 .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -170,6 +170,7 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .build();
     public static final SimpleAttributeDefinition MAX_RETRIES = create("max-retries", INT)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setAllowExpression(true)
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
@@ -123,6 +123,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -148,6 +149,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -246,6 +248,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -285,6 +288,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
@@ -293,6 +297,7 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
             .setRequired(false)
             .setAllowExpression(true)
+            .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();


### PR DESCRIPTION
Apply a ParameterCorrector to all messaging-activemq attributes that
interpret negative values as infinite so they consistently use -1.

JIRA: https://issues.jboss.org/browse/WFLY-9706