### PR TITLE
[WFLY-5966] Partial removal of unneeded module deps that came in when we dropped javax.ejb.api

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -58,6 +58,5 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -79,6 +79,5 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -45,7 +45,6 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="javax.transaction.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -71,7 +71,6 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.narayana.compensations" />
-        <module name="org.omg.api"/>
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -53,11 +53,5 @@
         <module name="org.jboss.weld.spi" export="true"/>
         <module name="org.jboss.logging" />
         <module name="sun.jdk" optional="true" />
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -65,6 +65,5 @@
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Partial completion of the https://issues.jboss.org/browse/WFLY-5966 task.  

**Do not resolve the JIRA based on this PR!**

The overall WFLY-5966 task is to analyze and clean out unneeded deps that were added to numerous modules to replace what javax.ejb.api previously exported.

This PR is in response to the comment by @mkouba on the JIRA, where he states that weld.core doesn't need the deps and also points out the heavy transitive dep chain that comes with org.omg.api. Analyzing whether code in the WF codebase itself uses org.omg is simple, so the second PR here removes org.omg.api from modules for our code where inspection shows there are no imports.