### PR TITLE
Add JPA 2.2 information to the Java EE 8 Preview table.

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -141,6 +141,7 @@ will remain at Java EE7 level.
 | Java API for XML-Based Web Services | 2.2 | JSR-224 | 2.3 | https://jcp.org/en/jsr/detail?id=224[JSR-224]
 | Common Annotations for the Java Platform | 1.2 | JSR-250 | 1.3 | http://download.oracle.com/otndocs/jcp/common_annotations-1_3-mrel3-spec/[JSR-250]
 | Java EE Security API | - | - | 1.0 | https://jcp.org/aboutJava/communityprocess/final/jsr375/index.html[JSR-375]
+| Java Persistence 2.2 | 2.1 | JSR-338 | 2.2 | https://jcp.org/en/jsr/detail?id=338[JSR-338]
 |=======================================================================
 
 [[download]]


### PR DESCRIPTION
No JIRA required. Follow up on #11234. Simply adds the JPA 2.2 information to the Java EE 8 preview table.