### PR TITLE
[WFLY-10110][WFLY-10111] Fix attribute setting for JCA pool configuration initial-size and blocking-timeout-wait-milis

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/Constants.java
@@ -147,7 +147,6 @@ public class Constants {
             .setXmlName(Pool.Tag.INITIAL_POOL_SIZE.getLocalName())
             .setAllowExpression(true)
             .setRequired(false)
-            .setDefaultValue(new ModelNode(Defaults.MIN_POOL_SIZE))
             .build();
 
     public static SimpleAttributeDefinition CAPACITY_INCREMENTER_CLASS = new SimpleAttributeDefinitionBuilder(CAPACITY_INCREMENTER_CLASS_NAME, ModelType.STRING, true)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolConfigurationRWHandler.java
@@ -137,10 +137,10 @@ public class PoolConfigurationRWHandler {
                     pc.setMinSize(newValue.asInt());
                 }
                 if (INITIAL_POOL_SIZE.getName().equals(parameterName)) {
-                    pc.setInitialSize(newValue.asInt());
+                    pc.setInitialSize(newValue.isDefined()? newValue.asInt(): 0);
                 }
                 if (BLOCKING_TIMEOUT_WAIT_MILLIS.getName().equals(parameterName)) {
-                    pc.setBlockingTimeout(newValue.asLong());
+                    pc.setBlockingTimeout(newValue.isDefined()? newValue.asLong(): 0);
                 }
                 if (POOL_USE_STRICT_MIN.getName().equals(parameterName)) {
                     pc.setStrictMin(newValue.asBoolean());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -152,7 +152,7 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
         Assert.assertNotNull(poolConfiguration);
         Assert.assertEquals(2, poolConfiguration.getMinSize());
         Assert.assertEquals(5, poolConfiguration.getMaxSize());
-        Assert.assertEquals(0, poolConfiguration.getInitialSize());
+        Assert.assertEquals(2, poolConfiguration.getInitialSize());
         Assert.assertEquals(30000, poolConfiguration.getBlockingTimeout());
         Assert.assertEquals(true, poolConfiguration.isFair());
         Assert.assertEquals(false, poolConfiguration.isStrictMin());


### PR DESCRIPTION
Jiras:
https://issues.jboss.org/browse/WFLY-10111
https://issues.jboss.org/browse/WFLY-10110