### PR TITLE
[WFLY-10194] WildFlyActivationRaWithSecurityDomainTestCase fails unde…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import javax.annotation.Resource;
 import javax.resource.cci.Connection;
+import javax.security.auth.PrivateCredentialPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -37,6 +38,7 @@ import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -140,6 +142,8 @@ public class WildFlyActivationRaWithElytronAuthContextTestCase {
                 .addAsLibrary(jar)
                 .addAsManifestResource(WildFlyActivationRaWithElytronAuthContextTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, org.jboss.as.controller-client\n"), "MANIFEST.MF");
+        rar.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                new PrivateCredentialPermission("javax.resource.spi.security.PasswordCredential org.wildfly.security.auth.principal.NamePrincipal \"sa\"", "read")), "permissions.xml");
 
         return rar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Resource;
 import javax.resource.cci.Connection;
+import javax.security.auth.PrivateCredentialPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -40,6 +41,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -138,6 +140,8 @@ public class WildFlyActivationRaWithSecurityDomainTestCase {
         jar.addClasses(AbstractLoginModuleSecurityDomainTestCaseSetup.class, AbstractSecurityDomainSetup.class);
         final ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, "wf-ra-security-domain.rar").addAsLibrary(jar)
                 .addAsManifestResource(WildFlyActivationRaWithSecurityDomainTestCase.class.getPackage(), "ra.xml", "ra.xml");
+        rar.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                new PrivateCredentialPermission("javax.resource.spi.security.PasswordCredential org.jboss.security.SimplePrincipal \"sa\"", "read")), "permissions.xml");
 
         return rar;
     }


### PR DESCRIPTION
…r security manager

fixes also WildFlyActivationRaWithElytronAuthContextTestCase and WildFlyActivationRaWithMixedSecurityTestCase

https://issues.jboss.org/browse/WFLY-10194