### PR TITLE
[WFLY-10446] Attach names associated with a deployment to DeploymentUnit

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/DeploymentNames.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/DeploymentNames.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow.deployment;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+
+/**
+ * Names related to a deployment.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+public class DeploymentNames {
+    public static final AttachmentKey<DeploymentNames> ATTACHMENT_KEY = AttachmentKey.create(DeploymentNames.class);
+
+    private final String servletContainerName;
+    private final String deploymentName;
+    private final String hostName;
+    private final String contextPath;
+    private final String serverName;
+
+    public DeploymentNames(String serverName, String containerName, String hostName, String deploymentName, String pathName) {
+        super();
+        this.serverName = serverName;
+        this.servletContainerName = containerName;
+        this.hostName = hostName;
+        this.deploymentName = deploymentName;
+        this.contextPath = pathName;
+    }
+
+    /**
+     * @return the name of the Undertow servlet container associated with this deployment
+     */
+    public String getServletContainerName() {
+        return servletContainerName;
+    }
+
+    /**
+     * @return the name under which this deployment is known in the management model
+     */
+    public String getDeploymentName() {
+        return deploymentName;
+    }
+
+    /**
+     * @return the name of the Undertow vitual host on which this deployment is deployed
+     */
+    public String getHostName() {
+        return hostName;
+    }
+
+    /**
+     * @return the context path under which this deployment is available
+     */
+    public String getContextPath() {
+        return contextPath;
+    }
+
+    /**
+     * @return the name of the Undertow server on which this deployment is deployed
+     */
+    public String getServerName() {
+        return serverName;
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10446

To be able to secure Camel CXF endpoints in WildFly Camel, we need an access to DeploymentInfo produced by UndertowDeploymentInfoService. Currently, the service name of UndertowDeploymentInfoService is assembled out of several parts including server name, host name and deployment name. These three are defined by a complex logic that checks various sources and defaults. So, rather than copying that logic to WildFly Camel, we propose to pack those names into a data object and attach it to the deploymentUnit so that it is available to our DeploymentProcessor.

@stuartwdouglas and @darranl could you please review?