### PR TITLE
[WFLY-10373] Declare default attributes explicitly in undertow subsystem config

### DIFF
--- a/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:6.0">
+    <subsystem xmlns="urn:jboss:domain:undertow:6.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default">
         <buffer-cache name="default" />
         <server name="default-server">
             <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"  />

--- a/undertow/src/main/resources/subsystem-templates/undertow.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:6.0">
+    <subsystem xmlns="urn:jboss:domain:undertow:6.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other">
         <buffer-cache name="default" />
         <server name="default-server">
             <?AJP?>


### PR DESCRIPTION
The various default-xxx attributes on root undertow subsystem element if not set have default values that map to the standard child elements in the config. The problem with relying on those defaults and not specifying the values is their usage becomes "black magic" and the fact that things will fail if the child elements are removed or renamed is lost.

Jira issue: https://issues.jboss.org/browse/WFLY-10373