### PR TITLE
[WFLY-10060] add jboss-module to jaxws-client to enable apache compil…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -71,5 +71,6 @@
         <module name="org.apache.commons.beanutils"/>
         <module name="javax.wsdl4j.api" />
         <module name="org.bouncycastle" />
+        <module name="org.jboss.modules"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10060

This dependency addition is needed for ./bin/wsconsume.* to run.
The complete fix also requires https://issues.jboss.org/browse/JBWS-4107