### PR TITLE
[WFLY-10374] Upgrade to Galleon 1.0.0.CR3 and plugins 1.0.0.CR6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>1.0.0.CR2</version.org.jboss.galleon>
+        <version.org.jboss.galleon>1.0.0.CR3</version.org.jboss.galleon>
 
         <!-- TODO This is an unusual case where we override the version only for this client. The parent pom version is
                   using the 1.1 version for the Java EE 8 tech preview though the client still currently expects 1.0.
@@ -171,7 +171,7 @@
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.1.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>1.0.0.CR3</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.0.CR6</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10374

This upgrade fixes a file descriptor leak in Galleon due to not closed file writer.