### PR TITLE
[WFLY-10338] Discovery subsystem is missing from the domain and standalone profiles

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -8,6 +8,7 @@
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>
@@ -41,6 +42,7 @@
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="ha">ejb3.xml</subsystem>
@@ -77,6 +79,7 @@
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
@@ -113,6 +116,7 @@
         <subsystem>bean-validation.xml</subsystem>
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full-ha">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full-ha">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="ha">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
@@ -60,6 +60,7 @@ public class DomainAdjuster710 extends DomainAdjuster {
         }
 
         list.addAll(removeEESecurity(profileAddress.append(SUBSYSTEM, "ee-security")));
+        list.addAll(removeDiscovery(profileAddress.append(SUBSYSTEM, "discovery")));
         if (withMasterServers) {
             list.addAll(reconfigureServers());
         }
@@ -116,4 +117,12 @@ public class DomainAdjuster710 extends DomainAdjuster {
         return list;
     }
 
+    private Collection<? extends ModelNode> removeDiscovery(final PathAddress subsystem) {
+        final List<ModelNode> list = new ArrayList<>();
+
+        //discovery subsystem and extension do not exist in previous versions, so remove it
+        list.add(createRemoveOperation(subsystem));
+        list.add(createRemoveOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.discovery")));
+        return list;
+    }
 }


### PR DESCRIPTION
Added discovery subsystem to all profiles except to `load-balancer`. Additionally, fix mixed-domain tests to take into account this subsystem and remove it from slaves configurations.

Jira issue: https://issues.jboss.org/browse/WFLY-10338