### PR TITLE
Legacy config tweaks

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -59,46 +59,78 @@
     <supplement name="s3-ping">
         <replacement placeholder="TCP-DISCOVERY">
             <protocol type="S3_PING">
-                <property name="access_key">${jboss.jgroups.s3_ping.access_key}</property>
-                <property name="secret_access_key">${jboss.jgroups.s3_ping.secret_access_key}</property>
-                <property name="location">${jboss.jgroups.s3_ping.bucket}</property>
+                <property name="access_key">
+                    ${jboss.jgroups.s3_ping.access_key}
+                </property>
+                <property name="secret_access_key">
+                    ${jboss.jgroups.s3_ping.secret_access_key}
+                </property>
+                <property name="location">
+                    ${jboss.jgroups.s3_ping.bucket}
+                </property>
             </protocol>
         </replacement>
         <replacement placeholder="UDP-DISCOVERY">
             <protocol type="S3_PING">
-                <property name="access_key">${jboss.jgroups.s3_ping.access_key}</property>
-                <property name="secret_access_key">${jboss.jgroups.s3_ping.secret_access_key}</property>
-                <property name="location">${jboss.jgroups.s3_ping.bucket}</property>
+                <property name="access_key">
+                    ${jboss.jgroups.s3_ping.access_key}
+                </property>
+                <property name="secret_access_key">
+                    ${jboss.jgroups.s3_ping.secret_access_key}
+                </property>
+                <property name="location">
+                    ${jboss.jgroups.s3_ping.bucket}
+                </property>
             </protocol>
         </replacement>
     </supplement>
     <supplement name="azure-ping">
         <replacement placeholder="TCP-DISCOVERY">
             <protocol type="azure.AZURE_PING">
-                <property name="storage_account_name">${jboss.jgroups.azure_ping.storage_account_name}</property>
-                <property name="storage_access_key">${jboss.jgroups.azure_ping.storage_access_key}</property>
-                <property name="container">${jboss.jgroups.azure_ping.container}</property>
+                <property name="storage_account_name">
+                    ${jboss.jgroups.azure_ping.storage_account_name}
+                </property>
+                <property name="storage_access_key">
+                    ${jboss.jgroups.azure_ping.storage_access_key}
+                </property>
+                <property name="container">
+                    ${jboss.jgroups.azure_ping.container}
+                </property>
             </protocol>
         </replacement>
         <replacement placeholder="UDP-DISCOVERY">
             <protocol type="azure.AZURE_PING">
-                <property name="storage_account_name">${jboss.jgroups.azure_ping.storage_account_name}</property>
-                <property name="storage_access_key">${jboss.jgroups.azure_ping.storage_access_key}</property>
-                <property name="container">${jboss.jgroups.azure_ping.container}</property>
+                <property name="storage_account_name">
+                    ${jboss.jgroups.azure_ping.storage_account_name}
+                </property>
+                <property name="storage_access_key">
+                    ${jboss.jgroups.azure_ping.storage_access_key}
+                </property>
+                <property name="container">
+                    ${jboss.jgroups.azure_ping.container}
+                </property>
             </protocol>
         </replacement>
     </supplement>
     <supplement name="gossip-discovery">
         <replacement placeholder="TCP-DISCOVERY">
             <protocol type="TCPGOSSIP">
-                <property name="initial_hosts">${jboss.jgroups.gossip.initial_hosts}</property>
-                <property name="num_initial_members">${jboss.jgroups.gossip.num_initial_members}</property>
+                <property name="initial_hosts">
+                    ${jboss.jgroups.gossip.initial_hosts}
+                </property>
+                <property name="num_initial_members">
+                    ${jboss.jgroups.gossip.num_initial_members}
+                </property>
             </protocol>
         </replacement>
         <replacement placeholder="UDP-DISCOVERY">
             <protocol type="TCPGOSSIP">
-                <property name="initial_hosts">${jboss.jgroups.gossip.initial_hosts}</property>
-                <property name="num_initial_members">${jboss.jgroups.gossip.num_initial_members}</property>
+                <property name="initial_hosts">
+                    ${jboss.jgroups.gossip.initial_hosts}
+                </property>
+                <property name="num_initial_members">
+                    ${jboss.jgroups.gossip.num_initial_members}
+                </property>
             </protocol>
         </replacement>
     </supplement>

