### PR TITLE
WFLY-10065 Clustering TS: change deployment/module names to match test case class names

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/CommandDispatcherTestCase.java
@@ -42,18 +42,18 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 public class CommandDispatcherTestCase extends AbstractClusteringTestCase {
+    private static final String MODULE_NAME = CommandDispatcherTestCase.class.getSimpleName();
     private static final long VIEW_CHANGE_WAIT = TimeoutUtil.adjust(2000);
-    private static final String MODULE_NAME = "command-dispatcher";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> createDeploymentForContainer1() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> createDeploymentForContainer2() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/NonTxClientEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/NonTxClientEJBForwardingTestCase.java
@@ -22,16 +22,34 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.forwarding;
 
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.NonTxForwardingStatefulSBImpl;
 import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
+import org.jboss.shrinkwrap.api.Archive;
 
 /**
  * Tests concurrent fail-over without a managed transaction context on the forwarder and using the client "API".
  *
  * @author Radoslav Husar
  */
-public class NonTxClientEJBForwardingTestCase extends NonTxRemoteEJBForwardingTestCase {
+public class NonTxClientEJBForwardingTestCase extends AbstractRemoteEJBForwardingTestCase {
+
+    public static final String MODULE_NAME = NonTxClientEJBForwardingTestCase.class.getSimpleName();
 
     public NonTxClientEJBForwardingTestCase() {
-        super(() -> new ClientEJBDirectory(MODULE_NAME));
+        super(() -> new ClientEJBDirectory(MODULE_NAME), NonTxForwardingStatefulSBImpl.class.getSimpleName());
+    }
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> deployment1() {
+        return createForwardingDeployment(MODULE_NAME, false);
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> deployment2() {
+        return createForwardingDeployment(MODULE_NAME, false);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/NonTxRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/NonTxRemoteEJBForwardingTestCase.java
@@ -22,21 +22,11 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.forwarding;
 
-import javax.naming.NamingException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.common.CommonStatefulSB;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.AbstractForwardingStatefulSBImpl;
 import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.NonTxForwardingStatefulSBImpl;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.stateful.RemoteStatefulSB;
-import org.jboss.as.test.clustering.ejb.EJBDirectory;
-import org.jboss.as.test.clustering.ejb.NamingEJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Tests concurrent fail-over without a managed transaction context on the forwarder.
@@ -45,38 +35,21 @@ import org.wildfly.common.function.ExceptionSupplier;
  */
 public class NonTxRemoteEJBForwardingTestCase extends AbstractRemoteEJBForwardingTestCase {
 
-    public static final String MODULE_NAME = "forwarder-nontx";
+    public static final String MODULE_NAME = NonTxRemoteEJBForwardingTestCase.class.getSimpleName();
 
     public NonTxRemoteEJBForwardingTestCase() {
-        this(() -> new RemoteEJBDirectory(MODULE_NAME));
-    }
-
-    NonTxRemoteEJBForwardingTestCase(ExceptionSupplier<EJBDirectory, NamingException> directorySupplier) {
-        super(directorySupplier, NonTxForwardingStatefulSBImpl.class.getSimpleName());
+        super(() -> new RemoteEJBDirectory(MODULE_NAME), NonTxForwardingStatefulSBImpl.class.getSimpleName());
     }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment1() {
-        return createForwardingDeployment();
+        return createForwardingDeployment(MODULE_NAME, false);
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment2() {
-        return createForwardingDeployment();
-    }
-
-    private static Archive<?> createForwardingDeployment() {
-        JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        ejbJar.addClass(CommonStatefulSB.class);
-        ejbJar.addClass(RemoteStatefulSB.class);
-        // the forwarding classes
-        ejbJar.addClass(AbstractForwardingStatefulSBImpl.class);
-        ejbJar.addClass(NonTxForwardingStatefulSBImpl.class);
-        ejbJar.addClasses(EJBDirectory.class, NamingEJBDirectory.class, RemoteEJBDirectory.class);
-        // remote outbound connection configuration
-        ejbJar.addAsManifestResource(AbstractRemoteEJBForwardingTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
-        return ejbJar;
+        return createForwardingDeployment(MODULE_NAME, false);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/TxClientEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/TxClientEJBForwardingTestCase.java
@@ -22,16 +22,34 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.forwarding;
 
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.ForwardingStatefulSBImpl;
 import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
+import org.jboss.shrinkwrap.api.Archive;
 
 /**
  * Tests concurrent fail-over with a managed transaction context on the forwarder and using the client "API".
  *
  * @author Radoslav Husar
  */
-public class TxClientEJBForwardingTestCase extends TxRemoteEJBForwardingTestCase {
+public class TxClientEJBForwardingTestCase extends AbstractRemoteEJBForwardingTestCase {
+
+    public static final String MODULE_NAME = TxClientEJBForwardingTestCase.class.getSimpleName();
 
     public TxClientEJBForwardingTestCase() {
-        super(() -> new ClientEJBDirectory(MODULE_NAME));
+        super(() -> new ClientEJBDirectory(MODULE_NAME), ForwardingStatefulSBImpl.class.getSimpleName());
+    }
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> deployment1() {
+        return createForwardingDeployment(MODULE_NAME, true);
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> deployment2() {
+        return createForwardingDeployment(MODULE_NAME, true);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/TxRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/TxRemoteEJBForwardingTestCase.java
@@ -22,21 +22,11 @@
 
 package org.jboss.as.test.clustering.cluster.ejb.forwarding;
 
-import javax.naming.NamingException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
-import org.jboss.as.test.clustering.ejb.EJBDirectory;
-import org.jboss.as.test.clustering.ejb.NamingEJBDirectory;
-import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.common.CommonStatefulSB;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.AbstractForwardingStatefulSBImpl;
 import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.forwarding.ForwardingStatefulSBImpl;
-import org.jboss.as.test.clustering.cluster.ejb.forwarding.bean.stateful.RemoteStatefulSB;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.wildfly.common.function.ExceptionSupplier;
 
 /**
  * Tests concurrent fail-over with a managed transaction context on the forwarder.
@@ -45,38 +35,21 @@ import org.wildfly.common.function.ExceptionSupplier;
  */
 public class TxRemoteEJBForwardingTestCase extends AbstractRemoteEJBForwardingTestCase {
 
-    public static final String MODULE_NAME = "forwarder-tx";
+    public static final String MODULE_NAME = TxRemoteEJBForwardingTestCase.class.getSimpleName();
 
     public TxRemoteEJBForwardingTestCase() {
-        this(() -> new RemoteEJBDirectory(MODULE_NAME));
-    }
-
-    TxRemoteEJBForwardingTestCase(ExceptionSupplier<EJBDirectory, NamingException> directorySupplier) {
-        super(directorySupplier, ForwardingStatefulSBImpl.class.getSimpleName());
+        super(() -> new RemoteEJBDirectory(MODULE_NAME), ForwardingStatefulSBImpl.class.getSimpleName());
     }
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
-        return createForwardingDeployment();
+    public static Archive<?> deployment1() {
+        return createForwardingDeployment(MODULE_NAME, true);
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
-        return createForwardingDeployment();
-    }
-
-    private static Archive<?> createForwardingDeployment() {
-        JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        ejbJar.addClass(CommonStatefulSB.class);
-        ejbJar.addClass(RemoteStatefulSB.class);
-        // the forwarding classes
-        ejbJar.addClass(AbstractForwardingStatefulSBImpl.class);
-        ejbJar.addClass(ForwardingStatefulSBImpl.class);
-        ejbJar.addClasses(EJBDirectory.class, NamingEJBDirectory.class, RemoteEJBDirectory.class);
-        // remote outbound connection configuration
-        ejbJar.addAsManifestResource(AbstractRemoteEJBForwardingTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
-        return ejbJar;
+    public static Archive<?> deployment2() {
+        return createForwardingDeployment(MODULE_NAME, true);
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AuthContextRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/AuthContextRemoteStatelessEJBFailoverTestCase.java
@@ -39,7 +39,7 @@ import org.wildfly.security.auth.client.MatchRule;
  * @author Paul Ferraro
  */
 public abstract class AuthContextRemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
-    private static final String MODULE_NAME = "secure-remote-stateless-ejb-failover-test";
+    private static final String MODULE_NAME = AuthContextRemoteStatelessEJBFailoverTestCase.class.getSimpleName();
 
     static final AuthenticationContext AUTHENTICATION_CONTEXT = AuthenticationContext.captureCurrent().with(
             MatchRule.ALL.matchAbstractType("ejb", "jboss"),

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class ClientExceptionRemoteEJBTestCase extends AbstractClusteringTestCase {
-    private static final String MODULE_NAME = "client-exception-remote-ejb-test";
+    private static final String MODULE_NAME = ClientExceptionRemoteEJBTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatefulEJBFailoverTestCase.java
@@ -28,7 +28,7 @@ import org.jboss.as.test.clustering.ejb.ClientEJBDirectory;
 import org.jboss.shrinkwrap.api.Archive;
 
 public class ClientRemoteStatefulEJBFailoverTestCase extends AbstractRemoteStatefulEJBFailoverTestCase {
-    private static final String MODULE_NAME = "client-remote-stateful-ejb-failover-test";
+    private static final String MODULE_NAME = ClientRemoteStatefulEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientRemoteStatelessEJBFailoverTestCase.java
@@ -34,7 +34,7 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author Paul Ferraro
  */
 public class ClientRemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
-    private static final String MODULE_NAME = "client-remote-stateless-ejb-failover-test";
+    private static final String MODULE_NAME = ClientRemoteStatelessEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBConcurrentFailoverTestCase.java
@@ -56,7 +56,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class RemoteStatefulEJBConcurrentFailoverTestCase extends AbstractClusteringTestCase {
-    private static final String MODULE_NAME = "remote-stateful-ejb-concurrent-failover-test";
+    private static final String MODULE_NAME = RemoteStatefulEJBConcurrentFailoverTestCase.class.getSimpleName();
 
     private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatefulEJBFailoverTestCase.java
@@ -41,7 +41,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author Paul Ferraro
  */
 public class RemoteStatefulEJBFailoverTestCase extends AbstractRemoteStatefulEJBFailoverTestCase {
-    private static final String MODULE_NAME = "remote-stateful-ejb-failover-test";
+    private static final String MODULE_NAME = RemoteStatefulEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatelessEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteStatelessEJBFailoverTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author Paul Ferraro
  */
 public class RemoteStatelessEJBFailoverTestCase extends AbstractRemoteStatelessEJBFailoverTestCase {
-    private static final String MODULE_NAME = "remote-stateless-ejb-failover-test";
+    private static final String MODULE_NAME = RemoteStatelessEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TransactionalRemoteStatefulEJBFailoverTestCase.java
@@ -52,7 +52,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class TransactionalRemoteStatefulEJBFailoverTestCase extends AbstractClusteringTestCase {
-    private static final String MODULE_NAME = "transactional-remote-stateful-ejb-failover-test";
+    private static final String MODULE_NAME = TransactionalRemoteStatefulEJBFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
@@ -67,7 +67,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class StatefulFailoverTestCase extends AbstractClusteringTestCase {
 
-    private static final String MODULE_NAME = "stateful-failover";
+    private static final String MODULE_NAME = StatefulFailoverTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
@@ -59,8 +59,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class StatefulTimeoutTestCase extends AbstractClusteringTestCase {
+
+    private static final String MODULE_NAME = StatefulTimeoutTestCase.class.getSimpleName();
     private static final long WAIT_FOR_TIMEOUT = TimeoutUtil.adjust(5000);
-    private static final String MODULE_NAME = "stateful-timeout";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -50,7 +50,7 @@ import org.junit.BeforeClass;
  */
 public abstract class ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestBase.class);
-    public static final String MODULE_NAME = "cluster-passivation-test";
+    public static final String MODULE_NAME = ClusterPassivationTestBase.class.getSimpleName();
 
     protected static EJBDirectory directory;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/dd/ClusterPassivationDDTestCase.java
@@ -68,13 +68,13 @@ public class ClusterPassivationDDTestCase extends ClusterPassivationTestBase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -67,16 +67,8 @@ public class RemoteStatelessFailoverTestCase {
     private static EJBDirectory directoryAnnotation;
     private static EJBDirectory directoryDD;
 
-    private static final String MODULE_NAME = "stateless-ejb2-failover-test";
-    private static final String MODULE_NAME_DD = "stateless-ejb2-failover-dd-test";
-
-//    private static final Integer PORT_2 = 8180;
-//    private static final String HOST_2 = TestSuiteEnvironment.getServerAddressNode1();
-//    private static final String REMOTE_PORT_PROPERTY_NAME = "remote.connection.default.port";
-//    private static final String REMOTE_HOST_PROPERTY_NAME = "remote.connection.default.host";
-
-    private static final String DEPLOYMENT_1_DD = DEPLOYMENT_1 + "-descriptor";
-    private static final String DEPLOYMENT_2_DD = DEPLOYMENT_2 + "-descriptor";
+    private static final String MODULE_NAME = RemoteStatelessFailoverTestCase.class.getSimpleName();
+    private static final String MODULE_NAME_DD = MODULE_NAME + "dd";
 
     private static final Map<String, Boolean> deployed = new HashMap<String, Boolean>();
     private static final Map<String, Boolean> started = new HashMap<String, Boolean>();
@@ -89,18 +81,18 @@ public class RemoteStatelessFailoverTestCase {
 
         deployed.put(DEPLOYMENT_1, false);
         deployed.put(DEPLOYMENT_2, false);
-        deployed.put(DEPLOYMENT_1_DD, false);
-        deployed.put(DEPLOYMENT_2_DD, false);
+        deployed.put(DEPLOYMENT_HELPER_1, false);
+        deployed.put(DEPLOYMENT_HELPER_2, false);
         started.put(NODE_1, false);
         started.put(NODE_2, false);
 
         List<String> deployments1 = new ArrayList<>();
         deployments1.add(DEPLOYMENT_1);
-        deployments1.add(DEPLOYMENT_1_DD);
+        deployments1.add(DEPLOYMENT_HELPER_1);
         container2deployment.put(NODE_1, deployments1);
         List<String> deployments2 = new ArrayList<>();
         deployments2.add(DEPLOYMENT_2);
-        deployments2.add(DEPLOYMENT_2_DD);
+        deployments2.add(DEPLOYMENT_HELPER_2);
         container2deployment.put(NODE_2, deployments2);
     }
 
@@ -127,13 +119,13 @@ public class RemoteStatelessFailoverTestCase {
         return createDeployment();
     }
 
-    @Deployment(name = DEPLOYMENT_1_DD, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> createDeploymentOnDescriptorForContainer1() {
         return createDeploymentOnDescriptor();
     }
 
-    @Deployment(name = DEPLOYMENT_2_DD, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> createDeploymentOnDescriptorForContainer2() {
         return createDeploymentOnDescriptor();
@@ -169,7 +161,7 @@ public class RemoteStatelessFailoverTestCase {
 
     @Test
     public void testFailoverOnStopBeanSpecifiedByDescriptor() throws Exception {
-        doFailover(true, directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        doFailover(true, directoryDD, DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2);
     }
 
     @Test
@@ -179,7 +171,7 @@ public class RemoteStatelessFailoverTestCase {
 
     @Test
     public void testFailoverOnUndeploySpecifiedByDescriptor() throws Exception {
-        doFailover(false, directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        doFailover(false, directoryDD, DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2);
     }
 
     private void doFailover(boolean isStop, EJBDirectory directory, String deployment1, String deployment2) throws Exception {
@@ -223,7 +215,7 @@ public class RemoteStatelessFailoverTestCase {
 
     @Test
     public void testLoadbalanceSpecifiedByDescriptor() throws Exception {
-        loadbalance(directoryDD, DEPLOYMENT_1_DD, DEPLOYMENT_2_DD);
+        loadbalance(directoryDD, DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2);
     }
 
     /**

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jpa2lc/ClusteredJPA2LCTestCase.java
@@ -62,7 +62,7 @@ import org.wildfly.test.api.Authentication;
 @RunWith(Arquillian.class)
 public class ClusteredJPA2LCTestCase {
 
-    private static final String MODULE_NAME = "clustered2lc";
+    private static final String MODULE_NAME = ClusteredJPA2LCTestCase.class.getSimpleName();
 
     @ArquillianResource
     protected ContainerController controller;
@@ -139,7 +139,7 @@ public class ClusteredJPA2LCTestCase {
      * The two nodes don't actually have a shared database instance, but that doesn't matter for this test.
      */
     @Test
-    @InSequence(0)
+    @InSequence
     public void testEntityCacheReplication(@ArquillianResource @OperateOnDeployment(DEPLOYMENT_1) URL url0,
                                            @ArquillianResource @OperateOnDeployment(DEPLOYMENT_2) URL url1)
             throws Exception {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -22,8 +22,6 @@
 package org.jboss.as.test.clustering.cluster.jsf;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,20 +67,22 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class JSFFailoverTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = JSFFailoverTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "numberguess-jsf.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClasses(Game.class, Generator.class, MaxNumber.class, Random.class);
         war.setWebXML(DistributableTestCase.class.getPackage(), "web.xml");
         war.addAsWebResource(JSFFailoverTestCase.class.getPackage(), "home.xhtml", "home.xhtml");
@@ -93,12 +93,6 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
 
     /**
      * Parses the response page and headers for a cookie, JSF view state and the numberguess game status.
-     *
-     * @param response
-     * @param sessionId
-     * @return
-     * @throws IllegalStateException
-     * @throws IOException
      */
     private static NumberGuessState parseState(HttpResponse response, String sessionId) throws IllegalStateException, IOException {
         Pattern smallestPattern = Pattern.compile("<span id=\"numberGuess:smallest\">([^<]+)</span>");
@@ -139,15 +133,8 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
 
     /**
      * Creates an HTTP POST request with a number guess.
-     *
-     * @param url
-     * @param sessionId
-     * @param viewState
-     * @param guess
-     * @return
-     * @throws UnsupportedEncodingException
      */
-    private static HttpUriRequest buildPostRequest(String url, String sessionId, String viewState, String guess) throws UnsupportedEncodingException {
+    private static HttpUriRequest buildPostRequest(String url, String sessionId, String viewState, String guess) {
         HttpPost post = new HttpPost(url);
 
         List<NameValuePair> list = new LinkedList<>();
@@ -167,10 +154,6 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
 
     /**
      * Creates an HTTP GET request, with a potential JSESSIONID cookie.
-     *
-     * @param url
-     * @param sessionId
-     * @return
      */
     private static HttpUriRequest buildGetRequest(String url, String sessionId) {
         HttpGet request = new HttpGet(url);
@@ -190,16 +173,12 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
      * 4/ Query second container verifying sessions got replicated.
      * 5/ Bring up the first container.
      * 6/ Query first container verifying that updated sessions replicated back.
-     *
-     * @throws java.io.IOException
-     * @throws InterruptedException
-     * @throws URISyntaxException
      */
     @Test
     public void testGracefulSimpleFailover(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException, URISyntaxException {
+            throws IOException {
 
         String url1 = baseURL1.toString() + "home.jsf";
         String url2 = baseURL2.toString() + "home.jsf";
@@ -316,16 +295,12 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
      * 4/ Query second container verifying sessions got replicated.
      * 5/ Redeploy application to the first container.
      * 6/ Query first container verifying that updated sessions replicated back.
-     *
-     * @throws java.io.IOException
-     * @throws InterruptedException
-     * @throws URISyntaxException
      */
     @Test
     public void testGracefulUndeployFailover(
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource() @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException, InterruptedException, URISyntaxException {
+            throws IOException {
 
         String url1 = baseURL1.toString() + "home.jsf";
         String url2 = baseURL2.toString() + "home.jsf";
@@ -428,8 +403,6 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
             Assert.assertEquals("3", state.smallest);
             Assert.assertEquals("49", state.biggest);
         }
-
-        // Assert.fail("Show me the logs please!");
     }
 
     /**

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 public class ServiceProviderRegistrationTestCase extends AbstractClusteringTestCase {
-    private static final String MODULE_NAME = "service-provider-registration";
+    private static final String MODULE_NAME = ServiceProviderRegistrationTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 public class RegistryTestCase extends AbstractClusteringTestCase {
-    private static final String MODULE_NAME = "registry";
+    private static final String MODULE_NAME = RegistryTestCase.class.getSimpleName();
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonBackupServiceTestCase.java
@@ -54,20 +54,22 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SingletonBackupServiceTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = SingletonBackupServiceTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(ValueServiceServlet.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, ValueServiceActivator.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentDescriptorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentDescriptorTestCase.java
@@ -35,27 +35,27 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  */
 public class SingletonDeploymentDescriptorTestCase extends SingletonDeploymentTestCase {
 
-    private static final String DEPLOYMENT_NAME = "singleton-deployment-descriptor";
+    private static final String MODULE_NAME = SingletonDeploymentDescriptorTestCase.class.getSimpleName();
 
     public SingletonDeploymentDescriptorTestCase() {
-        super(DEPLOYMENT_NAME);
+        super(MODULE_NAME);
     }
 
-    @Deployment(name = SINGLETON_DEPLOYMENT_1, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return createDeployment();
     }
 
-    @Deployment(name = SINGLETON_DEPLOYMENT_2, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, DEPLOYMENT_NAME + ".ear");
-        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war");
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, MODULE_NAME + ".ear");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(TraceServlet.class.getPackage());
         ear.addAsModule(war);
         ear.addAsManifestResource(SingletonDeploymentDescriptorTestCase.class.getPackage(), "singleton-deployment.xml", "singleton-deployment.xml");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentJBossAllTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentJBossAllTestCase.java
@@ -34,26 +34,26 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  */
 public class SingletonDeploymentJBossAllTestCase extends SingletonDeploymentTestCase {
 
-    private static final String DEPLOYMENT_NAME = "singleton-deployment-jboss-all";
+    private static final String MODULE_NAME = SingletonDeploymentJBossAllTestCase.class.getSimpleName();
 
     public SingletonDeploymentJBossAllTestCase() {
-        super(DEPLOYMENT_NAME);
+        super(MODULE_NAME);
     }
 
-    @Deployment(name = SINGLETON_DEPLOYMENT_1, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
         return createDeployment();
     }
 
-    @Deployment(name = SINGLETON_DEPLOYMENT_2, managed = false, testable = false)
+    @Deployment(name = DEPLOYMENT_HELPER_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(TraceServlet.class.getPackage());
         war.addAsManifestResource(SingletonDeploymentJBossAllTestCase.class.getPackage(), "jboss-all.xml", "jboss-all.xml");
         return war;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
@@ -57,19 +57,18 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public abstract class SingletonDeploymentTestCase extends AbstractClusteringTestCase {
 
-    private static final String DEPLOYMENT_NAME = "singleton-deployment-helper.war";
-    static final String SINGLETON_DEPLOYMENT_1 = "singleton-deployment-0";
-    static final String SINGLETON_DEPLOYMENT_2 = "singleton-deployment-1";
+    private static final String MODULE_NAME = SingletonDeploymentTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deploymentHelper0() {
+    public static Archive<?> deploymentHelper1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deploymentHelper1() {
+    public static Archive<?> deploymentHelper2() {
         return createDeployment();
     }
 
@@ -81,10 +80,10 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
 
     public static final int DELAY = TimeoutUtil.adjust(5000);
 
-    private final String deploymentName;
+    private final String moduleName;
 
-    SingletonDeploymentTestCase(String deploymentName) {
-        this.deploymentName = deploymentName;
+    SingletonDeploymentTestCase(String moduleName) {
+        this.moduleName = moduleName;
     }
 
     @Test
@@ -98,13 +97,13 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
         // In order to test undeploy in case another node becomes elected as the master, we need an election policy that will ever trigger that code path (WFLY-8184)
         executeOnNodesAndReload("/subsystem=singleton/singleton-policy=default/election-policy=simple:write-attribute(name=name-preferences,value=" + Arrays.toString(TWO_NODES) + ")", client1, client2);
 
-        this.deploy(SINGLETON_DEPLOYMENT_1);
+        this.deploy(DEPLOYMENT_HELPER_1);
         Thread.sleep(DELAY);
-        this.deploy(SINGLETON_DEPLOYMENT_2);
+        this.deploy(DEPLOYMENT_HELPER_2);
         Thread.sleep(DELAY);
 
-        URI uri1 = TraceServlet.createURI(new URL(baseURL1.getProtocol(), baseURL1.getHost(), baseURL1.getPort(), "/" + this.deploymentName + "/"));
-        URI uri2 = TraceServlet.createURI(new URL(baseURL2.getProtocol(), baseURL2.getHost(), baseURL2.getPort(), "/" + this.deploymentName + "/"));
+        URI uri1 = TraceServlet.createURI(new URL(baseURL1.getProtocol(), baseURL1.getHost(), baseURL1.getPort(), "/" + this.moduleName + "/"));
+        URI uri2 = TraceServlet.createURI(new URL(baseURL2.getProtocol(), baseURL2.getHost(), baseURL2.getPort(), "/" + this.moduleName + "/"));
 
         try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri1));
@@ -121,7 +120,7 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
                 HttpClientUtils.closeQuietly(response);
             }
 
-            this.undeploy(SINGLETON_DEPLOYMENT_1);
+            this.undeploy(DEPLOYMENT_HELPER_1);
 
             Thread.sleep(DELAY);
 
@@ -139,7 +138,7 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
                 HttpClientUtils.closeQuietly(response);
             }
 
-            this.deploy(SINGLETON_DEPLOYMENT_1);
+            this.deploy(DEPLOYMENT_HELPER_1);
 
             Thread.sleep(DELAY);
 
@@ -157,7 +156,7 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
                 HttpClientUtils.closeQuietly(response);
             }
 
-            this.undeploy(SINGLETON_DEPLOYMENT_2);
+            this.undeploy(DEPLOYMENT_HELPER_2);
 
             Thread.sleep(DELAY);
 
@@ -175,7 +174,7 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
                 HttpClientUtils.closeQuietly(response);
             }
 
-            this.deploy(SINGLETON_DEPLOYMENT_2);
+            this.deploy(DEPLOYMENT_HELPER_2);
 
             Thread.sleep(DELAY);
 
@@ -193,7 +192,7 @@ public abstract class SingletonDeploymentTestCase extends AbstractClusteringTest
                 HttpClientUtils.closeQuietly(response);
             }
         } finally {
-            this.undeploy(SINGLETON_DEPLOYMENT_1, SINGLETON_DEPLOYMENT_2);
+            this.undeploy(DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2);
 
             executeOnNodesAndReload("/subsystem=singleton/singleton-policy=default/election-policy=simple:undefine-attribute(name=name-preferences)", client1, client2);
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPolicyServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonPolicyServiceTestCase.java
@@ -55,20 +55,22 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SingletonPolicyServiceTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = SingletonPolicyServiceTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(NodeService.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsServiceProvider(org.jboss.msc.service.ServiceActivator.class, NodeServicePolicyActivator.class);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
@@ -55,20 +55,22 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SingletonServiceTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = SingletonServiceTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return createDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return createDeployment();
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(NodeService.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
@@ -32,7 +32,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class CoarseWebFailoverTestCase extends AbstractWebFailoverTestCase {
-    private static final String DEPLOYMENT_NAME = "coarse-distributable.war";
+
+    private static final String MODULE_NAME = CoarseWebFailoverTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public CoarseWebFailoverTestCase() {
         super(DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentCoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentCoarseWebFailoverTestCase.java
@@ -34,7 +34,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 @ServerSetup(ConcurrentWebFailoverServerSetup.class)
 public class ConcurrentCoarseWebFailoverTestCase extends AbstractWebFailoverTestCase {
-    private static final String DEPLOYMENT_NAME = "coarse-concurrent-distributable.war";
+
+    private static final String MODULE_NAME = ConcurrentCoarseWebFailoverTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public ConcurrentCoarseWebFailoverTestCase() {
         super(DEPLOYMENT_NAME, TransactionMode.NON_TRANSACTIONAL);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
@@ -37,7 +37,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  */
 @ServerSetup(ConcurrentWebFailoverServerSetup.class)
 public class ConcurrentFineWebFailoverTestCase extends AbstractWebFailoverTestCase {
-    private static final String DEPLOYMENT_NAME = "fine-concurrent-distributable.war";
+
+    private static final String MODULE_NAME = ConcurrentFineWebFailoverTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public ConcurrentFineWebFailoverTestCase() {
         super(DEPLOYMENT_NAME, TransactionMode.NON_TRANSACTIONAL);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/DistributableTestCase.java
@@ -63,22 +63,24 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class DistributableTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = DistributableTestCase.class.getSimpleName();
+
     private static final int REQUEST_DURATION = 10000;
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return getDeployment();
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClasses(SimpleServlet.class, Mutable.class);
         war.setWebXML(DistributableTestCase.class.getPackage(), "web.xml");
         return war;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
@@ -56,7 +56,9 @@ import org.wildfly.clustering.marshalling.Externalizer;
  */
 @RunWith(Arquillian.class)
 public class ExternalizerTestCase extends AbstractClusteringTestCase {
-    private static final String DEPLOYMENT_NAME = "externalizer.war";
+
+    private static final String MODULE_NAME = ExternalizerTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
@@ -35,7 +35,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  * @author Radoslav Husar
  */
 public class FineWebFailoverTestCase extends AbstractWebFailoverTestCase {
-    private static final String DEPLOYMENT_NAME = "fine-distributable.war";
+
+    private static final String MODULE_NAME = FineWebFailoverTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public FineWebFailoverTestCase() {
         super(DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
@@ -59,20 +59,22 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class NonDistributableTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = NonDistributableTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return getDeployment();
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "non-distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClasses(SimpleServlet.class, Mutable.class);
         return war;
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -55,10 +55,12 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class NonHaWebSessionPersistenceTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = NonHaWebSessionPersistenceTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_SINGLE)
     public static Archive<?> deployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "session-persistence.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClasses(SimpleServlet.class, Mutable.class);
         war.setWebXML(NonHaWebSessionPersistenceTestCase.class.getPackage(), "web.xml");
         return war;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
@@ -49,7 +49,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ReplicationForNegotiationAuthenticatorTestCase extends AbstractWebFailoverTestCase {
-    private static final String DEPLOYMENT_NAME = "negotiationAuthenticator.war";
+
+    private static final String MODULE_NAME = ReplicationForNegotiationAuthenticatorTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     public ReplicationForNegotiationAuthenticatorTestCase() {
         super(DEPLOYMENT_NAME, TransactionMode.TRANSACTIONAL);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
@@ -55,7 +55,9 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class AsyncServletTestCase extends AbstractClusteringTestCase {
-    private static final String DEPLOYMENT_NAME = "async.war";
+
+    private static final String MODULE_NAME = AsyncServletTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/BasicAuthenticationWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/BasicAuthenticationWebFailoverTestCase.java
@@ -59,6 +59,8 @@ import org.junit.runner.RunWith;
 @ServerSetup(WebSecurityDomainSetup.class)
 public class BasicAuthenticationWebFailoverTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = BasicAuthenticationWebFailoverTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
@@ -72,7 +74,7 @@ public class BasicAuthenticationWebFailoverTestCase extends AbstractClusteringTe
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "basic-authentication.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClass(SecureServlet.class);
         war.setWebXML(SecureServlet.class.getPackage(), "web-basic.xml");
         war.addAsWebInfResource(SecureServlet.class.getPackage(), "jboss-web.xml", "jboss-web.xml");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
@@ -57,17 +57,18 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class InvalidateConversationTestCase extends AbstractClusteringTestCase {
 
-    private static final String DEPLOYMENT_NAME = "conversation.war";
+    private static final String MODULE_NAME = InvalidateConversationTestCase.class.getSimpleName();
+    private static final String DEPLOYMENT_NAME = MODULE_NAME + ".war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return getDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/CoarseSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/CoarseSessionExpirationTestCase.java
@@ -31,6 +31,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
 
+    private static final String MODULE_NAME = CoarseSessionExpirationTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
@@ -44,6 +46,6 @@ public class CoarseSessionExpirationTestCase extends SessionExpirationTestCase {
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment().addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
@@ -31,6 +31,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
 
+    private static final String MODULE_NAME = FineSessionExpirationTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
@@ -44,6 +46,6 @@ public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment().addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-fine.xml", "jboss-web.xml");
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionExpirationTestCase.class.getPackage(), "jboss-web-fine.xml", "jboss-web.xml");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -48,8 +48,8 @@ import org.junit.Test;
  */
 public abstract class SessionExpirationTestCase extends AbstractClusteringTestCase {
 
-    static WebArchive getBaseDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "expiration.war");
+    static WebArchive getBaseDeployment(String moduleName) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, moduleName + ".war");
         war.addClasses(SessionOperationServlet.class, RecordingWebListener.class);
         // Take web.xml from the managed test.
         war.setWebXML(DistributableTestCase.class.getPackage(), "web.xml");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/CoarseSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/CoarseSessionPassivationTestCase.java
@@ -31,6 +31,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class CoarseSessionPassivationTestCase extends SessionPassivationTestCase {
 
+    private static final String MODULE_NAME = CoarseSessionPassivationTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
@@ -44,6 +46,6 @@ public class CoarseSessionPassivationTestCase extends SessionPassivationTestCase
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment().addAsWebInfResource(SessionPassivationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionPassivationTestCase.class.getPackage(), "jboss-web-coarse.xml", "jboss-web.xml");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
@@ -31,6 +31,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class FineSessionPassivationTestCase extends SessionPassivationTestCase {
 
+    private static final String MODULE_NAME = FineSessionPassivationTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
     public static Archive<?> deployment0() {
@@ -44,6 +46,6 @@ public class FineSessionPassivationTestCase extends SessionPassivationTestCase {
     }
 
     static WebArchive getDeployment() {
-        return getBaseDeployment().addAsWebInfResource(SessionPassivationTestCase.class.getPackage(), "jboss-web-fine.xml", "jboss-web.xml");
+        return getBaseDeployment(MODULE_NAME).addAsWebInfResource(SessionPassivationTestCase.class.getPackage(), "jboss-web-fine.xml", "jboss-web.xml");
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
@@ -42,7 +42,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.clustering.cluster.web.DistributableTestCase;
@@ -56,8 +55,8 @@ public abstract class SessionPassivationTestCase extends AbstractClusteringTestC
 
     private static final int MAX_PASSIVATION_WAIT = TimeoutUtil.adjust(10000);
 
-    static WebArchive getBaseDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "passivation.war");
+    static WebArchive getBaseDeployment(String moduleName) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, moduleName + ".war");
         war.addClasses(SessionOperationServlet.class);
         // Take web.xml from the managed test.
         war.setWebXML(DistributableTestCase.class.getPackage(), "web.xml");
@@ -65,7 +64,6 @@ public abstract class SessionPassivationTestCase extends AbstractClusteringTestC
     }
 
     @Test
-    @InSequence(1)
     public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL)
             throws IOException, URISyntaxException {
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionTestCase.java
@@ -57,19 +57,20 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SharedSessionTestCase extends AbstractClusteringTestCase {
 
-    private static final String MODULE = "shared";
-    private static final String MODULE_1 = "war1";
-    private static final String MODULE_2 = "war2";
+    private static final String MODULE_PREFIX = SharedSessionTestCase.class.getSimpleName() + '-';
+    private static final String MODULE = MODULE_PREFIX + "shared";
+    private static final String MODULE_1 = MODULE_PREFIX + "war1";
+    private static final String MODULE_2 = MODULE_PREFIX + "war2";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(NODE_1)
-    public static Archive<?> deployment0() {
+    public static Archive<?> deployment1() {
         return getDeployment();
     }
 
     @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
     @TargetsContainer(NODE_2)
-    public static Archive<?> deployment1() {
+    public static Archive<?> deployment2() {
         return getDeployment();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
@@ -78,6 +78,8 @@ import org.junit.runner.RunWith;
 @ServerSetup({XSiteSimpleTestCase.ServerSetupTask.class})
 public class XSiteSimpleTestCase extends AbstractClusteringTestCase {
 
+    private static final String MODULE_NAME = XSiteSimpleTestCase.class.getSimpleName();
+
     public XSiteSimpleTestCase() {
         super(FOUR_NODES, FOUR_DEPLOYMENTS);
     }
@@ -107,7 +109,7 @@ public class XSiteSimpleTestCase extends AbstractClusteringTestCase {
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "xsite.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClass(CacheAccessServlet.class);
         war.setWebXML(XSiteSimpleTestCase.class.getPackage(), "web.xml");
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.infinispan\n"));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/dispatcher/CommandDispatcherTestCase.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class CommandDispatcherTestCase {
-    private static final String MODULE_NAME = "command-dispatcher";
+    private static final String MODULE_NAME = CommandDispatcherTestCase.class.getSimpleName();
 
     @Deployment(testable = false)
     public static Archive<?> createDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/provider/ServiceProviderRegistrationTestCase.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class ServiceProviderRegistrationTestCase {
-    private static final String MODULE_NAME = "service-provider-registration";
+    private static final String MODULE_NAME = ServiceProviderRegistrationTestCase.class.getSimpleName();
 
     @Deployment(testable = false)
     public static Archive<?> createDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/registry/RegistryTestCase.java
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class RegistryTestCase {
-    private static final String MODULE_NAME = "registry";
+    private static final String MODULE_NAME = RegistryTestCase.class.getSimpleName();
 
     @Deployment(testable = false)
     public static Archive<?> createDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
@@ -57,10 +57,11 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 public class SingletonServiceTestCase {
+    private static final String MODULE_NAME = SingletonServiceTestCase.class.getSimpleName();
 
     @Deployment(testable = false)
     public static Archive<?> deployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "singleton.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addPackage(NodeService.class.getPackage());
         war.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.server\n"));
         war.addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -54,9 +54,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class SimpleWebTestCase {
 
+    private static final String MODULE_NAME = SimpleWebTestCase.class.getSimpleName();
+
     @Deployment(name = DEPLOYMENT_1, testable = false)
     public static Archive<?> deployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClasses(SimpleServlet.class, Mutable.class);
         war.setWebXML(SimpleWebTestCase.class.getPackage(), "web.xml");
         return war;


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-10065

This makes debugging in large logs much faster, since deployments can be associated with test cases without inspecting test class's deployments and test execution order.
