### PR TITLE
Revert "Workaround maven properties now not being inherited introduce…

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -44,10 +44,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
-
-        <!-- Workaround properties now not being inherited introduced with https://issues.jboss.org/browse/WFLY-9911 -->
-        <!-- Maven feature https://issues.apache.org/jira/browse/MNG-5102 -->
-        <version.org.infinispan>9.2.2.Final</version.org.infinispan>
     </properties>
 
     <profiles>


### PR DESCRIPTION
…d with WFLY-9911"

This reverts commit 353ee31f4c39ffa45374af8b88ad644874a93efb.

Follows up on https://github.com/wildfly/wildfly/pull/11200 