### PR TITLE
WFLY-10248 The jgroups-channel attribute of broadcast/discovery-group references a capabilities that uses a dynamic name mapper, which is not supported by DefaultCapabilityReferenceRecorder.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -88,11 +88,11 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
             .build();
 
     @Deprecated public static final SimpleAttributeDefinition JGROUPS_CHANNEL_FACTORY = create(CommonAttributes.JGROUPS_CHANNEL_FACTORY)
-            .setCapabilityReference("org.wildfly.clustering.jgroups.channel-factory", CAPABILITY)
+            .setCapabilityReference("org.wildfly.clustering.jgroups.channel-factory")
             .build();
 
     public static final SimpleAttributeDefinition JGROUPS_CHANNEL = create(CommonAttributes.JGROUPS_CHANNEL)
-            .setCapabilityReference(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getName(), CAPABILITY)
+            .setCapabilityReference(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getName())
             .build();
 
     public static final AttributeDefinition[] ATTRIBUTES = { JGROUPS_CHANNEL_FACTORY, JGROUPS_CHANNEL, JGROUPS_CLUSTER, SOCKET_BINDING,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -75,11 +75,11 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
             .build();
 
     @Deprecated public static final SimpleAttributeDefinition JGROUPS_CHANNEL_FACTORY = create(CommonAttributes.JGROUPS_CHANNEL_FACTORY)
-            .setCapabilityReference("org.wildfly.clustering.jgroups.channel-factory", CAPABILITY)
+            .setCapabilityReference("org.wildfly.clustering.jgroups.channel-factory")
             .build();
 
     public static final SimpleAttributeDefinition JGROUPS_CHANNEL = create(CommonAttributes.JGROUPS_CHANNEL)
-            .setCapabilityReference(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getName(), CAPABILITY)
+            .setCapabilityReference(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getName())
             .build();
 
     public static final AttributeDefinition[] ATTRIBUTES = { JGROUPS_CHANNEL_FACTORY, JGROUPS_CHANNEL, JGROUPS_CLUSTER, SOCKET_BINDING,


### PR DESCRIPTION
Use ContextDependencyRecorder instead.

https://issues.jboss.org/browse/WFLY-10248

@jmesnil Please review.