### PR TITLE
WFLY-10112 Upgrade Hibernate Validator to 6.0.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <version.org.glassfish.javax.json-1.0>1.0.4</version.org.glassfish.javax.json-1.0>
         <version.org.hibernate>5.1.13.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.2.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.validator>6.0.7.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.9.Final</version.org.hibernate.validator>
         <version.org.hibernate.validator.ee7>5.3.6.Final</version.org.hibernate.validator.ee7>
         <version.javax.persistence>2.2</version.javax.persistence>
         <version.org.hibernate.search>5.5.8.Final</version.org.hibernate.search>


### PR DESCRIPTION
 * https://issues.jboss.org/browse/WFLY-10112

Brings some performance improvements but more importantly fixes a 5.x -> 6.0.x regression - it's a corner case but still.