### PR TITLE
WFLY-10431 upgrade guava from 20.0 to 25.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.github.spullara.mustache>0.9.4</version.com.github.spullara.mustache>
-        <version.com.google.guava>20.0</version.com.google.guava>
+        <version.com.google.guava>25.0-jre</version.com.google.guava>
         <version.com.h2database>1.4.193</version.com.h2database>
         <version.com.microsoft.azure>6.1.0</version.com.microsoft.azure>
         <!--
@@ -1159,6 +1159,22 @@
                     <exclusion>
                         <artifactId>jsr305</artifactId>
                         <groupId>com.google.code.findbugs</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-compat-qual</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10431

This fixes [CVE-2018-10237](https://github.com/google/guava/wiki/CVE-2018-10237).