### PR TITLE
[WFLY-10311] Remove comments from the standard config files used in d…

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -7,7 +7,6 @@
     </extensions>
 
     <system-properties>
-        <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>
 
@@ -41,13 +40,6 @@
         </profile>
     </profiles>
 
-    <!--
-         Named interfaces that can be referenced elsewhere in the configuration. The configuration
-         for how to associate these logical names with an actual network interface can either
-         be specified here or can be declared on a per-host basis in the equivalent element in host.xml.
-
-         These default configurations require the binding specification to be done in host.xml.
-    -->
     <interfaces>
         <interface name="management"/>
         <interface name="public"/>
@@ -56,23 +48,18 @@
 
     <socket-binding-groups>
         <socket-binding-group name="standard-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'default' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="ha-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'ha' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="full-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'full' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="full-ha-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'full-ha' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="load-balancer-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'load-balancer' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
     </socket-binding-groups>

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,9 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<!--
-   A simple configuration for a Host Controller that only acts as the master domain controller
-   and does not itself directly control any servers.
--->
 <host xmlns="urn:jboss:domain:7.0" name="master">
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -9,7 +9,6 @@
         <security-realms>
             <security-realm name="ManagementRealm">
                 <server-identities>
-                    <!-- Replace this with either a base64 password of your own, or use a vault with a vault expression -->
                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA=="/>
                 </server-identities>
 
@@ -97,8 +96,6 @@
     <servers>
         <server name="server-one" group="main-server-group"/>
         <server name="server-two" group="other-server-group">
-            <!-- server-two avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
         </server>
     </servers>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -63,8 +63,6 @@
 
     <domain-controller>
         <local/>
-        <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>
@@ -92,25 +90,13 @@
     </jvms>
 
     <servers>
-        <server name="server-one" group="main-server-group">
-            <!-- Remote JPDA debugging for a specific server
-            <jvm name="default">
-              <jvm-options>
-                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
-              </jvm-options>
-           </jvm>
-           -->
-        </server>
+        <server name="server-one" group="main-server-group"/>
         <server name="server-two" group="main-server-group" auto-start="true">
             <jvm name="default" />
-            <!-- server-two avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
         </server>
         <server name="server-three" group="other-server-group" auto-start="false">
             <jvm name="default" />
-            <!-- server-three avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="250"/>
         </server>
     </servers>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,29 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<!--
-  ~
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2014, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  ~
-  -->
-
 <domain xmlns="urn:jboss:domain:7.0">
 
     <extensions>
@@ -31,7 +7,6 @@
     </extensions>
 
     <system-properties>
-        <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
         <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>
 
@@ -53,13 +28,6 @@
        </profile>
     </profiles>
 
-    <!--
-         Named interfaces that can be referenced elsewhere in the configuration. The configuration
-         for how to associate these logical names with an actual network interface can either
-         be specified here or can be declared on a per-host basis in the equivalent element in host.xml.
-
-         These default configurations require the binding specification to be done in host.xml.
-    -->
     <interfaces>
         <interface name="management"/>
         <interface name="public"/>
@@ -69,7 +37,6 @@
 
     <socket-binding-groups>
         <socket-binding-group name="standard-sockets" default-interface="public">
-            <!-- Needed for server groups using the 'default' profile  -->
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
     </socket-binding-groups>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,9 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<!--
-   A simple configuration for a Host Controller that only acts as the master domain controller
-   and does not itself directly control any servers.
--->
 <host name="master" xmlns="urn:jboss:domain:7.0">
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -9,7 +9,6 @@
         <security-realms>
             <security-realm name="ManagementRealm">
                 <server-identities>
-                    <!-- Replace this with either a base64 password of your own, or use a vault with a vault expression -->
                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA=="/>
                 </server-identities>
 
@@ -78,12 +77,9 @@
             <inet-address value="${jboss.bind.address:127.0.0.1}"/>
         </interface>
         <interface name="private">
-            <!-- Used for JGroups sockets in the standard configuration. -->
             <inet-address value="${jboss.bind.address.private:127.0.0.1}"/>
         </interface>
         <interface name="unsecure">
-            <!-- Used for IIOP sockets in the standard configuration.
-                 To secure JacORB you need to setup SSL -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>
     </interfaces>
@@ -102,8 +98,6 @@
     <servers>
         <server name="server-one" group="main-server-group"/>
         <server name="server-two" group="other-server-group">
-            <!-- server-two avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
         </server>
     </servers>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -63,8 +63,6 @@
 
     <domain-controller>
         <local/>
-        <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>
@@ -75,12 +73,9 @@
             <inet-address value="${jboss.bind.address:127.0.0.1}"/>
         </interface>
         <interface name="private">
-            <!-- Used for JGroups sockets in the standard configuration. -->
             <inet-address value="${jboss.bind.address.private:127.0.0.1}"/>
         </interface>
         <interface name="unsecure">
-            <!-- Used for IIOP sockets in the standard configuration.
-                 To secure JacORB you need to setup SSL -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>
     </interfaces>
@@ -97,23 +92,11 @@
     </jvms>
 
     <servers>
-        <server name="server-one" group="main-server-group">
-            <!-- Remote JPDA debugging for a specific server
-            <jvm name="default">
-              <jvm-options>
-                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
-              </jvm-options>
-           </jvm>
-           -->
-        </server>
+        <server name="server-one" group="main-server-group"/>
         <server name="server-two" group="main-server-group" auto-start="true">
-            <!-- server-two avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="150"/>
         </server>
         <server name="server-three" group="other-server-group" auto-start="false">
-            <!-- server-three avoids port conflicts by incrementing the ports in
-                 the default socket-group declared in the server-group -->
             <socket-bindings port-offset="250"/>
         </server>
     </servers>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10311

Comments in our standard configs are a bug as they will be dropped if the file is persisted, resulting in config file diffs unrelated to whatever change triggered persistence. We long ago got rid of them in the standalone configs but they've stuck around in the domain mode configs.

The galleon build is not going to produce such comments so now is the time to get rid of them in the legacy stuff too.