### PR TITLE
[WFLY-10292] Move the dependency so the server depends on the PicketBox bootstrap service if PicketBox security is in use instead of the connection factory depending on it.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -138,6 +138,7 @@ import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.plugins.SecurityDomainContext;
+import org.jboss.as.security.service.SecurityBootstrapService;
 import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -298,7 +299,10 @@ class ServerAdd extends AbstractAddStepHandler {
                     serviceBuilder.addDependency(DependencyType.REQUIRED,
                             SecurityDomainService.SERVICE_NAME.append(domain),
                             SecurityDomainContext.class,
-                            serverService.getSecurityDomainContextInjector());
+                            serverService.getSecurityDomainContextInjector())
+                    // WFLY-6652 / WFLY-10292 this dependency ensures that Artemis will be able to destroy any queues created on behalf of a
+                    // pooled-connection-factory client during server stop
+                    .addDependency(SecurityBootstrapService.SERVICE_NAME);
                 }
 
                 // inject credential-references for bridges

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -55,7 +55,6 @@ import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.network.SocketBinding;
-import org.jboss.as.security.service.SecurityBootstrapService;
 import org.jboss.as.server.Services;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
@@ -319,9 +318,6 @@ public class PooledConnectionFactoryService implements Service<Void> {
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(serverServiceName))
                 // ensures that Artemis client thread pools are not stopped before any deployment depending on a pooled-connection-factory
                 .addDependency(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL)
-                // WFLY-6652 this dependency ensures that Artemis will be able to destroy any queues created on behalf of a
-                // pooled-connection-factory client during server stop
-                .addDependency(SecurityBootstrapService.SERVICE_NAME)
                 .setInitialMode(ServiceController.Mode.PASSIVE);
         return serviceBuilder;
     }


### PR DESCRIPTION
Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)

https://issues.jboss.org/browse/WFLY-10292

- [x] Pull Request contains description of the issue(s)

A prior fix made under WFLY-6652 had added a dependency from the PooledConnectionFactory to the SecurityBootstrapService, at the time the legacy security subsystem was the only security available within the application server.

Technically however this is a client of a service having a dependency on something the service is using.

Since the addition of WildFly Elytron as the server service is installed we know if we are using legacy PicketBox security or if we are using Elytron so this PR adjusts the dependencies so the server service will depend on the PicketBox SecurityBootstrapService if it is using PicketBox security.

- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.