### PR TITLE
WFLY-10216 Replace clustering resource capability reference handling with native registration from wildfly-core

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AbstractCapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AbstractCapabilityReference.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.OperationContext;
+import org.wildfly.clustering.service.Requirement;
+
+/**
+ * Abstract {@link CapabilityReferenceRecorder} containing logic common to attribute and resource capability references
+ * @author Paul Ferraro
+ */
+public abstract class AbstractCapabilityReference implements CapabilityReferenceRecorder {
+
+    private final Capability capability;
+    private final Requirement requirement;
+
+    protected AbstractCapabilityReference(Capability capability, Requirement requirement) {
+        this.capability = capability;
+        this.requirement = requirement;
+    }
+
+    @Override
+    public String getBaseDependentName() {
+        return this.capability.getName();
+    }
+
+    @Override
+    public String getBaseRequirementName() {
+        return this.requirement.getName();
+    }
+
+    protected String getDependentName(OperationContext context) {
+        return this.capability.resolve(context.getCurrentAddress()).getName();
+    }
+
+    @Override
+    public int hashCode() {
+        return this.capability.getName().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return (object instanceof AbstractCapabilityReference) ? this.capability.getName().equals(((AbstractCapabilityReference) object).capability.getName()) : false;
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -209,8 +208,8 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
             }
         }
 
