### PR TITLE
[WFLY-10309] Put the host 'name' attribute after the xmlns

### DIFF
--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:7.0">
+<host xmlns="urn:jboss:domain:7.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:7.0">
+<host xmlns="urn:jboss:domain:7.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10309

Really, really minor; just cleaning out the 'todos' from comparing galleon built dists to legacy.