### PR TITLE
[WFLY-10354] Discovery subsystem is missing from example configurations

### DIFF
--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem>ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
@@ -7,6 +7,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -8,6 +8,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -7,6 +7,7 @@
         <subsystem>core-management.xml</subsystem>
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem>discovery.xml</subsystem>
         <subsystem>ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>


### PR DESCRIPTION
Some example configurations created on wildfly distribution do not contain the Discovery subsystem. Currently, there are not configurations for this subsystem but ejb3 uses the discovery API so all configuration examples that use ejb3 should have this subsystem.

Jira issue: https://issues.jboss.org/browse/WFLY-10354