### PR TITLE
[WFLY-10034] Sync content of wsconsume and wsprovide scripts

### DIFF
--- a/feature-pack/src/main/resources/content/bin/wsconsume.bat
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.bat
@@ -81,11 +81,10 @@ if "x%JBOSS_MODULEPATH%" == "x" (
 set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsconsume.bat"
 
 "%JAVA%" %JAVA_OPTS% ^
-    -classpath "%JAVA_HOME%\lib\tools.jar" ^
     -jar "%JBOSS_RUNJAR%" ^
     %MODULE_OPTS% ^
     -mp "%JBOSS_MODULEPATH%" ^
     org.jboss.ws.tools.wsconsume ^
-     %*
+    %*
 
 :END

--- a/feature-pack/src/main/resources/content/bin/wsconsume.ps1
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.ps1
@@ -13,7 +13,6 @@ $JAVA_OPTS = @()
 
 $JAVA_OPTS+="-Dprogram.name=wsconsume.ps1"
 
-
 $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.ws.tools.wsconsume" -logFileProperties $null -serverOpts $ARGS
 & $JAVA $PROG_ARGS
 

--- a/feature-pack/src/main/resources/content/bin/wsconsume.sh
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.sh
@@ -62,14 +62,10 @@ fi
 # Setup JBoss sepecific properties
 JAVA_OPTS="$JAVA_OPTS -Dprogram.name=wsconsume.sh"
 
-# Setup classpath
-JBOSS_CLASSPATH=$JAVA_HOME/lib/tools.jar
-
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
     JBOSS_HOME=`cygpath --path --windows "$JBOSS_HOME"`
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
-    JBOSS_CLASSPATH=`cygpath --path --windows "$JBOSS_CLASSPATH"`
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
@@ -87,7 +83,7 @@ fi
 NEW_SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "-secmgr"`
 if [ "x$NEW_SECURITY_MANAGER_SET" != "x" ]; then
     SECMGR="true"
-    JAVA_OPTS=${JAVA_OPTS/-secmgr/}
+    JAVA_OPTS=`echo $JAVA_OPTS | sed "s/-secmgr//" `
 fi
 
 # Set up the module arguments
@@ -98,7 +94,6 @@ fi
 
 # Execute the command
 eval \"$JAVA\" $JAVA_OPTS \
-    -classpath \""$JBOSS_CLASSPATH"\" \
     -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
     $MODULE_OPTS \
     -mp \""${JBOSS_MODULEPATH}"\" \

--- a/feature-pack/src/main/resources/content/bin/wsprovide.bat
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.bat
@@ -84,7 +84,7 @@ set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsprovide.bat"
     -jar "%JBOSS_RUNJAR%" ^
     %MODULE_OPTS% ^
     -mp "%JBOSS_MODULEPATH%" ^
-     org.jboss.ws.tools.wsprovide ^
-     %*
+    org.jboss.ws.tools.wsprovide ^
+    %*
 
 :END

--- a/feature-pack/src/main/resources/content/bin/wsprovide.ps1
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.ps1
@@ -1,6 +1,6 @@
 ##################################################################
 #                                                               ##
-#    wsprovide tool script for Windows                              ##
+#    wsprovide tool script for Windows                          ##
 #                                                               ##
 ##################################################################
 $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10034

The goal is both wsconsume and wsprovide scripts have the same content except the wsconsume/wsprovide names.
Use sed for replace to be able to execute the script with secmgr also on HPUX.
Remove the additional classpath containing $JAVA_HOME/lib/tools.jar - this shouldn't be needed anymore.