### PR TITLE
[WFLY-10434] Make interceptor order arrangements for CachedConnection…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -161,7 +161,6 @@ public class InterceptorOrder {
         public static final int CHECKING_INTERCEPTOR = 1;
         public static final int TCCL_INTERCEPTOR = 0x003;
         public static final int INVOCATION_TYPE = 0x005;
-        public static final int EE_SETUP = 0x010;
         public static final int EJB_IIOP_TRANSACTION = 0x020;
         public static final int JNDI_NAMESPACE_INTERCEPTOR = 0x050;
         public static final int REMOTE_EXCEPTION_TRANSFORMER = 0x200;
@@ -193,6 +192,7 @@ public class InterceptorOrder {
         public static final int REMOTE_TRANSACTION_PROPAGATION_INTERCEPTOR = 0x450;
         public static final int CDI_REQUEST_SCOPE = 0x480;
         public static final int CMT_TRANSACTION_INTERCEPTOR = 0x500;
+       public static final int EE_SETUP = 0x510;
         public static final int HOME_METHOD_INTERCEPTOR = 0x600;
         public static final int ASSOCIATING_INTERCEPTOR = 0x700;
         public static final int XTS_INTERCEPTOR = 0x701;


### PR DESCRIPTION
…ManagerSetupProcessor setup action, making sure it runs after CMTTxInterceptor
Jira: https://issues.jboss.org/browse/WFLY-10434

@dmlloyd please review, what do you think of using the already existent priority() for this?
@stuartwdouglas  any opinion on this is also welcome, since you wrote the SetupAction code.

Thanks!