### PR TITLE
[WFLY-10165] fix jdbc-network-timeout default value

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -149,10 +149,11 @@ public class MessagingExtension implements Extension {
 
     static final String RESOURCE_NAME = MessagingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
+    protected static final ModelVersion VERSION_3_1_0 = ModelVersion.create(3, 1, 0);
     protected static final ModelVersion VERSION_3_0_0 = ModelVersion.create(3, 0, 0);
     protected static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
     protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
-    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_3_0_0;
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_3_1_0;
     private static final MessagingSubsystemParser_3_0 CURRENT_PARSER = new MessagingSubsystemParser_3_0();
 
     public static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -60,10 +60,17 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
     public void registerTransformers(SubsystemTransformerRegistration registration) {
         ChainedTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
 
+        registerTransformers_EAP_7_2_0(builder.createBuilder(MessagingExtension.VERSION_3_1_0, MessagingExtension.VERSION_3_0_0));
         registerTransformers_EAP_7_1_0(builder.createBuilder(MessagingExtension.VERSION_3_0_0, MessagingExtension.VERSION_2_0_0));
         registerTransformers_EAP_7_0_0(builder.createBuilder(MessagingExtension.VERSION_2_0_0, MessagingExtension.VERSION_1_0_0));
 
-        builder.buildAndRegister(registration, new ModelVersion[] { MessagingExtension.VERSION_1_0_0, MessagingExtension.VERSION_2_0_0 });
+        builder.buildAndRegister(registration, new ModelVersion[] { MessagingExtension.VERSION_1_0_0, MessagingExtension.VERSION_2_0_0, MessagingExtension.VERSION_3_0_0 });
+    }
+
+    private void registerTransformers_EAP_7_2_0(ResourceTransformationDescriptionBuilder subsystem) {
+        ResourceTransformationDescriptionBuilder server = subsystem.addChildResource(MessagingExtension.SERVER_PATH);
+        // WFLY-10165 - journal-jdbc-network-timeout default value is 20 seconds.
+        defaultValueAttributeConverter(server, ServerDefinition.JOURNAL_JDBC_NETWORK_TIMEOUT);
     }
 
     private static void registerTransformers_EAP_7_1_0(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ACTIVEMQ_SERVER_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ELYTRON_DOMAIN_CAPABILITY;
@@ -519,6 +520,9 @@ class ServerAdd extends AbstractAddStepHandler {
         storageConfiguration.setMessageTableName(JOURNAL_MESSAGES_TABLE.resolveModelAttribute(context, model).asString());
         storageConfiguration.setLargeMessageTableName(JOURNAL_LARGE_MESSAGES_TABLE.resolveModelAttribute(context, model).asString());
         storageConfiguration.setPageStoreTableName(JOURNAL_PAGE_STORE_TABLE.resolveModelAttribute(context, model).asString());
+        long networkTimeout = SECONDS.toMillis(JOURNAL_JDBC_NETWORK_TIMEOUT.resolveModelAttribute(context, model).asInt());
+        // ARTEMIS-1493: Artemis API is not correct. the value must be in millis but it requires an int instead of a long.
+        storageConfiguration.setJdbcNetworkTimeout((int)networkTimeout);
         storageConfiguration.setJdbcNetworkTimeout(JOURNAL_JDBC_NETWORK_TIMEOUT.resolveModelAttribute(context, model).asInt());
         ModelNode databaseNode = JOURNAL_DATABASE.resolveModelAttribute(context, model);
         final String database = databaseNode.isDefined() ? databaseNode.asString() : null;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -265,10 +265,13 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJdbcNetworkTimeout()
+     */
     public static final AttributeDefinition JOURNAL_JDBC_NETWORK_TIMEOUT = create("journal-jdbc-network-timeout", INT)
             .setAttributeGroup("journal")
             .setXmlName("jdbc-network-timeout")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJdbcNetworkTimeout()))
+            .setDefaultValue(new ModelNode(20))
             .setMeasurementUnit(SECONDS)
             .setRequired(false)
             .setAllowExpression(true)


### PR DESCRIPTION
Default value of jdbc-network-timeout is 20 seconds.

JIRA: https://issues.jboss.org/browse/WFLY-10165