### PR TITLE
[WFLY-10181] Deadlock for threads executing org.jboss.jca.adapters.jdbc.xa.XAManagedConnectionFactory.isEqual - WildFly Part

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -534,16 +534,13 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
         @Override
         protected ManagedConnectionFactory createMcf(XaDataSource arg0, String arg1, ClassLoader arg2)
                 throws NotFoundException, DeployException {
-            final WildFlyXaMCF xaManagedConnectionFactory = new WildFlyXaMCF();
+            final XAManagedConnectionFactory xaManagedConnectionFactory = new XAManagedConnectionFactory(xaDataSourceConfig.getXaDataSourceProperty());
 
             if (xaDataSourceConfig.getUrlDelimiter() != null) {
                 xaManagedConnectionFactory.setURLDelimiter(xaDataSourceConfig.getUrlDelimiter());
             }
             if (xaDataSourceConfig.getXaDataSourceClass() != null) {
                 xaManagedConnectionFactory.setXADataSourceClass(xaDataSourceConfig.getXaDataSourceClass());
-            }
-            if (xaDataSourceConfig.getXaDataSourceProperty() != null) {
-                xaManagedConnectionFactory.setXaProps(xaDataSourceConfig.getXaDataSourceProperty());
             }
             if (xaDataSourceConfig.getUrlSelectorStrategyClassName() != null) {
                 xaManagedConnectionFactory
@@ -728,15 +725,4 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
         }
 
     }
-
-    private class WildFlyXaMCF extends XAManagedConnectionFactory {
-
-        private static final long serialVersionUID = 4876371551002746953L;
-
-        public void setXaProps(Map<String, String> inputProperties) {
-            xaProps.putAll(inputProperties);
-        }
-
-    }
-
 }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-10181

Please NOTE: this needs upgrade ironjacamar 1.4.9.Final to compile.