### PR TITLE
[WFLY-10451] Configure the product release version using the galleon …

### DIFF
--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -248,6 +248,9 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <release-name>${full.dist.product.release.name}</release-name>
+                            <task-properties>
+                                <product.release.version>${product.release.version}</product.release.version>
+                            </task-properties>
                         </configuration>
                     </execution>
                 </executions>

--- a/galleon-pack/src/main/resources/packages/product.conf/pm/wildfly/resources/modules/system/layers/base/org/jboss/as/product/wildfly-full/dir/META-INF/MANIFEST.MF
+++ b/galleon-pack/src/main/resources/packages/product.conf/pm/wildfly/resources/modules/system/layers/base/org/jboss/as/product/wildfly-full/dir/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
 JBoss-Product-Release-Name: ${product.release.name}
-JBoss-Product-Release-Version: ${project.version}
+JBoss-Product-Release-Version: ${product.release.version}

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -615,6 +615,9 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <release-name>${servlet.dist.product.release.name}</release-name>
+                            <task-properties>
+                                <product.release.version>${product.release.version}</product.release.version>
+                            </task-properties>
                         </configuration>
                     </execution>
                 </executions>

--- a/servlet-galleon-pack/src/main/resources/packages/product.conf/pm/wildfly/resources/modules/system/layers/base/org/jboss/as/product/wildfly-web/dir/META-INF/MANIFEST.MF
+++ b/servlet-galleon-pack/src/main/resources/packages/product.conf/pm/wildfly/resources/modules/system/layers/base/org/jboss/as/product/wildfly-web/dir/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
 JBoss-Product-Release-Name: ${product.release.name}
-JBoss-Product-Release-Version: ${project.version}
+JBoss-Product-Release-Version: ${product.release.version}


### PR DESCRIPTION
This patch configures the galleon maven plugin to use the pom property ${product.release.version}. It will allow us to use a different value instead of the ${project.version}

Jira issue: https://issues.jboss.org/browse/WFLY-10451