### PR TITLE
[WFCORE-3656] Add the version for the org.jboss.logmanager:commons-lo…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,8 @@
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.4.7.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
+        <!-- Only used for testing -->
+        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.narayana>5.5.31.Final</version.org.jboss.narayana>
         <version.org.jboss.metadata>11.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.8.Final</version.org.jboss.mod_cluster>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -171,6 +171,7 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <version>${version.org.jboss.logmanager.commons-logging-jboss-logmanager}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.logmanager</groupId>


### PR DESCRIPTION
This is required for https://github.com/wildfly/wildfly-core/pull/3146. The commons-logging implementation is changing in WildFly Core and only used for tests in WildFly.

https://issues.jboss.org/browse/WFCORE-3656