### PR TITLE
Use the <doclint/> configuration setting to turn off doclint.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                     </configuration>
                 </plugin>
                 <!-- Checkstyle -->


### PR DESCRIPTION
Currently the JavaDoc's fail because the `doclint` is not properly disabled. This means the `release` profile fails. This change simply uses the `<doclint>none</doclint>` configuration vs the parameter.