### PR TITLE
WFLY-10025 Use new org.jboss.modules.ClassTransformer interface in addition to j.l.i.ClassFileTransformer

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/classloader/JPADelegatingClassFileTransformer.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/classloader/JPADelegatingClassFileTransformer.java
@@ -26,8 +26,10 @@ import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
+import java.nio.ByteBuffer;
 import java.security.ProtectionDomain;
 
+import org.jboss.as.jpa.messages.JpaLogger;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 
 /**
@@ -35,7 +37,7 @@ import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
  *
  * @author Scott Marlow
  */
-public class JPADelegatingClassFileTransformer implements ClassFileTransformer {
+public class JPADelegatingClassFileTransformer implements ClassFileTransformer, org.jboss.modules.ClassTransformer {
     private final PersistenceUnitMetadata persistenceUnitMetadata;
 
     public JPADelegatingClassFileTransformer(PersistenceUnitMetadata pu) {
@@ -43,21 +45,55 @@ public class JPADelegatingClassFileTransformer implements ClassFileTransformer {
     }
 
     @Override
-    public byte[] transform(ClassLoader classLoader, String className, Class<?> aClass, ProtectionDomain protectionDomain, byte[] originalBuffer) throws
-        IllegalClassFormatException {
-        byte[] transformedBuffer = originalBuffer;
+    public byte[] transform(ClassLoader classLoader, String className, Class<?> aClass, ProtectionDomain protectionDomain, byte[] originalBuffer) {
+        return getBytes(transform(classLoader, className, protectionDomain, ByteBuffer.wrap(originalBuffer)));
+    }
+
+    @Override
+    public ByteBuffer transform(ClassLoader classLoader, String className, ProtectionDomain protectionDomain, ByteBuffer classBytes)
+            throws IllegalArgumentException {
+        byte[] transformedBuffer = getBytes(classBytes);
+        boolean transformed = false;
         for (javax.persistence.spi.ClassTransformer transformer : persistenceUnitMetadata.getTransformers()) {
             if (ROOT_LOGGER.isTraceEnabled())
                 ROOT_LOGGER.tracef("rewrite entity class '%s' using transformer '%s' for '%s'", className,
                         transformer.getClass().getName(),
                         persistenceUnitMetadata.getScopedPersistenceUnitName());
-
-            byte[] result = transformer.transform(classLoader, className, aClass, protectionDomain, transformedBuffer);
+            byte[] result;
+            try {
+                // parameter classBeingRedefined is always passed as null
+                // because we won't ever be called to transform already loaded classes.
+                result = transformer.transform(classLoader, className, null, protectionDomain, transformedBuffer);
+            } catch (IllegalClassFormatException e) {
+                throw JpaLogger.ROOT_LOGGER.invalidClassFormat(e, className);
+            }
             if (result != null) {
                 transformedBuffer = result;
+                transformed = true;
+            if (ROOT_LOGGER.isTraceEnabled())
+                ROOT_LOGGER.tracef("entity class '%s' was rewritten", className);
             }
         }
-        return transformedBuffer;
 
+        return transformed ? ByteBuffer.wrap(transformedBuffer) : null;
+    }
+
+    private byte[] getBytes(ByteBuffer classBytes) {
+
+        if (classBytes == null) {
+            return null;
+        }
+
+        final int position = classBytes.position();
+        final int limit = classBytes.limit();
+        final byte[] bytes;
+        if (classBytes.hasArray() && classBytes.arrayOffset() == 0 && position == 0 && limit == classBytes.capacity()) {
+            bytes = classBytes.array();
+        } else {
+            bytes = new byte[limit - position];
+            classBytes.get(bytes);
+            classBytes.position(position);
+        }
+        return bytes;
     }
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -26,6 +26,8 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.lang.instrument.IllegalClassFormatException;
+
 import javax.ejb.EJBException;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceException;
@@ -752,4 +754,8 @@ public interface JpaLogger extends BasicLogger {
     DeploymentUnitProcessingException differentSearchModuleDependencies(String deployment, String searchModuleName1, String searchModuleName2);
 
     // id = 72, value = "Could not obtain TransactionListenerRegistry from transaction manager")
+
+    @Message(id = 73, value = "Transformation of class %s failed")
+    IllegalStateException invalidClassFormat(@Cause IllegalClassFormatException cause, String className);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10025
Note that we should remove the j.l.i.ClassFileTransformer interface after https://issues.jboss.org/browse/WFCORE-3685 changes DelegatingClassFileTransformer to use org.jboss.modules.ClassTransformer.