### PR TITLE
WFLY-10019 Fix remaining intermittent failures in @Stateful EJB passivation tests.

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
@@ -93,7 +93,6 @@ public class InfinispanBean<I, T> implements Bean<I, T> {
         if (this.valid.compareAndSet(true, false)) {
             InfinispanEjbLogger.ROOT_LOGGER.tracef("Removing bean %s", this.id);
             this.remover.remove(this.id, listener);
-            this.close();
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb2/PassivationSucceedsEJB2TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/ejb2/PassivationSucceedsEJB2TestCase.java
@@ -29,7 +29,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.ejb.stateful.passivation.PassivationTestCaseSetup;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -47,7 +46,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @ServerSetup(PassivationTestCaseSetup.class)
 public class PassivationSucceedsEJB2TestCase {
-    private static final long PASSIVATION_WAIT = TimeoutUtil.adjust(5000);
     private static String jndi;
 
     @ArquillianResource
@@ -60,11 +58,9 @@ public class PassivationSucceedsEJB2TestCase {
     @Deployment
     public static Archive<?> deploy() throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "passivation-ejb2-test.jar");
-        jar.addClass(TimeoutUtil.class);
         jar.addPackage(PassivationSucceedsEJB2TestCase.class.getPackage());
         jar.addClasses(PassivationTestCaseSetup.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"),
-                "MANIFEST.MF");
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr"), "MANIFEST.MF");
         return jar;
     }
 
@@ -85,9 +81,6 @@ public class PassivationSucceedsEJB2TestCase {
                 Assert.assertEquals("Returned remote2 result was not expected", TestPassivationRemote.EXPECTED_RESULT,
                         remote2.returnTrueString());
 
-                // Passivation is asynchronous, so wait a sec for it to complete
-                Thread.sleep(PASSIVATION_WAIT);
-
                 Assert.assertFalse("ejbPassivate not called on remote2, check cache configuration and client sleep time",
                         remote2.hasBeenPassivated());
                 Assert.assertFalse("ejbActivate not called on remote2", remote2.hasBeenActivated());
@@ -95,6 +88,10 @@ public class PassivationSucceedsEJB2TestCase {
                 Assert.assertTrue("ejbPassivate not called on remote1, check cache configuration and client sleep time",
                         remote1.hasBeenPassivated());
                 Assert.assertTrue("ejbActivate not called on remote1", remote1.hasBeenActivated());
+
+                Assert.assertTrue("ejbPassivate not called on remote2, check cache configuration and client sleep time",
+                        remote2.hasBeenPassivated());
+                Assert.assertTrue("ejbActivate not called on remote2", remote2.hasBeenActivated());
             } finally {
                 remote2.remove();
             }


### PR DESCRIPTION
Includes a workaround for ISPN-8959, which is the root cause of the intermittent failures.

https://issues.jboss.org/browse/WFLY-10019