### PR TITLE
[WFLY-9778] generate necessary test module in test suite server image

### DIFF
--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -85,7 +85,7 @@
                             <reuseForks>false</reuseForks>
 
                             <environmentVariables>
-                                        <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
+                                        <JBOSS_HOME>${wildfly.dir}</JBOSS_HOME>
                             </environmentVariables>
 
                             <!-- Parameters to test cases. -->

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -18,6 +18,7 @@
                 <!-- AS7-4070 -->
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
                 <property name="waitForPortsTimeoutInSeconds">8</property>
+                <property name="modulePath">${basedir}/target/wildfly/modules</property>
             </configuration>
         </container>
 

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -81,6 +81,10 @@
             <fileset dir="${jboss.dist}/modules"/>
         </copy>
 
+        <copy todir="target/wildfly/modules">
+            <fileset dir="${jboss.dist}/modules"/>
+        </copy>
+
         <echo message="Copying and configuring instance jbossas-admin-only"/>
         <copy todir="target/jbossas-admin-only">
             <fileset dir="target/wildfly"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9778

Test adds this extra module `connlistener` because [AbstractTestsuite](https://github.com/wildfly/wildfly/blob/01652cb0a271654813c0d812be237745eca4c009/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/AbstractTestsuite.java#L106)  does not remove module in `tearDown` for manualmode tests after copying it into build modules directory of server.

This change makes sure test generates modules in their own module directory of default server copy. 