### PR TITLE
WFLY-10337

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -324,7 +324,7 @@ public class AuthenticationPolicyContextTestCase {
         }
 
         try {
-            URL wsdl = new URL("http://localhost:8080/picketlink-sts-ws/EchoService?wsdl");
+            URL wsdl = new URL("http://" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort() +"/picketlink-sts-ws/EchoService?wsdl");
             QName serviceName = new QName("http://ws.picketlink.sts.jboss.org/", "EchoServiceService");
             Service service = Service.create(wsdl, serviceName);
             EchoServiceRemote port = service.getPort(new QName("http://ws.picketlink.sts.jboss.org/", "EchoServicePort"),


### PR DESCRIPTION
Fixes issue AuthenticationPolicyContextTestCase doesn't work with -Dnode{0,1} properties. URL is built using TestSuiteEnvironment.

Upstream JIRA issue: https://issues.jboss.org/browse/WFLY-10337