### PR TITLE
[WFLY-10661] Don't run session close task if session is already closed.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/logging/UndertowClusteringLogger.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/logging/UndertowClusteringLogger.java
@@ -40,4 +40,7 @@ public interface UndertowClusteringLogger extends BasicLogger {
 
     @Message(id = 3, value = "Session manager was stopped")
     IllegalStateException sessionManagerStopped();
+
+    @Message(id = 4, value = "Session %s was closed")
+    IllegalStateException sessionClosed(String sessionId);
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10661
Don't run session close task if session is already closed, and throw ISE with specific message.