### PR TITLE
WFLY-10177 disabled EclipseLink/OpenJPA tests which are failing under Java 10

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -162,7 +162,6 @@
         </copy-artifact>
     </copy-artifacts>
     <mkdirs>
-        <dir name="domain/data/content"/>
         <dir name="standalone/lib/ext"/>
         <dir name="domain/tmp/auth"/>
         <dir name="standalone/tmp/auth"/>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/EclipseLinkSharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/EclipseLinkSharedModuleProviderTestCase.java
@@ -37,12 +37,14 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Scott Marlow
  */
+@Ignore("WFLY-10177")
 @RunWith(Arquillian.class)
 public class EclipseLinkSharedModuleProviderTestCase {
 

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import javax.naming.InitialContext;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,6 +44,7 @@ import org.junit.runner.RunWith;
  * @author Antti Laisi
  */
 @RunWith(Arquillian.class)
+@Ignore("WFLY-10340")
 public class OpenJPASharedModuleProviderTestCase {
 
     private static final String ARCHIVE_NAME = "openjpa_module_test";


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10177
Created tracking issues https://issues.jboss.org/browse/WFLY-10341 + https://issues.jboss.org/browse/WFLY-10340 to enable EclipseLink/OpenJPA tests again after their projects support JDK10.