### PR TITLE
WFLY-10285 Upgrade Weld to 3.0.4.Final and Weld API to 3.0.SP3.

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -209,8 +209,8 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.5.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
-        <version.org.jboss.weld.weld>3.0.3.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>3.0.SP2</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>3.0.4.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>3.0.SP3</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.0.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.2.0.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.0.Final</version.org.jboss.ws.common.tools>


### PR DESCRIPTION
Component upgrade of Weld to 3.0.4.Final as well as Weld API to 3.0.SP3.
JIRA - https://issues.jboss.org/browse/WFLY-10285

This is blocking - https://issues.jboss.org/browse/WFLY-10062
This release also (hopefully) solves illegal access issues on JDK 10 coming from Weld.