### PR TITLE
[WFLY-10470] Upgrade WildFly Core 5.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.1.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
-        <version.org.wildfly.core>5.0.0.CR1</version.org.wildfly.core>
+        <version.org.wildfly.core>5.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.0.4.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10470

WildFly Core 5.0.0.Final is identical to 5.0.0.CR1 (minus the version change): https://github.com/wildfly/wildfly-core/compare/5.0.0.CR1...5.0.0.Final