### PR TITLE
[WFLY-10007] Restore org.infinispan.cachestore.remote as an alias for…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module-alias xmlns="urn:jboss:module:1.5" name="org.infinispan.cachestore.remote" target-name="org.infinispan.persistence.remote"/>


### PR DESCRIPTION
… org.infinispan.persistence.remote

https://issues.jboss.org/browse/WFLY-10007

Restores a module that was dropped as part of WFLY-8207 that the Keycloak adapters depend upon.

@pferraro Please approve.  With this module in place @luck3y was able to test the OpenShift application template that demonstrates Red Hat SSO integration (I.e. installs the RHSSO adapter in EAP and uses an RHSSO server.)