### PR TITLE
[WFLY-10703] Upgrade to Galleon and WildFly Galleon Plugins 2.0.0.Alpha4

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -67,7 +67,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -77,6 +77,18 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${project.build.finalName}</install-dir>
+                            <resolve-locals>
+                                <resolve-local>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                </resolve-local>
+                                <resolve-local>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                </resolve-local>
+                            </resolve-locals>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -75,7 +75,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -88,6 +88,18 @@
                             <plugin-options>
                                 <jboss-fork-embedded/>
                             </plugin-options>
+                            <resolve-locals>
+                                <resolve-local>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                </resolve-local>
+                                <resolve-local>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                </resolve-local>
+                            </resolve-locals>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -112,7 +112,7 @@
             </plugin>
             <plugin>
                 <groupId>org.wildfly.galleon-plugins</groupId>
-                <artifactId>wildfly-galleon-maven-plugins</artifactId>
+                <artifactId>wildfly-galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>feature-spec-build</id>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -20,16 +20,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:2.0">
-    <dependencies>
-        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly@maven(org.jboss.universe:community-universe):current">
+
+    <transitive>
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>
-            <packages inherit="false">
-                <exclude name="product.conf"/>
-            </packages>
-            <default-configs inherit="false"/>
         </dependency>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-servlet-galleon-pack">
+    </transitive>
+    <dependencies>
+        <dependency group-id="org.wildfly" artifact-id="wildfly-servlet-galleon-pack" producer="wildfly-servlet@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly:wildfly-servlet-galleon-pack</name>
             <packages inherit="false">
                 <exclude name="product.conf"/>

--- a/pom.xml
+++ b/pom.xml
@@ -171,13 +171,13 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>1.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>2.0.0.Alpha4</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>1.0.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>2.0.0.Alpha4</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->
@@ -6564,7 +6564,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.jboss.galleon</groupId>
-                    <artifactId>galleon-maven-plugins</artifactId>
+                    <artifactId>galleon-maven-plugin</artifactId>
                     <version>${version.org.jboss.galleon}</version>
                 </plugin>
                 <plugin>
@@ -6579,7 +6579,7 @@
                 </plugin>
                 <plugin>
                     <groupId>org.wildfly.galleon-plugins</groupId>
-                    <artifactId>wildfly-galleon-maven-plugins</artifactId>
+                    <artifactId>wildfly-galleon-maven-plugin</artifactId>
                     <version>${version.org.wildfly.galleon-plugins}</version>
                 </plugin>
                 <plugin>

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -65,7 +65,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -79,9 +79,9 @@
                                 <feature-pack>
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <inherit-configs>false</inherit-configs>
+                                    <version>${version.org.wildfly.core}</version>
+                                    <transitive>true</transitive>
                                     <excluded-packages>
-                                        <name>product.conf</name>
                                         <name>docs.schema</name>
                                     </excluded-packages>
                                 </feature-pack>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -66,7 +66,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -79,6 +79,13 @@
                             <plugin-options>
                                 <jboss-fork-embedded/>
                             </plugin-options>
+                            <resolve-locals>
+                                <resolve-local>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                </resolve-local>
+                            </resolve-locals>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -533,7 +533,7 @@
 
             <plugin>
                 <groupId>org.wildfly.galleon-plugins</groupId>
-                <artifactId>wildfly-galleon-maven-plugins</artifactId>
+                <artifactId>wildfly-galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>feature-spec-build</id>

--- a/servlet-galleon-pack/wildfly-feature-pack-build.xml
+++ b/servlet-galleon-pack/wildfly-feature-pack-build.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:2.0">
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly-servlet@maven(org.jboss.universe:community-universe):current">
     <dependencies>
-        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>
             <packages inherit="false">
                 <exclude name="product.conf"/>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -83,7 +83,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -93,19 +93,19 @@
                         <phase>generate-test-resources</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/${wildfly.instance.name}</install-dir>
-                            <feature-packs>
-                                <feature-pack>
+                            <resolve-locals>
+                                <resolve-local>
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                                <feature-pack>
+                                    <version>${version.org.wildfly.core}</version>
+                                </resolve-local>
+                                <resolve-local>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
+                                    <version>${project.version}</version>
+                                </resolve-local>
+                            </resolve-locals>
+                            <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -74,7 +74,7 @@
         <plugins>
             <plugin>
                 <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugins</artifactId>
+                <artifactId>galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -84,19 +84,19 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <install-dir>${project.build.directory}/wildfly</install-dir>
-                            <feature-packs>
-                                <feature-pack>
+                            <resolve-locals>
+                                <resolve-local>
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
-                                <feature-pack>
+                                    <version>${version.org.wildfly.core}</version>
+                                </resolve-local>
+                                <resolve-local>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
-                                    <inherit-packages>false</inherit-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                </feature-pack>
+                                    <version>${project.version}</version>
+                                </resolve-local>
+                            </resolve-locals>
+                            <feature-packs>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-galleon-pack</artifactId>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10703

Normally, we upgraded Core first and then follow up with the changes in WildFly. In this case I am opening this PR to upgrade WildFly to Galleon 2.x first to avoid breaking integration with current Core release.
Galleon 1.x is not able to process Galleon 2.x feature-pack descriptions but Galleon 2.x can handle feature-packs built for Galleon 1.x. Which is why current Core feature-pack is going to be consumable in WildFly with Galleon 2.x. Once WildFly switches to Galleon 2.x, I'll open the equivalent PR for Core.