### PR TITLE
[WFLY-10334] Don't create a domain/data dir

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -162,7 +162,6 @@
         </copy-artifact>
     </copy-artifacts>
     <mkdirs>
-        <dir name="domain/data/content"/>
         <dir name="standalone/lib/ext"/>
         <dir name="domain/tmp/auth"/>
         <dir name="standalone/tmp/auth"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10334

There's no reason to have this dir and we don't plan to have it in the galleon build, so get rid of it.