### PR TITLE
[WFLY-10465] Upgrade WildFly Core 5.0.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.1.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
-        <version.org.wildfly.core>5.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>5.0.0.CR1</version.org.wildfly.core>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.0.4.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10465


## Release Notes - WildFly Core - Version 5.0.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3883'>WFCORE-3883</a>] -         Upgrade WildFly Elytron to 1.3.3.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3890'>WFCORE-3890</a>] -         Upgrade WildFly Elytron Tool to 1.2.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3893'>WFCORE-3893</a>] -         Upgrade to Galleon 1.0.0.Final and Galleon Plugins 1.0.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3894'>WFCORE-3894</a>] -         Undertow 2.0.9.Final
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3884'>WFCORE-3884</a>] -         Securing EJB with legacy ldap realm does not work
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3889'>WFCORE-3889</a>] -         Legacy kerberos realm cant load com.sun.security.auth.module.Krb5LoginModule
</li>
</ul>
                                            