### PR TITLE
WFLY-10321 Configuring dns.DNS_PING protocol fails with ClassNotFound…

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
@@ -39,5 +39,6 @@
         <module name="org.jboss.threads"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
…Exception: com.sun.jndi.dns.DnsContextFactory

https://issues.jboss.org/browse/WFLY-10321