### PR TITLE
[WFLY-10116] Upgrade WildFly Naming Client from 1.0.7.Final to 1.0.8.Final

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -235,7 +235,7 @@
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.maven.plugins>1.0.0</version.org.wildfly.maven.plugins>
-        <version.org.wildfly.naming-client>1.0.7.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.naming-client>1.0.8.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <version.org.wildfly.transaction.client>1.0.3.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.17</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-10116
