### PR TITLE
[WFLY-10704] Upgrade WildFly Core 6.0.0.Alpha4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.Alpha3</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Alpha4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10704

---

# Release Notes - WildFly Core - Version 6.0.0.Alpha4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3951'>WFCORE-3951</a>] -         Upgrade jboss-logmanager from 2.1.2.Final to 2.1.3.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3954'>WFCORE-3954</a>] -         Upgrade jboss-logmanager from 2.1.3.Final to 2.1.4.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3956'>WFCORE-3956</a>] -         Upgrade Undertow to 2.0.10.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3957'>WFCORE-3957</a>] -         Upgrade JBoss Remoting to 5.0.8.Final
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3945'>WFCORE-3945</a>] -         Support associating a SecurityDomain with a web deployment instead of a http-authentication-factory
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3944'>WFCORE-3944</a>] -         Backup slave not reconnecting after master shutdown
</li>
</ul>
                                            