### PR TITLE
WFLY-9920/WFLY-9890 Fix timeouts following topology change

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -30,11 +30,13 @@
         ucast_recv_buf_size="20m"
         ucast_send_buf_size="1m"
         port_range="0"
+        bundler_type="no-bundler"
     />
     <TCP
         send_buf_size="640k"
         sock_conn_timeout="300"
         port_range="0"
+        bundler_type="no-bundler"
     />
     <TCP_NIO2
         send_buf_size="640k"
@@ -58,7 +60,9 @@
         timeout_check_interval="5000"/>
     <FD_SOCK port_range="0"/>
     <VERIFY_SUSPECT timeout="5000"/>
-    <pbcast.NAKACK2 xmit_table_num_rows="50"/>
+    <pbcast.NAKACK2
+        xmit_table_num_rows="50"
+    />
     <UNICAST3
         conn_expiry_timeout="0"
         xmit_table_num_rows="50"
@@ -71,5 +75,4 @@
     <pbcast.GMS print_local_addr="false"/>
     <UFC max_credits="2m"/>
     <MFC max_credits="2m"/>
-    <FRAG2 frag_size="30k"/>
 </config>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9920
https://issues.jboss.org/browse/WFLY-9890

Disable message bundler by default.