### PR TITLE
[WFLY-10386] Replace hard coded dependent groupId with project.groupId

### DIFF
--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -55,7 +55,7 @@
             <artifactId>wildfly-clustering-infinispan-spi</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-jboss</artifactId>
         </dependency>
         <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -94,7 +94,7 @@
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
                             <feature-packs>
                                 <feature-pack>
-                                    <groupId>org.wildfly</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${project.version}</version>
                                     <included-packages>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -131,7 +131,7 @@
                                     <extension>zip</extension>
                                 </feature-pack>
                                 <feature-pack>
-                                    <groupId>org.wildfly</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                     <version>${project.version}</version>
                                     <type>zip</type>

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -86,7 +86,7 @@
                                     </excluded-packages>
                                 </feature-pack>
                                 <feature-pack>
-                                    <groupId>org.wildfly</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                     <version>${project.version}</version>
                                     <excluded-packages>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -83,7 +83,7 @@
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
                             <feature-packs>
                                 <feature-pack>
-                                    <groupId>org.wildfly</groupId>
+                                    <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                     <version>${project.version}</version>
                                 </feature-pack>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10386

Use a var so it's easy to convert code to org.jboss.eap groupId.