### PR TITLE
[WFLY-9926] Follows up on the change of the JBoss Metadata hard-coded…

### DIFF
--- a/testsuite/integration/smoke/server-provisioning.xml
+++ b/testsuite/integration/smoke/server-provisioning.xml
@@ -19,7 +19,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<server-provisioning xmlns="urn:wildfly:server-provisioning:1.2" copy-module-artifacts="false" extract-schemas="true">
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.2" copy-module-artifacts="false" extract-schemas="true" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core org.wildfly.security org.jboss.metadata">
     <feature-packs>
         <feature-pack groupId="org.wildfly" artifactId="wildfly-feature-pack" version="${project.version}"/>
     </feature-packs>


### PR DESCRIPTION
… schema version to ensure issues like this are caught sooner by copying the schemas.

https://issues.jboss.org/browse/WFLY-9926

Please note until #10951 is merged this PR will fail the `StandardConfigsXMLValidationUnitTestCase` test. This is a follow up to #10951 which simply fixes the test itself. This PR should allow for earlier detection of such errors. However given we're so close to a release it's been decided this should be a follow up PR as in some cases the GAV for the `server-provisioning.xml` may change and we want to have as few conflicts as possible for other branches/forkes.