### PR TITLE
[WFLY-10028] Move XML validation test to dist

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -58,6 +58,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.metadata</groupId>
+            <artifactId>jboss-metadata-common</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
@@ -124,11 +134,43 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>ts.copy-widfly-for-validation</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/${project.build.finalName}-for-validation</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target/${project.build.finalName}</directory>
+                                    <includes>
+                                        <include>docs/**/*.xml</include>
+                                        <include>docs/**/*.xsd</include>
+                                        <include>standalone/**/*.xml</include>
+                                        <include>domain/**/*.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-verifier-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Parameters to test cases. -->
+                    <systemPropertyVariables combine.children="append">
+                        <jboss.dist>${basedir}/target/${project.build.finalName}-for-validation</jboss.dist>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/AbstractValidationUnitTest.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/AbstractValidationUnitTest.java
@@ -20,7 +20,12 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.smoke.subsystem.xml;
+package org.wildfly.dist.subsystem.xml;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -44,11 +49,6 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Date: 23.06.2011

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -19,7 +19,8 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.smoke.subsystem.xml;
+
+package org.wildfly.dist.subsystem.xml;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/XSDValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/XSDValidationUnitTestCase.java
@@ -19,7 +19,10 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.smoke.subsystem.xml;
+
+package org.wildfly.dist.subsystem.xml;
+
+import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
 import java.net.URL;
@@ -35,8 +38,6 @@ import javax.xml.validation.Validator;
 import org.jboss.metadata.parser.util.XMLResourceResolver;
 import org.junit.Test;
 import org.w3c.dom.Document;
-
-import static org.junit.Assert.assertNotNull;
 
 /**
  * A XSDValidationUnitTestCase.


### PR DESCRIPTION
Running the XML and XSD validation test from dist module ensures that
the test validates the *actual* files shipped with WildFly before there
is any chance they are modified by another test in smoke (or web) test
suite.

JIRA: https://issues.jboss.org/browse/WFLY-10028