### PR TITLE
[WFLY-10617] Upgrade WildFly Core 6.0.0.Alpha2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.bridge.servlet-api-bridge>1.0.1.Final</version.org.wildfly.bridge.servlet-api-bridge>
         <version.org.wildfly.cdi-api-bridge>1.0.1.Final</version.org.wildfly.cdi-api-bridge>
-        <version.org.wildfly.core>6.0.0.Alpha1</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Alpha2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10617

--

## Release Notes - WildFly Core - Version 6.0.0.Alpha2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3678'>WFCORE-3678</a>] -         Upgrade PicketBox to 5.0.3.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3903'>WFCORE-3903</a>] -         Upgrade CLI to use aesh 1.6, aesh-extensions 1.5 and aesh-readline 1.9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3916'>WFCORE-3916</a>] -         Upgrade to Galleon 1.0.1.Final and Galleon Plugins 1.0.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3102'>WFCORE-3102</a>] -         Implement the LocalClient close
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3806'>WFCORE-3806</a>] -         Eliminate code that was using transitive MSC dependencies
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3337'>WFCORE-3337</a>] -         Logging resources shouldn&#39;t be allowed to removed if they are in-use
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3545'>WFCORE-3545</a>] -         Composed keys don&#39;t have to be recognized by CLI
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3751'>WFCORE-3751</a>] -         DefaultCapabilityReferenceRecorder generates wrong dependent name if corresponding RuntimeCapability uses a dynamic name mapper
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3830'>WFCORE-3830</a>] -         JAVA_OPTS is not passed correctly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3866'>WFCORE-3866</a>] -         CLI pom has an unneeded dependency on MSC, causing MSC to get included in the shaded jboss-cli-client.jar 
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3897'>WFCORE-3897</a>] -         Host starts with server assigned to non-existent server group
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3904'>WFCORE-3904</a>] -         NPE at TAB completion
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3910'>WFCORE-3910</a>] -         jboss-cli not starting using jre10 (possible regression)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3912'>WFCORE-3912</a>] -         Wrong permissions for domain/tmp/auth and standalone/tmp/auth dirs
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3915'>WFCORE-3915</a>] -         Do not deploy test suite modules
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3918'>WFCORE-3918</a>] -         Extension index service is not part of stability monitor
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3919'>WFCORE-3919</a>] -         Missing algorithms in jdbc-realm scram-mapper
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3921'>WFCORE-3921</a>] -         Revert PicketBox Upgrade (WFCORE-3898)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3924'>WFCORE-3924</a>] -         Add APLv2 to README
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3858'>WFCORE-3858</a>] -         Add model version 4.0.0 to the Elytron Subsystem version.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3907'>WFCORE-3907</a>] -         Rename wildfly-component-matrix-builder to wildfly-core-component-matrix-builder to be able to import it into Eclipse
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3922'>WFCORE-3922</a>] -         Support Maven staged repositories
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3928'>WFCORE-3928</a>] -         Exclusion groupId and artifactId in the wrong order in the root pom
</li>
</ul>
                                    