### PR TITLE
[WFLY-9978] Fix RA deployment failure due to unready ConnectionDefinitionService in combined with legacy security-domain

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -44,6 +44,8 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.msc.service.ServiceController.State;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 import org.jboss.vfs.VirtualFile;
 
@@ -911,4 +913,8 @@ public interface ConnectorLogger extends BasicLogger {
 
     @Message(id = 114, value = "Failed to load datasource class: %s")
     IllegalStateException failedToLoadDataSourceClass(String clsName, @Cause Throwable t);
+
+    @LogMessage(level = WARN)
+    @Message(id = 115, value = "The required service '%s' is not UP, it is currently '%s'.")
+    void requiredServiceNotUp(ServiceName name, State state);
 }


### PR DESCRIPTION
RA deployment sometimes fails as explained in https://issues.jboss.org/browse/WFLY-9978

RA deployment service activation depends on _raxml_ connections configuration attributes to determine security implementation type, and it assumes ConnectionDefinitionService is ready (see [RaServicesFactory.java#L96](https://github.com/wildfly/wildfly/blob/13.0.0.Beta1/connector/src/main/java/org/jboss/as/connector/util/RaServicesFactory.java#L96) and [ActivationSecurityUtil.java#L39](https://github.com/wildfly/wildfly/blob/13.0.0.Beta1/connector/src/main/java/org/jboss/as/connector/metadata/api/resourceadapter/ActivationSecurityUtil.java#L39)) which is not always true.

This change allows to wait explicitly 500 ms to make sure ConnectionDefinitionService is ready to use.
