### PR TITLE
[WFLY-6682] Upgrade Hibernate to 5.2.17

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -147,7 +147,7 @@
         <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
         <version.org.glassfish.javax.json-1.0>1.0.4</version.org.glassfish.javax.json-1.0>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
-        <version.org.hibernate>5.1.13.Final</version.org.hibernate>
+        <version.org.hibernate>5.2.17.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.2.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.5.8.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.9.Final</version.org.hibernate.validator>
@@ -3837,7 +3837,7 @@
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-hibernate-cache-v51</artifactId>
+                <artifactId>infinispan-hibernate-cache</artifactId>
                 <version>${version.org.infinispan}</version>
                 <exclusions>
                     <exclusion>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2251,7 +2251,7 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-v51</artifactId>
+            <artifactId>infinispan-hibernate-cache</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-cache/main/module.xml
@@ -33,7 +33,7 @@
         <artifact name="${org.infinispan:infinispan-hibernate-cache-spi}"/>
         <artifact name="${org.infinispan:infinispan-hibernate-cache-commons}"/>
         <artifact name="${org.infinispan:infinispan-hibernate-cache-spi}"/>
-        <artifact name="${org.infinispan:infinispan-hibernate-cache-v51}"/>
+        <artifact name="${org.infinispan:infinispan-hibernate-cache}"/>
     </resources>
 
     <dependencies>

--- a/jpa/hibernate5-legacy/pom.xml
+++ b/jpa/hibernate5-legacy/pom.xml
@@ -45,7 +45,7 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-hibernate-cache-v51</artifactId>
+            <artifactId>infinispan-hibernate-cache</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/DeprecatedInfinispanRegionFactory.java
+++ b/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/DeprecatedInfinispanRegionFactory.java
@@ -31,7 +31,7 @@ import org.hibernate.cache.CacheException;
  * Common implementation class for deprecated region factory implementations.
  * @author Paul Ferraro
  */
-class DeprecatedInfinispanRegionFactory extends org.infinispan.hibernate.cache.v51.InfinispanRegionFactory {
+class DeprecatedInfinispanRegionFactory extends org.infinispan.hibernate.cache.main.InfinispanRegionFactory {
     private static final long serialVersionUID = 6795961780643120068L;
     private static final String SHARED = "hibernate.cache.infinispan.shared";
     private final String shared;

--- a/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/InfinispanRegionFactory.java
+++ b/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/InfinispanRegionFactory.java
@@ -21,7 +21,7 @@ package org.jboss.as.jpa.hibernate5.infinispan;
  * Infinispan-backed region factory for use with standalone (i.e. non-JPA) Hibernate applications.
  * @author Paul Ferraro
  * @author Scott Marlow
- * @deprecated Use {@link org.infinispan.hibernate.cache.v51.InfinispanRegionFactory} instead in conjunction with "hibernate.cache.infinispan.shared" set to false.
+ * @deprecated Use {@link org.infinispan.hibernate.cache.main.InfinispanRegionFactory} instead in conjunction with "hibernate.cache.infinispan.shared" set to false.
  */
 @Deprecated
 public class InfinispanRegionFactory extends DeprecatedInfinispanRegionFactory {

--- a/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/SharedInfinispanRegionFactory.java
+++ b/jpa/hibernate5-legacy/src/main/java/org/jboss/as/jpa/hibernate5/infinispan/SharedInfinispanRegionFactory.java
@@ -24,7 +24,7 @@ package org.jboss.as.jpa.hibernate5.infinispan;
  *
  * @author Paul Ferraro
  * @author Scott Marlow
- * @deprecated Use {@link org.infinispan.hibernate.cache.v51.InfinispanRegionFactory} instead.
+ * @deprecated Use {@link org.infinispan.hibernate.cache.main.InfinispanRegionFactory} instead.
  */
 @Deprecated
 public class SharedInfinispanRegionFactory extends DeprecatedInfinispanRegionFactory {


### PR DESCRIPTION
This PR is an initial attempt to see what the current status is for Hibernate 5.2.17 compatibility. The Hibernate 5.2.x branch has some neat features and bugfixes that are not available to 5.1.x. I've long used Hibernate 5.2 on WildFly 10 and WildFly 11. With `infinispan-hibernate` 9.1.x in WildFly 12 however, Hibernate 5.2 is almost impossible to get to work and I probably will end up skipping WildFly 12 altogether. With WildFly 13 targeting `infinispan-hibernate`  9.2.x, I think it should be good to go to finally transition to 5.2.x in WildFly.

Issue: https://issues.jboss.org/browse/WFLY-6682
Supersedes: #8961