### PR TITLE
[WFLY-7823] ActiveMQ AMQP protocol is dependent on io.netty

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/protocol/amqp/main/module.xml
@@ -30,6 +30,7 @@
     <dependencies>
         <module name="javax.jms.api"/>
         <module name="org.apache.qpid.proton"/>
+        <module name="io.netty"/>
         <!-- required to load ActiveMQ protocol SPI -->
         <module name="org.apache.activemq.artemis"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
Fixes: https://issues.jboss.org/browse/WFLY-7823?focusedCommentId=13599179&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel