### PR TITLE
[WFLY-10523] Upgrade WildFly Core 6.0.0.Alpha1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.wildfly.arquillian>2.1.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.1.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
-        <version.org.wildfly.core>5.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Alpha1</version.org.wildfly.core>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.2.Final</version.org.wildfly.transaction.client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10523

----

# Release Notes - WildFly Core - Version 6.0.0.Alpha1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3844'>WFCORE-3844</a>] -         Upgrade CLI to use aesh 1.5 and aesh-readline 1.8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3898'>WFCORE-3898</a>] -         Upgrade PicketBox to 5.1.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3817'>WFCORE-3817</a>] -         Remove usages of deprecated ServiceListeners
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3559'>WFCORE-3559</a>] -         FilePermissionTestCase permission checking issue
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3795'>WFCORE-3795</a>] -         Read Feature Description doesn&#39;t return ObjectAttributeDefinition capabilities
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3828'>WFCORE-3828</a>] -         ArrayIndexOutOfBoundsException on clear screen if the cursor in on the start position
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3829'>WFCORE-3829</a>] -         ReloadRedirectTestCase#testRedirectWithSecurityCommands fails on IBM JDK
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3868'>WFCORE-3868</a>] -         Domain mode shutdown of EE executor service with :stop() or :stop(timeout=0) command doesn&#39;t work
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3896'>WFCORE-3896</a>] -         Wrong description of custom-formatter resource&#39;s attributes
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3864'>WFCORE-3864</a>] -         Switch to using WildFly Common byte and code point iterators
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3900'>WFCORE-3900</a>] -         Bump the kernel management API version to 8.0.0 and the xsd to 8.0
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3902'>WFCORE-3902</a>] -         Support Maven staged repositories
</li>
</ul>
                                    