### PR TITLE
[WFLY-10631] fixed modulePath for infinispan in clustering testsuite

### DIFF
--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -99,6 +99,7 @@
                 <property name="jbossHome">${basedir}/target/infinispan-server-${version.org.infinispan}</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} -Djboss.bind.address.private=${node0} -Djboss.socket.binding.port-offset=400</property>
                 <property name="serverConfig">clustered.xml</property>
+                <property name="modulePath">${basedir}/target/infinispan-server-${version.org.infinispan}/modules</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">10390</property>
                 <property name="waitForPorts">10390</property>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10631

Fixed minor "Duplicate layer" error in clustering testsuite (two module paths with base layer - from infinispan (correct) and built wildfly - which should not be here and is ignored - but with the warning).
This also blocks https://github.com/wildfly/wildfly-arquillian/pull/141