### PR TITLE
[WFLY-10772] --add-modules java.se for modular.jdk.args in jdk9 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6677,6 +6677,7 @@
                 <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
                     --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+                    --add-modules=java.se
                     --illegal-access=permit</modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>

--- a/testsuite/integration/vdx/pom.xml
+++ b/testsuite/integration/vdx/pom.xml
@@ -122,6 +122,7 @@
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <jboss.home>${basedir}/target/wildfly</jboss.home>
+                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -141,6 +142,7 @@
                                 <domain>true</domain>
                                 <jboss.home>${basedir}/target/wildfly</jboss.home>
                                 <arquillian.xml>arquillian-domain.xml</arquillian.xml>
+                                <modular.jdk.args>${modular.jdk.args}</modular.jdk.args>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/testsuite/integration/vdx/src/test/resources/arquillian-domain.xml
+++ b/testsuite/integration/vdx/src/test/resources/arquillian-domain.xml
@@ -5,7 +5,7 @@
     <container qualifier="jboss-domain" mode="manual" default="true" >
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m ${modular.jdk.args}</property>
             <property name="containerNameMap">
                 main-server-group=main-server-group,
                 master:server-one=jboss-domain,

--- a/testsuite/integration/vdx/src/test/resources/arquillian.xml
+++ b/testsuite/integration/vdx/src/test/resources/arquillian.xml
@@ -5,7 +5,7 @@
     <container qualifier="jboss" mode="manual" default="true" >
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms64m -Xmx512m</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m ${modular.jdk.args}</property>
             <property name="serverConfig">standalone-full-ha.xml</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10772
--add-modules java.se for modular.jdk.args in jdk9 module

Note for reviewer(s): WS failures on Java 11 ea are know, see https://github.com/jboss/cxf/tree/3.2.5-jbossorg

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted