### PR TITLE
Revert "WFLY-10538 JMSService installs services into the root service container"

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -160,7 +160,7 @@ public class JMSService implements Service<JMSServerManager> {
                         return;
                     }
                     if (activeMQActivationController == null) {
-                        activeMQActivationController = context.getChildTarget().addService(ActiveMQActivationService.getServiceName(serverServiceName), new ActiveMQActivationService())
+                        activeMQActivationController = serviceContainer.addService(ActiveMQActivationService.getServiceName(serverServiceName), new ActiveMQActivationService())
                                 .setInitialMode(Mode.ACTIVE)
                                 .install();
                     } else {


### PR DESCRIPTION
This reverts commit 932a18fab4bb3cc667f2189c2deb9e6b060effcc.

This commit for https://issues.jboss.org/browse/WFLY-10538 causes a regression when an Artemis backup broker becomes active (as explained in [this comment](https://issues.jboss.org/browse/WFLY-10562?focusedCommentId=13591601&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13591601))