--- a/connector/src/main/resources/subsystem-templates/resource-adapters-genericjms.xml
+++ b/connector/src/main/resources/subsystem-templates/resource-adapters-genericjms.xml
@@ -10,8 +10,12 @@
                 <transaction-support>NoTransaction</transaction-support>
                 <connection-definitions>
                     <connection-definition class-name="org.jboss.resource.adapter.jms.JmsManagedConnectionFactory" jndi-name="${genericjms.cf.jndi-name}" pool-name="${genericjms.cf.pool-name}">
-                        <config-property name="JndiParameters">java.naming.factory.initial=${genericjms.cf.jndi.contextfactory};java.naming.provider.url=${genericjms.cf.jndi.url}</config-property>
-                        <config-property name="ConnectionFactory">${genericjms.cf.jndi.lookup}</config-property>
+                        <config-property name="JndiParameters">
+                            java.naming.factory.initial=${genericjms.cf.jndi.contextfactory};java.naming.provider.url=${genericjms.cf.jndi.url}
+                        </config-property>
+                        <config-property name="ConnectionFactory">
+                            ${genericjms.cf.jndi.lookup}
+                        </config-property>
                         <security>
                             <application/>
                         </security>

--- a/ejb3/src/main/resources/subsystem-templates/ejb3.xml
+++ b/ejb3/src/main/resources/subsystem-templates/ejb3.xml
@@ -13,8 +13,8 @@
        <?MDB?>
        <pools>
            <bean-instance-pools>
-               <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
                <strict-max-pool name="mdb-strict-max-pool" derive-size="from-cpu-count" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+               <strict-max-pool name="slsb-strict-max-pool" derive-size="from-worker-pools" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
            </bean-instance-pools>
        </pools>
        <caches>

--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -26,14 +26,14 @@
         <profile name="default">
             <?SUBSYSTEMS socket-binding-group="standard-sockets"?>
         </profile>
-        <profile name="ha">
-            <?SUBSYSTEMS socket-binding-group="ha-sockets"?>
-        </profile>
         <profile name="full">
             <?SUBSYSTEMS socket-binding-group="full-sockets"?>
         </profile>
         <profile name="full-ha">
             <?SUBSYSTEMS socket-binding-group="full-ha-sockets"?>
+        </profile>
+        <profile name="ha">
+            <?SUBSYSTEMS socket-binding-group="ha-sockets"?>
         </profile>
         <profile name="load-balancer">
             <?SUBSYSTEMS socket-binding-group="load-balancer-sockets"?>
@@ -50,13 +50,13 @@
         <socket-binding-group name="standard-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
-        <socket-binding-group name="ha-sockets" default-interface="public">
-            <?SOCKET-BINDINGS?>
-        </socket-binding-group>
         <socket-binding-group name="full-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="full-ha-sockets" default-interface="public">
+            <?SOCKET-BINDINGS?>
+        </socket-binding-group>
+        <socket-binding-group name="ha-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="load-balancer-sockets" default-interface="public">

--- a/mod_cluster/extension/src/main/resources/subsystem-templates/mod_cluster.xml
+++ b/mod_cluster/extension/src/main/resources/subsystem-templates/mod_cluster.xml
@@ -17,7 +17,7 @@
     </supplement>
     <supplement name="no-multicast">
         <replacement placeholder="SUBSYSTEM">
-            <mod-cluster-config advertise="false" proxies="" connector="ajp">
+            <mod-cluster-config proxies="" advertise="false" connector="ajp">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>

--- a/picketlink/src/main/resources/subsystem-templates/picketlink-identity-management.xml
+++ b/picketlink/src/main/resources/subsystem-templates/picketlink-identity-management.xml
@@ -28,7 +28,6 @@
     <extension-module>org.wildfly.extension.picketlink</extension-module>
     <subsystem xmlns="urn:jboss:domain:picketlink-identity-management:2.0">
 
