### PR TITLE
WFLY-9962 ReverseProxyTestCase fails when running after ForwardedHand…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/Filter.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/Filter.java
@@ -30,12 +30,13 @@ import io.undertow.Handlers;
 import io.undertow.predicate.Predicate;
 import io.undertow.server.HttpHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.undertow.AbstractHandlerDefinition;
 import org.wildfly.extension.undertow.Constants;
+import org.wildfly.extension.undertow.UndertowService;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 
 /**
@@ -54,7 +55,7 @@ abstract class Filter extends AbstractHandlerDefinition {
         FilterAdd add = new FilterAdd(this);
         registerAddOperation(resourceRegistration, add, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         //registerRemoveOperation(resourceRegistration, new ServiceRemoveStepHandler(UndertowService.FILTER, add), OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        registerRemoveOperation(resourceRegistration, ReloadRequiredRemoveStepHandler.INSTANCE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
+        registerRemoveOperation(resourceRegistration, new ServiceRemoveStepHandler(UndertowService.FILTER, add), OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
 
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterRefDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterRefDefinition.java
@@ -33,7 +33,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.dmr.ModelNode;
@@ -74,7 +74,12 @@ public class FilterRefDefinition extends PersistentResourceDefinition {
         super(UndertowExtension.PATH_FILTER_REF,
                 UndertowExtension.getResolver(Constants.FILTER_REF),
                 new FilterRefAdd(),
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+                new ServiceRemoveStepHandler(new FilterRefAdd()) {
+                    @Override
+                    protected ServiceName serviceName(String name, PathAddress address) {
+                        return UndertowService.getFilterRefServiceName(address, name);
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
Similar to https://github.com/wildfly/wildfly/pull/10980 , but makes the remove ops not require a reload rather than just executing the reload.