### PR TITLE
[WFLY-10428] Upgrade to WildFly Galleon plugins 1.0.0.CR12 and fork em…

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -89,6 +89,7 @@
                             </feature-packs>
                             <plugin-options>
                                 <jboss-maven-dist/>
+                                <jboss-fork-embedded/>
                             </plugin-options>
                         </configuration>
                     </execution>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -85,6 +85,9 @@
                         <phase>compile</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
+                            <plugin-options>
+                                <jboss-fork-embedded/>
+                            </plugin-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -122,6 +122,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <output-dir>${basedir}/target/resources/features</output-dir>
+                            <fork-embedded>true</fork-embedded>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>org.wildfly.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>1.0.0.CR6</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.0.CR12</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -97,6 +97,7 @@
                             </feature-packs>
                             <plugin-options>
                                 <jboss-maven-dist/>
+                                <jboss-fork-embedded/>
                             </plugin-options>
                         </configuration>
                     </execution>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -76,6 +76,9 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
+                            <plugin-options>
+                                <jboss-fork-embedded/>
+                            </plugin-options>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -559,6 +559,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <output-dir>${basedir}/target/resources/features</output-dir>
+                            <fork-embedded>true</fork-embedded>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>org.wildfly.core</groupId>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -127,6 +127,7 @@
                             </feature-packs>
                             <plugin-options>
                                 <jboss-maven-dist/>
+                                <jboss-fork-embedded/>
                             </plugin-options>
                         </configuration>
                     </execution>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -120,6 +120,7 @@
                             </feature-packs>
                             <plugin-options>
                                 <jboss-maven-dist/>
+                                <jboss-fork-embedded/>
                             </plugin-options>
                         </configuration>
                     </execution>


### PR DESCRIPTION
…bedded in the build

https://issues.jboss.org/browse/WFLY-10428

The 1.0.0.CR12 significantly reduces the classpath for the embedded server prepared by the plugins and includes an option to execute embedded operations in a separate process to avoid FD leaks in jboss-modules.