### PR TITLE
WFLY-10095 Upgrade JGroups to 4.0.11.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <version.org.jboss.ws.common.tools>1.3.0.Final</version.org.jboss.ws.common.tools>
         <version.org.jboss.ws.cxf>5.2.0.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
-        <version.org.jgroups>4.0.10.Final</version.org.jgroups>
+        <version.org.jgroups>4.0.11.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.2.0.Final</version.org.jgroups.azure>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10095