### PR TITLE
[WFLY-10775] Upgrade to Apache CXF 3.2.5-jbossorg-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
         <version.org.apache.activemq.artemis>1.5.5.jbossorg-012</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
-        <version.org.apache.cxf>3.2.5</version.org.apache.cxf>
+        <version.org.apache.cxf>3.2.5-jbossorg-1</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.1.0</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpasyncclient>4.1.3</version.org.apache.httpcomponents.httpasyncclient>


### PR DESCRIPTION
https://github.com/jboss/cxf/compare/cxf-3.2.5...cxf-3.2.5-jbossorg-1
Basically, this is needed to avoid failures with JDK 11 EA versions.