### PR TITLE
[WFLY-10771] Fix namespace version number for legacy domain/template.xml file

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:7.0">
+<domain xmlns="urn:jboss:domain:8.0">
 
     <extensions>
         <?EXTENSIONS?>


### PR DESCRIPTION
This PR follows #11349

The domain/template.xml file was missing in that PR. The template is still using an obsolete namespace version number, and then, the legacy distribution cannot be built.

Jira issue: https://issues.jboss.org/browse/WFLY-10771

CC: @jmesnil 