### PR TITLE
WFLY-10604 Remove Hibernate Validator 5.3 and Bean Validation 1.1

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2133,17 +2133,6 @@
             <artifactId>hibernate-validator-cdi</artifactId>
         </dependency>
 
-        <!-- Hibernate Validator dependencies for EE7 compliance -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator-cdi</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-envers</artifactId>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
@@ -25,16 +25,7 @@
 <module xmlns="urn:jboss:module:1.7" name="org.hibernate.validator.cdi">
 
   <resources>
-    <artifact name="${org.hibernate.validator:hibernate-validator-cdi}">
-      <conditions>
-        <property-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </artifact>
-    <artifact name="${org.hibernate:hibernate-validator-cdi}">
-      <conditions>
-        <property-not-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </artifact>
+    <artifact name="${org.hibernate.validator:hibernate-validator-cdi}"/>
   </resources>
 
   <dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -25,16 +25,7 @@
 <module xmlns="urn:jboss:module:1.7" name="org.hibernate.validator">
 
   <resources>
-    <artifact name="${org.hibernate.validator:hibernate-validator}">
-      <conditions>
-        <property-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </artifact>
-    <artifact name="${org.hibernate:hibernate-validator}">
-      <conditions>
-        <property-not-equal name="ee8.preview.mode" value="true" />
-      </conditions>
-    </artifact>
+    <artifact name="${org.hibernate.validator:hibernate-validator}"/>
   </resources>
 
   <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -2305,17 +2305,6 @@
             <artifactId>hibernate-validator-cdi</artifactId>
         </dependency>
 
-        <!-- Hibernate Validator dependencies for EE7 compliance -->
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator-cdi</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-envers</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -249,8 +249,6 @@
         <version.javax.persistence>2.2</version.javax.persistence>
         <version.javax.security.enterprise>1.0</version.javax.security.enterprise>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
-        <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
-        <version.javax.validation-1.1>1.1.0.Final</version.javax.validation-1.1>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.joda-time>2.9.7</version.joda-time>
@@ -299,7 +297,6 @@
         <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
         <version.org.hibernate.search5_10>5.10.1.Final</version.org.hibernate.search5_10>
         <version.org.hibernate.validator>6.0.10.Final</version.org.hibernate.validator>
-        <version.org.hibernate.validator.ee7>5.3.6.Final</version.org.hibernate.validator.ee7>
         <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.2.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
@@ -3852,31 +3849,6 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-serialization-avro</artifactId>
                 <version>${version.org.hibernate.search}</version>
-            </dependency>
-
-            <!-- Hibernate Validator dependencies for EE 7 -->
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${version.org.hibernate.validator.ee7}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-validator-cdi</artifactId>
-                <version>${version.org.hibernate.validator.ee7}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -24,21 +24,7 @@
 
 <module xmlns="urn:jboss:module:1.7" name="javax.validation.api">
     <resources>
-        <artifact name="${javax.validation:validation-api}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <!--
-          The version is hardcoded as property resolution is not supported
-          when building feature packs. It is not a big issue as this will
-          be removed once we fully support EE 8.
-        -->
-        <artifact name="javax.validation:validation-api:1.1.0.Final"> <!-- ${version.javax.validation-1.1} -->
-            <conditions>
-                <property-not-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${javax.validation:validation-api}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
 * https://issues.jboss.org/browse/WFLY-10604

I supposed the EE 8 temp tests will be moved globally once the EE 8 features have been incorporated as the default so I haven't touched the tests.