### PR TITLE
Partial WFLY-5966 -- org.omg.api brute force removal

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -41,7 +41,6 @@
              reexported by javaee.api. -->
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 
     <resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -29,7 +29,6 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 
     <resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
@@ -37,7 +37,6 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -47,7 +47,6 @@
              reexported by javaee.api. -->
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
 
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
@@ -52,6 +52,5 @@
         <module name="javax.transaction.api" optional="true"/>
         <module name="javax.xml.rpc.api" optional="true"/>
         <module name="javax.rmi.api" optional="true"/>
-        <module name="org.omg.api" optional="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
@@ -50,6 +50,5 @@
         <module name="javax.transaction.api" optional="true"/>
         <module name="javax.xml.rpc.api" optional="true"/>
         <module name="javax.rmi.api" optional="true"/>
-        <module name="org.omg.api" optional="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -52,6 +52,5 @@
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Partial completion of the https://issues.jboss.org/browse/WFLY-5966 task.

**Do not resolve the JIRA based on this PR!**

At this point this is just an experiment to see how CI reacts.

Removing org.omg.api from the modules listed in the JIRA won't help much if they all depend on javax.ejb.api and it depends on org.omg.api.  But grepping the imports of the ejb spec jar's codebase I don't see any imports of org.omg.api so I don't see why it needs the module dep. So the first commit here removes that.

