### PR TITLE
WFLY-10264:Resteasy JSON provider fails in EE7 module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -29,7 +29,11 @@
     </properties>
     
     <resources>
-        <artifact name="${org.jboss.resteasy:resteasy-json-binding-provider}"/>
+        <artifact name="${org.jboss.resteasy:resteasy-json-binding-provider}">
+            <conditions>
+              <property-equal name="ee8.preview.mode" value="true"/>
+            </conditions>
+        </artifact>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10264
This PR to fix : "org.jboss.resteasy.plugins.providers.jsonb.AbstractJsonBindingProvider depends on org.eclipse.yasoon classes, however these are not present when in EE7 mode"