### PR TITLE
[WFLY-10142] fixed missing permissions in naming tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ExternalContextBindingTestCase.java
@@ -312,7 +312,10 @@ public class ExternalContextBindingTestCase {
     public static JavaArchive deploy() {
         return ShrinkWrap.create(JavaArchive.class, "externalContextBindingTest.jar")
                 .addClasses(ExternalContextBindingTestCase.class, LookupEjb.class)
-                .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("*", "lookup")), "jboss-permissions.xml");
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new JndiPermission("*", "lookup"),
+                        new RuntimePermission("accessClassInPackage.com.sun.jndi.ldap")
+                ), "jboss-permissions.xml");
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -87,7 +87,11 @@ public class LdapUrlInSearchBaseTestCase {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "ldap-test.war");
         war.addClasses(LdapUrlTestServlet.class);
 
-        war.addAsManifestResource(createPermissionsXmlAsset(new SocketPermission("*:10389", "connect,resolve")), "permissions.xml");
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new SocketPermission("*:10389", "connect,resolve"),
+                new RuntimePermission("accessClassInPackage.com.sun.jndi.ldap"),
+                new RuntimePermission("accessClassInPackage.com.sun.jndi.url.ldap")
+        ), "permissions.xml");
 
         return war;
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10142

Added missing permissions into naming tests to succeed with security manager enabled.