### PR TITLE
[WFLY-6409]:  Update default domain configuration to use http-remoting

### DIFF
--- a/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -206,7 +206,9 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.management.http.port:9990}", "9990");
         result = result.replace("${jboss.management.https.port:9993}", "9993");
         result = result.replace("${jboss.domain.master.protocol:remote}", "remote");
+        result = result.replace("${jboss.domain.master.protocol:remote+http}", "remote+http");
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
+        result = result.replace("${jboss.domain.master.port:9990}", "9990");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");
         result = result.replace("${jboss.http.port:8080}", "8080");

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -206,7 +206,9 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.management.http.port:9990}", "9990");
         result = result.replace("${jboss.management.https.port:9993}", "9993");
         result = result.replace("${jboss.domain.master.protocol:remote}", "remote");
+        result = result.replace("${jboss.domain.master.protocol:remote+http}", "remote+http");
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
+        result = result.replace("${jboss.domain.master.port:9990}", "9990");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");
         result = result.replace("${jboss.http.port:8080}", "8080");

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -51,9 +51,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true"/>
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -55,16 +55,17 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
         </management-interfaces>
     </management>
 
     <domain-controller>
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote+http}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
             </discovery-options>
         </remote>
     </domain-controller>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -51,9 +51,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true"/>
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -67,7 +67,7 @@ public class CommandLineMain {
     public static void main(String[] args) {
         int port = 9990;
         String host = "localhost";
-        String protocol = "http-remoting";
+        String protocol = "remote+http";
         String config = null;
         try {
             CommandLine line = parser.parse(options, args, false);

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -51,9 +51,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true"/>
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -55,16 +55,17 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
         </management-interfaces>
     </management>
 
     <domain-controller>
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote+http}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
             </discovery-options>
         </remote>
     </domain-controller>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -51,9 +51,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true"/>
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
@@ -20,10 +20,13 @@
             </feature>
         </feature>
 
-        <feature spec="host.core-service.management.management-interface.native-interface">
+        <feature spec="host.core-service.management.management-interface.http-interface">
             <param name="security-realm" value="ManagementRealm"/>
             <param name="interface" value="management"/>
-            <param name="port" value="${jboss.management.native.port:9999}"/>
+            <param name="port" value="${jboss.management.http.port:9990}"/>
+            <feature spec="host.core-service.management.management-interface.http-interface.http-upgrade">
+                <param name="enabled" value="true"/>
+            </feature>
         </feature>
 
         <feature spec="host.jvm">

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
@@ -37,10 +37,13 @@
             </feature>
         </feature>
 
-        <feature spec="host.core-service.management.management-interface.native-interface">
+        <feature spec="host.core-service.management.management-interface.http-interface">
             <param name="security-realm" value="ManagementRealm"/>
             <param name="interface" value="management"/>
-            <param name="port" value="${jboss.management.native.port:9999}"/>
+            <param name="port" value="${jboss.management.http.port:9990}"/>
+            <feature spec="host.core-service.management.management-interface.http-interface.http-upgrade">
+                <param name="enabled" value="true"/>
+            </feature>
         </feature>
 
         <feature spec="host.interface">
@@ -51,8 +54,8 @@
         <feature spec="host.core-service.discovery-options">
             <feature spec="host.core-service.discovery-options.static-discovery">
                 <param name="static-discovery" value="primary"/>
-                <param name="protocol" value="${jboss.domain.master.protocol:remote}"/>
-                <param name="port" value="${jboss.domain.master.port:9999}"/>
+                <param name="protocol" value="${jboss.domain.master.protocol:remote+http}"/>
+                <param name="port" value="${jboss.domain.master.port:9990}"/>
             </feature>
         </feature>
     </feature>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -50,7 +50,7 @@ public abstract class BuildConfigurationTestBase {
     static final File CONFIG_DIR = new File("target/wildfly/domain/configuration/");
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName, final String testConfiguration) {
-        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "master", masterAddress, 9999);
+        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "master", masterAddress, 9990);
     }
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName,
@@ -60,8 +60,9 @@ public abstract class BuildConfigurationTestBase {
 
         configuration.setHostControllerManagementAddress(hostAddress);
         configuration.setHostControllerManagementPort(hostPort);
+        configuration.setHostControllerManagementProtocol("remote+http");
         configuration.setHostCommandLineProperties("-Djboss.domain.master.address=" + masterAddress +
-                " -Djboss.management.native.port=" + hostPort);
+                " -Djboss.management.http.port=" + hostPort);
         configuration.setDomainConfigFile(hackFixDomainConfig(new File(CONFIG_DIR, domainXmlName)).getAbsolutePath());
         configuration.setHostConfigFile(hackFixHostConfig(new File(CONFIG_DIR, hostXmlName), hostName, hostAddress).getAbsolutePath());
         //configuration.setHostConfigFile(new File(CONFIG_DIR, hostXmlName).getAbsolutePath());
