### PR TITLE
WFLY-10180 CDI.current() should return the BeanManager from JNDI if a…

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldProvider.java
@@ -24,8 +24,11 @@ package org.jboss.as.weld;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
 import javax.enterprise.inject.spi.CDIProvider;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import org.jboss.as.weld.deployment.WeldDeployment;
 import org.jboss.as.weld.services.ModuleGroupSingletonProvider;
@@ -87,7 +90,15 @@ public class WeldProvider implements CDIProvider {
         }
 
         @Override
-        public BeanManagerProxy getBeanManager() {
+        public BeanManager getBeanManager() {
+            try {
+                BeanManager bm = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
+                if(bm != null) {
+                    return bm;
+                }
+            } catch (NamingException e) {
+                //ignore
+            }
             checkContainerState(container);
             final String callerName = getCallingClassName();
 


### PR DESCRIPTION
…vailble
https://issues.jboss.org/browse/WFLY-10180