### PR TITLE
[WFLY-6770] test fix - protected LdapExtPasswordCachingTestCase againt spurious wakeups

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtPasswordCachingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtPasswordCachingTestCase.java
@@ -50,7 +50,6 @@ import org.jboss.security.auth.spi.LdapExtLoginModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -155,7 +154,7 @@ public class LdapExtPasswordCachingTestCase {
         assertEquals("Password from cache: 1", 1, passwordProvider.readFileCounter());
 
         long WAIT = 800;
-        Thread.sleep(WAIT);
+        sleep(WAIT);
 
         checkPrincipal(webAppURL, "jduke");
         assertEquals("Password from cache: 1", 1, passwordProvider.readFileCounter());
@@ -172,7 +171,6 @@ public class LdapExtPasswordCachingTestCase {
      */
     @Test
     @OperateOnDeployment(DEP3)
-    @Ignore("WFLY-6770")
     public void test3(@ArquillianResource URL webAppURL) throws Exception {
 
         passwordProvider.resetFileCounter();
@@ -184,7 +182,7 @@ public class LdapExtPasswordCachingTestCase {
         assertEquals("Password from cache 1", 1, passwordProvider.readFileCounter());
 
         long WAIT = 800;
-        Thread.sleep(WAIT);
+        sleep(WAIT);
 
         checkPrincipal(webAppURL, "jduke");
         assertEquals("Password call 2", 2, passwordProvider.readFileCounter());
@@ -195,6 +193,18 @@ public class LdapExtPasswordCachingTestCase {
     }
 
     // Private methods -------------------------------------------------------
+
+    /**
+     * Sleep the thread for given time, protected against spurious wakeups.
+     */
+    private void sleep(long millis) throws InterruptedException {
+        long endTime = System.currentTimeMillis() + millis;
+        long sleepTime = millis;
+        while(sleepTime > 0) {
+            Thread.sleep(sleepTime);
+            sleepTime = endTime - System.currentTimeMillis();
+        }
+    }
 
     private void checkPrincipal(URL webAppURL, String username) throws
             IOException, URISyntaxException, LoginException {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6770
https://issues.jboss.org/browse/JBEAP-10551

Test was ignored as unstable. As it was failing very rarely, I am not sure this is a real solution, however spurious wakeups are any possible entry point for test instability I see here.
In any case, better then pure unignoring the test as suggested in JBEAP-10551 - in worst case (the test start to fail is some cases) we will be sure spurious wakeups was not the problem.