### PR TITLE
[WFLY-10324] Upgrade WildFly Core 5.0.0.Alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
-        <version.org.wildfly.core>5.0.0.Alpha4</version.org.wildfly.core>
+        <version.org.wildfly.core>5.0.0.Alpha5</version.org.wildfly.core>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10324

---

  Release Notes - WildFly Core - Version 5.0.0.Alpha5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3763'>WFCORE-3763</a>] -         Upgrade JBoss MSC to 1.4.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3764'>WFCORE-3764</a>] -         Upgrade WildFly Elytron to 1.3.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3779'>WFCORE-3779</a>] -         Upgrade JBoss Modules to 1.8.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3781'>WFCORE-3781</a>] -         Upgrade WildFly Common to 1.3.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3794'>WFCORE-3794</a>] -         Undertow 2.0.5.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3798'>WFCORE-3798</a>] -         Upgrade WildFly Elytron to 1.3.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3527'>WFCORE-3527</a>] -         Remove OSGi obsolete code
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3672'>WFCORE-3672</a>] -         Extend CLI security command with support for SASL and HTTP authentication
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3752'>WFCORE-3752</a>] -         Add support for multi-value MSC services
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3772'>WFCORE-3772</a>] -         Elytron legacy feature pack subsystem template uses wrong attribute order for http-authentication-factory
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3773'>WFCORE-3773</a>] -         Legacy feature pack host-master xml template should put the &#39;host&#39; element attributes in the correct order
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3775'>WFCORE-3775</a>] -         Legacy feature pack template for host-slave.xml using outdated http-interface http-upgrade-enabled config
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3784'>WFCORE-3784</a>] -         Standard WildFly Core domain.xml is missing discovery and security-manager subsystems
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3789'>WFCORE-3789</a>] -         Unable to pass any attribute to jboss-cli.ps1 script
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3791'>WFCORE-3791</a>] -         Cannot debug the subsystem transformer tests in IntelliJ
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1917'>WFCORE-1917</a>] -         Deprecate &quot;reload&quot;, &quot;suspend&quot; and &quot;resume&quot; ops on the server-config resource
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3771'>WFCORE-3771</a>] -         Eliminate comments from the WildFly Core xml config files
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3776'>WFCORE-3776</a>] -         Deprecate attribute &quot;show-model&quot; in jmx subsystem 
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3783'>WFCORE-3783</a>] -         read-feature-description: remove the default module slot main from the provisioning package name
</li>
</ul>