### PR TITLE
[WFLY-9987] The attribute 'driver-datasource-class-name' is missing from 'get-installed-driver' operation

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
@@ -28,6 +28,7 @@ package org.jboss.as.connector.subsystems.datasources;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_CLASS_INFO;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DEPLOYMENT_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_CLASS_NAME;
+import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_DATASOURCE_CLASS_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MAJOR_VERSION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MINOR_VERSION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DRIVER_MODULE_NAME;
@@ -87,11 +88,14 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
                         driverNode.get(DEPLOYMENT_NAME.getName()).set(driver.getDriverName());
                         driverNode.get(DRIVER_MODULE_NAME.getName());
                         driverNode.get(MODULE_SLOT.getName());
+                        driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName());
                         driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName());
                     } else {
                         driverNode.get(DEPLOYMENT_NAME.getName());
                         driverNode.get(DRIVER_MODULE_NAME.getName()).set(driver.getModuleName().getName());
                         driverNode.get(MODULE_SLOT.getName()).set(driver.getModuleName() != null ? driver.getModuleName().getSlot() : "");
+                        driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName()).set(
+                                driver.getDataSourceClassName() != null ? driver.getDataSourceClassName() : "");
                         driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).set(driver.getXaDataSourceClassName());
 
                     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/DataSourceClassInfoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/DataSourceClassInfoTestCase.java
@@ -117,6 +117,7 @@ public class DataSourceClassInfoTestCase extends ContainerResourceMgmtTestBase {
         Assert.assertEquals("success", result.get("outcome").asString());
         ModelNode dsInfoList = result.get("result");
         Assert.assertNotNull(dsInfoList);
+        Assert.assertTrue(dsInfoList.get(0).has("driver-datasource-class-name"));
         ModelNode dsInfo = dsInfoList.get(0).get("datasource-class-info").get(0).get("org.h2.jdbcx.JdbcDataSource");
         Assert.assertNotNull(dsInfo);
 
@@ -143,6 +144,7 @@ public class DataSourceClassInfoTestCase extends ContainerResourceMgmtTestBase {
         Assert.assertEquals("success", result.get("outcome").asString());
         ModelNode dsInfoList = result.get("result");
         Assert.assertNotNull(dsInfoList);
+        Assert.assertTrue(dsInfoList.get(0).has("driver-datasource-class-name"));
         ModelNode dsInfo = dsInfoList.get(0).get("datasource-class-info").get(0).get("org.h2.jdbcx.JdbcDataSource");
         Assert.assertNotNull(dsInfo);
 


### PR DESCRIPTION

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

Jira: https://issues.jboss.org/browse/WFLY-9987

This issue was revealed when implementing https://issues.jboss.org/browse/WFLY-5603.

This PR contains model changes on the read only attribute: `driver-datasource-class-name` for the operation: `/subsystem=datasources:get-installed-driver(driver-name=h2)`.

Because in WFLY-5603 implementation, there is model version bump up already, and there is no releases yet after that. So this PR won't update the model version any more as long as it can be merged before next release.