### PR TITLE
WFLY-9877 Auto-update obsolete protocols to their current variants.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
@@ -23,9 +23,7 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Map;
-import java.util.Optional;
 
-import org.jboss.as.clustering.function.Predicates;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
@@ -88,8 +86,9 @@ public class ResourceRegistration implements Registration<ManagementResourceRegi
 
     private void registerTransformedOperation(ManagementResourceRegistration registration, OperationDefinition definition, OperationStepHandler handler) {
         // Only override global operation handlers for non-identity transformations
-        Optional.of(handler).map(this.descriptor.getOperationTransformation())
-                .filter(Predicates.same(handler).negate())
-                .ifPresent(transformedHandler -> registration.registerOperationHandler(definition, transformedHandler));
+        OperationStepHandler transformedHandler = this.descriptor.getOperationTransformation().apply(handler);
+        if (handler != transformedHandler) {
+            registration.registerOperationHandler(definition, transformedHandler);
+        }
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -27,7 +27,6 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.net.URL;
 import java.net.UnknownHostException;
-import java.util.Map;
 
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.network.OutboundSocketBinding;
@@ -154,7 +153,11 @@ public interface JGroupsLogger extends BasicLogger {
     @Message(id = 28, value = "Could not resolve destination address for outbound socket binding named '%s'")
     IllegalArgumentException failedToResolveSocketBinding(@Cause UnknownHostException cause, OutboundSocketBinding binding);
 
+//    @LogMessage(level = WARN)
+//    @Message(id = 29, value = "Ignoring unrecognized %s properties: %s")
+//    void ignoredProperties(String protocol, Map<String, String> properties);
+
     @LogMessage(level = WARN)
-    @Message(id = 29, value = "Ignoring unrecognized %s properties: %s")
-    void ignoredProperties(String protocol, Map<String, String> properties);
+    @Message(id = 30, value = "Protocol %s is obsolete and will be auto-updated to %s")
+    void legacyProtocol(String legacyProtocol, String targetProtocol);
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/LegacyProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/LegacyProtocolResourceDefinition.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.jgroups.subsystem;
+
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
+import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
+import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jgroups.stack.Protocol;
+import org.wildfly.clustering.jgroups.spi.ChannelFactory;
+
+/**
+ * Resource definition for legacy protocols.
+ * @author Paul Ferraro
+ */
+public class LegacyProtocolResourceDefinition<P extends Protocol> extends ProtocolResourceDefinition<P> {
+
+    private static class OperationTransformation implements Consumer<ResourceDescriptor>, UnaryOperator<OperationStepHandler>, OperationStepHandler {
+        private final String targetName;
+
+        OperationTransformation(String targetName) {
+            this.targetName = targetName;
+        }
+
+        @Override
+        public void accept(ResourceDescriptor descriptor) {
+            descriptor.setAddOperationTransformation(this).setOperationTransformation(this);
+        }
+
+        @Override
+        public OperationStepHandler apply(OperationStepHandler handler) {
+            return this;
+        }
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) {
+            PathAddress address = context.getCurrentAddress();
+            JGroupsLogger.ROOT_LOGGER.legacyProtocol(address.getLastElement().getValue(), this.targetName);
+            PathAddress targetAddress = address.getParent().append(pathElement(this.targetName));
+            Operations.setPathAddress(operation, targetAddress);
+            PathAddress targetRegistrationAddress = address.getParent().append(ProtocolResourceDefinition.WILDCARD_PATH);
+            String operationName = Operations.getName(operation);
+            context.addStep(operation, context.getRootResourceRegistration().getOperationHandler(targetRegistrationAddress, operationName), OperationContext.Stage.MODEL);
+        }
+    }
+
+    LegacyProtocolResourceDefinition(String name, String targetName, JGroupsModel deprecation, Consumer<ResourceDescriptor> descriptorConfigurator, ResourceServiceBuilderFactory<ChannelFactory> parentBuilderFactory) {
+        super(pathElement(name), descriptorConfigurator.andThen(new OperationTransformation(targetName)), null, parentBuilderFactory);
+        this.setDeprecated(deprecation.getVersion());
+    }
+}

--- a/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
+++ b/clustering/jgroups/extension/src/main/resources/org/jboss/as/clustering/jgroups/subsystem/LocalDescriptions.properties
@@ -115,6 +115,9 @@ jgroups.protocol.org.jgroups.protocols.JDBC_PING.deprecated=Deprecated. Use prot
 jgroups.protocol.org.jgroups.protocols.TCPGOSSIP.deprecated=Deprecated. Use protocol=TCPGOSSIP instead.
 jgroups.protocol.org.jgroups.protocols.TCPPING.deprecated=Deprecated. Use protocol=TCPPING instead.
 jgroups.protocol.org.jgroups.protocols.AUTH.deprecated=Deprecated. Use protocol=AUTH instead.
+jgroups.protocol.pbcast.NAKACK.deprecated=Obsolete protocol. Superseded by pbcast.NAKACK2.
+jgroups.protocol.UNICAST2.deprecated=Obsolete protocol. Superseded by UNICAST3.
+jgroups.protocol.MERGE2.deprecated=Obsolete protocol. Superseded MERGE3.
 
 jgroups.token=An authentication token
 jgroups.token.add=Adds an authentication token

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemParsingTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemParsingTestCase.java
@@ -139,7 +139,7 @@ public class JGroupsSubsystemParsingTestCase extends ClusteringSubsystemTest {
         transport.get("socket-binding").set("jgroups-udp");
 
         ModelNode protocols = new ModelNode();
-        String[] protocolList = {"PING", "MERGE3", "FD_SOCK", "FD", "VERIFY_SUSPECT", "BARRIER", "pbcast.NAKACK2", "UNICAST2",
+        String[] protocolList = {"PING", "MERGE3", "FD_SOCK", "FD", "VERIFY_SUSPECT", "BARRIER", "pbcast.NAKACK2", "UNICAST3",
                           "pbcast.STABLE", "pbcast.GMS", "UFC", "MFC", "FRAG2", "RSVP"} ;
 
         for (int i = 0; i < protocolList.length; i++) {
@@ -206,7 +206,7 @@ public class JGroupsSubsystemParsingTestCase extends ClusteringSubsystemTest {
         final PathAddress stackAddress = subsystemAddress.append(StackResourceDefinition.pathElement("maximal"));
 
         //Check the fork protocols honour indexed adds by inserting a protocol at the start
-        ModelNode add = Operations.createAddOperation(forkAddress.append(ProtocolResourceDefinition.pathElement("MERGE2")), 0);
+        ModelNode add = Operations.createAddOperation(forkAddress.append(ProtocolResourceDefinition.pathElement("MERGE3")), 0);
         ModelTestUtils.checkOutcome(services.executeOperation(add));
 
         ModelNode subsystemModel = services.readWholeModel().get(JGroupsSubsystemResourceDefinition.PATH.getKeyValuePair());
@@ -214,7 +214,7 @@ public class JGroupsSubsystemParsingTestCase extends ClusteringSubsystemTest {
         ModelNode forkModel = channelModel.get(ForkResourceDefinition.pathElement("web").getKeyValuePair());
 
         Assert.assertEquals(originalForkModel.keys().size() + 1, forkModel.get(ProtocolResourceDefinition.WILDCARD_PATH.getKey()).keys().size());
-        Assert.assertEquals("MERGE2", forkModel.get(ProtocolResourceDefinition.WILDCARD_PATH.getKey()).keys().iterator().next());
+        Assert.assertEquals("MERGE3", forkModel.get(ProtocolResourceDefinition.WILDCARD_PATH.getKey()).keys().iterator().next());
 
         //Check the stack protocols honour indexed adds by removing a protocol in the middle and readding it
         ModelNode remove = Util.createRemoveOperation(stackAddress.append(ProtocolResourceDefinition.pathElement("FD")));

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationsTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationsTestCase.java
@@ -242,4 +242,22 @@ public class OperationsTestCase extends OperationTestCaseBase {
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
         Assert.assertFalse(result.get(RESULT).isDefined());
     }
+
+    @Test
+    public void testLegacyProtocolAddRemoveOperation() throws Exception {
+        KernelServices services = this.buildKernelServices();
+
+        testProtocolAddRemoveOperation(services, "MERGE2");
+        testProtocolAddRemoveOperation(services, "pbcast.NAKACK");
+        testProtocolAddRemoveOperation(services, "UNICAST2");
+    }
+
+    private static void testProtocolAddRemoveOperation(KernelServices services, String protocol) {
+
+        ModelNode result = services.executeOperation(getProtocolAddOperation("minimal", protocol));
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+
+        result = services.executeOperation(getProtocolRemoveOperation("minimal", protocol));
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+    }
 }

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-1_1.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-1_1.xml
@@ -33,13 +33,13 @@
         <protocol type="MPING" socket-binding="jgroups-mping">
             <property name="name">${test.expr:value}</property>
         </protocol>
-        <protocol type="MERGE2"/>
+        <protocol type="MERGE3"/>
         <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
         <protocol type="FD"/>
         <protocol type="VERIFY_SUSPECT"/>
         <protocol type="BARRIER"/>
-        <protocol type="pbcast.NAKACK"/>
-        <protocol type="UNICAST2"/>
+        <protocol type="pbcast.NAKACK2"/>
+        <protocol type="UNICAST3"/>
         <protocol type="pbcast.STABLE"/>
         <protocol type="pbcast.GMS"/>
         <protocol type="UFC"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-2_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-2_0.xml
@@ -33,12 +33,12 @@
         <protocol type="MPING" socket-binding="jgroups-mping">
             <property name="name">${test.expr:value}</property>
         </protocol>
-        <protocol type="MERGE2"/>
+        <protocol type="MERGE3"/>
         <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
         <protocol type="FD"/>
         <protocol type="VERIFY_SUSPECT"/>
         <protocol type="pbcast.NAKACK2"/>
-        <protocol type="UNICAST2"/>
+        <protocol type="UNICAST3"/>
         <protocol type="pbcast.STABLE"/>
         <protocol type="pbcast.GMS"/>
         <protocol type="UFC"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-3_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-3_0.xml
@@ -65,12 +65,12 @@
             <protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping">
                 <property name="name">${test.expr:value}</property>
             </protocol>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <protocol type="UFC"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_0.xml
@@ -65,12 +65,12 @@
             <protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping">
                 <property name="name">${test.expr:value}</property>
             </protocol>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <protocol type="UFC"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-5_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-5_0.xml
@@ -66,7 +66,7 @@
                 <property name="name">${test.expr:value}</property>
             </socket-protocol>
             <jdbc-protocol type="JDBC_PING" data-source="ExampleDS"/>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
@@ -74,7 +74,7 @@
                 <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
             </encrypt-protocol>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <auth-protocol type="AUTH">

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-6_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-6_0.xml
@@ -53,7 +53,7 @@
                 <property name="name">${test.expr:value}</property>
             </socket-protocol>
             <jdbc-protocol type="JDBC_PING" data-source="ExampleDS"/>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
@@ -61,7 +61,7 @@
                 <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
             </encrypt-protocol>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <auth-protocol type="AUTH">

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
@@ -45,12 +45,12 @@
                              keepalive-time="14"/>
             </transport>
             <socket-protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping"/>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <protocol type="UFC"/>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
@@ -41,12 +41,12 @@
                 <property name="ip_ttl">1</property>
                 <property name="receive_on_all_interfaces">true</property>
             </socket-protocol>
-            <protocol type="MERGE2"/>
+            <protocol type="MERGE3"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
             <protocol type="pbcast.NAKACK2"/>
-            <protocol type="UNICAST2"/>
+            <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
             <protocol type="UFC"/>


### PR DESCRIPTION
Fixes JGroups configuration compatibility using obsolete protocols.

https://issues.jboss.org/browse/WFLY-9877