### PR TITLE
[WFLY-9971] Fix wsconsume & wsprovide scripts execution on windows

### DIFF
--- a/feature-pack/src/main/resources/content/bin/wsconsume.bat
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.bat
@@ -83,7 +83,7 @@ set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsconsume.bat"
 "%JAVA%" %JAVA_OPTS% ^
     -classpath "%JAVA_HOME%\lib\tools.jar" ^
     -jar "%JBOSS_RUNJAR%" ^
-    "%MODULE_OPTS%"^
+    %MODULE_OPTS% ^
     -mp "%JBOSS_MODULEPATH%" ^
     org.jboss.ws.tools.wsconsume ^
      %*

--- a/feature-pack/src/main/resources/content/bin/wsprovide.bat
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.bat
@@ -82,7 +82,7 @@ set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsprovide.bat"
 
 "%JAVA%" %JAVA_OPTS% ^
     -jar "%JBOSS_RUNJAR%" ^
-    "%MODULE_OPTS%"^
+    %MODULE_OPTS% ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.ws.tools.wsprovide ^
      %*


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9971

wsconsume.bat and wsprovide.bat scripts didn't work because %MODULE_OPTS% was quoted - quotes itselves were then understood as a parameter for jboss-modules.jar. The fix is to pass it the same way it is passed in standalone.bat, without quotes.