### PR TITLE
[WFLY-10108] Upgrade to CXF 3.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>1.5.5.jbossorg-010</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
-        <version.org.apache.cxf>3.2.2</version.org.apache.cxf>
+        <version.org.apache.cxf>3.2.4</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.1.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M20</version.org.apache.ds>
         <version.org.apache.jstl>1.2.6-RC1</version.org.apache.jstl>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10108

An upgrade to CXF 3.2.4 is required by WildFly Camel, see https://github.com/wildfly-extras/wildfly-camel/issues/2460
