### PR TITLE
WFLY-10252 Migrate Weld-related modules to JBoss Modules 1.8

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jsf-injection">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.jsf-injection">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -34,7 +34,8 @@
 
     <dependencies>
         <module name="com.sun.jsf-impl"/>
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.desktop"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.jsf"/>
         <module name="org.jboss.as.web-common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.beanvalidation">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.beanvalidation">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.common">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.common">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -49,6 +49,7 @@
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.annotation.api"/>
+        <module name="java.desktop"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/ejb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.ejb">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.ejb">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -37,6 +37,7 @@
     </resources>
 
     <dependencies>
+        <module name="java.naming"/>
         <module name="org.jboss.weld.api" />
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.weld.core" />
@@ -50,7 +51,6 @@
         <module name="org.jboss.msc"/>
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>
-        <module name="javax.api"/>
         <module name="javax.ejb.api" />
         <module name="org.jboss.as.ejb3"/>
         <module name="org.jboss.ejb3"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/jpa/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.jpa">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.jpa">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -44,7 +44,8 @@
         <module name="org.jboss.as.weld.beanvalidation" optional="true" services="import" />
         <module name="org.jboss.as.weld.webservices" optional="true" services="import" />
         <module name="org.jboss.as.weld.transactions" optional="true" services="import" />
-        <module name="javax.api"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.transactions">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.transactions">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.weld.webservices">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.as.weld.webservices">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
@@ -22,14 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.api">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.api">
 
     <resources>
         <artifact name="${org.jboss.weld:weld-api}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.core">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.core">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -36,7 +36,6 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.ejb.api" />
         <module name="javax.enterprise.api"/>
@@ -52,6 +51,10 @@
         <module name="org.jboss.weld.api" export="true"/>
         <module name="org.jboss.weld.spi" export="true"/>
         <module name="org.jboss.logging" />
-        <module name="sun.jdk" optional="true" />
+        <module name="jdk.unsupported"/>
+        <module name="java.desktop"/>
+        <module name="java.logging"/>
+        <module name="java.naming"/>
+        <module name="java.xml"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.probe">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.probe">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,7 +33,8 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.management"/>
+        <module name="java.desktop"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.weld.spi">
+<module xmlns="urn:jboss:module:1.8" name="org.jboss.weld.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>
@@ -33,8 +33,9 @@
     </resources>
 
     <dependencies>
+        <module name="java.desktop"/>
+        <module name="java.naming"/>
         <module name="javax.annotation.api"/>
-        <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
         <module name="org.wildfly.cdi-api-bridge"/>
         <module name="javax.inject.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/cdi-api-bridge/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="org.wildfly.cdi-api-bridge">
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.cdi-api-bridge">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.enterprise.api">
+<module xmlns="urn:jboss:module:1.8" name="javax.enterprise.api">
     <dependencies>
         <module name="org.glassfish.javax.el" export="true"/>
         <module name="javax.inject.api" export="true"/>


### PR DESCRIPTION
JIRA issue - https://issues.jboss.org/browse/WFLY-10252

This PR updates all the Weld-related modules I could find to JBoss Modules 1.8 and uses JDK 9+ syntax of modules.

No new tests are needed for this - passing all the existing tests is the verification we seek here.

These changes were tested on Weld side (with CDI TCK and Weld TS).
I also ran parts of WFLY TS but I am leaving most part of that to CI.