### PR TITLE
[WFLY-10372] Upgrade Hibernate Validator to 6.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <version.org.hibernate>5.1.14.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.2.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.5.8.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.9.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.10.Final</version.org.hibernate.validator>
         <version.org.hibernate.validator.ee7>5.3.6.Final</version.org.hibernate.validator.ee7>
         <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>


### PR DESCRIPTION
* https://issues.jboss.org/browse/WFLY-10372

This upgrade fixes a couple of important issues:

 * https://hibernate.atlassian.net/browse/HV-1604 - Initializing JPATraversableResolver fails with IllegalAccessException: this is a regression from 6.0.3.Final, the JPATraversableResolver was not correctly instantiated and thus not used, even in a JPA environment.
 * https://hibernate.atlassian.net/browse/HV-1609 - CDI extension should not rely on @WithAnnotations filtering: @WithAnnotations does not consider the annotations in the class hierarchy so a bean with constraint annotations only in the class hierarchy would not see these constraints applied.
 * https://hibernate.atlassian.net/browse/HV-1614 - Unable to specify constraints at more than 1 nested parameter of a typed container: in the programmatic API, nested container element constraints and cascading were not working as expected.
It is only available in EE8 preview mode.

**Note: this upgrade will require we upgrade the Bean Validation TCK used to validate EE8 to 2.0.3.Final (some tests will fail otherwise).** (I'm going to ping Scott soon)