### PR TITLE
[WFLY-10525] Upgrade to Galleon 1.0.1.Final and Galleon Plugins 1.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,13 +171,13 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>1.0.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>1.0.1.Final</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>1.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
Upgrade releases of Galleon and WildFly Galleon plugins in wildfly.
This upgrade will allow creating the correct file permissions defined by wildfly-core galleon-pack. 

Jira issue: https://issues.jboss.org/browse/WFLY-10525

cc: @aloubyansky 