### PR TITLE
[WFLY-10278] Bean discovery in deployment dependencies (modules) fail…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/AliasCdiModulesDependencyTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/AliasCdiModulesDependencyTest.java
@@ -1,0 +1,94 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.alias;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import java.io.File;
+
+/**
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+@RunWith(Arquillian.class)
+public class AliasCdiModulesDependencyTest {
+
+    private static final String REF_MODULE_NAME = "weld-module-ref";
+    private static final String IMPL_MODULE_NAME = "weld-module-impl";
+    private static final String ALIAS_MODULE_NAME = "weld-module-alias";
+    private static TestModule testModuleRef;
+    private static TestModule testModuleImpl;
+    private static TestModule testModuleAlias;
+
+    public static void doSetup() throws Exception {
+        testModuleImpl = ModuleUtils.createTestModuleWithEEDependencies(IMPL_MODULE_NAME);
+        testModuleImpl.addResource("test-module.jar")
+            .addClasses(ModuleBean.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        testModuleImpl.create();
+
+        // load the module.xml file and use it to create module, we need this to have Module B as exported dependency
+        File moduleFile = new File(AliasCdiModulesDependencyTest.class.getResource("module-ref.xml").toURI());
+        testModuleRef = new TestModule("test." + REF_MODULE_NAME, moduleFile);
+        testModuleRef.create();
+
+        File aliasModuleFile = new File(AliasCdiModulesDependencyTest.class.getResource("module-alias.xml").toURI());
+        testModuleAlias = new TestModule("test." + ALIAS_MODULE_NAME, aliasModuleFile);
+        testModuleAlias.create();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        testModuleAlias.remove();
+        testModuleRef.remove();
+        testModuleImpl.remove();
+    }
+
+    @Deployment
+    public static WebArchive getDeployment() throws Exception {
+        doSetup();
+        return ShrinkWrap.create(WebArchive.class)
+            .addClasses(AliasCdiModulesDependencyTest.class, WarBean.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsManifestResource(new StringAsset("Dependencies: test." + ALIAS_MODULE_NAME + " meta-inf export\n"), "MANIFEST.MF");
+    }
+
+    @Inject
+    WarBean warBean;
+
+    @Test
+    public void testBeanAccessibilities() {
+        Assert.assertNotNull(warBean.getInjectedBean());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/ModuleBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/ModuleBean.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.alias;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+@ApplicationScoped
+public class ModuleBean {
+
+    public String test() {
+        return "test";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/WarBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/WarBean.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.alias;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+@ApplicationScoped
+public class WarBean {
+
+    @Inject
+    private ModuleBean moduleBean;
+
+    public ModuleBean getInjectedBean() {
+        return moduleBean;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/module-alias.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/module-alias.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module-alias xmlns="urn:jboss:module:1.1" name="test.weld-module-alias" slot="main" target-name="test.weld-module-ref" target-slot="main"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/module-ref.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/alias/module-ref.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.7" name="test.weld-module-ref">
+    <dependencies>
+        <module name="test.weld-module-impl" export="true">
+            <imports>
+                <include path="META-INF**"/>
+                <include path="org**"/>
+            </imports>
+            <exports>
+                <include path="META-INF**"/>
+                <include path="org**"/>
+            </exports>
+        </module>
+
+        <module name="javax.enterprise.api"/>
+        <module name="javax.inject.api"/>
+    </dependencies>
+</module>

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
@@ -38,6 +38,8 @@ import org.jboss.as.weld.util.ServiceLoaders;
 import org.jboss.modules.DependencySpec;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleDependencySpec;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
 import org.jboss.weld.bootstrap.api.Service;
 import org.jboss.weld.bootstrap.api.ServiceRegistry;
 import org.jboss.weld.bootstrap.api.helpers.SimpleServiceRegistry;
@@ -244,6 +246,12 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
                 if (moduleDependency.getIdentifier().equals(that.getModule().getIdentifier())) {
                     return true;
                 }
+
+                // moduleDependency might be an alias - try to load it to get lined module
+                Module module = loadModule(moduleDependency);
+                if (module != null && module.getIdentifier().equals(that.getModule().getIdentifier())) {
+                    return true;
+                }
             }
         }
 
@@ -261,6 +269,19 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
             }
         }
         return false;
+    }
+
+    private Module loadModule(ModuleDependencySpec moduleDependency) {
+        try {
+            ModuleLoader moduleLoader = moduleDependency.getModuleLoader();
+            if (moduleLoader == null) {
+                return null;
+            } else {
+                return moduleLoader.loadModule(moduleDependency.getIdentifier());
+            }
+        } catch (ModuleLoadException e) {
+            return null;
+        }
     }
 
     public BeanArchiveType getBeanArchiveType() {


### PR DESCRIPTION
…s to inject from static module-alias's exported dependency

JIRA: https://issues.jboss.org/browse/WFLY-10278

It seems the problems is in BeanDeploymentArchiveImpl#isAccessible method. The check https://github.com/wildfly/wildfly/blob/master/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java#L244 fails because the dependencies of the module list the original alias, while the target BeanDeploymentArchiveImpl references the underlying module.

This proposal tries to load the module as a 2nd step of the check - this way alias will get resolved to the underlying module. 

@mkouba @stuartwdouglas could you please review?