### PR TITLE
WFLY-10015 Using store=remote fails with "NoClassDefFoundError: io/ne…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
@@ -32,6 +32,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="com.google.protobuf" optional="true"/>
+        <module name="io.netty"/>
         <module name="org.apache.commons.pool"/>
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
…tty/channel/ChannelHandler"

Jira
https://issues.jboss.org/browse/WFLY-10015