### PR TITLE
[WFLY-10162] : Upgrade FasterXML Jackson from 2.9.4 to 2.9.5 .

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -60,7 +60,7 @@
         <version.antlr>2.7.7</version.antlr>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.9.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.9.5</version.com.fasterxml.jackson>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>


### PR DESCRIPTION
[WFLY-10162] : https://issues.jboss.org/browse/WFLY-10162