### PR TITLE
Legacy config tweaks

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -26,14 +26,14 @@
         <profile name="default">
             <?SUBSYSTEMS socket-binding-group="standard-sockets"?>
         </profile>
+        <profile name="ha">
+            <?SUBSYSTEMS socket-binding-group="ha-sockets"?>
+        </profile>
         <profile name="full">
             <?SUBSYSTEMS socket-binding-group="full-sockets"?>
         </profile>
         <profile name="full-ha">
             <?SUBSYSTEMS socket-binding-group="full-ha-sockets"?>
-        </profile>
-        <profile name="ha">
-            <?SUBSYSTEMS socket-binding-group="ha-sockets"?>
         </profile>
         <profile name="load-balancer">
             <?SUBSYSTEMS socket-binding-group="load-balancer-sockets"?>
@@ -50,13 +50,13 @@
         <socket-binding-group name="standard-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
+        <socket-binding-group name="ha-sockets" default-interface="public">
+            <?SOCKET-BINDINGS?>
+        </socket-binding-group>
         <socket-binding-group name="full-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="full-ha-sockets" default-interface="public">
-            <?SOCKET-BINDINGS?>
-        </socket-binding-group>
-        <socket-binding-group name="ha-sockets" default-interface="public">
             <?SOCKET-BINDINGS?>
         </socket-binding-group>
         <socket-binding-group name="load-balancer-sockets" default-interface="public">

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -9,7 +9,7 @@
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>discovery.xml</subsystem>
-        <subsystem>ee.xml</subsystem>
+        <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -8,7 +8,7 @@
         <subsystem>datasources.xml</subsystem>
         <subsystem>deployment-scanner.xml</subsystem>
         <subsystem>discovery.xml</subsystem>
-        <subsystem>ee.xml</subsystem>
+        <subsystem supplement="full">ee.xml</subsystem>
         <subsystem>ee-security.xml</subsystem>
         <subsystem supplement="full">ejb3.xml</subsystem>
         <subsystem supplement="standalone-wildfly">elytron.xml</subsystem>


### PR DESCRIPTION
Reverts part of #11202 that isn't needed.

Fixes https://issues.jboss.org/browse/WFLY-10368

Besides being right to do this is mostly about removing pointless diffs to what galleon will produce.