@@ -104,9 +105,9 @@ public abstract class BuildConfigurationTestBase {
                         if (start >= 0) {
                             StringBuilder sb = new StringBuilder();
                             sb.append(line.substring(0, start))
-                                .append("<inet-address value=\"")
-                                .append(hostAddress)
-                                .append("\"/>");
+                                    .append("<inet-address value=\"")
+                                    .append(hostAddress)
+                                    .append("\"/>");
                             writer.write(sb.toString());
                         } else {
                             start = line.indexOf("<option value=\"");
@@ -123,7 +124,7 @@ public abstract class BuildConfigurationTestBase {
 
                                 writer.write(sb.toString());
                                 processedOpt = true;
-                            } else if (!line.contains("java.net.")){
+                            } else if (!line.contains("java.net.")) {
                                 writer.write(line);
                             }
                         }
@@ -131,15 +132,15 @@ public abstract class BuildConfigurationTestBase {
                     writer.write("\n");
                     line = reader.readLine();
                 }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
             } finally {
                 safeClose(reader);
                 safeClose(writer);
-            }
+        }
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
-        }
+    }
         return file.toFile();
     }
 
@@ -154,8 +155,7 @@ public abstract class BuildConfigurationTestBase {
             throw new RuntimeException(e);
         }
         try (BufferedReader reader = new BufferedReader(new FileReader(domainConfigFile));
-             BufferedWriter writer = Files.newBufferedWriter(file.toPath())
-        ) {
+                BufferedWriter writer = Files.newBufferedWriter(file.toPath())) {
             String line = reader.readLine();
             while (line != null) {
                 if (line.contains("<security-setting name=\"#\">")) { //super duper hackish, just IO optimization

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
@@ -80,7 +80,7 @@ public class DefaultConfigSmokeTestCase extends BuildConfigurationTestBase {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19999);
+                "slave", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -62,7 +62,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19999);
+                "slave", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm"/>
+         <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="9990" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <!--

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="ignored"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -56,7 +56,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm"/>
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -81,7 +81,7 @@
         <!-- Remote domain controller configuration with a host and port -->
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="start-option" host="${jboss.test.host.master.address}" port="9999" />
+                <static-discovery name="start-option" host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" />
             </discovery-options>
         </remote>
     </domain-controller>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -82,7 +82,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -79,7 +79,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -79,7 +79,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
@@ -267,7 +267,7 @@ public class EJBManagementUtil {
             addRemoteOutboundConnection.get("outbound-socket-binding-ref").set(outboundSocketRef);
             addRemoteOutboundConnection.get(SECURITY_REALM).set("PasswordRealm");
             addRemoteOutboundConnection.get("username").set("user1");
-            addRemoteOutboundConnection.get("protocol").set("http-remoting");
+            addRemoteOutboundConnection.get("protocol").set("remote+http");
 
             final ModelNode op = Util.getEmptyOperation(COMPOSITE, new ModelNode());
             final ModelNode steps = op.get(STEPS);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -103,7 +103,7 @@ public class ModelControllerMBeanTestCase {
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         // Make sure that we can connect to the MBean server
         String urlString = System
-                .getProperty("jmx.service.url", "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
+                .getProperty("jmx.service.url", "service:jmx:remote+http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL, DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
@@ -28,7 +28,7 @@ public class CallEjbServlet extends HttpServlet {
             String address = System.getProperty("node0", "localhost");
             // format possible IPv6 address
             address = NetworkUtils.formatPossibleIpv6Address(address);
-            env.put(Context.PROVIDER_URL, "http-remoting://" + address + ":8080");
+            env.put(Context.PROVIDER_URL, "remote+http://" + address + ":8080");
             env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
             ctx = new InitialContext(env);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
@@ -37,7 +37,7 @@ public class RunRmiServlet extends HttpServlet {
             String address = System.getProperty("node0", "localhost");
             // format possible IPv6 address
             address = NetworkUtils.formatPossibleIpv6Address(address);
-            env.put(Context.PROVIDER_URL, "http-remoting://" + address + ":8080");
+            env.put(Context.PROVIDER_URL, "remote+http://" + address + ":8080");
             env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
             Context ctx = new InitialContext(env);
             try {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -71,6 +71,7 @@ public class RemoteNamingTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
+        //TODO replace with remote+http once the New WildFly Naming Client is merged
         URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "" ,"");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jms/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jms/ClusteredMessagingTestCase.java
@@ -172,7 +172,7 @@ public class ClusteredMessagingTestCase extends AbstractClusteringTestCase {
     protected static InitialContext createJNDIContextFromServer0() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, "http-remoting://" + TestSuiteEnvironment.getServerAddress() + ":8080");
+        env.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":8080");
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);
@@ -181,7 +181,7 @@ public class ClusteredMessagingTestCase extends AbstractClusteringTestCase {
     protected static InitialContext createJNDIContextFromServer1() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, "http-remoting://" + TestSuiteEnvironment.getServerAddress() + ":8180");
+        env.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":8180");
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -246,7 +246,7 @@ public class EJBClientClusterConfigurationTestCase {
         final int managementPort = TestSuiteEnvironment.getServerPort() + portOffset;
         final String managementAddress = getServerAddress(container);
 
-        return new ManagementClient(client, managementAddress, managementPort, "http-remoting");
+        return new ManagementClient(client, managementAddress, managementPort, "remote+http");
     }
 
     private static int getContainerPortOffset(final String container) {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
@@ -126,13 +126,13 @@ public class SSLEJBRemoteClientTestCase {
             log.trace("*** starting server");
             container.start(DEFAULT_JBOSSAS);
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
             log.trace("*** will configure server now");
             SSLRealmSetupTool.setup(managementClient);
             log.trace("*** restarting server");
             container.stop(DEFAULT_JBOSSAS);
             container.start(DEFAULT_JBOSSAS);
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
             // write SSL realm config to output - debugging purposes
             SSLRealmSetupTool.readSSLRealmConfig(managementClient);
             serverConfigDone = true;
@@ -144,7 +144,7 @@ public class SSLEJBRemoteClientTestCase {
     @AfterClass
     public static void tearDown() throws Exception {
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
         SSLRealmSetupTool.tearDown(mClient, container);
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/AbstractMessagingHATestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/AbstractMessagingHATestCase.java
@@ -151,7 +151,7 @@ public abstract class AbstractMessagingHATestCase {
     protected static InitialContext createJNDIContextFromServer1() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8080"));
+        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "remote+http://127.0.0.1:8080"));
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);
@@ -160,7 +160,7 @@ public abstract class AbstractMessagingHATestCase {
     protected static  InitialContext createJNDIContextFromServer2() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8180"));
+        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "remote+http://127.0.0.1:8180"));
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
@@ -167,7 +167,7 @@ public class OutboundLdapConnectionTestCase {
         if (containerController.isStarted(CONTAINER) && !serverConfigured) {
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
             ManagementClient mgmtClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                    TestSuiteEnvironment.getServerPort(), "http-remoting");
+                    TestSuiteEnvironment.getServerPort(), "remote+http");
             prepareServer(mgmtClient);
         }
     }
@@ -177,7 +177,7 @@ public class OutboundLdapConnectionTestCase {
         if (serverConfigured && containerController.isStarted(CONTAINER)) {
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
             ManagementClient mgmtClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                    TestSuiteEnvironment.getServerPort(), "http-remoting");
+                    TestSuiteEnvironment.getServerPort(), "remote+http");
             cleanUpServer(mgmtClient);
         }
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
@@ -107,7 +107,7 @@ public class VaultSystemPropertyOnServerStartTestCase {
 
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         serverSetup.setup(managementClient, CONTAINER);
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
@@ -101,7 +101,7 @@ public class CertificateRolesLoginModuleTestCase extends AbstractCertificateLogi
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
         snapshot = ServerSnapshot.takeSnapshot(managementClient);
 
         LOGGER.trace("*** will configure server now");

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
@@ -109,7 +109,7 @@ public class DatabaseCertLoginModuleTestCase extends AbstractCertificateLoginMod
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
         snapshot = ServerSnapshot.takeSnapshot(managementClient);
 
         LOGGER.trace("*** will configure server now");

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -159,7 +159,7 @@ public class HTTPSWebConnectorTestCase {
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** will configure server now");
         serverSetup(managementClient);
@@ -320,7 +320,7 @@ public class HTTPSWebConnectorTestCase {
         deployer.undeploy(APP_CONTEXT);
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         final ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
         LOGGER.trace("*** reseting test configuration");
         serverTearDown(managementClient);
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
@@ -100,7 +100,7 @@ public class ReloadRequiringChangesTestCase {
     public void testWSDLHostChangeRequiresReloadAndDoesNotAffectRuntime() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;
@@ -132,7 +132,7 @@ public class ReloadRequiringChangesTestCase {
     public void testWSDLHostUndefineRequiresReloadAndDoesNotAffectRuntime() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
@@ -94,7 +94,7 @@ public class ReloadWSDLPublisherTestCase {
     public void testHelloStringAfterReload() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
         QName serviceName = new QName("http://jbossws.org/basic", "POJOService");
         URL wsdlURL = new URL(managementClient.getWebUri().toURL(), '/' + DEPLOYMENT + "/POJOService?wsdl");
         checkWsdl(wsdlURL);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
@@ -116,7 +116,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlHostAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;
@@ -181,7 +181,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlPortAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         try {
@@ -240,7 +240,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlUriSchemeAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlUriScheme = null;
@@ -312,7 +312,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlPathRewriteRuleAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -206,7 +206,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
-        URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
+        URI namingUri = new URI("remote+http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
         env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -244,7 +244,7 @@ public class DatabaseTimerServiceMultiNodeTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
-        URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
+        URI namingUri = new URI("remote+http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
         env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -210,7 +210,7 @@
         <attribute name="remotePort" default="4447"/>
         <attribute name="securityRealm" default="NOT_DEFINED"/>
         <attribute name="userName" default="NOT_DEFINED"/>
-        <attribute name="protocol" default="http-remoting"/>
+        <attribute name="protocol" default="remote+http"/>
 
         <sequential>
             <echo message="Adding a new remote outbound connection @{connectionName} for config @{name}"/>

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -112,7 +112,7 @@
 
         <!-- Connects back to original host (node0) -->
         <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
-                                                     remotePort="8080" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>
+                                                     remotePort="8080" protocol="remote+http" securityRealm="PasswordRealm" userName="user1"/>
         <ts.config-as.add-identity-realm name="jbossas-with-remote-outbound-connection" realmName="PasswordRealm"
                                          secret="cGFzc3dvcmQx"/>
 

--- a/testsuite/integration/src/test/scripts/multinode-build.xml
+++ b/testsuite/integration/src/test/scripts/multinode-build.xml
@@ -33,7 +33,7 @@
         <copy todir="target/jbossas-multinode-client">
             <fileset dir="target/wildfly"/>
         </copy>
-        <ts.config-as.add-remote-outbound-connection name="jbossas-multinode-client" node="${node1}" remotePort="8180" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>
+        <ts.config-as.add-remote-outbound-connection name="jbossas-multinode-client" node="${node1}" remotePort="8180" protocol="remote+http" securityRealm="PasswordRealm" userName="user1"/>
         <ts.config-as.add-identity-realm name="jbossas-multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
 
    

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -17,7 +17,7 @@
     <xsl:param name="remotePort" select="'4447'"/>
     <xsl:param name="securityRealm" select="NOT_DEFINED"/>
     <xsl:param name="userName" select="NOT_DEFINED"/>
-    <xsl:param name="protocol" select="http-remoting"/>
+    <xsl:param name="protocol" select="remote+http"/>
 
     <xsl:template name="newRemoteOutboundConnection">        
         <xsl:element name="remote-outbound-connection" namespace="{namespace-uri()}">

--- a/testsuite/shared/enable-elytron-domain.cli
+++ b/testsuite/shared/enable-elytron-domain.cli
@@ -45,9 +45,6 @@ embed-host-controller
 /host=master/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
 /host=master/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
 
-/host=master/core-service=management/management-interface=native-interface:write-attribute(name=sasl-authentication-factory,value=management-sasl-authentication)
-/host=master/core-service=management/management-interface=native-interface:undefine-attribute(name=security-realm)
-
 /host=master/core-service=management/security-realm=ManagementRealm:remove
 /host=master/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
 /host=master/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
@@ -7,7 +7,7 @@
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
-    	<protocol>http-remoting</protocol>
+	<protocol>remote+http</protocol>
         <host>${hostname}</host>
         <port>9990</port>
     </default-controller>

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
-    <distributable/>
     <description>WebApp Integration Tests</description>
     <servlet>
         <servlet-name>LogoutServlet</servlet-name>


### PR DESCRIPTION
Updating default domain configurations.

Jira: https://issues.jboss.org/browse/WFLY-6409
JBEAP: https://issues.jboss.org/browse/JBEAP-9093
Supersede: https://github.com/wildfly/wildfly/pull/8798