### PR TITLE
[WFLY-9960] Remove SLF4J dependency from the Hibernate Validator module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -48,7 +48,6 @@
     <module name="org.jboss.weld.spi"/>
     <module name="org.joda.time"/>
     <module name="org.jsoup"/>
-    <module name="org.slf4j"/>
     <module name="org.apache.xerces" services="import"/>
     <module name="sun.jdk" services="import"/>
   </dependencies>


### PR DESCRIPTION
 * https://issues.jboss.org/browse/WFLY-9960

The SLF4J dependency is not used anymore by Hibernate Validator (and it's been a while). Let's remove it.