### PR TITLE
[WFLY-10282] Test enables elytron, removes security subsystem and checks if correct response is returned after the EJB is called from the secured servlet

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/BasicAuthMechanismServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/BasicAuthMechanismServerSetupTask.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.web.security.authentication;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ServletElytronDomainSetup;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ * Server setup task for test BasicAuthenticationMechanismPicketboxRemovedTestCase.
+ * Enables elytron and removes security subsystem.
+ */
+public class BasicAuthMechanismServerSetupTask extends SnapshotRestoreSetupTask {
+
+    protected String getSecurityDomainName() {
+        return "auth-test";
+    }
+
+    protected String getUsersFile() {
+        return new File(BasicAuthMechanismServerSetupTask.class.getResource("users.properties").getFile()).getAbsolutePath();
+    }
+
+    protected String getGroupsFile() {
+        return new File(BasicAuthMechanismServerSetupTask.class.getResource("roles.properties").getFile()).getAbsolutePath();
+    }
+
+    @Override
+    public void doSetup(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+
+        // /subsystem=elytron/properties-realm=auth-test-ejb3-UsersRoles:add(users-properties={path=users.properties, plain-text=true},groups-properties={path=roles.properties})
+        // /subsystem=elytron/security-domain=auth-test:add(default-realm=auth-test-ejb3-UsersRoles, realms=[{realm=auth-test-ejb3-UsersRoles}])
+        ElytronDomainSetup elytronDomainSetup = new ElytronDomainSetup(getUsersFile(), getGroupsFile(), getSecurityDomainName());
+        elytronDomainSetup.setup(managementClient, containerId);
+
+        // /subsystem=elytron/http-authentication-factory=auth-test:add(http-server-mechanism-factory=global,security-domain=auth-test,mechanism-configurations=[{mechanism-name=BASIC}])
+        // /subsystem=undertow/application-security-domain=auth-test:add(http-authentication-factory=auth-test)
+        ServletElytronDomainSetup servletElytronDomainSetup = new ServletElytronDomainSetup(getSecurityDomainName());
+        servletElytronDomainSetup.setup(managementClient, containerId);
+
+        // /subsystem=elytron/sasl-authentication-factory=auth-test:add(sasl-server-factory=configured,security-domain=auth-test,mechanism-configurations=[{mechanism-name=BASIC}])
+        ModelNode addSaslAuthentication = createOpNode("subsystem=elytron/sasl-authentication-factory=" + getSecurityDomainName(), ADD);
+        addSaslAuthentication.get("sasl-server-factory").set("configured");
+        addSaslAuthentication.get("security-domain").set(getSecurityDomainName());
+        addSaslAuthentication.get("mechanism-configurations").get(0).get("mechanism-name").set("PLAIN");
+        operations.add(addSaslAuthentication);
+        // /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=auth-test)
+        ModelNode updateRemotingConnector = createOpNode("subsystem=remoting/http-connector=http-remoting-connector", WRITE_ATTRIBUTE_OPERATION);
+        updateRemotingConnector.get(ClientConstants.NAME).set("sasl-authentication-factory");
+        updateRemotingConnector.get(ClientConstants.VALUE).set(getSecurityDomainName());
+        operations.add(updateRemotingConnector);
+        // subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+        ModelNode undefineAttrOp2 = createOpNode("subsystem=remoting/http-connector=http-remoting-connector", UNDEFINE_ATTRIBUTE_OPERATION);
+        undefineAttrOp2.get(ClientConstants.NAME).set("security-realm");
+        operations.add(undefineAttrOp2);
+
+        // /subsystem=ejb3/application-security-domain=auth-test:add(security-domain=auth-test)
+        ModelNode addEjbDomain = createOpNode("subsystem=ejb3/application-security-domain=" + getSecurityDomainName(), ADD);
+        addEjbDomain.get("security-domain").set(getSecurityDomainName());
+        operations.add(addEjbDomain);
+        // /subsystem=ejb3:write-attribute(name=default-missing-method-permissions-deny-access, value=false)
+        ModelNode updateDefaultMissingMethod = createOpNode("subsystem=ejb3", WRITE_ATTRIBUTE_OPERATION);
+        updateDefaultMissingMethod.get(ClientConstants.NAME).set("default-missing-method-permissions-deny-access");
+        updateDefaultMissingMethod.get(ClientConstants.VALUE).set(false);
+        operations.add(updateDefaultMissingMethod);
+
+        // core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+        ModelNode writeAttrOp4 = createOpNode("core-service=management/management-interface=http-interface", WRITE_ATTRIBUTE_OPERATION);
+        writeAttrOp4.get(ClientConstants.NAME).set("http-upgrade");
+        writeAttrOp4.get(ClientConstants.VALUE).add("enabled", true);
+        writeAttrOp4.get(ClientConstants.VALUE).add("sasl-authentication-factory", getSecurityDomainName());
+        operations.add(writeAttrOp4);
+        // core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+        ModelNode writeAttrOp5 = createOpNode("core-service=management/management-interface=http-interface", WRITE_ATTRIBUTE_OPERATION);
+        writeAttrOp5.get(ClientConstants.NAME).set("http-authentication-factory");
+        writeAttrOp5.get(ClientConstants.VALUE).set(getSecurityDomainName());
+        operations.add(writeAttrOp5);
+        // core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+        ModelNode undefineAttrOp3 = createOpNode("core-service=management/management-interface=http-interface", UNDEFINE_ATTRIBUTE_OPERATION);
+        undefineAttrOp3.get(ClientConstants.NAME).set("security-realm");
+        operations.add(undefineAttrOp3);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+
+        ModelNode removeSecurityOp = new ModelNode();
+        removeSecurityOp.get(OP).set(REMOVE);
+        removeSecurityOp.get(OP_ADDR).add(SUBSYSTEM, "security");
+        CoreUtils.applyUpdate(removeSecurityOp, managementClient.getControllerClient());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/BasicAuthenticationMechanismPicketboxRemovedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/BasicAuthenticationMechanismPicketboxRemovedTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.security.authentication;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.web.security.authentication.deployment.SecuredEJB;
+import org.jboss.as.test.integration.web.security.authentication.deployment.SecuredEJBServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Automated test for [ WFLY-10671 ] - tests tracker for picketbox subsystem removing.
+ *
+ * [ WFLY-10671 ] is a tracker for issues:
+ * [ WFLY-10282 ] Test Enables elytron and removes security subsystem. After secured EJB is deployed and accessed using basic authorization test checks if correct response is returned after the EJB is called from the secured servlet.
+ * [ WFLY-10292 ] After switching to elytron and removing picketbox subsystem DefaultJMSConnectionFactory is not found during server startup.
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(BasicAuthMechanismServerSetupTask.class)
+@RunAsClient
+public class BasicAuthenticationMechanismPicketboxRemovedTestCase {
+
+    private static final String USER = "user1";
+    private static final String PASSWORD = "password1";
+    private static final String EJB_SECURITY = "ejb-security";
+
+    @Deployment(name = EJB_SECURITY)
+    public static WebArchive appDeployment1() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, EJB_SECURITY + ".war");
+        war.addClasses(BasicAuthenticationMechanismPicketboxRemovedTestCase.class, SecuredEJB.class, SecuredEJBServlet.class);
+        war.addAsWebInfResource(BasicAuthenticationMechanismPicketboxRemovedTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebInfResource(BasicAuthenticationMechanismPicketboxRemovedTestCase.class.getPackage(), "web.xml", "web.xml");
+        return war;
+    }
+
+    /**
+     * Test checks if correct response is returned after the EJB is called from the secured servlet.
+     *
+     * @param url
+     * @throws Exception
+     */
+    @Test
+    public void test(@ArquillianResource URL url) throws Exception {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(url.getHost(), url.getPort()),
+                new UsernamePasswordCredentials(USER, PASSWORD));
+        try (CloseableHttpClient httpclient = HttpClients.custom()
+                .setDefaultCredentialsProvider(credentialsProvider)
+                .build()) {
+
+            HttpGet httpget = new HttpGet(url.toExternalForm() + "SecuredEJBServlet/");
+            HttpResponse response = httpclient.execute(httpget);
+            assertNotNull("Response is 'null', we expected non-null response!", response);
+            String text = Utils.getContent(response);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertTrue("User principal different from what we expected!", text.contains("Principal: " + USER));
+            assertTrue("Remote user different from what we expected!", text.contains("Remote User: " + USER));
+            assertTrue("Authentication type different from what we expected!", text.contains("Authentication Type: BASIC"));
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/deployment/SecuredEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/deployment/SecuredEJB.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.web.security.authentication.deployment;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+@Stateless
+@RolesAllowed({ "guest" })
+@SecurityDomain("auth-test")
+public class SecuredEJB {
+
+    @Resource
+    private SessionContext ctx;
+
+    public String getSecurityInfo() {
+        return ctx.getCallerPrincipal().toString();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/deployment/SecuredEJBServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/deployment/SecuredEJBServlet.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.web.security.authentication.deployment;
+
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * A simple secured Servlet which calls a secured EJB. Upon successful authentication and authorization the EJB will return the
+ * principal's name. Servlet security is implemented using annotations.
+ *
+ * @author Sherif Makary
+ *
+ */
+@SuppressWarnings("serial")
+@WebServlet(name = "SecuredEJBServlet", urlPatterns = {"/SecuredEJBServlet/"}, loadOnStartup = 1)
+@ServletSecurity(@HttpConstraint(rolesAllowed = {"guest"}))
+public class SecuredEJBServlet extends HttpServlet {
+
+    private static String PAGE_HEADER = "<html><head><title>ejb-security</title></head><body>";
+    private static String PAGE_FOOTER = "</body></html>";
+
+    @EJB
+    private SecuredEJB securedEJB;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        PrintWriter writer = resp.getWriter();
+
+        String principal = securedEJB.getSecurityInfo();
+        String remoteUser = req.getRemoteUser();
+        String authType = req.getAuthType();
+
+        writer.println(PAGE_HEADER);
+        writer.println("<h1>" + "Successfully called Secured EJB " + "</h1>");
+        writer.println("<p>" + "Principal: " + principal + "</p>");
+        writer.println("<p>" + "Remote User: " + remoteUser + "</p>");
+        writer.println("<p>" + "Authentication Type: " + authType + "</p>");
+        writer.println(PAGE_FOOTER);
+        writer.close();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <security-domain>auth-test</security-domain>
+</jboss-web>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/roles.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/roles.properties
@@ -1,0 +1,1 @@
+user1=guest

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/users.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/users.properties
@@ -1,0 +1,1 @@
+user1=password1

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/authentication/web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.1"
+         xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>Protect all application</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <!-- Configure login to be HTTP Basic -->
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Application Realm</realm-name>
+    </login-config>
+
+    <security-role>
+        <description>Role required to log in to the Application</description>
+        <role-name>guest</role-name>
+    </security-role>
+</web-app>


### PR DESCRIPTION
Automated test for [ WFLY-10671 ] - tests tracker for picketbox subsystem removing.
 
 [ WFLY-10671 ] is a tracker for issues:
 [ WFLY-10282 ] Test Enables elytron and removes security subsystem. After secured EJB is deployed and accessed using basic authorization test checks if correct response is returned after the EJB is called from the secured servlet.
 [ WFLY-10292 ] After switching to elytron and removing picketbox subsystem DefaultJMSConnectionFactory is not found during server startup.