### PR TITLE
[WFLY-10343] Put subsystems in alphabetical order

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -12,8 +12,8 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>
         <subsystem supplement="domain-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
         <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -24,8 +24,8 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
@@ -45,8 +45,8 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="ha">ejb3.xml</subsystem>
         <subsystem supplement="domain-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
         <subsystem supplement="ha">infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -59,8 +59,8 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
@@ -81,9 +81,9 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
         <subsystem supplement="domain-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -96,8 +96,8 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>
@@ -117,9 +117,9 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full-ha">ejb3.xml</subsystem>
         <subsystem supplement="domain-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem supplement="ha">infinispan.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem supplement="ha">infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -134,8 +134,8 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>security-manager.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -11,9 +11,10 @@
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -27,12 +28,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -11,9 +11,10 @@
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -25,12 +26,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters-genericjms.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters-genericjms.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
@@ -11,9 +11,10 @@
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -24,12 +25,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem supplement="jts-example">transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
@@ -10,9 +10,10 @@
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -27,12 +28,11 @@
         <subsystem>picketlink-identity-management.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem supplement="picketlink">security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -11,9 +11,10 @@
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -26,16 +27,15 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
+        <subsystem>rts.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>
         <subsystem>weld.xml</subsystem>
-        <subsystem>rts.xml</subsystem>
     </subsystems>
 </config>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -10,9 +10,10 @@
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
+        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -25,12 +26,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
-        <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -12,9 +12,9 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full-ha">ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem supplement="ha">infinispan.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem supplement="ha">infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -29,11 +29,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>singleton.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem supplement="ha">undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -12,9 +12,9 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
-        <subsystem>infinispan.xml</subsystem>
         <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -27,11 +27,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -12,8 +12,8 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="ha">ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
         <subsystem supplement="ha">infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -26,11 +26,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>singleton.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem supplement="ha">undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -12,8 +12,8 @@
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>
-        <subsystem>io.xml</subsystem>
         <subsystem>infinispan.xml</subsystem>
+        <subsystem>io.xml</subsystem>
         <subsystem>jaxrs.xml</subsystem>
         <subsystem>jca.xml</subsystem>
         <subsystem>jdr.xml</subsystem>
@@ -24,11 +24,11 @@
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>
-        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>
         <subsystem>webservices.xml</subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10343

Time for us to go back to 2nd grade for some alphabet practice!

Besides being the correct order, it may help the transition to the galleon build by having a "correct" basis of comparison to the galleon build output.