### PR TITLE
[WFLY-10228] Upgrade Picketlink from 2.5.5.SP10 to 2.5.5.SP11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <version.org.opensaml.opensaml>3.3.0</version.org.opensaml.opensaml>
         <version.org.ow2.asm>6.0</version.org.ow2.asm>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.5.5.SP10</version.org.picketlink>
+        <version.org.picketlink>2.5.5.SP11</version.org.picketlink>
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-10228

This upgrade contains one bug fix needed by downstream.