### PR TITLE
[WFLY-10365] Generate the component-matrix

### DIFF
--- a/component-matrix-builder/pom.xml
+++ b/component-matrix-builder/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>13.0.0.Alpha1-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.wildfly</groupId>
+    <artifactId>wildfly-component-matrix-builder</artifactId>
+    <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+    -->
+    <version>13.0.0.Alpha1-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <name>WildFly: Component matrix builder</name>
+    <description>WildFly: Dependency Component matrix BOM Builder</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-component-matrix-plugin</artifactId>
+                <version>${version.org.wildfly.component-matrix-plugin}</version>
+                <executions>
+                    <execution>
+                        <id>build-bom</id>
+                        <goals>
+                            <goal>build-bom</goal>
+                        </goals>
+                        <configuration>
+                            <parent>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jboss-parent</artifactId>
+                                <version>26</version>
+                                <relativePath/>
+                            </parent>
+                            <bomGroupId>${project.groupId}</bomGroupId>
+                            <bomArtifactId>wildfly-component-matrix</bomArtifactId>
+                            <bomVersion>${project.version}</bomVersion>
+                            <bomName>WildFly: Component Matrix</bomName>
+                            <bomDescription>WildFly: Component Matrix</bomDescription>
+                            <inheritExclusions>true</inheritExclusions>
+                            <licenses>true</licenses>
+                            <includeProfiles>
+                                <profile>JDK9</profile>
+                            </includeProfiles>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <module>build</module>
         <module>client/shade</module>
         <module>clustering</module>
+        <module>component-matrix-builder</module>
         <module>connector</module>
         <module>dist</module>
         <module>ee</module>
@@ -162,6 +163,7 @@
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
+        <version.org.wildfly.component-matrix-plugin>1.0.1.Final</version.org.wildfly.component-matrix-plugin>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10365

Output from build:
```
$mvn clean install -pl component-matrix-builder/
[INFO] Scanning for projects...
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building WildFly: Component matrix builder 13.0.0.Alpha1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:3.0.0:clean (default-clean) @ wildfly-component-matrix-builder ---
[INFO] Deleting /Users/kabir/sourcecontrol/wildfly/git/wildfly/component-matrix-builder/target
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (ban-bad-dependencies) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-java-version) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M1:enforce (enforce-maven-version) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- buildnumber-maven-plugin:1.4:create (get-scm-revision) @ wildfly-component-matrix-builder ---
[INFO] Executing: /bin/sh -c cd '/Users/kabir/sourcecontrol/wildfly/git/wildfly/component-matrix-builder' && 'git' 'rev-parse' '--verify' 'HEAD'
[INFO] Working directory: /Users/kabir/sourcecontrol/wildfly/git/wildfly/component-matrix-builder
[INFO] Storing buildNumber: 14932f15e391c4d41e42e8ec0cfa7c422fb6adfc at timestamp: 1526313503587
[INFO] Storing buildScmBranch: WFLY-10365-generate-bom
[INFO] 
[INFO] --- wildfly-component-matrix-plugin:1.0.1.Final:build-bom (build-bom) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- maven-checkstyle-plugin:3.0.0:checkstyle (check-style) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- maven-source-plugin:3.0.1:jar-no-fork (attach-sources) @ wildfly-component-matrix-builder ---
[INFO] 
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ wildfly-component-matrix-builder ---
[INFO] Installing /Users/kabir/sourcecontrol/wildfly/git/wildfly/component-matrix-builder/pom.xml to /Users/kabir/.m2/repository/org/wildfly/wildfly-component-matrix-builder/13.0.0.Alpha1-SNAPSHOT/wildfly-component-matrix-builder-13.0.0.Alpha1-SNAPSHOT.pom
[INFO] Installing /Users/kabir/sourcecontrol/wildfly/git/wildfly/component-matrix-builder/target/bom-pom.xml to /Users/kabir/.m2/repository/org/wildfly/wildfly-component-matrix/13.0.0.Alpha1-SNAPSHOT/wildfly-component-matrix-13.0.0.Alpha1-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.808 s
[INFO] Finished at: 2018-05-14T16:58:24+01:00
[INFO] Final Memory: 208M/683M
[INFO] ------------------------------------------------------------------------
```
https://gist.github.com/kabir/6db0a7070ea6019b1c93a1c60e01757a contains both the core and the full generated component matrix contents (There are 2 separate files in the gist). 

The original hand-coded component-matrix was removed in https://github.com/wildfly/wildfly/pull/11200https://github.com/wildfly/wildfly/pull/11200. This is a slight change from the original component matrix in that it includes the dependencies from core, while previously the user would have to include both matrices. 