### PR TITLE
[WFLY-9168] test case

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/SecurityDomainAnnotationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/SecurityDomainAnnotationTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.annotation;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * Tests if ERROR message is logged when org.jboss.security.annotation.SecurityDomain is used for specifying the JBoss security domain for EJBs
+ * Test for [ WFLY-9168 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+public class SecurityDomainAnnotationTestCase {
+
+    private static final String SECURITY_DOMAIN_DEPLOYMENT = "security-domain-deployment";
+
+    @ArquillianResource
+    Deployer deployer;
+
+    @Deployment(name = SECURITY_DOMAIN_DEPLOYMENT, managed = false, testable = false)
+    public static Archive<?> deploy() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, SECURITY_DOMAIN_DEPLOYMENT + ".jar");
+        ejbJar.addClasses(SecurityDomainAnnotationTestCase.class, StatelessBean.class, StatelessInterface.class);
+        ejbJar.addAsManifestResource(SecurityDomainAnnotationTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        return ejbJar;
+    }
+
+    @Test
+    public void testSecurityDomainAnnotation() {
+        PrintStream oldOut = System.out;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(baos));
+            deployer.deploy(SECURITY_DOMAIN_DEPLOYMENT);
+            try {
+                System.setOut(oldOut);
+                String output = new String(baos.toByteArray());
+                Assert.assertTrue(output, output.contains("ERROR"));
+                Assert.assertTrue(output, output.contains("Legacy org.jboss.security.annotation.SecurityDomain annotation is used in class"));
+            } finally {
+                deployer.undeploy(SECURITY_DOMAIN_DEPLOYMENT);
+            }
+        } finally {
+            System.setOut(oldOut);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/StatelessBean.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.annotation;
+
+import org.jboss.security.annotation.SecurityDomain;
+
+import javax.ejb.Stateless;
+
+/**
+ * Interface for stateless EJB with annotation org.jboss.security.annotation.SecurityDomain
+ *
+ * @author Daniel Cihak
+ */
+@Stateless
+@SecurityDomain("sp")
+public class StatelessBean {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/StatelessInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/StatelessInterface.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.security.annotation;
+
+import javax.ejb.Local;
+
+@Local
+public interface StatelessInterface {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/annotation/ejb-jar.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN" "http://java.sun.com/dtd/ejb-jar_2_0.dtd">
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>StatelessBean</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.security.annotation.StatelessBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
Tests if ERROR message is logged when org.jboss.security.annotation.SecurityDomain is used for specifying the JBoss security domain for EJBs