### PR TITLE
[WFLY-9818] xts adding element to enable async endpoints registration

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/CommonAttributes.java
+++ b/xts/src/main/java/org/jboss/as/xts/CommonAttributes.java
@@ -29,5 +29,6 @@ interface CommonAttributes {
     String HOST = "host";
     String XTS_ENVIRONMENT= "xts-environment";
     String DEFAULT_CONTEXT_PROPAGATION = "default-context-propagation";
+    String ASYNC_REGISTRATION = "async-registration";
     // TODO, many more!
 }

--- a/xts/src/main/java/org/jboss/as/xts/Element.java
+++ b/xts/src/main/java/org/jboss/as/xts/Element.java
@@ -37,6 +37,7 @@ enum Element {
     HOST(CommonAttributes.HOST),
     XTS_ENVIRONMENT(CommonAttributes.XTS_ENVIRONMENT),
     DEFAULT_CONTEXT_PROPAGATION(CommonAttributes.DEFAULT_CONTEXT_PROPAGATION),
+    ASYNC_REGISTRATION(CommonAttributes.ASYNC_REGISTRATION),
     ;
 
     private final String name;

--- a/xts/src/main/java/org/jboss/as/xts/Namespace.java
+++ b/xts/src/main/java/org/jboss/as/xts/Namespace.java
@@ -36,12 +36,13 @@ enum Namespace {
 
     XTS_1_0("urn:jboss:domain:xts:1.0"),
     XTS_2_0("urn:jboss:domain:xts:2.0"),
+    XTS_3_0("urn:jboss:domain:xts:3.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = XTS_2_0;
+    public static final Namespace CURRENT = XTS_3_0;
 
     private final String name;
 

--- a/xts/src/main/java/org/jboss/as/xts/XTSExtension.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSExtension.java
@@ -43,10 +43,10 @@ public class XTSExtension implements Extension {
     public static final String SUBSYSTEM_NAME = "xts";
     protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
 
+    static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(3, 0, 0);
 
     private static final String RESOURCE_NAME = XTSExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(2, 0, 0);
 
     static StandardResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
         String prefix = SUBSYSTEM_NAME + (keyPrefix == null ? "" : "." + keyPrefix);
@@ -64,5 +64,6 @@ public class XTSExtension implements Extension {
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.XTS_1_0.getUriString(), XTSSubsystemParser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.XTS_2_0.getUriString(), XTSSubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.XTS_3_0.getUriString(), XTSSubsystemParser::new);
     }
 }

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
@@ -67,6 +67,14 @@ public class XTSSubsystemDefinition extends SimpleResourceDefinition {
                     .setFlags(AttributeAccess.Flag.RESTART_JVM)
                     .build();
 
+    protected static final SimpleAttributeDefinition ASYNC_REGISTRATION =
+            new SimpleAttributeDefinitionBuilder(CommonAttributes.ASYNC_REGISTRATION, ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setXmlName(Attribute.ENABLED.getLocalName())
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES) // we need to register new WS endpoints
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
     @Deprecated //just legacy support
     private static final ObjectTypeAttributeDefinition ENVIRONMENT = ObjectTypeAttributeDefinition.
             Builder.of(CommonAttributes.XTS_ENVIRONMENT, ENVIRONMENT_URL)
@@ -97,6 +105,7 @@ public class XTSSubsystemDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(HOST_NAME, null, new ReloadRequiredWriteAttributeHandler(HOST_NAME));
         resourceRegistration.registerReadWriteAttribute(ENVIRONMENT_URL, null, new ReloadRequiredWriteAttributeHandler(ENVIRONMENT_URL));
         resourceRegistration.registerReadWriteAttribute(DEFAULT_CONTEXT_PROPAGATION, null, new ReloadRequiredWriteAttributeHandler(DEFAULT_CONTEXT_PROPAGATION));
+        resourceRegistration.registerReadWriteAttribute(ASYNC_REGISTRATION, null, new ReloadRequiredWriteAttributeHandler(ASYNC_REGISTRATION));
         //this here just for legacy support!
         resourceRegistration.registerReadOnlyAttribute(ENVIRONMENT, new OperationStepHandler() {
             @Override

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemRemove.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemRemove.java
@@ -45,7 +45,7 @@ class XTSSubsystemRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        for (ContextInfo contextInfo : XTSSubsystemAdd.getContextDefinitions()) {
+        for (ContextInfo contextInfo : XTSSubsystemAdd.getContextDefinitions(context, model)) {
             String contextName = contextInfo.contextPath;
             context.removeService(WSServices.ENDPOINT_PUBLISH_SERVICE.append(contextName));
         }

--- a/xts/src/main/resources/org/jboss/as/xts/LocalDescriptions.properties
+++ b/xts/src/main/resources/org/jboss/as/xts/LocalDescriptions.properties
@@ -33,3 +33,5 @@ xts.xts-environment.deprecated=Deprecated since it was complex attribute and now
 xts.url=If set configures a remote coordinator service to be used when an XTS client start a transaction.
 
 xts.default-context-propagation=Automatically sets up client side handlers.
+
+xts.async-registration=Initialize endpoints for asynchronous registration needed for WS-AT .NET integration.

--- a/xts/src/main/resources/schema/jboss-as-xts_3_0.xsd
+++ b/xts/src/main/resources/schema/jboss-as-xts_3_0.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:xts:3.0"
+            xmlns="urn:jboss:domain:xts:3.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+
+    <!-- The xts subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the XTS subsystem.
+
+                This is just the minimum to get XTS bootstrapped as an AS7 extension.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="host" type="host" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="xts-environment" type="xts-environment" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="default-context-propagation" type="default-context-propagation" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="async-registration" type="async-registration" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="host">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    name configures which host should be used by the XTS subsystem to register endpoints.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="xts-environment">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                url configures XTS clients to use remote transaction coordination services.
+                if it is left unset then clients employ the local coordinator services.
+                the value should identify an OASIS WSTX 1.1 Activation Coordinator service.
+                The local JBoss Activation Service url has the format
+                    "http://<bindadd>r:<webport>/ws-c11/ActivationService"
+                where
+                    <bindaddr> is the app server bind address (localhost by default) and
+                    <webport> is the unsecured JBoss Web server port (8080 by default).
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="url" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="default-context-propagation">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                'enabled' states whether to automatically propagate transactional context.
+                When set to 'true', Web Service clients will automatically propagate a WS-AT
+                transactional context if a JTA or WS-AT transaction is running when the call is made.
+                Similarly, a WS-BA transactional context will be propagated if a WS-BA transaction
+                is running when the call is made. This behavior can be overridden on a per client
+                basis using the org.jboss.jbossts.txbridge.outbound.JTAOverWSATFeature and
+                com.arjuna.mw.wst11.client.WSTXFeature features.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="async-registration">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                'enabled' feature of asynchronous registration of endpoints. This is way how to integrate
+                Narayana WS-AT with .NET (even this is non-standard non-spec defined).
+                The details of implementation could be consulted at JBTM-2928
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false" />
+    </xs:complexType>
+
+</xs:schema>

--- a/xts/src/main/resources/subsystem-templates/xts.xml
+++ b/xts/src/main/resources/subsystem-templates/xts.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.xts</extension-module>
-   <subsystem xmlns="urn:jboss:domain:xts:2.0">
+   <subsystem xmlns="urn:jboss:domain:xts:3.0">
        <host name="default-host"/>
        <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
        <default-context-propagation enabled="true"/>

--- a/xts/src/test/resources/org/jboss/as/xts/subsystem-1.0.0.xml
+++ b/xts/src/test/resources/org/jboss/as/xts/subsystem-1.0.0.xml
@@ -20,8 +20,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:xts:2.0">
-    <host name="default-host"/>
+<subsystem xmlns="urn:jboss:domain:xts:1.0">
     <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
-    <default-context-propagation enabled="false"/>
 </subsystem>

--- a/xts/src/test/resources/org/jboss/as/xts/subsystem-2.0.0.xml
+++ b/xts/src/test/resources/org/jboss/as/xts/subsystem-2.0.0.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:xts:2.0">
+    <host name="default-host"/>
+    <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
+    <default-context-propagation enabled="true"/>
+</subsystem>

--- a/xts/src/test/resources/org/jboss/as/xts/subsystem-3.0.0.xml
+++ b/xts/src/test/resources/org/jboss/as/xts/subsystem-3.0.0.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:xts:3.0">
+    <host name="bad-host-for-6.4"/>
+    <xts-environment url="http://${jboss.bind.address:127.0.0.1}:8080/ws-c11/ActivationService"/>
+    <default-context-propagation enabled="true"/>
+    <async-registration enabled="true" />
+</subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9818
https://github.com/wildfly/wildfly-proposals/pull/53

this is for .NET integration with Narayana WS-AT. The related Narayana jira is here:
https://issues.jboss.org/browse/JBTM-2928

The content of this PR is enabling the new WS endpoints needed for WS-AT async handling. The endpoints are registred if new element `<async-registration enabled="true" />` is added under the XTS subsystem.

I will be really glad for any comment about the subsystem change where the new element is added (I'm not sure about the best practices in this area). Thanks.
