### PR TITLE
[WFLY-10409] Add product module and licenses to thin builds; add some…

### DIFF
--- a/build-legacy/pom.xml
+++ b/build-legacy/pom.xml
@@ -83,6 +83,136 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>distribution-configuration</id>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <overwrite>true</overwrite>
+                                    <outputDirectory>${basedir}/target/${project.build.finalName}</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <!-- Pull the shared content from dist-legacy -->
+                                            <directory>../dist-legacy/src/distribution/resources</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>verifications-configuration</id>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <phase>process-classes</phase>
+                                <configuration>
+                                    <overwrite>true</overwrite>
+                                    <outputDirectory>${basedir}/target/verifier</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/verifier</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-verifier-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.7</version>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <tasks>
+                                        <filelist id="licenses.xml.list" dir="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses"
+                                                  files="full-feature-pack-licenses.xml,servlet-feature-pack-licenses.xml,core-feature-pack-licenses.xml"/>
+                                        <!--
+                                        <property name="prop.licenses.xml.list" refid="licenses.xml.list"/>
+                                        <echo>List of licenses.xml in ${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</echo>
+                                        <echo>${prop.licenses.xml.list}</echo>
+                                        -->
+                                        <pathconvert pathsep="&#xA;" property="license-files-list-items" refid="licenses.xml.list">
+                                            <chainedmapper>
+                                                <mapper type="flatten"/>
+                                                <globmapper from="*" to="&lt;item&gt;*"/>
+                                                <globmapper from="*" to="*&lt;/item&gt;"/>
+                                            </chainedmapper>
+                                        </pathconvert>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#xA;&lt;list&gt;&#xA;</echo>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml" append="true">${license-files-list-items}&#xA;</echo>
+                                        <echo file="${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xml" append="true">&lt;/list&gt;</echo>
+                                    </tasks>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>xml-maven-plugin</artifactId>
+                        <version>1.0.1</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>generate-licenses-html</id>
+                                <goals>
+                                    <goal>transform</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <transformationSets>
+                                        <transformationSet>
+                                            <dir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</dir>
+                                            <includes>
+                                                <include>licenses.xml</include>
+                                            </includes>
+                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses-merged.xsl</stylesheet>
+                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</outputDir>
+                                            <fileMappers>
+                                                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                                    <targetExtension>.xml</targetExtension>
+                                                </fileMapper>
+                                            </fileMappers>
+                                        </transformationSet>
+                                        <transformationSet>
+                                            <dir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</dir>
+                                            <includes>
+                                                <include>licenses.xml</include>
+                                            </includes>
+                                            <stylesheet>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses/licenses.xsl</stylesheet>
+                                            <outputDir>${basedir}/target/${server.output.dir.prefix}-${server.output.dir.version}/docs/licenses</outputDir>
+                                            <fileMappers>
+                                                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                                    <targetExtension>.html</targetExtension>
+                                                </fileMapper>
+                                            </fileMappers>
+                                            <parameters>
+                                                <parameter>
+                                                    <name>version</name>
+                                                    <value>${project.version}</value>
+                                                </parameter>
+                                            </parameters>
+                                        </transformationSet>
+                                    </transformationSets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/build-legacy/src/verifier/verifications.xml
+++ b/build-legacy/src/verifier/verifications.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 JBoss by Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+<!--
+    1) bin/product.conf exists
+    2) bin/product.conf has a slot property with a value equal to the value of the
+       'full.dist.product.slot' property
+    3) jboss-modules.jar must exist
+    4) standalone/configuration/standalone.xml must exist
+    5) modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF exists
+    6) JBoss-Product-Release-Name key in manifest.mf above has value equal to the value of the
+       'full.dist.product.release.name' property
+    7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
+       'verifier.product.release.version' property
+    8) JBossEULA.txt exists
+    8) version.txt exists
+    9) copyright.txt does not exist
+    10) README.txt does not exist
+    11) docs/contrib does not exist
+-->
+  <files>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
+      <contains>slot=${full.dist.product.slot}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Name: ${full.dist.product.release.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/standalone/configuration/standalone.xml</location>
+      <exists>true</exists>
+    </file>
+  </files>
+</verifications>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -46,6 +46,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-galleon-pack</artifactId>
+            <type>pom</type>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-galleon-pack</artifactId>
             <type>zip</type>
             <exclusions>
                 <exclusion>
@@ -73,38 +79,9 @@
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
                             <feature-packs>
                                 <feature-pack>
-                                    <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <inherit-configs>false</inherit-configs>
-                                    <excluded-packages>
-                                        <name>product.conf</name>
-                                        <name>docs.schema</name>
-                                        <name>docs.licenses.merge</name>
-                                    </excluded-packages>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
-                                    <inherit-configs>false</inherit-configs>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-load-balancer.xml</name>
-                                        </config>
-                                    </included-configs>
-                                    <excluded-packages>
-                                        <name>product.conf</name>
-                                        <name>docs.schema</name>
-                                    </excluded-packages>
-                                </feature-pack>
-                                <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${project.version}</version>
-                                    <excluded-packages>
-                                        <name>product.conf</name>
-                                        <name>docs.schema</name>
-                                    </excluded-packages>
                                     <included-packages>
                                         <name>docs.examples.configs</name>
                                     </included-packages>
@@ -116,6 +93,33 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verifications-configuration</id>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <overwrite>true</overwrite>
+                            <outputDirectory>${basedir}/target/verifier</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/verifier</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-verifier-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/build/src/verifier/verifications.xml
+++ b/build/src/verifier/verifications.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2017 JBoss by Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<verifications xmlns="http://maven.apache.org/verifications/1.0.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://maven.apache.org/verifications/1.0.0 http://maven.apache.org/xsd/verifications-1.0.0.xsd">
+<!--
+    1) bin/product.conf exists
+    2) bin/product.conf has a slot property with a value equal to the value of the
+       'full.dist.product.slot' property
+    3) jboss-modules.jar must exist
+    4) standalone/configuration/standalone.xml must exist
+    5) modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF exists
+    6) JBoss-Product-Release-Name key in manifest.mf above has value equal to the value of the
+       'full.dist.product.release.name' property
+    7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
+       'verifier.product.release.version' property
+    8) JBossEULA.txt exists
+    8) version.txt exists
+    9) copyright.txt does not exist
+    10) README.txt does not exist
+    11) docs/contrib does not exist
+-->
+  <files>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/bin/product.conf</location>
+      <contains>slot=${full.dist.product.slot}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/product/${full.dist.product.slot}/dir/META-INF/MANIFEST.MF</location>
+      <contains>JBoss-Product-Release-Name: ${full.dist.product.release.name}</contains>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/jboss-modules.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/standalone/configuration/standalone.xml</location>
+      <exists>true</exists>
+    </file>
+  </files>
+</verifications>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -102,7 +102,6 @@
                                     <artifactId>wildfly-galleon-pack</artifactId>
                                     <version>${project.version}</version>
                                     <excluded-packages>
-                                        <name>product.conf</name>
                                         <name>docs</name>
                                         <name>docs.licenses.merge</name>
                                     </excluded-packages>


### PR DESCRIPTION
… thin build structure verification

https://issues.jboss.org/browse/WFLY-10409

NOTE: this is not a complete fix for the issue; more analysis is needed to look at servlet-build vs servlet-dist.

But, this fixes the critical problem of the product module not being present in the main 'build' module output.  I think that's enough for WF 13 and any further changes can wait for 14 if not fixed in time.

@aloubyansky FYI.