### PR TITLE
[WFLY-10288] Remove the ee8.preview.mode option for JSON-P and JSON-B

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -211,11 +211,6 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
-            <!-- This is an unusual case where we override the version only for this client. The parent pom version is
-                 using the 1.1 version for the Java EE 8 tech preview though the client still currently expects 1.0.
-                 Once we fully move to Java EE 8 this can be removed.
-            -->
-            <version>${version.org.glassfish.javax.json-1.0}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -288,8 +288,6 @@
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
-        <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->
-        <version.org.glassfish.javax.json-1.0>1.0.4</version.org.glassfish.javax.json-1.0>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
         <version.org.hibernate53>5.3.1.Final</version.org.hibernate53>
         <!-- Hardcoded in module.xml for the dual EE7 and EE8 support -->

--- a/servlet-feature-pack/src/main/resources/content/docs/licenses/servlet-feature-pack-licenses-addendum.html
+++ b/servlet-feature-pack/src/main/resources/content/docs/licenses/servlet-feature-pack-licenses-addendum.html
@@ -22,7 +22,7 @@
 <!--
 javax.enterprise:cdi-api:1.2
 javax.validation:validation-api:1.1.0.Final
-org.glassfish:javax.json:1.0.4
+org.glassfish:javax.json:1.1.2
 -->
 <html>
 <head>
@@ -53,7 +53,7 @@ org.glassfish:javax.json:1.0.4
     </td>
     </tr>
     <tr>
-        <td>org.glassfish</td><td>javax.json</td><td>1.0.4</td><td><a href="https://javaee.github.io/glassfish/LICENSE">Common Development and Distribution License 1.1</a>
+        <td>org.glassfish</td><td>javax.json</td><td>1.1.2</td><td><a href="https://javaee.github.io/glassfish/LICENSE">Common Development and Distribution License 1.1</a>
         <br>
         <a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html">GNU General Public License v2.0 only</a>
         <br>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -28,22 +28,14 @@
         <property name="jboss.api" value="public"/>
     </properties>
     <resources>
-        <artifact name="${javax.json:javax.json-api}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${javax.json:javax.json-api}"/>
     </resources>
     <dependencies>
-        <!-- The 1.0 RI ships with the API bundled. We can just export the API from the 1.0 RI if it's present. -->
-        <module name="org.glassfish.javax.json" services="import">
-            <exports>
-                <include-set>
-                    <path name="javax/json"/>
-                    <path name="javax/json/spi"/>
-                    <path name="javax/json/stream"/>
-                </include-set>
-            </exports>
-        </module>
+        <!--
+            This is required as a circular dependency because the RI does not include a META-INF/services provider file.
+            It must also be exported so that modules that depend on the API, e.g. deployments, will be able to see the
+            implementation.
+        -->
+        <module name="org.glassfish.javax.json" export="true"/>
     </dependencies>
 </module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -22,11 +22,7 @@
         <property name="jboss.api" value="public"/>
     </properties>
     <resources>
-        <artifact name="${javax.json.bind:javax.json.bind-api}">
-            <conditions>
-                <property-equal name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${javax.json.bind:javax.json.bind-api}"/>
     </resources>
     <dependencies>
         <module name="javax.json.api"/>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/yasson/main/module.xml
@@ -29,10 +29,6 @@
         <module name="javax.json.bind.api"/>
     </dependencies>
     <resources>
-        <artifact name="${org.eclipse:yasson}">
-            <conditions>
-                <property-equal  name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${org.eclipse:yasson}"/>
     </resources>
 </module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -23,18 +23,9 @@
     </properties>
 
     <dependencies>
-        <module name="javax.json.api" />
+        <module name="javax.json.api"/>
     </dependencies>
     <resources>
-        <artifact name="org.glassfish:javax.json:1.0.4"> <!-- ${version.org.glassfish.javax.json-1.0} -->
-            <conditions>
-                <property-not-equal  name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
-        <artifact name="${org.glassfish:javax.json}">
-            <conditions>
-                <property-equal  name="ee8.preview.mode" value="true"/>
-            </conditions>
-        </artifact>
+        <artifact name="${org.glassfish:javax.json}"/>
     </resources>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBServlet.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.ee8.json;
+package org.jboss.as.test.integration.json;
 
 import javax.json.bind.JsonbBuilder;
 import javax.servlet.ServletException;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONBTestCase.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.test.integration.ee8.json;
+package org.jboss.as.test.integration.json;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONPServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONPServlet.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.test.integration.ee8.json;
+package org.jboss.as.test.integration.json;
 
 import javax.json.Json;
 import javax.json.JsonArray;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONPTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/json/JSONPTestCase.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.test.integration.ee8.json;
+package org.jboss.as.test.integration.json;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
@@ -60,12 +60,6 @@ public class NoEE8InDefaultConfigurationTestCase {
     }
 
     @Test
-    public void unavailableJSONB10() throws Exception {
-        String fqcn = "javax.json.bind.JsonbBuilder";
-        assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));
-    }
-
-    @Test
     public void unavailableCDI20() throws Exception {
         String fqcn = "javax.enterprise.inject.spi.InterceptionFactory";
         assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ee/NoEE8InDefaultConfigurationTestCase.java
@@ -60,18 +60,6 @@ public class NoEE8InDefaultConfigurationTestCase {
     }
 
     @Test
-    public void unavailableJSONP11() throws Exception {
-        String fqcn = "javax.json.stream.JsonCollectors";
-        assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));
-    }
-
-    @Test
-    public void ensureJSONP10() throws Exception {
-        String fqcn = "javax.json.stream.JsonParser";
-        assertTrue("Class " + fqcn +" is not available", isClassAvailable(fqcn));
-    }
-
-    @Test
     public void unavailableJSONB10() throws Exception {
         String fqcn = "javax.json.bind.JsonbBuilder";
         assertFalse("Class " + fqcn +" is available", isClassAvailable(fqcn));


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10288

Remove the support for the `ee8.preview.mode` system property for JSON-P and JSON-B. This makes JSON-P 1.1 the default JSON-P provider and includes JSON-B on all deployments by default.

One note is the JSON-P RI does not include a `META-INF/services/javax.json.spi.JsonProvider` service file for some reason. This requires the `javax.json.api` module to have a dependency on the `org.glassfish.javax.json` module and export that module.