### PR TITLE
WFLY-10171 Use default conn_expiry_timeout for UNICAST3.

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -62,7 +62,6 @@
         xmit_table_num_rows="50"
     />
     <UNICAST3
-        conn_expiry_timeout="0"
         xmit_interval="100"
         xmit_table_num_rows="50"
     />


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10171