### PR TITLE
WFLY-9964 Create JGroups subsystem transformer tests for EAP 7.1

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
@@ -210,7 +210,7 @@ public class ChannelResourceDefinition extends ChildResourceDefinition<Managemen
                         ;
             }
 
-            ProtocolRegistration.buildTransformation(version, builder);
+            ForkResourceDefinition.buildTransformation(version, builder);
         }
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinition.java
@@ -33,8 +33,10 @@ import org.jboss.as.clustering.controller.SimpleResourceRegistration;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.JGroupsRequirement;
 import org.wildfly.clustering.service.UnaryRequirement;
@@ -76,6 +78,12 @@ public class ForkResourceDefinition extends ChildResourceDefinition<ManagementRe
         for (ClusteringRequirement requirement : EnumSet.allOf(ClusteringRequirement.class)) {
             CLUSTERING_CAPABILITIES.put(requirement, new UnaryRequirementCapability(requirement));
         }
+    }
+
+    static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder builder = parent.addChildResource(WILDCARD_PATH);
+
+        ProtocolRegistration.buildTransformation(version, builder);
     }
 
     ForkResourceDefinition() {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolRegistration.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolRegistration.java
@@ -107,11 +107,13 @@ public class ProtocolRegistration implements Registration<ManagementResourceRegi
     }
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
-
-        ProtocolResourceDefinition.buildTransformation(version, parent);
+        ProtocolResourceDefinition.addTransformations(version, parent.addChildResource(ProtocolResourceDefinition.WILDCARD_PATH));
 
         for (MulticastProtocol protocol : EnumSet.allOf(MulticastProtocol.class)) {
-            SocketBindingProtocolResourceDefinition.addTransformations(version, parent.addChildResource(ProtocolResourceDefinition.pathElement(protocol.name())));
+            PathElement path = ProtocolResourceDefinition.pathElement(protocol.name());
+            if (!JGroupsModel.VERSION_5_0_0.requiresTransformation(version)) {
+                SocketBindingProtocolResourceDefinition.addTransformations(version, parent.addChildResource(path));
+            }
         }
 
         for (JdbcProtocol protocol : EnumSet.allOf(JdbcProtocol.class)) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -83,12 +83,6 @@ public class ProtocolResourceDefinition<P extends Protocol> extends AbstractProt
         }
     }
 
-    static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
-        ResourceTransformationDescriptionBuilder builder = parent.addChildResource(WILDCARD_PATH);
-
-        addTransformations(version, builder);
-    }
-
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
         AbstractProtocolResourceDefinition.addTransformations(version, builder);
 

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
@@ -77,6 +77,8 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
                 return JGroupsModel.VERSION_1_3_0;
             case EAP_7_0_0:
                 return JGroupsModel.VERSION_4_0_0;
+            case EAP_7_1_0:
+                return JGroupsModel.VERSION_5_0_0;
             default:
                 throw new IllegalArgumentException();
         }
@@ -95,6 +97,14 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
                         formatArtifact("org.jboss.eap:wildfly-clustering-common:%s", version),
                         formatArtifact("org.jboss.eap:wildfly-clustering-service:%s", version),
                         formatArtifact("org.jboss.eap:wildfly-clustering-jgroups-spi:%s", version),
+                };
+            case EAP_7_1_0:
+                return new String[] {
+                        formatEAP7SubsystemArtifact(version),
+                        formatArtifact("org.jboss.eap:wildfly-clustering-common:%s", version),
+                        formatArtifact("org.jboss.eap:wildfly-clustering-service:%s", version),
+                        formatArtifact("org.jboss.eap:wildfly-clustering-jgroups-spi:%s", version),
+                        formatArtifact("org.jboss.eap:wildfly-clustering-spi:%s", version),
                 };
             default:
                 throw new IllegalArgumentException();
@@ -117,6 +127,11 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
         testTransformation(ModelTestControllerVersion.EAP_7_0_0);
     }
 
+    @Test
+    public void testTransformerEAP710() throws Exception {
+        testTransformation(ModelTestControllerVersion.EAP_7_1_0);
+    }
+
     /**
      * Tests transformation of model from current version into specified version.
      */
@@ -129,7 +144,11 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
                 .setSubsystemXmlResource("subsystem-jgroups-transform.xml");
 
         // initialize the legacy services and add required jars
-        builder.createLegacyKernelServicesBuilder(null, controller, version).addMavenResourceURL(dependencies).skipReverseControllerCheck();
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controller, version)
+                .addMavenResourceURL(dependencies)
+                .addSingleChildFirstClass(AdditionalInitialization.class)
+                .skipReverseControllerCheck()
+                .dontPersistXml();
 
         KernelServices services = builder.build();
 
@@ -302,6 +321,11 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
     @Test
     public void testRejectionsEAP700() throws Exception {
         testRejections(ModelTestControllerVersion.EAP_7_0_0);
+    }
+
+    @Test
+    public void testRejectionsEAP710() throws Exception {
+        testRejections(ModelTestControllerVersion.EAP_7_1_0);
     }
 
     private void testRejections(final ModelTestControllerVersion controller) throws Exception {

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
@@ -46,7 +46,7 @@
             </transport>
             <socket-protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping"/>
             <protocol type="MERGE3"/>
-            <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+            <protocol type="FD_SOCK"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
@@ -42,7 +42,7 @@
                 <property name="receive_on_all_interfaces">true</property>
             </socket-protocol>
             <protocol type="MERGE3"/>
-            <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+            <protocol type="FD_SOCK"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>


### PR DESCRIPTION
Requires wildfly-core upgrade to pull in fix for https://issues.jboss.org/browse/WFCORE-3676 [1]

[1] https://github.com/wildfly/wildfly-core/pull/3165