### PR TITLE
WFLY-9938  WFLY-9983 Fix testsuite for JDK 10 and build for JDK 11

### DIFF
--- a/clustering/web/spi/pom.xml
+++ b/clustering/web/spi/pom.xml
@@ -68,6 +68,10 @@
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
+        </dependency>   
+        <dependency>
+            <groupId>org.jboss.spec.javax.xml.bind</groupId>
+            <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
         </dependency>
     </dependencies>
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1033,17 +1033,6 @@
 
         <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
-            <artifactId>ironjacamar-spec-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.ironjacamar</groupId>
             <artifactId>ironjacamar-validator</artifactId>
         </dependency>
 

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -2819,17 +2819,6 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.ironjacamar</groupId>
-      <artifactId>ironjacamar-spec-api</artifactId>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License v2.1 only</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.ironjacamar</groupId>
       <artifactId>ironjacamar-validator</artifactId>
       <licenses>
         <license>

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -78,6 +78,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -28,7 +28,6 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.security.Permission;
 
-import javax.annotation.Resource;
 import javax.naming.Context;
 import javax.naming.InvalidNameException;
 import javax.naming.Name;
@@ -551,7 +550,7 @@ public interface NamingLogger extends BasicLogger {
 //    String failedToTransformExternalContext(String modelVersion);
 
     /**
-     * Creates an exception indicating a lookup failed, wrt {@link Resource} injection.
+     * Creates an exception indicating a lookup failed, wrt {@link javax.annotation.Resource} injection.
      *
      * @param jndiName the JNDI name.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>25</version>
+      <version>26</version>
     </parent>
 
     <groupId>org.wildfly</groupId>
@@ -73,8 +73,6 @@
             For example: <version.surefire.plugin>2.11</version.surefire.plugin>
           -->
         <maven.min.version>3.3.1</maven.min.version>
-        <!-- 2.20.x is broken on JDK10 -->
-        <version.surefire.plugin>2.19.1</version.surefire.plugin>
         <!-- use older version of checkstyle as otherwise lots of checks fail -->
         <version.checkstyle>6.8</version.checkstyle>
         <!--
@@ -4642,20 +4640,6 @@
 
             <dependency>
                 <groupId>org.jboss.ironjacamar</groupId>
-                <artifactId>ironjacamar-spec-api</artifactId>
-                <version>${version.org.jboss.ironjacamar}</version>
-                <exclusions>
-                    <!-- TODO remove this exclusion once this supports JTA 1.2 -->
-                    <!-- superseded by org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec -->
-                    <exclusion>
-                        <groupId>org.jboss.spec.javax.transaction</groupId>
-                        <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.ironjacamar</groupId>
                 <artifactId>ironjacamar-jdbc</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
@@ -4672,6 +4656,12 @@
                 <groupId>org.jboss.ironjacamar</groupId>
                 <artifactId>ironjacamar-validator</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.ironjacamar</groupId>
+                        <artifactId>ironjacamar-spec-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -6597,16 +6587,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>jdk9-surefire</id>
-            <activation>
-                <jdk>9</jdk>
-            </activation>
-            <properties>
-                <!-- 2.20.1 works fine on JDK9 but breaks on JDK10, so we set it only for 9-->
-                <version.surefire.plugin>2.20.1</version.surefire.plugin>
-            </properties>
         </profile>
         <profile>
             <id>docs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6567,7 +6567,6 @@
                     --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
                     --illegal-access=permit
-                    --add-modules=java.xml.bind,java.sql
                 </modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>

--- a/pom.xml
+++ b/pom.xml
@@ -6573,19 +6573,7 @@
                 <!-- There are lots of issues with checkstyle runtime on JDK9, it somewhat works but really slows down build, disabling it for now-->
                 <checkstyle.skip>true</checkstyle.skip>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.compiler.plugin}</version>
-                        <configuration>
-                            <!-- jdk.unsupported is needed for security subsystem FastConcurrentDirectDeque-->
-                            <compilerArgument>-J--add-modules=java.xml.ws.annotation,jdk.unsupported</compilerArgument>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            
         </profile>
         <profile>
             <id>docs</id>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -158,6 +158,10 @@
       <groupId>org.jboss.spec.javax.management.j2ee</groupId>
       <artifactId>jboss-j2eemgmt-api_1.1_spec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.jws</groupId>
+      <artifactId>jsr181-api</artifactId>
+    </dependency>
   </dependencies>
 
   <!-- Modules -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -44,9 +44,8 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.LdapContext;
 
-import com.sun.jndi.ldap.LdapCtx;
-import com.sun.jndi.ldap.LdapCtxFactory;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
@@ -136,7 +135,7 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(CLASS).set(InitialDirContext.class.getName());
             bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
                     ExternalContextBindingTestCase.LDAP_PORT);
-            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
             bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
             bindingAdd.get(ENVIRONMENT)
                     .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
@@ -155,7 +154,7 @@ public class ExternalContextBindingTestCase {
             bindingAdd.get(CACHE).set(true);
             bindingAdd.get(ENVIRONMENT).add("java.naming.provider.url", "ldap://"+managementClient.getMgmtAddress()+":"+
                     ExternalContextBindingTestCase.LDAP_PORT);
-            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", LdapCtxFactory.class.getName());
+            bindingAdd.get(ENVIRONMENT).add("java.naming.factory.initial", "com.sun.jndi.ldap.LdapCtxFactory");
             bindingAdd.get(ENVIRONMENT).add(Context.SECURITY_AUTHENTICATION, "simple");
             bindingAdd.get(ENVIRONMENT)
                     .add(Context.SECURITY_PRINCIPAL, "uid=jduke,ou=People,dc=jboss,dc=org");
@@ -373,8 +372,8 @@ public class ExternalContextBindingTestCase {
                 Assert.assertNotSame(ldapContext1, ldapContext2);
             }
             LOGGER.debug("acquired external LDAP context: " + ldapContext1.toString());
-            LdapCtx c = (LdapCtx)ldapContext1.lookup("dc=jboss,dc=org");
-            c = (LdapCtx)c.lookup("ou=People");
+            LdapContext c = (LdapContext)ldapContext1.lookup("dc=jboss,dc=org");
+            c = (LdapContext)c.lookup("ou=People");
             Attributes attributes = c.getAttributes("uid=jduke");
             Assert.assertTrue(attributes.get("description").contains("awesome"));
             // resource injection
@@ -382,7 +381,7 @@ public class ExternalContextBindingTestCase {
             Assert.assertNotNull(ejb);
             c = ejb.getLdapCtx();
             Assert.assertNotNull(c);
-            c = (LdapCtx)c.lookup("ou=People");
+            c = (LdapContext)c.lookup("ou=People");
             attributes = c.getAttributes("uid=jduke");
             Assert.assertTrue(attributes.get("description").contains("awesome"));
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/LookupEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/LookupEjb.java
@@ -2,8 +2,7 @@ package org.jboss.as.test.integration.naming;
 
 import javax.annotation.Resource;
 import javax.ejb.Stateless;
-
-import com.sun.jndi.ldap.LdapCtx;
+import javax.naming.ldap.LdapContext;
 
 /**
  * @author Stuart Douglas
@@ -12,9 +11,9 @@ import com.sun.jndi.ldap.LdapCtx;
 public class LookupEjb {
 
     @Resource(lookup = "java:global/ldap/dc=jboss,dc=org")
-    private LdapCtx ldapCtx;
+    private LdapContext ldapCtx;
 
-    public LdapCtx getLdapCtx() {
+    public LdapContext getLdapCtx() {
         return ldapCtx;
     }
 }

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -375,7 +375,7 @@
         <profile>
             <id>jdk9</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <properties>
                 <!-- JDK9 does not support endorsing mechanism -->

--- a/testsuite/integration/web/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/web/src/test/config/arq/arquillian.xml
@@ -16,8 +16,6 @@
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
-            <!-- AS7-4070 -->
-            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
         </configuration>
     </container>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/resources/restricted/errors.jsp
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/resources/restricted/errors.jsp
@@ -39,7 +39,7 @@
    else
    {
       response.setHeader("X-NoJException", "true");
-      Thread.dumpStack();
+      //Thread.dumpStack();
    }
 %>
 </ul>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextEarUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextEarUnitTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.web.rootcontext;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -66,7 +65,7 @@ public class RootContextEarUnitTestCase {
 
     private static String HOST = "context-host";
 
-    @Deployment(name = "root-web.ear", testable = false)
+    @Deployment(name = "root-web.ear")
     public static EnterpriseArchive earDeployment() {
 
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
@@ -86,7 +85,6 @@ public class RootContextEarUnitTestCase {
     }
 
     @Test
-    @OperateOnDeployment("root-web.ear")
     public void testRootContextEAR(@ArquillianResource URL url) throws Exception {
         String response = RootContextUtil.hitRootContext(url, HOST);
         assertTrue(response.contains("A Root Context Page"));

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextUtil.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextUtil.java
@@ -22,8 +22,10 @@
 package org.jboss.as.test.integration.web.rootcontext;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
@@ -65,6 +67,7 @@ import org.jboss.logging.Logger;
         op.get(OP_ADDR).add(SUBSYSTEM, WEB_SUBSYSTEM_NAME);
         op.get(OP_ADDR).add(SERVER, "default-server");
         op.get(OP_ADDR).add(HOST, virtualHost);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         op.get("default-web-module").set("somewar.war");
 
         updates.add(op);
@@ -80,6 +83,7 @@ import org.jboss.logging.Logger;
         op.get(OP_ADDR).add(SUBSYSTEM, WEB_SUBSYSTEM_NAME);
         op.get(OP_ADDR).add(SERVER, "default-server");
         op.get(OP_ADDR).add(HOST, virtualHost);
+        op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         updates.add(op);
 
         applyUpdates(updates, client);
@@ -96,7 +100,7 @@ import org.jboss.logging.Logger;
         applyUpdates(updates, client);
     }
 
-    public static void applyUpdates(final List<ModelNode> updates, final ModelControllerClient client) throws Exception {
+    private static void applyUpdates(final List<ModelNode> updates, final ModelControllerClient client) throws Exception {
         for (ModelNode update : updates) {
             log.trace("+++ Update on " + client + ":\n" + update.toString());
             ModelNode result = client.execute(new OperationBuilder(update).build());

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextWarUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/rootcontext/RootContextWarUnitTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.test.integration.web.rootcontext;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -64,7 +63,7 @@ public class RootContextWarUnitTestCase {
         }
     }
 
-    @Deployment(name = "root-context.war", testable = false)
+    @Deployment(name = "root-context.war")
     public static WebArchive warDeployment() {
 
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
@@ -80,7 +79,6 @@ public class RootContextWarUnitTestCase {
     }
 
     @Test
-    @OperateOnDeployment("root-context.war")
     public void testRootContextWAR(@ArquillianResource URL url) throws Exception {
         String response = RootContextUtil.hitRootContext(url, HOST);
         assertTrue(response.contains("A Root Context Page"));

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1026,6 +1026,27 @@
             </properties>
         </profile>
         <profile>
+            <id>jdk-target</id>
+            <activation>
+                <jdk>[9,)</jdk>
+                <property>
+                    <name>jdk-release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${version.compiler.plugin}</version>
+                        <configuration>
+                            <release>${jdk-release}</release>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>ci-cleanup</id>
             <activation>
                 <property>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -66,13 +66,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-testsuite-shared</artifactId>
-            <exclusions>
-                <exclusion>
-                    <!-- workaround until we get new core release -->
-                    <groupId>org.syslog4j</groupId>
-                    <artifactId>syslog4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -106,7 +106,6 @@
         <scope>provided</scope>
         <optional>true</optional>
     </dependency>
-
     <dependency>
        <groupId>org.jboss.logging</groupId>
        <artifactId>jboss-logging-processor</artifactId>
@@ -139,7 +138,6 @@
     <dependency>
         <groupId>org.jboss.spec.javax.xml.ws</groupId>
         <artifactId>jboss-jaxws-api_2.2_spec</artifactId>
-        <scope>test</scope>
     </dependency>
     </dependencies>
 </project>

--- a/weld/webservices/pom.xml
+++ b/weld/webservices/pom.xml
@@ -33,6 +33,10 @@
          <artifactId>jboss-logging-annotations</artifactId>
          <scope>provided</scope>
       </dependency>
+      <dependency>
+         <groupId>org.jboss.spec.javax.xml.ws</groupId>
+         <artifactId>jboss-jaxws-api_2.2_spec</artifactId>
+      </dependency>
 
       <dependency>
          <groupId>${project.groupId}</groupId>

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -127,7 +127,6 @@
         <dependency>
             <groupId>javax.jws</groupId>
             <artifactId>jsr181-api</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.xml.ws</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9983
https://issues.jboss.org/browse/WFLY-9938
Make testsuite pass work on JDK 10

Main update is updating jboss-parent to 26.
Which brings in surefire plugin 2.21.0.
Also fix build to work on JDK11, mostly deal with removed java.se.ee modules.

JDK 10 job https://ci.wildfly.org/viewLog.html?buildTypeId=WF_MasterLinuxJdk10&buildId=93645
JDK 11 job https://ci.wildfly.org/viewLog.html?buildId=93760&tab=buildResultsDiv&buildTypeId=WF_MasterLinuxJdk11