### PR TITLE
[JBWS-4120] SOAP logging stopped working with WildFly 12 / JBossWS 5.2.0.Final (Apache CXF 3.2.2)

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -610,6 +610,11 @@
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-features-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-aegis</artifactId>
         </dependency>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -26,6 +26,7 @@
 
     <resources>
         <artifact name="${org.apache.cxf:cxf-core}"/>
+        <artifact name="${org.apache.cxf:cxf-rt-features-logging}"/>
     </resources>
 
     <dependencies>
@@ -35,6 +36,7 @@
                 <include path="META-INF"/>
             </imports>
         </module>
+        <module name="org.slf4j"/>
         <module name="asm.asm" />
         <module name="javax.api" />
         <module name="javax.annotation.api" />

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -782,6 +782,11 @@
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-features-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-aegis</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1787,6 +1787,18 @@
 
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-features-logging</artifactId>
+                <version>${version.org.apache.cxf}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>slf4j-api</artifactId>
+                        <groupId>org.slf4j</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-bindings-coloc</artifactId>
                 <version>${version.org.apache.cxf}</version>
                 <exclusions>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/JBWS-4120

Added new dependency since old CXF logging feature has been moved to a separate library.