### PR TITLE
WFLY-5966 updated JPA modules to not export modules previously exported by javax.ejb.api

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -78,11 +78,5 @@
         <module name="org.wildfly.clustering.infinispan.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.transaction.client"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
@@ -32,20 +32,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.ejb.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
-        <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.server"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.msc"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Covers the JPA part of WFLY-5966 for:
feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
