### PR TITLE
[WFLY-10520] Transform classes to replace deprecated API method call with changes from Gail Badner + Scott Marlow

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -49,5 +49,6 @@
         <module name="org.hibernate.jipijapa-hibernate5-3" services="import"/>
         <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
         <module name="net.bytebuddy"/>
+        <module name="asm.asm"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -78,5 +78,6 @@
         <module name="org.wildfly.clustering.infinispan.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.transaction.client"/>
+        <module name="asm.asm"/>
     </dependencies>
 </module>

--- a/jpa/subsystem/pom.xml
+++ b/jpa/subsystem/pom.xml
@@ -120,5 +120,10 @@
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/Hibernate51CompatibilityTransformer.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/Hibernate51CompatibilityTransformer.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.jpa;
+
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+
+import org.jboss.modules.ModuleClassLoader;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A class file transformer which makes deployment classes written for Hibernate 5.1 be compatible with Hibernate 5.3.
+ *
+ * @deprecated
+ */
+public class Hibernate51CompatibilityTransformer implements ClassFileTransformer {
+
+    private static final Hibernate51CompatibilityTransformer instance = new Hibernate51CompatibilityTransformer();
+    private static final boolean disableAmbiguousChanges = Boolean.parseBoolean(
+            WildFlySecurityManager.getPropertyPrivileged("Hibernate51CompatibilityTransformer.disableAmbiguousChanges", "false"));
+
+    private Hibernate51CompatibilityTransformer() {
+    }
+
+    public static Hibernate51CompatibilityTransformer getInstance() {
+        return instance;
+    }
+
+    public byte[] transform(final ClassLoader loader, final String className, final Class<?> classBeingRedefined, final ProtectionDomain protectionDomain, final byte[] classfileBuffer) {
+        ROOT_LOGGER.debugf("Hibernate51CompatibilityTransformer transforming deployment class '%s' from '%s'", className, getModuleName(loader));
+        final ClassReader classReader = new ClassReader(classfileBuffer);
+        final ClassWriter cv = new ClassWriter(classReader, 0);
+        classReader.accept(new ClassVisitor(Opcodes.ASM6, cv) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+                return new MethodVisitor(Opcodes.ASM6, super.visitMethod(access, name, desc, signature, exceptions)) {
+                    // Change call to org.hibernate.BasicQueryContract.getFlushMode() to instead call BasicQueryContract.getHibernateFlushMode().
+                    // Change call to org.hibernate.Session.getFlushMode, to instead call Session.getHibernateFlushMode()
+                    // Calls to Hibernate ORM 5.3 getFlushMode(), will not be changed as the desc will not match (desc == "()Ljavax.persistence.FlushModeType;")
+                    public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+                        if (opcode == Opcodes.INVOKEINTERFACE &&
+                                (owner.equals("org/hibernate/Session") || owner.equals("org/hibernate/BasicQueryContract"))
+                                && name.equals("getFlushMode") && desc.equals("()Lorg/hibernate/FlushMode;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s' is calling %s.getFlushMode, which must be changed to call getHibernateFlushMode().",
+                                    getModuleName(loader), className, owner);
+                            name = "getHibernateFlushMode";
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        } else if (opcode == Opcodes.INVOKEINTERFACE &&
+                                owner.equals("org/hibernate/Query") &&
+                                name.equals("getFirstResult") &&
+                                desc.equals("()Ljava/lang/Integer;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s' is calling %s.%s, which must be changed to expect int result, instead of Integer.",
+                                    getModuleName(loader), className, name, owner);
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s', is calling org.hibernate.Query.getFirstResult, which must be changed to call getHibernateFirstResult() " +
+                                            "so null can be returned when the value is uninitialized. Please note that if a negative value was set using " +
+                                            "org.hibernate.Query.setFirstResult, then getHibernateFirstResult() will return 0.",
+                                    getModuleName(loader), className);
+                            name = "getHibernateFirstResult";
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        } else if (opcode == Opcodes.INVOKEINTERFACE &&
+                                owner.equals("org/hibernate/Query") &&
+                                name.equals("getMaxResults") &&
+                                desc.equals("()Ljava/lang/Integer;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s' is calling %s.%s, which must be changed to expect int result, instead of Integer.",
+                                    getModuleName(loader), className, name, owner);
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s', is calling org.hibernate.Query.getMaxResults, which must be changed to call getHibernateMaxResults() " +
+                                            "so that null will be returned when the value is uninitialized or ORM 5.1 org.hibernate.Query#setMaxResults was " +
+                                            "used to set a value <= 0"
+                                    , getModuleName(loader), className);
+                            name = "getHibernateMaxResults";
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        } else if (!disableAmbiguousChanges && opcode == Opcodes.INVOKEINTERFACE &&
+                                owner.equals("org/hibernate/Query") &&
+                                name.equals("setFirstResult") &&
+                                desc.equals("(I)Lorg/hibernate/Query;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s', is calling org.hibernate.Query.setFirstResult, which must be changed to call setHibernateFirstResult() " +
+                                            "so setting a value < 0 results in pagination starting with the 0th row as was done in Hibernate ORM 5.1 " +
+                                            "(instead of throwing IllegalArgumentException as specified by JPA)."
+                                    , getModuleName(loader), className);
+                            name = "setHibernateFirstResult";
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        } else if (!disableAmbiguousChanges && opcode == Opcodes.INVOKEINTERFACE &&
+                                owner.equals("org/hibernate/Query") &&
+                                name.equals("setMaxResults") &&
+                                desc.equals("(I)Lorg/hibernate/Query;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s', is calling org.hibernate.Query.setMaxResults, which must be changed to call setHibernateMaxResults() " +
+                                            "so that values <= 0 are the same as uninitialized."
+                                    , getModuleName(loader), className);
+                            name = "setHibernateMaxResults";
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        } else
+
+                        {
+                            super.visitMethodInsn(opcode, owner, name, desc, itf);
+                        }
+
+                    }
+
+                    public void visitFieldInsn(int opcode, String owner, String name, String desc) {
+                        // App References to Enum org.hibernate.FlushMode.NEVER (0) should be transformed to reference FlushMode.MANUAL (0) instead.
+                        if (opcode == Opcodes.GETSTATIC &&
+                                owner.equals("org/hibernate/FlushMode") &&
+                                name.equals("NEVER") &&
+                                desc.equals("Lorg/hibernate/FlushMode;")) {
+                            ROOT_LOGGER.debugf("Deprecated Hibernate51CompatibilityTransformer transformed application classes in '%s', " +
+                                            "class '%s' is using org.hibernate.FlushMode.NEVER, change to org.hibernate.FlushMode.MANUAL."
+                                    , getModuleName(loader), className);
+                            super.visitFieldInsn(opcode, owner, "MANUAL", desc);
+                        } else {
+                            super.visitFieldInsn(opcode, owner, name, desc);
+                        }
+                    }
+                }
+
+                        ;
+            }
+        }, 0);
+        return cv.toByteArray();
+    }
+
+    private static final String getModuleName(ClassLoader loader) {
+        if (loader instanceof ModuleClassLoader) {
+            return ((ModuleClassLoader) loader).getName();
+        }
+        return loader.toString();
+    }
+}

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -758,4 +758,8 @@ public interface JpaLogger extends BasicLogger {
     @Message(id = 73, value = "Transformation of class %s failed")
     IllegalStateException invalidClassFormat(@Cause IllegalClassFormatException cause, String className);
 
+    @LogMessage(level = INFO)
+    @Message(id = 74, value = "Deprecated Hibernate51CompatibilityTransformer is enabled for all application deployments.")
+    void hibernate51CompatibilityTransformerEnabled();
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAClassFileTransformerProcessor.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.jpa.processor;
 
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
+
+import org.jboss.as.jpa.Hibernate51CompatibilityTransformer;
 import org.jboss.as.jpa.classloader.JPADelegatingClassFileTransformer;
 import org.jboss.as.jpa.config.Configuration;
 import org.jboss.as.jpa.config.PersistenceUnitMetadataHolder;
@@ -33,6 +36,7 @@ import org.jboss.as.server.deployment.DeploymentUtils;
 import org.jboss.as.server.deployment.module.DelegatingClassFileTransformer;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Deployment processor which ensures the persistence provider ClassFileTransformer are used.
@@ -41,6 +45,14 @@ import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
  */
 public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor {
 
+    private static final boolean hibernate51CompatibilityTransformer = Boolean.parseBoolean(
+            WildFlySecurityManager.getPropertyPrivileged("Hibernate51CompatibilityTransformer","false"));
+
+    static {
+        if(hibernate51CompatibilityTransformer) {
+            ROOT_LOGGER.hibernate51CompatibilityTransformerEnabled();
+        }
+    }
 
     /**
      * Add dependencies for modules required for JPA deployments
@@ -56,8 +68,9 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
         // during the call to CreateContainerEntityManagerFactory.
 
         DelegatingClassFileTransformer transformer = deploymentUnit.getAttachment(DelegatingClassFileTransformer.ATTACHMENT_KEY);
-
+        boolean appContainsPersistenceProviderJars = false;  // remove when we revert WFLY-10520
         if ( transformer != null) {
+
             for (ResourceRoot resourceRoot : DeploymentUtils.allResourceRoots(deploymentUnit)) {
                 PersistenceUnitMetadataHolder holder = resourceRoot.getAttachment(PersistenceUnitMetadataHolder.PERSISTENCE_UNITS);
                 if (holder != null) {
@@ -65,8 +78,20 @@ public class JPAClassFileTransformerProcessor implements DeploymentUnitProcessor
                         if (Configuration.needClassFileTransformer(pu)) {
                             transformer.addTransformer(new JPADelegatingClassFileTransformer(pu));
                         }
+                        // remove this check when we revert WFLY-10520
+                        String provider = pu.getProperties().getProperty(Configuration.PROVIDER_MODULE);
+                        if (provider != null) {
+                            if (provider.equals(Configuration.PROVIDER_MODULE_APPLICATION_SUPPLIED)) {
+                                appContainsPersistenceProviderJars = true;
+                            }
+                        }
+
                     }
                 }
+            }
+            // WFLY-10520 Add Hibernate ORM 5.3 compatibility transformer
+            if(!appContainsPersistenceProviderJars && hibernate51CompatibilityTransformer) {
+                transformer.addTransformer(Hibernate51CompatibilityTransformer.getInstance());
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -3621,6 +3621,7 @@
                 <artifactId>javax.security.enterprise</artifactId>
                 <version>${version.org.glassfish.soteria}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -47,6 +47,7 @@
         <!-- This value is overridden in modules with the correct relative pathname. -->
         <jboss.dist>${jbossas.project.dir}/${wildfly.build.output.dir}</jboss.dist>
         <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
+        <version.org.hibernate>5.1.14.Final</version.org.hibernate>
     </properties>
 
     <!--
@@ -93,16 +94,104 @@
             <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>jipijapa-hibernate5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${version.org.hibernate}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>classmate</artifactId>
+                    <groupId>com.fasterxml</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javassist</artifactId>
+                    <groupId>javassist</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jta</artifactId>
+                    <groupId>javax.transaction</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                    <groupId>org.jboss.logging</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
+            <version>${version.org.hibernate}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>ejb3-persistence</artifactId>
+                    <groupId>org.hibernate</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hibernate-java8</artifactId>
+                    <groupId>org.hibernate</groupId>
+                </exclusion>
+
+                <exclusion>
+                    <artifactId>hibernate</artifactId>
+                    <groupId>org.hibernate</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>javassist</artifactId>
+                    <groupId>javassist</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jta</artifactId>
+                    <groupId>javax.transaction</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hibernate-core</artifactId>
+                    <groupId>org.hibernate</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>cglib</artifactId>
+                    <groupId>cglib</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>hibernate-jpa-2.1-api</artifactId>
+                    <groupId>org.hibernate.javax.persistence</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>slf4j-api</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                    <groupId>org.jboss.spec.javax.transaction</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                    <groupId>org.jboss.logging</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-java8</artifactId>
+            <version>${version.org.hibernate}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>*</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
@@ -55,8 +55,9 @@ public class HibernateJarsInDeploymentTestCase {
         final String testdir = basedir + File.separatorChar + "target" + File.separatorChar + "test-libs";
 
         File hibernatecore = new File(testdir, "hibernate-core.jar");
-        File bytebuddy = new File(testdir, "byte-buddy.jar");
+        File hibernatejava8 = new File(testdir, "hibernate-java8.jar");
         File hibernateannotations = new File(testdir, "hibernate-commons-annotations.jar");
+        File hibernateentitymanager = new File(testdir, "hibernate-entitymanager.jar");
         File jipi = new File(testdir,"jipijapa-hibernate5.jar");
         File dom4j = new File(testdir, "dom4j.jar");
         File antlr = new File(testdir, "antlr.jar");
@@ -64,7 +65,8 @@ public class HibernateJarsInDeploymentTestCase {
         ear.addAsLibraries(
                 hibernatecore,
                 hibernateannotations,
-                bytebuddy,
+                hibernatejava8,
+                hibernateentitymanager,
                 dom4j,
                 antlr,
                 classmate,

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/SFSBHibernateSessionFactory.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/SFSBHibernateSessionFactory.java
@@ -1,0 +1,190 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+import java.util.List;
+import java.util.Properties;
+
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+
+import org.hibernate.BasicQueryContract;
+import org.hibernate.FlushMode;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.hibernate.internal.util.config.ConfigurationHelper;
+
+/**
+ * Test that a Hibernate sessionfactory can be inititated from hibernate.cfg.xml and properties added to Hibernate Configuration
+ * in AS7 container without any JPA assistance
+ *
+ * @author Madhumita Sadhukhan
+ */
+@Stateful
+@TransactionManagement(TransactionManagementType.BEAN)
+public class SFSBHibernateSessionFactory {
+
+    private static SessionFactory sessionFactory;
+
+    public void cleanup() {
+        sessionFactory.close();
+    }
+
+    public void setupConfig() {
+        // static {
+        try {
+
+            // prepare the configuration
+            Configuration configuration = new Configuration().setProperty(AvailableSettings.USE_NEW_ID_GENERATOR_MAPPINGS,
+                    "true");
+            configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
+            configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
+            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
+
+            // fetch the properties
+            Properties properties = new Properties();
+            configuration = configuration.configure("hibernate.cfg.xml");
+            properties.putAll(configuration.getProperties());
+
+            Environment.verifyProperties( properties );
+            ConfigurationHelper.resolvePlaceHolders( properties );
+
+            sessionFactory = configuration.buildSessionFactory();
+        } catch (Throwable ex) { // Make sure you log the exception, as it might be swallowed
+            throw new RuntimeException("Could not setup config", ex);
+        }
+
+    }
+
+    // create student
+    public Student createStudent(String firstName, String lastName, String address, int id) {
+
+        Student student = new Student();
+        student.setStudentId(id);
+        student.setAddress(address);
+        student.setFirstName(firstName);
+        student.setLastName(lastName);
+
+        try {
+            Session session = sessionFactory.openSession();
+            Transaction tx = session.beginTransaction();
+            session.save( student );
+            session.flush();
+            tx.commit();
+            session.close();
+        } catch (Exception e) {
+            throw new RuntimeException("transactional failure while persisting student entity", e);
+        }
+
+        return student;
+    }
+
+    // fetch student
+    public Student getStudent(int id) {
+        Student emp = sessionFactory.openSession().load(Student.class, id);
+        return emp;
+    }
+
+    public FlushMode getFlushModeFromQueryTest(FlushMode flushMode) {
+        FlushMode result;
+        Session session = sessionFactory.openSession();
+        Transaction transaction = session.beginTransaction();
+        try {
+            BasicQueryContract basicQueryContract = session.createQuery("from Student");
+            if ( flushMode != null ) {
+                basicQueryContract.setFlushMode(flushMode);
+            }
+            result = basicQueryContract.getFlushMode();
+            return result;
+        } finally {
+            transaction.rollback();
+            session.close();
+        }
+    }
+
+    public FlushMode getFlushModeFromSessionTest(FlushMode flushMode) {
+        Session session = sessionFactory.openSession();
+        Transaction transaction = session.beginTransaction();
+        try {
+            if ( flushMode != null ) {
+                session.setFlushMode(flushMode);
+            }
+            return session.getFlushMode();
+        } finally {
+            transaction.rollback();
+            session.close();
+        }
+     }
+
+    public Integer getFirstResultTest(Integer firstValue) {
+
+        Session session = sessionFactory.openSession();
+
+        try {
+            Query query = session.createQuery("from Student");
+            if ( firstValue != null ) {
+                query.setFirstResult( firstValue );
+            }
+            return query.getFirstResult();
+        } finally {
+            session.close();
+        }
+    }
+
+    public Integer getMaxResultsTest(Integer maxResults) {
+
+        Session session = sessionFactory.openSession();
+        try {
+            Query query = session.createQuery( "from Student" );
+            if ( maxResults != null ) {
+                query.setMaxResults( maxResults );
+            }
+            return query.getMaxResults();
+        } finally {
+            session.close();
+        }
+    }
+
+    public List executeQuery(String queryString, Integer firstResult, Integer maxResults) {
+        Session session = sessionFactory.openSession();
+        try {
+            Query query = session.createQuery( queryString );
+            if ( firstResult != null ) {
+                query.setFirstResult( firstResult );
+            }
+            if ( maxResults != null ) {
+                query.setMaxResults(maxResults);
+            }
+            return query.list();
+        } finally {
+            session.close();
+        }
+
+    }
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/Student.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/Student.java
@@ -1,0 +1,143 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+/**
+ * Represents a student object.
+ *
+ * @author Madhumita Sadhukhan
+ */
+public class Student {
+    // unique student id
+    private int studentId;
+    // first name of the student
+    private String firstName;
+    // last name of the student
+    private String lastName;
+    // address of the student
+    private String address;
+
+    /**
+     * Default constructor
+     */
+    public Student() {
+    }
+
+    /**
+     * Creates a new instance of Student.
+     *
+     * @param firstName first name.
+     * @param lastName  last name.
+     * @param address   address.
+     */
+    public Student(String firstName, String lastName, String address) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.address = address;
+    }
+
+    /**
+     * Gets the student id for this student.
+     *
+     * @return student id.
+     */
+    public int getStudentId() {
+        return studentId;
+    }
+
+    /**
+     * Sets the student id for this student.
+     *
+     * @return student id.
+     */
+    public void setStudentId(int studentId) {
+        this.studentId = studentId;
+    }
+
+    /**
+     * Gets the first name for this student.
+     *
+     * @return first name.
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Sets the first name for this student.
+     *
+     * @param first name.
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    /**
+     * Gets the last name for this student.
+     *
+     * @return last name.
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Sets the last name for this student.
+     *
+     * @param last name.
+     */
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    /**
+     * Gets the address for this student.
+     *
+     * @return address.
+     */
+    public String getAddress() {
+        return address;
+    }
+
+    /**
+     * Sets the address for this student.
+     *
+     * @param address.
+     */
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    /**
+     * Method used by the UI to clear information on the screen.
+     *
+     * @return String used in the navigation rules.
+     */
+    public String clear() {
+        firstName = "";
+        lastName = "";
+        address = "";
+        return "clear";
+    }
+
+}

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityTestCase.java
@@ -1,0 +1,404 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.hibernate.FlushMode;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verify that an application compiled against Hibernate ORM 5.1.x, will run against Hibernate ORM 5.3.x on WildFly,
+ * using a WildFly bytecode transformer that modifies the application bytecode at runtime to map the older Hibernate 5.1
+ * calls, to 5.3.
+ *
+ * @author Scott Marlow
+ * @author Gail Badner
+ */
+@RunWith(Arquillian.class)
+public class VerifyHibernate51CompatibilityTestCase {
+    private static final String ARCHIVE_NAME = "VerifyHibernate51CompatibilityTestCase";
+
+    public static final String hibernate_cfg = "<?xml version='1.0' encoding='utf-8'?>"
+            + "<!DOCTYPE hibernate-configuration PUBLIC " + "\"//Hibernate/Hibernate Configuration DTD 3.0//EN\" "
+            + "\"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd\">"
+            + "<hibernate-configuration><session-factory>" + "<property name=\"show_sql\">false</property>"
+            + "<property name=\"current_session_context_class\">thread</property>"
+// only needed for ORM 5.3.0    + "<property name=\"hibernate.allow_update_outside_transaction\">true</property>"
+            + "<mapping resource=\"testmapping.hbm.xml\"/>" + "</session-factory></hibernate-configuration>";
+
+    public static final String testmapping = "<?xml version=\"1.0\"?>" + "<!DOCTYPE hibernate-mapping PUBLIC "
+            + "\"-//Hibernate/Hibernate Mapping DTD 3.0//EN\" " + "\"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd\">"
+            + "<hibernate-mapping package=\"org.jboss.as.test.integration.hibernate\">"
+            + "<class name=\"org.jboss.as.test.compat.jpa.hibernate.transformer.Student\" table=\"STUDENT\">"
+            + "<id name=\"studentId\" column=\"student_id\">" + "<generator class=\"assigned\"/>" + "</id>"
+            + "<property name=\"firstName\" column=\"first_name\"/>" + "<property name=\"lastName\" column=\"last_name\"/>"
+            + "<property name=\"address\"/>"
+            + "</class></hibernate-mapping>";
+
+    @ArquillianResource
+    private static InitialContext iniCtx;
+
+    @BeforeClass
+    public static void beforeClass() throws NamingException {
+        iniCtx = new InitialContext();
+    }
+
+    @Deployment
+    public static Archive<?> deploy() throws Exception {
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME + ".ear");
+        // add required jars as manifest dependencies
+        ear.addAsManifestResource(new StringAsset("Dependencies: org.hibernate\n"), "MANIFEST.MF");
+
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
+        lib.addClasses(SFSBHibernateSessionFactory.class);
+        ear.addAsModule(lib);
+
+        lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
+        lib.addClasses(Student.class);
+        lib.addAsResource(new StringAsset(testmapping), "testmapping.hbm.xml");
+        lib.addAsResource(new StringAsset(hibernate_cfg), "hibernate.cfg.xml");
+        ear.addAsLibraries(lib);
+
+        final WebArchive main = ShrinkWrap.create(WebArchive.class, "main.war");
+        main.addClasses(VerifyHibernate51CompatibilityTestCase.class);
+        ear.addAsModule(main);
+
+        ear.addAsManifestResource(new StringAsset("<jboss-deployment-structure>" + " <deployment>" + " <dependencies>"
+                + " <module name=\"com.h2database.h2\" />" + " <module name=\"org.slf4j\"/>" + " </dependencies>"
+                + " </deployment>" + "</jboss-deployment-structure>"), "jboss-deployment-structure.xml");
+        return ear;
+    }
+
+    protected static <T> T lookup(String beanName, Class<T> interfaceType) throws NamingException {
+        try {
+            return interfaceType.cast(iniCtx.lookup("java:global/" + ARCHIVE_NAME + "/" + "beans/" + beanName + "!"
+                    + interfaceType.getName()));
+        } catch (NamingException e) {
+            throw e;
+        }
+    }
+
+    @Test
+    public void testSimpleOperation() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            Student s1 = sfsb.createStudent("MADHUMITA", "SADHUKHAN", "99 Purkynova REDHAT BRNO CZ", 1);
+            Student s2 = sfsb.createStudent("REDHAT", "LINUX", "Worldwide", 3);
+            Student st = sfsb.getStudent(s1.getStudentId());
+            assertEquals( "name read from hibernate session is MADHUMITA", "MADHUMITA", st.getFirstName() );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromSessionUninitialized() throws Exception{
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // Session#getFlushMode returns FlushMode.AUTO by default
+            assertEquals(
+                    "can handle Hibernate ORM 5.1 call to Session.getFlushMode() without setting FlushMode",
+                    FlushMode.AUTO,
+                    sfsb.getFlushModeFromSessionTest( null )
+            );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromSession() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertEquals(
+                    "can handle Hibernate ORM 5.1 call to Session.getFlushMode()",
+                    FlushMode.MANUAL,
+                    sfsb.getFlushModeFromSessionTest( FlushMode.MANUAL)
+            );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromSessionNever() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertEquals(
+                    "can handle Hibernate ORM 5.1 call to Session.getFlushMode() using FlushMode.NEVER",
+                    FlushMode.NEVER,
+                    sfsb.getFlushModeFromSessionTest( FlushMode.NEVER )
+            );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromQueryUninitialized() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertNull( sfsb.getFlushModeFromQueryTest( null ) );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromQuery() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertEquals(
+                    "can handle Hibernate ORM 5.1 call to Query.getFlushMode()",
+                    FlushMode.MANUAL,
+                    sfsb.getFlushModeFromQueryTest( FlushMode.MANUAL )
+            );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFlushModeFromQueryNever() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertEquals(
+                    "can handle Hibernate ORM 5.1 call to Query.getFlushMode() using FlushMode.NEVER",
+                    FlushMode.NEVER,
+                    sfsb.getFlushModeFromQueryTest( FlushMode.NEVER )
+            );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFirstResultUninitialized() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getFirstResult returns null if no value was set via o.h.Query#setFirstResult
+            assertNull( sfsb.getFirstResultTest( null ) );
+
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFirstResultZero() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getFirstResult returned 0 if set via o.h.Query#setFirstResult(0)
+            assertTrue(
+                    "Hibernate ORM 5.1 call to Query.getFirstResult() returned Integer " + sfsb.getFirstResultTest(0),
+                    sfsb.getFirstResultTest(0) instanceof Integer
+            );
+            assertEquals( Integer.valueOf( 0 ), sfsb.getFirstResultTest( 0 ) );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFirstResultNegative() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getFirstResult returned negative number if set via o.h.Query.setFirstResult( negativeNumber )
+            assertTrue(
+                    "Hibernate ORM 5.1 call to Query.getFirstResult() returned Integer " + sfsb.getFirstResultTest(-1),
+                    sfsb.getFirstResultTest(-1) instanceof Integer
+            );
+            // check for value of 0 being returned, to match what query.getHibernateFirstResult() is expected to
+            // return when -1 is passed into query.setHibernateFirstResult()
+            assertEquals( Integer.valueOf( 0 ), sfsb.getFirstResultTest( -1 ) );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getFirstResultPositive() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertTrue(
+                    "Hibernate ORM 5.1 call to Query.getMaxResult() returned Integer " + sfsb.getFirstResultTest( 1 ),
+                    sfsb.getFirstResultTest( 1 ) instanceof Integer
+            );
+            assertEquals( Integer.valueOf(1), sfsb.getFirstResultTest( 1 ) );
+
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getMaxResultsUninitialized() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getMaxResults returns null if no value was set via o.h.Query#setMaxResults
+            assertNull( sfsb.getMaxResultsTest( null ) );
+
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getMaxResultsZero() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getMaxResults returns null if 0 was set via o.h.Query.setMaxResults(0)
+            assertNull( sfsb.getMaxResultsTest( 0 ) );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getMaxResultsNegative() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getMaxResults returns null if set via o.h.Query.setMaxResults( negativeNumber )
+            assertNull( sfsb.getMaxResultsTest( -1 ) );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getMaxResultsMaxValue() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup( "SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class );
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            // In 5.1, o.h.Query#getMaxResults returns Integer.MAX_VALUE if set via o.h.Query.setMaxResults( Integer.MAX_VALUE )
+            assertTrue(
+                    "Hibernate ORM 5.1 call to Query.getMaxResult() returned Integer " + sfsb.getMaxResultsTest( Integer.MAX_VALUE ),
+                    sfsb.getMaxResultsTest( Integer.MAX_VALUE ) instanceof Integer
+            );
+            assertEquals( Integer.valueOf( Integer.MAX_VALUE ), sfsb.getMaxResultsTest( Integer.MAX_VALUE ) );
+        }
+        finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testORA5_3_1_Compatibility_getMaxResultsPositive() throws Exception {
+        SFSBHibernateSessionFactory sfsb = lookup( "SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class );
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            assertTrue(
+                    "Hibernate ORM 5.1 call to Query.getMaxResult() returned Integer " + sfsb.getMaxResultsTest( 1 ),
+                    sfsb.getMaxResultsTest( 1 ) instanceof Integer
+            );
+            assertEquals( Integer.valueOf( 1 ), sfsb.getMaxResultsTest( 1 ) );
+        }
+        finally {
+            sfsb.cleanup();
+        }
+    }
+
+    @Test
+    public void testQueryResults() throws Exception  {
+        SFSBHibernateSessionFactory sfsb = lookup("SFSBHibernateSessionFactory", SFSBHibernateSessionFactory.class);
+        // setup Configuration and SessionFactory
+        sfsb.setupConfig();
+        try {
+            for ( int i = 0; i < 5; i++ ) {
+                sfsb.createStudent( null, null, null, i );
+            }
+            final String query = "from Student order by id";
+            checkResults( sfsb.executeQuery( query, null, null ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, 0, null ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, -1, null ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, null, 0 ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, null, -1 ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, null, 2 ), 0, 1 );
+            checkResults( sfsb.executeQuery( query, -1, 0 ), 0, 4 );
+            checkResults( sfsb.executeQuery( query, -1, 3 ), 0, 2 );
+            checkResults( sfsb.executeQuery( query, 1, null ), 1, 4 );
+            checkResults( sfsb.executeQuery( query, 1, 0 ), 1, 4 );
+            checkResults( sfsb.executeQuery( query, 1, -1 ), 1, 4 );
+            checkResults( sfsb.executeQuery( query, 1, 1 ), 1, 1 );
+        } finally {
+            sfsb.cleanup();
+        }
+    }
+
+    private void checkResults( List results, int firstIdExpected, int lastIdExpected ) {
+        int resultIndex = 0;
+        for( int i = firstIdExpected ; i <= lastIdExpected ; i++, resultIndex++ ) {
+            assertEquals( i, ( (Student) results.get( resultIndex ) ).getStudentId() );
+        }
+    }
+}

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/wildfly</property>
-            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="javaVmArguments">-DHibernate51CompatibilityTransformer=true ${server.jvm.args}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/compat/src/test/scripts/build-jars.xml
+++ b/testsuite/compat/src/test/scripts/build-jars.xml
@@ -26,7 +26,8 @@
     <target name="copy-jars" description="Copy jars to be tested.">
     <copy file="${org.hibernate:hibernate-core:jar}"                       tofile="${tests.output.dir}/test-libs/hibernate-core.jar"/>
     <copy file="${org.hibernate.common:hibernate-commons-annotations:jar}" tofile="${tests.output.dir}/test-libs/hibernate-commons-annotations.jar"/>
-    <copy file="${net.bytebuddy:byte-buddy:jar}"              tofile="${tests.output.dir}/test-libs/byte-buddy.jar"/>
+    <copy file="${org.hibernate:hibernate-java8:jar}"              tofile="${tests.output.dir}/test-libs/hibernate-java8.jar"/>
+    <copy file="${org.hibernate:hibernate-entitymanager:jar}"              tofile="${tests.output.dir}/test-libs/hibernate-entitymanager.jar"/>
     <copy file="${dom4j:dom4j:jar}"                                        tofile="${tests.output.dir}/test-libs/dom4j.jar"/>
     <copy file="${org.wildfly:jipijapa-hibernate5:jar}"                    tofile="${tests.output.dir}/test-libs/jipijapa-hibernate5.jar"/>
     <copy file="${antlr:antlr:jar}"                                        tofile="${tests.output.dir}/test-libs/antlr.jar"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10520

I started working on the doc, that will be separate.

We plan to include additional transformations, just waiting for test cases to prove that we need them (as per https://docs.google.com/document/d/1cAVBdeQXQfpTwH0f_GKSahh_gRd7bKI6kII-wxoMglU/edit?ts=5b45a2c4).

The current transformations are:

- Change calls to org.hibernate.BasicQueryContract.getFlushMode(), to instead call BasicQueryContract.getHibernateFlushMode().
- Change calls to org.hibernate.Session.getFlushMode, to instead call Session.getHibernateFlushMode()
- Change references to Enum org.hibernate.FlushMode.NEVER (0), to FlushMode.MANUAL (0).
- Change calls to org.hibernate.Query.getMaxResults() returning Integer, to instead call org.hibernate.Query.getHibernateMaxResults() (returning Integer).
- Change calls to org.hibernate.Query.setMaxResults(int), to instead call org.hibernate.Query.setHibernateMaxResults(int).
- Change calls to org.hibernate.Query.getFirstResult(int) returning Integer, to instead call org.hibernate.Query.getHibernateFirstResult() (returning Integer).
- Change calls to org.hibernate.Query.setFirstResult(int), to instead call org.hibernate.Query.setHibernateFirstResult(int)