### PR TITLE
[WFLY-9967] Deletes directory recursively.

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/layered/LayeredDistributionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/layered/LayeredDistributionTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.manualmode.layered;
 
 import java.io.BufferedOutputStream;
+import java.io.File;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import org.apache.commons.io.FileUtils;
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -159,7 +161,10 @@ public class LayeredDistributionTestCase {
         Assert.assertTrue(Files.exists(layersDir));
 
         Path layerDir = layersDir.resolve(layer);
-        Files.deleteIfExists(layerDir);
+        File layerDirFile = layerDir.toFile();
+        if(layerDirFile.exists()) {
+            FileUtils.deleteDirectory(layerDirFile);
+        }
 
         // set layers.conf
         Path layersConf = AS_PATH.resolve("modules").resolve("layers.conf");


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9967 Deletes directory recursively.

This happens due to commit change in https://github.com/wildfly/wildfly/pull/10689/files?diff=unified#diff-67008a28eac0ddfad0a78eec3537155dL167
```
-        File layerDir = new File(layersDir, layer);
-        if (layerDir.exists()) {
-            FileUtils.deleteDirectory(layerDir);
-        }
+        Path layerDir = layersDir.resolve(layer);
+        Files.deleteIfExists(layerDir);
```
which throws  DirectoryNotEmptyException if the file is a directory and could not otherwise be deleted because the directory is not empty