### PR TITLE
[WFLY-10450] Upgrade WildFly Core 5.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.1.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
-        <version.org.wildfly.core>5.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>5.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.8.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.0.3.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10450


# Release Notes - WildFly Core - Version 5.0.0.Beta5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3872'>WFCORE-3872</a>] -         Upgrade to WildFly Galleon plugins 1.0.0.CR11 and fork embedded in the build
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3886'>WFCORE-3886</a>] -         Upgrade to WildFly Galleon plugins 1.0.0.CR12
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3888'>WFCORE-3888</a>] -         Undertow 2.0.8.Final
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3826'>WFCORE-3826</a>] -         anonymous authentication for ejbs using legacy configuration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3849'>WFCORE-3849</a>] -         CLI cursor disorder for Up and Down Arrow
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3853'>WFCORE-3853</a>] -         CLI prompt contains extra space when colors are enabled
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3859'>WFCORE-3859</a>] -         The Elytron subsystem is currently missing any transformation from version 2.0.0 to 1.2.0
</li>
</ul>
                                            
