### PR TITLE
[WFLY-10337] Fix hardcoded hostname in properties file

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -139,7 +139,7 @@ public class AuthenticationPolicyContextTestCase {
         war.addClasses(EchoService.class);
         war.addAsResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/sp-users.properties", "sp-users.properties");
         war.addAsResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/sp-roles.properties", "sp-roles.properties");
-        war.addAsResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/sts-config.properties", "sts-config.properties");
+        war.addAsResource(createFilteredAsset("resources/sts-config.properties"), "sts-config.properties");
         war.addAsWebInfResource(createFilteredAsset("resources/WEB-INF/wsdl/PicketLinkSTS.wsdl"), "wsdl/PicketLinkSTS.wsdl");
         war.addAsWebInfResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/WEB-INF/beans.xml", "beans.xml");
         war.addAsWebInfResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/WEB-INF/jboss-web-ws.xml", "jboss-web-ws.xml");

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/resources/sts-config.properties
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/resources/sts-config.properties
@@ -1,5 +1,5 @@
 serviceName=PicketLinkSTS
 portName=PicketLinkSTSPort
-endpointAddress=http://localhost:8080/picketlink-sts/PicketLinkSTS
+endpointAddress=http://@node0@:8080/picketlink-sts/PicketLinkSTS
 username=JBoss
 password=JBoss


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10337

Test fix, enable replacing server hostname with actual host set by node0 property