### PR TITLE
[WFLY-9942] Remove hornetq-journal and hornetq-native dependencies

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2195,6 +2195,12 @@
         <dependency>
             <groupId>org.hornetq</groupId>
             <artifactId>hornetq-core-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -2206,22 +2212,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-journal</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-native</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -1769,28 +1769,6 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-journal</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.hornetq</groupId>
-      <artifactId>hornetq-native</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-cachestore-jdbc</artifactId>
       <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4303,18 +4303,6 @@
             </dependency>
 
             <dependency>
-               <groupId>org.hornetq</groupId>
-               <artifactId>hornetq-journal</artifactId>
-               <version>${version.org.hornetq}</version>
-               <exclusions>
-                   <exclusion>
-                       <groupId>org.jboss.logmanager</groupId>
-                       <artifactId>jboss-logmanager</artifactId>
-                   </exclusion>
-               </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-core-client</artifactId>
                 <version>${version.org.hornetq}</version>
@@ -4323,12 +4311,6 @@
             <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-jms-client</artifactId>
-                <version>${version.org.hornetq}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hornetq</groupId>
-                <artifactId>hornetq-native</artifactId>
                 <version>${version.org.hornetq}</version>
             </dependency>
 


### PR DESCRIPTION
hornetq-core-client has a compile dependency to hornetq-journal to
access String constants in JournalConstants.
hornetq-native dependency is a dependency from hornet-journal.

Since the constants from JournalConstants are inlined at compile time in
hornetq-core-client, we can remove these dependencies as the
hornetq-journal jar is not required to run code using the
hornetq-core-client.

JIRA: https://issues.jboss.org/browse/WFLY-9942