### PR TITLE
[WFLY-10713] Can't build WF master with Java 11-ea+22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>2.0.0.Alpha4</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>2.0.0.Alpha5</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10713

This is a component upgrade of WildFly Galleon Plugins. The new version which makes sure a forked embedded controller is started with --add-modules java.se on JDK 11.