### PR TITLE
 WFLY-10649 Fix CacheConfigurationException if cache memory was configured with a maximum size, but max-active-sessions is unbounded

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryServiceConfiguratorFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryServiceConfiguratorFactory.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.ExpirationConfiguration;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
 import org.jboss.as.clustering.controller.CapabilityServiceConfigurator;
 import org.jboss.as.clustering.controller.ServiceConfiguratorAdapter;
@@ -107,8 +108,9 @@ public class InfinispanBeanManagerFactoryServiceConfiguratorFactory<I> implement
             }
 
             int size = this.config.getMaxSize();
-            builder.memory().evictionType(EvictionType.COUNT).storageType(StorageType.OBJECT).size(size);
-            if (size >= 0) {
+            EvictionStrategy strategy = (size > 0) ? EvictionStrategy.REMOVE : EvictionStrategy.MANUAL;
+            builder.memory().evictionStrategy(strategy).evictionType(EvictionType.COUNT).storageType(StorageType.OBJECT).size(size);
+            if (strategy.isEnabled()) {
                 // Only evict bean group entries
                 // We will cascade eviction to the associated beans
                 builder.dataContainer().dataContainer(new EvictableDataContainer<>(size, BeanGroupKey.class::isInstance));

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -214,6 +214,7 @@ infinispan.memory.off-heap=Off-heap memory configuration.
 infinispan.memory.add=Adds a memory configuration element to the cache.
 infinispan.memory.remove=Removes an eviction configuration element from the cache.
 infinispan.memory.size=Eviction threshold, as defined by the eviction-type.
+infinispan.memory.object.size=Triggers eviction of the least recently used entries when the number of cache entries exceeds this threshold.
 infinispan.memory.eviction-type=Indicates whether the size attribute refers to the number of cache entries (i.e. COUNT) or the collective size of the cache entries (i.e. MEMORY).
 infinispan.memory.capacity=Defines the capacity of the off-heap storage.
 infinispan.memory.strategy=Sets the cache eviction strategy. Available options are 'UNORDERED', 'FIFO', 'LRU', 'LIRS' and 'NONE' (to disable eviction).

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryServiceConfigurator.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryServiceConfigurator.java
@@ -29,6 +29,7 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.ExpirationConfiguration;
 import org.infinispan.configuration.cache.StorageType;
+import org.infinispan.eviction.EvictionStrategy;
 import org.infinispan.eviction.EvictionType;
 import org.infinispan.remoting.transport.Address;
 import org.jboss.as.clustering.controller.CapabilityServiceConfigurator;
@@ -100,8 +101,9 @@ public class InfinispanSessionManagerFactoryServiceConfigurator<C extends Marsha
             }
 
             int size = configuration.getMaxActiveSessions();
-            builder.memory().evictionType(EvictionType.COUNT).storageType(StorageType.OBJECT).size(size);
-            if (size >= 0) {
+            EvictionStrategy strategy = (size > 0) ? EvictionStrategy.REMOVE : EvictionStrategy.MANUAL;
+            builder.memory().evictionStrategy(strategy).evictionType(EvictionType.COUNT).storageType(StorageType.OBJECT).size(size);
+            if (strategy.isEnabled()) {
                 // Only evict creation meta-data entries
                 // We will cascade eviction to the remaining entries for a given session
                 builder.dataContainer().dataContainer(new EvictableDataContainer<>(size, SessionCreationMetaDataKey.class::isInstance));


### PR DESCRIPTION
Also fixes analogous issue with distributed SFSBs.

https://issues.jboss.org/browse/WFLY-10649