### PR TITLE
[WFLY-10223] providing Providers from bouncycastle module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.bouncycastle">
+<module xmlns="urn:jboss:module:1.8" name="org.bouncycastle">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -38,5 +38,11 @@
         <module name="javax.mail.api" optional="true"/>
         <module name="javax.activation.api" optional="true"/>
     </dependencies>
+    <provides>
+        <service name="java.security.Provider">
+            <with-class name="org.bouncycastle.jce.provider.BouncyCastleProvider"/>
+            <with-class name="org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider"/>
+        </service>
+    </provides>
 
 </module>


### PR DESCRIPTION
Publishing Provider from bouncycastle using new jboss-modules 1.8 feature.
Depends on jboss-modules upgrade: https://github.com/wildfly/wildfly-core/pull/3201

https://issues.jboss.org/browse/WFLY-10223
https://issues.jboss.org/browse/JBEAP-8823