### PR TITLE
[WFLY-10778] Upgrade WildFly Core 6.0.0.Alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.Alpha4</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Alpha5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10778

---


## Release Notes - WildFly Core - Version 6.0.0.Alpha5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3955'>WFCORE-3955</a>] -         Upgrade WildFly Elytron to 1.4.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3961'>WFCORE-3961</a>] -         Upgrade Elytron Web to 1.2.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3967'>WFCORE-3967</a>] -         Upgrade to Galleon and WildFly Galleon Plugins 2.0.0.Alpha4
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3968'>WFCORE-3968</a>] -         Upgrade CLI to use aesh 1.7 and aesh-readline 1.10
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3972'>WFCORE-3972</a>] -         Upgrade WildFly Elytron to 1.5.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3973'>WFCORE-3973</a>] -         Upgrade CLI to use aesh-extensions 1.6
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3986'>WFCORE-3986</a>] -         Upgrade WildFly Elytron to 1.5.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3923'>WFCORE-3923</a>] -         Provide a profile to run enforcer rule for downstream projects - wildfly-core
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3396'>WFCORE-3396</a>] -         Provide certificate authority integration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3666'>WFCORE-3666</a>] -         Provide Elytron alternative to RoleMappingLoginModule
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3819'>WFCORE-3819</a>] -         Missing subsystem component to use a custom audit endpoint
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3877'>WFCORE-3877</a>] -         Make implementing the org.wildfly.extension.elytron.Configurable optional for configurable components.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3933'>WFCORE-3933</a>] -         CLI output compact response option
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3711'>WFCORE-3711</a>] -         Ctrl-C in CLI multi page output mode kills the whole CLI
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3943'>WFCORE-3943</a>] -         Embedded server operations executed using different classloaders
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3950'>WFCORE-3950</a>] -         Unclear exception when specifying non-archive file as resource-root
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3963'>WFCORE-3963</a>] -         Fix of WFCORE-3826 breaks plain authentication for ejbs using legacy configuration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3965'>WFCORE-3965</a>] -         Cover possible error when host controllers can not connect to domain after creating a rollout plan and restarting the master host controller
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3985'>WFCORE-3985</a>] -         The DeploymentOverlayTestCase uses the incorrect suite reference
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3987'>WFCORE-3987</a>] -         The ReloadWithRolloutPlanTestCase test should wait for the host controller and servers to reload
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3989'>WFCORE-3989</a>] -         AuditLogBootingSyslogTest should make assertion on lower and upper bound for queue size
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3360'>WFCORE-3360</a>] -         Eliminate org.wildfly.extension.elytron.ProviderUtil
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3591'>WFCORE-3591</a>] -         Add Elytron Web undertow-servlet module
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3613'>WFCORE-3613</a>] -         Remove org.wildfly.javax.json module when WildFly targets Java EE 8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3920'>WFCORE-3920</a>] -         Update the testsuite to make use of the utilities for certificate generation instead of using pre-generated CAs and certs 
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3974'>WFCORE-3974</a>] -         Make the AuditLogBootingSyslogTest test more forgiving
</li>
</ul>
                                    