### PR TITLE
[WFLY-10586] set capability reference for journal-datasource

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -32,6 +32,13 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 public class Capabilities {
 
     /**
+     * Represents the data source capability
+     *
+     * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/data-source/capability.adoc">Capability documentation</a>
+     */
+    static final String DATA_SOURCE_CAPABILITY = "org.wildfly.data-source";
+
+    /**
      * The capability name for the JMX management.
      *
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/management/jmx/capability.adoc">Capability documentation</a>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -169,9 +169,6 @@ import org.wildfly.security.credential.source.CredentialSource;
  * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
  */
 class ServerAdd extends AbstractAddStepHandler {
-
-    static final String PATH_BASE = "paths";
-
     public static final ServerAdd INSTANCE = new ServerAdd();
 
     private ServerAdd() {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -208,6 +208,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRequired(false)
             // references another resource
             .setAllowExpression(false)
+            .setCapabilityReference(Capabilities.DATA_SOURCE_CAPABILITY, Capabilities.ACTIVEMQ_SERVER_CAPABILITY)
             .setRestartAllServices()
             .build();
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_2_0_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_2_0_TestCase.java
@@ -215,7 +215,7 @@ public class MessagingActiveMQSubsystem_2_0_TestCase extends AbstractSubsystemBa
                 .require(Capabilities.ELYTRON_DOMAIN_CAPABILITY)
                 .require(Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain")
                 .require(CommonUnaryRequirement.CREDENTIAL_STORE, "cs1")
-                ;
+                .require(Capabilities.DATA_SOURCE_CAPABILITY + ".fooDS");
     }
 
     @Override

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_3_0_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_3_0_TestCase.java
@@ -231,7 +231,8 @@ public class MessagingActiveMQSubsystem_3_0_TestCase extends AbstractSubsystemBa
                 JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(),
                 Capabilities.ELYTRON_DOMAIN_CAPABILITY,
                 Capabilities.ELYTRON_DOMAIN_CAPABILITY + ".elytronDomain",
-                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".cs1");
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".cs1",
+                Capabilities.DATA_SOURCE_CAPABILITY + ".fooDS");
     }
 
     private static class ChangeToTrueConfig extends FailedOperationTransformationConfig.AttributesPathAddressConfig<ChangeToTrueConfig> {


### PR DESCRIPTION
* set missing capability reference for journal-datasource that represents
  the name of a data-source resource.

JIRA: https://issues.jboss.org/browse/WFLY-10586