-        for (Map.Entry<CapabilityReferenceRecorder, Function<PathAddress, String>> entry : this.descriptor.getResourceCapabilityReferences().entrySet()) {
-            entry.getKey().addCapabilityRequirements(context, resource, null, entry.getValue().apply(address));
+        for (CapabilityReferenceRecorder recorder : context.getResourceRegistration().getRequirements()) {
+            recorder.addCapabilityRequirements(context, resource, null);
         }
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryCapabilityNameResolver.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryCapabilityNameResolver.java
@@ -27,28 +27,10 @@ import java.util.function.Function;
 import org.jboss.as.controller.PathAddress;
 
 /**
- * Dynamic name mapper implementations.
+ * Dynamic name mapper implementations for binary capability names.
  * @author Paul Ferraro
  */
-public enum DynamicCapabilityNameResolver implements Function<PathAddress, String[]> {
-    DEFAULT() {
-        @Override
-        public String[] apply(PathAddress address) {
-            return new String[] { address.getLastElement().getValue() };
-        }
-    },
-    PARENT() {
-        @Override
-        public String[] apply(PathAddress address) {
-            return new String[] { address.getParent().getLastElement().getValue() };
-        }
-    },
-    GRANDPARENT() {
-        @Override
-        public String[] apply(PathAddress address) {
-            return new String[] { address.getParent().getParent().getLastElement().getValue() };
-        }
-    },
+public enum BinaryCapabilityNameResolver implements Function<PathAddress, String[]> {
     PARENT_CHILD() {
         @Override
         public String[] apply(PathAddress address) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryRequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/BinaryRequirementCapability.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-
-import java.util.function.UnaryOperator;
-
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.clustering.service.BinaryRequirement;
 
@@ -41,7 +38,7 @@ public class BinaryRequirementCapability implements Capability {
      * @param requirement the requirement basis
      */
     public BinaryRequirementCapability(BinaryRequirement requirement) {
-        this(requirement, UnaryOperator.identity());
+        this(requirement, BinaryCapabilityNameResolver.PARENT_CHILD);
     }
 
     /**
@@ -49,12 +46,11 @@ public class BinaryRequirementCapability implements Capability {
      * @param requirement the requirement basis
      * @param configurator configures the capability
      */
-    public BinaryRequirementCapability(final BinaryRequirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> configurator) {
-        RuntimeCapability.Builder<Void> builder = RuntimeCapability.Builder.of(requirement.getName(), true)
+    public BinaryRequirementCapability(BinaryRequirement requirement, BinaryCapabilityNameResolver resolver) {
+        this.definition = RuntimeCapability.Builder.of(requirement.getName(), true)
                 .setServiceType(requirement.getType())
-                .setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT_CHILD)
-                ;
-        this.definition = configurator.apply(builder).build();
+                .setDynamicNameMapper(resolver)
+                .build();
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
@@ -23,7 +23,6 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Map;
-import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
@@ -89,8 +88,8 @@ public class RemoveStepHandler extends AbstractRemoveStepHandler implements Regi
                 }
             }
 
-            for (Map.Entry<CapabilityReferenceRecorder, Function<PathAddress, String>> entry : this.descriptor.getResourceCapabilityReferences().entrySet()) {
-                entry.getKey().removeCapabilityRequirements(context, resource, null, entry.getValue().apply(address));
+            for (CapabilityReferenceRecorder recorder : registration.getRequirements()) {
+                recorder.removeCapabilityRequirements(context, resource, null);
             }
 
             if (this.requiresRuntime(context)) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandlerDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandlerDescriptor.java
@@ -23,13 +23,11 @@ package org.jboss.as.clustering.controller;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
-import java.util.function.Function;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 
 /**
@@ -57,8 +55,8 @@ public interface RemoveStepHandlerDescriptor extends OperationStepHandlerDescrip
      * Returns a mapping of capability references to an ancestor resource.
      * @return a tuple of capability references and requirement resolvers.
      */
-    default Map<CapabilityReferenceRecorder, Function<PathAddress, String>> getResourceCapabilityReferences() {
-        return Collections.emptyMap();
+    default Set<CapabilityReferenceRecorder> getResourceCapabilityReferences() {
+        return Collections.emptySet();
     }
 
     /**

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
@@ -47,6 +47,16 @@ public class ResourceCapabilityReference extends AbstractCapabilityReference {
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
      */
+    public ResourceCapabilityReference(Capability capability, Requirement requirement) {
+        this(capability, requirement, new SimpleCapabilityNameResolver());
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
+     */
     public ResourceCapabilityReference(Capability capability, UnaryRequirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
         this(capability, (Requirement) requirement, requirementNameResolver);
     }
@@ -77,7 +87,8 @@ public class ResourceCapabilityReference extends AbstractCapabilityReference {
     }
 
     private String getRequirementName(OperationContext context) {
-        return RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), this.requirementNameResolver.apply(context.getCurrentAddress()));
+        String[] parts = this.requirementNameResolver.apply(context.getCurrentAddress());
+        return (parts.length > 0) ? RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), parts) : this.getBaseRequirementName();
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
@@ -57,7 +57,7 @@ public class ResourceCapabilityReference extends AbstractCapabilityReference {
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
      */
-    public ResourceCapabilityReference(Capability capability, UnaryRequirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
+    public ResourceCapabilityReference(Capability capability, UnaryRequirement requirement, UnaryCapabilityNameResolver requirementNameResolver) {
         this(capability, (Requirement) requirement, requirementNameResolver);
     }
 
@@ -67,7 +67,7 @@ public class ResourceCapabilityReference extends AbstractCapabilityReference {
      * @param requirement the requirement of the specified capability
      * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
      */
-    public ResourceCapabilityReference(Capability capability, BinaryRequirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
+    public ResourceCapabilityReference(Capability capability, BinaryRequirement requirement, BinaryCapabilityNameResolver requirementNameResolver) {
         this(capability, (Requirement) requirement, requirementNameResolver);
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceCapabilityReference.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import java.util.function.Function;
+
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.Resource;
+import org.wildfly.clustering.service.BinaryRequirement;
+import org.wildfly.clustering.service.Requirement;
+import org.wildfly.clustering.service.UnaryRequirement;
+
+/**
+ * {@link CapabilityReferenceRecorder} for resource-level capability references.
+ * @author Paul Ferraro
+ */
+public class ResourceCapabilityReference extends AbstractCapabilityReference {
+
+    private final Function<PathAddress, String[]> requirementNameResolver;
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
+     */
+    public ResourceCapabilityReference(Capability capability, UnaryRequirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
+        this(capability, (Requirement) requirement, requirementNameResolver);
+    }
+
+    /**
+     * Creates a new reference between the specified capability and the specified requirement
+     * @param capability the capability referencing the specified requirement
+     * @param requirement the requirement of the specified capability
+     * @param requirementNameResolver function for resolving the dynamic elements of the requirement name
+     */
+    public ResourceCapabilityReference(Capability capability, BinaryRequirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
+        this(capability, (Requirement) requirement, requirementNameResolver);
+    }
+
+    private ResourceCapabilityReference(Capability capability, Requirement requirement, Function<PathAddress, String[]> requirementNameResolver) {
+        super(capability, requirement);
+        this.requirementNameResolver = requirementNameResolver;
+    }
+
+    @Override
+    public void addCapabilityRequirements(OperationContext context, Resource resource,  String attributeName, String... values) {
+        context.registerAdditionalCapabilityRequirement(this.getRequirementName(context), this.getDependentName(context), attributeName);
+    }
+
+    @Override
+    public void removeCapabilityRequirements(OperationContext context, Resource resource, String attributeName, String... values) {
+        context.deregisterCapabilityRequirement(this.getRequirementName(context), this.getDependentName(context));
+    }
+
+    private String getRequirementName(OperationContext context) {
+        return RuntimeCapability.buildDynamicCapabilityName(this.getBaseRequirementName(), this.requirementNameResolver.apply(context.getCurrentAddress()));
+    }
+
+    @Override
+    public String[] getRequirementPatternSegments(String name, PathAddress address) {
+        String[] segments = this.requirementNameResolver.apply(address);
+        for (int i = 0; i < segments.length; ++i) {
+            String segment = segments[i];
+            if (segment.charAt(0) == '$') {
+                segments[i] = segment.substring(1);
+            }
+        }
+        return segments;
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
@@ -27,13 +27,13 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
@@ -41,7 +41,6 @@ import org.jboss.as.clustering.function.Predicates;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -72,7 +71,7 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     private final Set<PathElement> requiredSingletonChildren = new TreeSet<>(PATH_COMPARATOR);
     private final Map<AttributeDefinition, AttributeTranslation> attributeTranslations = new TreeMap<>(ATTRIBUTE_COMPARATOR);
     private final List<RuntimeResourceRegistration> runtimeResourceRegistrations = new LinkedList<>();
-    private final Map<CapabilityReferenceRecorder, Function<PathAddress, String>> resourceCapabilityReferences = new HashMap<>();
+    private final Set<CapabilityReferenceRecorder> resourceCapabilityReferences = new HashSet<>();
     private volatile UnaryOperator<OperationStepHandler> addOperationTransformer = UnaryOperator.identity();
     private volatile UnaryOperator<OperationStepHandler> operationTransformer = UnaryOperator.identity();
 
@@ -222,12 +221,12 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     }
 
     @Override
-    public Map<CapabilityReferenceRecorder, Function<PathAddress, String>> getResourceCapabilityReferences() {
+    public Set<CapabilityReferenceRecorder> getResourceCapabilityReferences() {
         return this.resourceCapabilityReferences;
     }
 
-    public ResourceDescriptor addResourceCapabilityReference(CapabilityReferenceRecorder reference, Function<PathAddress, String> resolver) {
-        this.resourceCapabilityReferences.put(reference, resolver);
+    public ResourceDescriptor addResourceCapabilityReference(CapabilityReferenceRecorder reference) {
+        this.resourceCapabilityReferences.add(reference);
         return this;
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
@@ -58,6 +58,8 @@ public class ResourceRegistration implements Registration<ManagementResourceRegi
     public void register(ManagementResourceRegistration registration) {
         new CapabilityRegistration(this.descriptor.getCapabilities().keySet()).register(registration);
 
+        registration.registerRequirements(this.descriptor.getResourceCapabilityReferences());
+
         // Register attributes before add operation
         this.writeAttributeRegistration.register(registration);
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryCapabilityNameResolver.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryCapabilityNameResolver.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import java.util.function.Function;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+
+/**
+ * Dynamic name mapper implementations for unary capability names.
+ * @author Paul Ferraro
+ */
+public enum UnaryCapabilityNameResolver implements Function<PathAddress, String[]> {
+    DEFAULT() {
+        @Override
+        public String[] apply(PathAddress address) {
+            return new String[] { address.getLastElement().getValue() };
+        }
+    },
+    PARENT() {
+        @Override
+        public String[] apply(PathAddress address) {
+            return new String[] { address.getParent().getLastElement().getValue() };
+        }
+    },
+    GRANDPARENT() {
+        @Override
+        public String[] apply(PathAddress address) {
+            return new String[] { address.getParent().getParent().getLastElement().getValue() };
+        }
+    },
+    LOCAL() {
+        @Override
+        public String[] apply(PathAddress address) {
+            return new String[] { ModelDescriptionConstants.LOCAL };
+        }
+    },
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/UnaryRequirementCapability.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.function.UnaryOperator;
-
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.wildfly.clustering.service.UnaryRequirement;
 
@@ -40,20 +38,18 @@ public class UnaryRequirementCapability implements Capability {
      * @param requirement the unary requirement basis
      */
     public UnaryRequirementCapability(UnaryRequirement requirement) {
-        this(requirement, UnaryOperator.identity());
+        this(requirement, UnaryCapabilityNameResolver.DEFAULT);
     }
 
     /**
      * Creates a new capability based on the specified unary requirement
      * @param requirement the unary requirement basis
-     * @param configurator configures the capability
      */
-    public UnaryRequirementCapability(UnaryRequirement requirement, UnaryOperator<RuntimeCapability.Builder<Void>> configurator) {
-        RuntimeCapability.Builder<Void> builder = RuntimeCapability.Builder.of(requirement.getName(), true)
+    public UnaryRequirementCapability(UnaryRequirement requirement, UnaryCapabilityNameResolver resolver) {
+        this.definition = RuntimeCapability.Builder.of(requirement.getName(), true)
                 .setServiceType(requirement.getType())
-                .setDynamicNameMapper(DynamicCapabilityNameResolver.DEFAULT)
-                ;
-        this.definition = configurator.apply(builder).build();
+                .setDynamicNameMapper(resolver)
+                .build();
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
@@ -130,7 +130,7 @@ public class CacheContainerResourceDefinition extends ChildResourceDefinition<Ma
         DEFAULT_CACHE("default-cache", ModelType.STRING) {
             @Override
             public SimpleAttributeDefinitionBuilder apply(SimpleAttributeDefinitionBuilder builder) {
-                return builder.setAllowExpression(false).setCapabilityReference(new CapabilityReference(DEFAULT_CAPABILITIES.get(InfinispanCacheRequirement.CONFIGURATION), InfinispanCacheRequirement.CONFIGURATION));
+                return builder.setAllowExpression(false).setCapabilityReference(new CapabilityReference(DEFAULT_CAPABILITIES.get(InfinispanCacheRequirement.CONFIGURATION), InfinispanCacheRequirement.CONFIGURATION, WILDCARD_PATH));
             }
         },
         MODULE("module", ModelType.STRING) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -24,10 +24,10 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ManagementResourceRegistration;
 import org.jboss.as.clustering.controller.MetricHandler;
+import org.jboss.as.clustering.controller.ResourceCapabilityReference;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.validation.EnumValidator;
 import org.jboss.as.controller.AttributeDefinition;
@@ -149,7 +149,7 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
                     .addAttributes(Attribute.class)
                     .addAttributes(DeprecatedAttribute.class)
                     .addCapabilities(Capability.class)
-                    .addResourceCapabilityReference(new CapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL), address -> address.getParent().getLastElement().getValue())
+                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL, DynamicCapabilityNameResolver.PARENT))
                     ;
         }
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -24,7 +24,8 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
+import org.jboss.as.clustering.controller.BinaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ManagementResourceRegistration;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.ResourceCapabilityReference;
@@ -56,7 +57,7 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
         private final RuntimeCapability<Void> definition;
 
         Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT_CHILD).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(BinaryCapabilityNameResolver.PARENT_CHILD).build();
         }
 
         @Override
@@ -149,7 +150,7 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
                     .addAttributes(Attribute.class)
                     .addAttributes(DeprecatedAttribute.class)
                     .addCapabilities(Capability.class)
-                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL, DynamicCapabilityNameResolver.PARENT))
+                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.TRANSPORT, JGroupsTransportResourceDefinition.Requirement.CHANNEL, UnaryCapabilityNameResolver.PARENT))
                     ;
         }
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemResourceDefinition.java
@@ -34,8 +34,8 @@ import org.jboss.as.clustering.controller.DeploymentChainContributingResourceReg
 import org.jboss.as.clustering.controller.RequirementCapability;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.SimpleCapabilityNameResolver;
 import org.jboss.as.clustering.controller.SubsystemResourceDefinition;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
 import org.jboss.as.clustering.infinispan.deployment.ClusteringDependencyProcessor;
 import org.jboss.as.controller.ModelVersion;
@@ -48,7 +48,6 @@ import org.jboss.as.controller.transform.description.TransformationDescriptionBu
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.wildfly.clustering.spi.ClusteringRequirement;
-import org.wildfly.clustering.spi.LocalGroupBuilderProvider;
 
 /**
  * The root resource of the Infinispan subsystem.
@@ -61,14 +60,8 @@ public class InfinispanSubsystemResourceDefinition extends SubsystemResourceDefi
 
     static final Map<ClusteringRequirement, org.jboss.as.clustering.controller.Capability> LOCAL_CLUSTERING_CAPABILITIES = new EnumMap<>(ClusteringRequirement.class);
     static {
-        UnaryOperator<RuntimeCapability.Builder<Void>> configurator = new UnaryOperator<RuntimeCapability.Builder<Void>>() {
-            @Override
-            public RuntimeCapability.Builder<Void> apply(RuntimeCapability.Builder<Void> builder) {
-                return builder.setDynamicNameMapper(new SimpleCapabilityNameResolver(LocalGroupBuilderProvider.LOCAL));
-            }
-        };
         for (ClusteringRequirement requirement : EnumSet.allOf(ClusteringRequirement.class)) {
-            LOCAL_CLUSTERING_CAPABILITIES.put(requirement, new UnaryRequirementCapability(requirement, configurator));
+            LOCAL_CLUSTERING_CAPABILITIES.put(requirement, new UnaryRequirementCapability(requirement, UnaryCapabilityNameResolver.LOCAL));
         }
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceCapabilityReference;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -91,23 +91,18 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
         }
     }
 
-    enum Capability implements org.jboss.as.clustering.controller.Capability, UnaryOperator<RuntimeCapability.Builder<Void>> {
+    enum Capability implements org.jboss.as.clustering.controller.Capability {
         TRANSPORT_CHANNEL(Requirement.CHANNEL),
         ;
         private final RuntimeCapability<Void> definition;
 
         Capability(UnaryRequirement requirement) {
-            this.definition = new UnaryRequirementCapability(requirement, this).getDefinition();
+            this.definition = new UnaryRequirementCapability(requirement, UnaryCapabilityNameResolver.PARENT).getDefinition();
         }
 
         @Override
         public RuntimeCapability<Void> getDefinition() {
             return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability.Builder<Void> apply(RuntimeCapability.Builder<Void> builder) {
-            return builder.setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT);
         }
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
@@ -27,6 +27,7 @@ import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.ResourceCapabilityReference;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
@@ -91,12 +92,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability, UnaryOperator<RuntimeCapability.Builder<Void>> {
-        TRANSPORT_CHANNEL(Requirement.CHANNEL) {
-            @Override
-            public RuntimeCapability.Builder<Void> apply(RuntimeCapability.Builder<Void> builder) {
-                return super.apply(builder).addRequirements(JGroupsDefaultRequirement.CHANNEL_FACTORY.getName());
-            }
-        },
+        TRANSPORT_CHANNEL(Requirement.CHANNEL),
         ;
         private final RuntimeCapability<Void> definition;
 
@@ -295,6 +291,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
                     .addAttributes(ExecutorAttribute.class)
                     .addAttributes(DeprecatedAttribute.class)
                     .addCapabilities(Capability.class)
+                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.TRANSPORT_CHANNEL, JGroupsDefaultRequirement.CHANNEL_FACTORY))
                     ;
         }
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
@@ -24,8 +24,8 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import java.util.function.UnaryOperator;
 
 import org.infinispan.configuration.cache.PersistenceConfiguration;
+import org.jboss.as.clustering.controller.BinaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ManagementResourceRegistration;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.Operations;
@@ -75,7 +75,7 @@ public abstract class StoreResourceDefinition extends ChildResourceDefinition<Ma
         private final RuntimeCapability<Void> definition;
 
         Capability(String name, Class<?> type) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setDynamicNameMapper(DynamicCapabilityNameResolver.GRANDPARENT_PARENT).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setDynamicNameMapper(BinaryCapabilityNameResolver.GRANDPARENT_PARENT).build();
         }
 
         @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportResourceDefinition.java
@@ -28,13 +28,12 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceRegistration;
 import org.jboss.as.clustering.controller.UnaryRequirementCapability;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.wildfly.clustering.spi.ClusteringRequirement;
 
@@ -50,14 +49,8 @@ public abstract class TransportResourceDefinition extends ChildResourceDefinitio
 
     static final Map<ClusteringRequirement, org.jboss.as.clustering.controller.Capability> CLUSTERING_CAPABILITIES = new EnumMap<>(ClusteringRequirement.class);
     static {
-        UnaryOperator<RuntimeCapability.Builder<Void>> configurator = new UnaryOperator<RuntimeCapability.Builder<Void>>() {
-            @Override
-            public RuntimeCapability.Builder<Void> apply(RuntimeCapability.Builder<Void> builder) {
-                return builder.setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT);
-            }
-        };
         for (ClusteringRequirement requirement : EnumSet.allOf(ClusteringRequirement.class)) {
-            CLUSTERING_CAPABILITIES.put(requirement, new UnaryRequirementCapability(requirement, configurator));
+            CLUSTERING_CAPABILITIES.put(requirement, new UnaryRequirementCapability(requirement, UnaryCapabilityNameResolver.PARENT));
         }
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
@@ -24,7 +24,8 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.ResourceCapabilityReference;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.controller.ModelVersion;
@@ -55,7 +56,7 @@ public class AuthProtocolResourceDefinition extends ProtocolResourceDefinition<A
             return this.configurator.apply(descriptor)
                     .setAddOperationTransformation(new LegacyAddOperationTransformation("auth_class"))
                     .setOperationTransformation(LEGACY_OPERATION_TRANSFORMER)
-                    .addResourceCapabilityReference(new CapabilityReference(Capability.PROTOCOL, AuthTokenResourceDefinition.Capability.AUTH_TOKEN), address -> address.getParent().getLastElement().getValue())
+                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.PROTOCOL, AuthTokenResourceDefinition.Capability.AUTH_TOKEN, DynamicCapabilityNameResolver.PARENT))
                     ;
         }
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
@@ -24,7 +24,7 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceCapabilityReference;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -56,7 +56,7 @@ public class AuthProtocolResourceDefinition extends ProtocolResourceDefinition<A
             return this.configurator.apply(descriptor)
                     .setAddOperationTransformation(new LegacyAddOperationTransformation("auth_class"))
                     .setOperationTransformation(LEGACY_OPERATION_TRANSFORMER)
-                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.PROTOCOL, AuthTokenResourceDefinition.Capability.AUTH_TOKEN, DynamicCapabilityNameResolver.PARENT))
+                    .addResourceCapabilityReference(new ResourceCapabilityReference(Capability.PROTOCOL, AuthTokenResourceDefinition.Capability.AUTH_TOKEN, UnaryCapabilityNameResolver.PARENT))
                     ;
         }
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
@@ -27,7 +27,7 @@ import java.util.function.UnaryOperator;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.SimpleResourceRegistration;
@@ -58,7 +58,7 @@ public class AuthTokenResourceDefinition<T extends AuthToken> extends ChildResou
         private final RuntimeCapability<Void> definition;
 
         Capability(String name, Class<?> type) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setAllowMultipleRegistrations(true).setDynamicNameMapper(DynamicCapabilityNameResolver.GRANDPARENT).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setAllowMultipleRegistrations(true).setDynamicNameMapper(UnaryCapabilityNameResolver.GRANDPARENT).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -26,7 +26,7 @@ import java.util.EnumSet;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.BinaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -68,7 +68,7 @@ public class ProtocolResourceDefinition<P extends Protocol> extends AbstractProt
         private final RuntimeCapability<Void> definition;
 
         Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT_CHILD).setAllowMultipleRegistrations(true).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(BinaryCapabilityNameResolver.PARENT_CHILD).setAllowMultipleRegistrations(true).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
@@ -23,9 +23,9 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.function.UnaryOperator;
 
+import org.jboss.as.clustering.controller.BinaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -67,7 +67,7 @@ public class RemoteSiteResourceDefinition extends ChildResourceDefinition<Manage
         private final RuntimeCapability<Void> definition;
 
         Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(DynamicCapabilityNameResolver.GRANDPARENT_CHILD).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(BinaryCapabilityNameResolver.GRANDPARENT_CHILD).build();
         }
 
         @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -32,7 +32,7 @@ import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -99,7 +99,7 @@ public class TransportResourceDefinition<T extends TP> extends AbstractProtocolR
         private final RuntimeCapability<Void> definition;
 
         Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(UnaryCapabilityNameResolver.PARENT).build();
         }
 
         @Override

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
@@ -27,7 +27,7 @@ import java.util.function.UnaryOperator;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -60,7 +60,7 @@ public abstract class ElectionPolicyResourceDefinition extends ChildResourceDefi
         private final RuntimeCapability<Void> definition;
 
         Capability(String name, Class<?> type) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setServiceType(type).setDynamicNameMapper(UnaryCapabilityNameResolver.PARENT).build();
         }
 
         @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
@@ -26,7 +26,7 @@ import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.DynamicCapabilityNameResolver;
+import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ReloadRequiredResourceRegistration;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.controller.AttributeDefinition;
@@ -50,7 +50,7 @@ public class ApplicationSecurityDomainSingleSignOnDefinition extends SingleSignO
         private final RuntimeCapability<Void> definition;
 
         Capability(String name) {
-            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(DynamicCapabilityNameResolver.PARENT).build();
+            this.definition = RuntimeCapability.Builder.of(name, true).setDynamicNameMapper(UnaryCapabilityNameResolver.PARENT).build();
         }
 
         @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10216

Requires wildfly-core upgrade containing https://github.com/wildfly/wildfly-core/pull/3180
Dependency of provisioning work.