### PR TITLE
[WFLY-10204] Upgrade openjdk-orb to 8.1.1.Final

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -162,7 +162,7 @@
         <version.org.jboss.metadata>11.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.9.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.8.0.Final</version.org.jboss.narayana>
-        <version.org.jboss.openjdk-orb>8.1.0.Final</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>8.1.1.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>3.5.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.4.Final</version.org.jboss.security.jboss-negotiation>


### PR DESCRIPTION
Fix for correct openjdk-orb sources JAR generation