### PR TITLE
[WFLY-10452] Don't overwrite deployment-scanner config in servlet's s…

### DIFF
--- a/servlet-galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
@@ -7,14 +7,7 @@
         </feature-group>
     </origin>
 
-    <feature-group name="deployment-scanner">
-        <include feature-id="subsystem.deployment-scanner.scanner:scanner=default">
-            <param name="path" value="deployments" />
-            <param name="relative-to" value="jboss.server.base.dir" />
-            <param name="scan-interval" value="5000" />
-            <param name="runtime-failure-causes-rollback" value="${jboss.deployment.scanner.rollback.on.failure:false}"/>
-        </include>
-    </feature-group>
+    <feature-group name="deployment-scanner"/>
 
     <feature-group name="basic-profile"/>
 


### PR DESCRIPTION
…tandalone-profile

https://issues.jboss.org/browse/WFLY-10452

This commits removes the unnecessary deployment-scanner configuration from the servlet configs. The default config is defined in the core and should not be overwritten  in default configs.