### PR TITLE
[WFLY-10310] Use the correct file extension

### DIFF
--- a/feature-pack/src/main/resources/content/docs/licenses/licenses.xsl
+++ b/feature-pack/src/main/resources/content/docs/licenses/licenses.xsl
@@ -6,7 +6,7 @@
     <xsl:param name="version"/>
     <xsl:variable name="lowercase" select="'abcdefghijklmnopqrstuvwxyz '" />
     <xsl:variable name="uppercase" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ!'" />
-    
+
     <xsl:template match="/">
         <html>
             <head>
@@ -73,7 +73,7 @@
                 <xsl:text>creative commons attribution 2.5.html</xsl:text>
             </xsl:when>
             <xsl:when test="$name = 'GNU Lesser General Public License v2.1 or later'">
-                <xsl:text>gnu lesser general public license v2.1 or later.html</xsl:text>
+                <xsl:text>gnu lesser general public license v2.1 or later.txt</xsl:text>
             </xsl:when>
             <xsl:when test="$name = 'Mozilla Public License 2.0'">
                 <xsl:text>mozilla public license 2.0.html</xsl:text>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10310

The xsl was generating a link to a file with the wrong extension; this fixes it.