-        <!-- A complete configuration using a file-based identity store. -->
         <partition-manager jndi-name="picketlink/FileCompletePartitionManager" name="file.complete.partition.manager">
             <identity-configuration name="file.config">
                 <file-store relative-to="jboss.server.data.dir" working-dir="pl-idm-complete" always-create-files="true" async-write="true"
@@ -38,7 +37,6 @@
             </identity-configuration>
         </partition-manager>
 
-        <!-- A simple configuration using a file-based identity store. -->
         <partition-manager jndi-name="picketlink/FileSimplePartitionManager" name="file.simple.partition.manager">
             <identity-configuration name="file.config">
                 <file-store>
@@ -47,7 +45,6 @@
             </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using a JPA-based identity store. The store is configured using a existing datasource. -->
         <partition-manager jndi-name="picketlink/JPADSBasedPartitionManager" name="jpa.ds.based.partition.manager">
             <identity-configuration name="jpa.config">
                 <jpa-store data-source="jboss/datasources/ExampleDS">
@@ -56,7 +53,6 @@
             </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using a JPA-based identity store. The store is configured using a existing JPA EntityManagerFactory, obtained via JNDI. -->
         <partition-manager jndi-name="picketlink/JPAEMFBasedPartitionManager" name="jpa.emf.based.partition.manager">
             <identity-configuration name="jpa.config">
                 <jpa-store entity-manager-factory="jboss/TestingIDMEMF">
@@ -69,7 +65,6 @@
           </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using a JPA-based identity store. The store is configured using a existing JPA Persistence Unit from a static module. -->
         <partition-manager jndi-name="picketlink/JPAEMFModulePartitionManager" name="jpa.emf.modules.partition.manager">
             <identity-configuration name="jpa.config">
                 <jpa-store entity-module="my.module" entity-module-unit-name="my-persistence-unit-name">
@@ -78,7 +73,6 @@
           </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using a LDAP-based identity store. -->
         <partition-manager name="ldap.idm" jndi-name="picketlink/LDAPBasedPartitionManager">
             <identity-configuration name="ldap.store">
                 <ldap-store url="ldap://${jboss.bind.address:127.0.0.1}:10389" bind-dn="uid=admin,ou=system" bind-credential="secret" base-dn-suffix="dc=jboss,dc=org">
@@ -114,7 +108,6 @@
             </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using a LDAP and JPA identity store. In this example we use JPA to store relationships and LDAP for users, roles and groups. -->
         <partition-manager name="multiple.store.idm" jndi-name="picketlink/MultipleStoreBasedPartitionManager">
             <identity-configuration name="multiple.store">
                 <jpa-store data-source="jboss/datasources/ExampleDS" support-credential="false" support-attribute="false">
@@ -151,7 +144,6 @@
             </identity-configuration>
         </partition-manager>
 
-        <!-- A configuration using two identity configurations. Each identity configuration has a JPA store. -->
         <partition-manager jndi-name="picketlink/MultipleConfigurationPartitionManager" name="multiple.config.partition.manager">
             <identity-configuration name="partition.jboss.config">
                 <jpa-store data-source="jboss/datasources/JBossIdentityDS">

--- a/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -10,7 +10,7 @@
         <security-realms>
             <security-realm name="ManagementRealm">
                 <authentication>
-                    <local default-user="$local" />
+                    <local default-user="$local" skip-group-loading="true"/>
                     <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization map-groups-to-roles="false">
@@ -35,7 +35,7 @@
         <audit-log>
             <formatters>
                <json-formatter name="json-formatter"/>
-            </formatters>        
+            </formatters>
             <handlers>
                <file-handler name="file" formatter="json-formatter" path="audit-log.log" relative-to="jboss.server.data.dir"/>
             </handlers>


### PR DESCRIPTION
This commit makes a number of changes to the structure of the legacy configs to clean things up or to align arbitrarily ordered things with how a galleon build will order them. (Where the galleon build can produce the current order without inappropriate hacks, that is what is being done. This PR is for things where this is not practical.)

The first two commits change the order of things. Only the 2nd one is noteworthy IMO. The legacy domain.xml profile order is more intuitive than what galleon produces, but it's not a huge problem to me.

The last commit fixes an actual bug in a legacy example config: https://issues.jboss.org/browse/WFLY-10355