### PR TITLE
[WFLY-10533] Test configures JASPI in security subsystem and sends HT…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JaspiFormAuthTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JaspiFormAuthTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.security.jaspi;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test configures JASPI in security subsystem and sends HTTP request to the deployed web application with the FORM authentication.
+ * Test for [ WFLY-10533 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ JaspiSimpleServerLoginDomainSetup.class })
+@RunAsClient
+public class JaspiFormAuthTestCase {
+
+    private static final String DEPLOYMENT = "test";
+
+    @Deployment(name = DEPLOYMENT)
+    public static WebArchive createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
+        war.addAsWebInfResource(JaspiFormAuthTestCase.class.getPackage(), "jaspiDeployment/web.xml", "/web.xml");
+        war.addAsWebInfResource(JaspiFormAuthTestCase.class.getPackage(), "jaspiDeployment/jboss-web.xml", "jboss-web.xml");
+        war.addAsWebResource(JaspiFormAuthTestCase.class.getPackage(), "jaspiDeployment/login.html", "login.html");
+        war.addAsWebResource(JaspiFormAuthTestCase.class.getPackage(), "jaspiDeployment/error.jsp", "error.jsp");
+        return war;
+    }
+
+    @Test
+    public void testJaspiFormAuth(@ArquillianResource URL url) throws Exception {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            final HttpGet httpGet = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort() + "/test/");
+            HttpResponse response = httpClient.execute(httpGet);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JaspiSimpleServerLoginDomainSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JaspiSimpleServerLoginDomainSetup.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.security.jaspi;
+
+import org.jboss.as.security.Constants;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.config.AuthnModule;
+import org.jboss.as.test.integration.security.common.config.JaspiAuthn;
+import org.jboss.as.test.integration.security.common.config.LoginModuleStack;
+import org.jboss.as.test.integration.security.common.config.SecurityDomain;
+import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule;
+
+/**
+ * A {@link org.jboss.as.arquillian.api.ServerSetupTask} instance which creates security domains for test class JaspiFormAuthTestCase.
+ *
+ * @author Daniel Cihak
+ */
+public class JaspiSimpleServerLoginDomainSetup extends AbstractSecurityDomainsServerSetupTask {
+
+    static final String UNDERTOW_MODULE_NAME = "org.wildfly.extension.undertow";
+
+    static final String SECURITY_DOMAIN_NAME = "jaspi";
+
+    @Override
+    protected SecurityDomain[] getSecurityDomains() {
+        String loginModuleStackName = "jaspi-stack";
+
+        return new SecurityDomain[] { new SecurityDomain.Builder().name(SECURITY_DOMAIN_NAME)
+                .jaspiAuthn(new JaspiAuthn.Builder()
+                        .loginModuleStacks(new LoginModuleStack.Builder()
+                                .name(loginModuleStackName)
+                                .loginModules(new SecurityModule.Builder().name("org.jboss.security.auth.spi.SimpleServerLoginModule").flag(Constants.OPTIONAL).build())
+                                .build())
+                        .authnModules(new AuthnModule.Builder()
+                                .name(HTTPSchemeServerAuthModule.class.getName())
+                                .loginModuleStackRef(loginModuleStackName)
+                                .module(UNDERTOW_MODULE_NAME)
+                                .build())
+                        .build())
+                .cacheType("default")
+                .build() };
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/error.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/error.jsp
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>error</title>
+</head>
+<body>
+
+  error.jsp
+
+  <% // =exception %>
+
+  <%
+  out.println("message="+request.getAttribute("javax.servlet.error.message"));
+  %>
+
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+  <security-domain>jaspi</security-domain>
+</jboss-web>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/login.html
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Insert title here</title>
+</head>
+<body>
+<form method="POST" action="j_security_check" name="loginform">
+<input type="text" name="j_username" size="16">
+<input type="password" name="j_password" size="16">
+<input type="submit" value="login">
+</form>
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/jaspiDeployment/web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+   metadata-complete="true"
+   version="3.0">
+  <display-name>test</display-name>
+  <security-constraint>
+    <display-name>guest</display-name>
+    <web-resource-collection>
+      <web-resource-name>/*</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>guest</role-name>
+    </auth-constraint>
+  </security-constraint>
+  <login-config>
+    <auth-method>FORM</auth-method>
+    <realm-name>test</realm-name>
+    <form-login-config>
+      <form-login-page>/login.html</form-login-page>
+      <form-error-page>/error.jsp</form-error-page>
+    </form-login-config>
+  </login-config>
+  <security-role>
+    <role-name>guest</role-name>
+  </security-role>
+</web-app>


### PR DESCRIPTION
Automated test for https://issues.jboss.org/browse/WFLY-10533.

Test configures JASPI in security subsystem and sends HTTP request to the deployed web application with the FORM authentication.