### PR TITLE
[WFLY-10682] add missing json dependency for JMS client

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -214,6 +214,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_2.0_spec</artifactId>
         </dependency>


### PR DESCRIPTION
org.glassfish:javax.json:1.1.2 no longer contains javax.json packages.
Add dependency to javax.json:javax.json-api to add them back to the
client jar.

JIRA: https://issues.jboss.org/browse/WFLY-10682