### PR TITLE
[WFLY-10416] Upgrade ActiveMQ Artemis from 1.5.5.jbossorg-011 to 1.5.5.jbossorg-012

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.5.5.jbossorg-011</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.5.5.jbossorg-012</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.2.4-jbossorg-1</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.1.0</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-10416

This upgrade include the fix for the regression: https://issues.jboss.org/browse/WFLY-10392


