### PR TITLE
WFLY-9890 Override Infinispan's default global configuration manager

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
@@ -22,8 +22,12 @@
 
 package org.jboss.as.clustering.infinispan;
 
+import java.util.EnumSet;
+
 import org.infinispan.Cache;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.manager.EmbeddedCacheManagerAdmin;
 import org.infinispan.manager.impl.AbstractDelegatingEmbeddedCacheManager;
 import org.wildfly.clustering.infinispan.spi.CacheContainer;
 
@@ -31,7 +35,7 @@ import org.wildfly.clustering.infinispan.spi.CacheContainer;
  * EmbeddedCacheManager decorator that overrides the default cache semantics of a cache manager.
  * @author Paul Ferraro
  */
-public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManager implements CacheContainer {
+public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManager implements CacheContainer, EmbeddedCacheManagerAdmin {
 
     private final BatcherFactory batcherFactory;
 
@@ -85,6 +89,42 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
     public EmbeddedCacheManager startCaches(String... cacheNames) {
         super.startCaches(cacheNames);
         return this;
+    }
+
+    @Override
+    public EmbeddedCacheManagerAdmin administration() {
+        return this;
+    }
+
+    @Override
+    public EmbeddedCacheManagerAdmin withFlags(AdminFlag... flags) {
+        return this;
+    }
+
+    @Override
+    public EmbeddedCacheManagerAdmin withFlags(EnumSet<AdminFlag> flags) {
+        return this;
+    }
+
+    @Override
+    public <K, V> Cache<K, V> createCache(String name, String template) {
+        return this.createCache(name, this.getCacheConfiguration(name));
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getOrCreateCache(String name, String template) {
+        return this.getOrCreateCache(name, this.getCacheConfiguration(name));
+    }
+
+    @Override
+    public synchronized <K, V> Cache<K, V> createCache(String name, Configuration configuration) {
+        this.defineConfiguration(name, configuration);
+        return this.getCache(name);
+    }
+
+    @Override
+    public synchronized <K, V> Cache<K, V> getOrCreateCache(String name, Configuration configuration) {
+        return (this.getCacheConfiguration(name) != null) ? this.createCache(name, configuration) : this.getCache(name);
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/LocalGlobalConfigurationManager.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/LocalGlobalConfigurationManager.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan;
+
+import java.util.EnumSet;
+
+import org.infinispan.commons.api.CacheContainerAdmin.AdminFlag;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.globalstate.GlobalConfigurationManager;
+
+/**
+ * Local implementation of {@link GlobalConfigurationManager}.
+ * @author Paul Ferraro
+ */
+public class LocalGlobalConfigurationManager implements GlobalConfigurationManager {
+
+    @Override
+    public Configuration createCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags) {
+        return configuration;
+    }
+
+    @Override
+    public Configuration getOrCreateCache(String cacheName, Configuration configuration, EnumSet<AdminFlag> flags) {
+        return configuration;
+    }
+
+    @Override
+    public Configuration createCache(String cacheName, String template, EnumSet<AdminFlag> flags) {
+        return null;
+    }
+
+    @Override
+    public Configuration getOrCreateCache(String cacheName, String template, EnumSet<AdminFlag> flags) {
+        return null;
+    }
+
+    @Override
+    public void removeCache(String cacheName, EnumSet<AdminFlag> flags) {
+    }
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
+import org.infinispan.globalstate.GlobalConfigurationManager;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.notifications.Listener;
@@ -48,6 +49,7 @@ import org.jboss.as.clustering.infinispan.BatcherFactory;
 import org.jboss.as.clustering.infinispan.DefaultCacheContainer;
 import org.jboss.as.clustering.infinispan.InfinispanBatcherFactory;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
+import org.jboss.as.clustering.infinispan.LocalGlobalConfigurationManager;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -96,7 +98,8 @@ public class CacheContainerBuilder extends CapabilityServiceNameProvider impleme
             manager.undefineConfiguration(defaultCacheName);
         }
         manager.addListener(this);
-
+        // Override GlobalConfigurationManager with a local implementation
+        manager.getGlobalComponentRegistry().registerComponent(new LocalGlobalConfigurationManager(), GlobalConfigurationManager.class);
         manager.start();
         InfinispanLogger.ROOT_LOGGER.debugf("%s cache container started", this.name);
         return manager;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/GlobalConfigurationBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/GlobalConfigurationBuilder.java
@@ -40,6 +40,7 @@ import org.infinispan.configuration.global.SiteConfiguration;
 import org.infinispan.configuration.global.ThreadPoolConfiguration;
 import org.infinispan.configuration.global.TransportConfiguration;
 import org.infinispan.configuration.internal.PrivateGlobalConfigurationBuilder;
+import org.infinispan.globalstate.ConfigurationStorage;
 import org.jboss.as.clustering.controller.CapabilityServiceNameProvider;
 import org.jboss.as.clustering.controller.CommonRequirement;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
@@ -159,6 +160,8 @@ public class GlobalConfigurationBuilder extends CapabilityServiceNameProvider im
         // Disable triangle algorithm
         // We optimize for originator as primary owner
         builder.addModule(PrivateGlobalConfigurationBuilder.class).serverMode(true);
+        // Disable configuration storage
+        builder.globalState().configurationStorage(ConfigurationStorage.IMMUTABLE).disable();
 
         return builder.build();
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
@@ -238,9 +238,7 @@ public abstract class AbstractDwmTestCase {
             ModelNode compositeOp = ModelUtil.createCompositeNode(
                     new ModelNode[] { removeDwm, removeContext });
             mcc.execute(compositeOp);
-            //large reload time is due to https://issues.jboss.org/browse/WFLY-10008
-            //when this is fixed reload time can be dropped
-            ServerReload.executeReloadAndWaitForCompletion(mcc, 90000, false,
+            ServerReload.executeReloadAndWaitForCompletion(mcc, 60000, false,
                     CONTAINER_0.equals(containerId) ? TestSuiteEnvironment.getServerAddress() : TestSuiteEnvironment.getServerAddressNode1(),
                     serverPort);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9890
https://issues.jboss.org/browse/WFLY-10008

Restores original reload timeouts for DwmTestCase.