### PR TITLE
[WFLY-9844] test case

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/ClientInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/ClientInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.interceptor.register;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+import java.util.logging.Logger;
+
+/**
+ * Client side JBoss interceptor.
+ */
+public class ClientInterceptor implements EJBClientInterceptor {
+
+  private Logger log = Logger.getLogger(ClientInterceptor.class.getName());
+
+  /**
+   * Creates a new ClientInterceptor object.
+   */
+  public ClientInterceptor() {
+  }
+
+  @Override
+  public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+
+    log.info("In the client interceptor handleInvocation : " + this.getClass().getName() + " " + context.getViewClass() + " " + context.getLocator());
+    context.getContextData().put("ClientInterceptorInvoked", this.getClass().getName() + " " + context.getViewClass() + " " + context.getLocator());
+
+    // Must make this call
+    context.sendRequest();
+  }
+
+  @Override
+  public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+
+    log.info("In the client interceptor handleInvocationResult : " + this.getClass().getName() + " " + context.getViewClass() + " " + context.getLocator());
+
+    // Must make this call
+    return context.getResult();
+  }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/RegisterInterceptorViaMetaFileTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/RegisterInterceptorViaMetaFileTest.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.interceptor.register;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * @author Jiri Bilek
+ * jbilek@redhat.com on 12/03/18.
+ * Test for WFLY-9844
+ *
+ * EJB invocation for Remote interface fails when Client Interceptor
+ * registered via META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
+ */
+@RunWith(Arquillian.class)
+public class RegisterInterceptorViaMetaFileTest {
+   private static final String ARCHIVE_NAME = "test-register-interceptor";
+   @ArquillianResource
+   Deployer deployer;
+
+   @Deployment(name = "test-register-interceptor", testable = false, managed = false)
+   public static Archive<?> deploy() {
+      JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
+      jar.addPackage(TestRemote.class.getPackage());
+      jar.addPackage(TestSingleton.class.getPackage());
+      jar.addPackage(TestSLSB.class.getPackage());
+      jar.addAsManifestResource(
+            RegisterInterceptorViaMetaFileTest.class.getPackage(),
+            "org.jboss.ejb.client.EJBClientInterceptor",
+            "services/org.jboss.ejb.client.EJBClientInterceptor");
+      return jar;
+   }
+
+   @Test
+   public void testInvalidTransactionAttributeWarnLogged() {
+      PrintStream oldOut = System.out;
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try {
+         System.setOut(new PrintStream(baos));
+         deployer.deploy(ARCHIVE_NAME);
+         try {
+            System.setOut(oldOut);
+            String output = new String(baos.toByteArray());
+            Assert.assertFalse(output, output.contains("EJBCLIENT000079"));
+            Assert.assertFalse(output, output.contains("ERROR"));
+         } finally {
+            deployer.undeploy(ARCHIVE_NAME);
+         }
+      } finally {
+         System.setOut(oldOut);
+      }
+   }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.interceptor.register;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface TestRemote {
+
+  void invoke();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestSLSB.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.interceptor.register;
+
+import javax.ejb.Stateless;
+import java.util.logging.Logger;
+
+@Stateless
+//@LocalBean
+public class TestSLSB implements TestRemote {
+
+  private Logger log = Logger.getLogger(TestSLSB.class.getName());
+
+  public void invoke() {
+    log.info("Test Invoked");
+  }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestSingleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/TestSingleton.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.interceptor.register;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.ejb.SessionContext;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.naming.InitialContext;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Logger;
+
+@Startup
+@Singleton
+public class TestSingleton {
+
+  @Resource
+  private SessionContext context;
+
+  private Logger log = Logger.getLogger(TestSingleton.class.getName());
+
+  @EJB
+  private TestRemote slsbRemote;
+
+  private TestRemote workaroundLookupEJB() throws Exception {
+    log.info("Looking up java:global/remote-interface-test/TestSLSB!reproducer.TestRemote");
+    return (TestRemote) new InitialContext().lookup("java:global/remote-interface-test/TestSLSB!reproducer.TestRemote");
+  }
+
+  private String wasClientInterceptorInvoked() {
+    return (String) context.getContextData().get("ClientInterceptorInvoked");
+  }
+
+  @PostConstruct
+  public void test() {
+    Map<String,String> results = new TreeMap<>();
+    Boolean success = null;
+    String clientInterceptor = null;
+    try {
+      log.info("Testing Remote Interface");
+      slsbRemote.invoke();
+      success = true;
+    } catch(Throwable t) {
+        success = false;
+        t.printStackTrace();
+    } finally {
+      results.put("Remote Interface Test", String.format("%b clientInterceptorInvoked: %b %s", success, (clientInterceptor!=null), clientInterceptor));
+    }
+
+    for(Map.Entry<String,String> entry : results.entrySet()) {
+      log.info(String.format("%s : %s\n", entry.getKey(), entry.getValue()));
+    }
+  }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/org.jboss.ejb.client.EJBClientInterceptor
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/register/org.jboss.ejb.client.EJBClientInterceptor
@@ -1,0 +1,1 @@
+org.jboss.as.test.integration.ejb.interceptor.register.ClientInterceptor


### PR DESCRIPTION
test case for [WFLY-9844] https://issues.jboss.org/browse/WFLY-9844
EJB invocation for Remote interface fails when Client Interceptor registered via META-INF/services/org.jboss.ejb.client.EJBClientInterceptor
