### PR TITLE
[WFLY-9589] Upgrade JBossXACML to 2.0.10

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -166,7 +166,7 @@
         <version.org.jboss.resteasy>3.5.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.4.Final</version.org.jboss.security.jboss-negotiation>
-        <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
+        <version.org.jboss.security.jbossxacml>2.0.10.Final</version.org.jboss.security.jbossxacml>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-10</version.org.jboss.shrinkwrap.descriptors>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
PR for https://issues.jboss.org/browse/WFLY-9589.

Upgraded JBossXACML to 2.0.10.Final.