### PR TITLE
[WFLY-10782] Do not require twice socket-binding dependency

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -326,8 +326,11 @@ class ServerAdd extends AbstractAddStepHandler {
                         Supplier<OutboundSocketBinding> outboundSocketBinding = serviceBuilder.requires(outboundSocketName);
                         outboundSocketBindings.put(connectorSocketBinding, outboundSocketBinding);
                     } else {
-                        Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding));
-                        socketBindings.put(connectorSocketBinding, socketBinding);
+                        // check if the socket binding has not already been added by the acceptors
+                        if (!socketBindings.containsKey(connectorSocketBinding)) {
+                            Supplier<SocketBinding> socketBinding = serviceBuilder.requires(SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding));
+                            socketBindings.put(connectorSocketBinding, socketBinding);
+                        }
                     }
                 }
                 // if there is any HTTP acceptor, add a dependency on the http-upgrade-registry service to


### PR DESCRIPTION
* Socket binding dependencies can be required both by acceptors and
  connectors. When checking connectors, verify that the socket-binding
  dependency has not already been required by a previous acceptor.

JIRA: https://issues.jboss.org/browse/WFLY-10782
