### PR TITLE
WFLY-10269 RemoteStore should use unresolved hostnames to accomodate dynamic environments

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
@@ -25,17 +25,13 @@ package org.jboss.as.clustering.infinispan;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
-import java.net.UnknownHostException;
-
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.msc.inject.InjectionException;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -110,8 +106,8 @@ public interface InfinispanLogger extends BasicLogger {
      *
      * @return a {@link org.jboss.as.controller.persistence.ConfigurationPersistenceException} for the error.
      */
-    @Message(id = 8, value = "Could not resolve destination address for outbound socket binding named '%s'")
-    InjectionException failedToInjectSocketBinding(@Cause UnknownHostException cause, OutboundSocketBinding binding);
+//    @Message(id = 8, value = "Could not resolve destination address for outbound socket binding named '%s'")
+//    InjectionException failedToInjectSocketBinding(@Cause UnknownHostException cause, OutboundSocketBinding binding);
 
     /**
      * Creates an exception indicating an invalid cache store.

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreBuilder.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.clustering.infinispan.subsystem.RemoteStoreResourceDefinition.Attribute.*;
 
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,7 +31,6 @@ import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfiguration;
 import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationBuilder;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -91,11 +89,7 @@ public class RemoteStoreBuilder extends StoreBuilder<RemoteStoreConfiguration, R
                 ;
         for (Value<OutboundSocketBinding> bindingDependency : this.bindings) {
             OutboundSocketBinding binding = bindingDependency.getValue();
-            try {
-                builder.addServer().host(binding.getResolvedDestinationAddress().getHostAddress()).port(binding.getDestinationPort());
-            } catch (UnknownHostException e) {
-                throw InfinispanLogger.ROOT_LOGGER.failedToInjectSocketBinding(e, binding);
-            }
+            builder.addServer().host(binding.getUnresolvedDestinationAddress()).port(binding.getDestinationPort());
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10269