### PR TITLE
[WFLY-9658] Allow visible batch jobs to be queried from the JobOperat…

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/WildFlyJobXmlResolver.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/WildFlyJobXmlResolver.java
@@ -249,6 +249,13 @@ public class WildFlyJobXmlResolver implements JobXmlResolver {
     }
 
     private static void merge(final WildFlyJobXmlResolver target, final WildFlyJobXmlResolver toCopy) {
+        for (Map.Entry<String, Set<String>> entry : toCopy.jobNames.entrySet()) {
+            if (target.jobNames.containsKey(entry.getKey())) {
+                target.jobNames.get(entry.getKey()).addAll(entry.getValue());
+            } else {
+                target.jobNames.put(entry.getKey(), entry.getValue());
+            }
+        }
         toCopy.jobXmlNames.forEach(target.jobXmlNames::putIfAbsent);
         toCopy.jobXmlFiles.forEach(target.jobXmlFiles::putIfAbsent);
         target.jobXmlResolvers.addAll(toCopy.jobXmlResolvers);


### PR DESCRIPTION
…or. Previously only jobs directly associated with the deployment were allowed to be queried.

https://issues.jboss.org/browse/WFLY-9658

Previously jobs were allowed to be started or stopped, but information could not be queried. This allows the information to be queried.