### PR TITLE
[WFLY-9946] Add the JSON-B implementation to deployments explicitly and remove the dependency from the API.

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -57,6 +57,8 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             ModuleIdentifier.create("javax.rmi.api"),
             ModuleIdentifier.create("javax.xml.bind.api"),
             ModuleIdentifier.create("javax.api"),
+            // javax.json.bind.api (JSON-B) implementation
+            ModuleIdentifier.create("org.eclipse.yasson"),
             ModuleIdentifier.create("org.glassfish.javax.el"),
             ModuleIdentifier.create("org.glassfish.javax.enterprise.concurrent")
     };

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -30,6 +30,5 @@
     </resources>
     <dependencies>
         <module name="javax.json.api"/>
-        <module name="org.eclipse.yasson" services="import"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9946