### PR TITLE
[WFLY-10770] Provision an Infinispan server to ensure all dependencie…

### DIFF
--- a/testsuite/integration/clustering/infinispan-server-provisioning.xml
+++ b/testsuite/integration/clustering/infinispan-server-provisioning.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.2" extract-schemas="true" copy-module-artifacts="false" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core org.infinispan.server org.infinispan">
+    <feature-packs>
+        <!-- We must specify the exact wildfly version as some of our external feature-pack dependencies may reference a different version -->
+        <feature-pack groupId="org.wildfly" artifactId="wildfly-feature-pack" version="${version.org.jboss.infinispan-wildfly}">
+            <!--Exclude wildfly config-->
+            <config/>
+            <!--Exclude wildfly content -->
+            <contents include="false"/>
+        </feature-pack>
+        <feature-pack groupId="org.infinispan.server" artifactId="infinispan-server-feature-pack" version="${version.org.infinispan}"/>
+    </feature-packs>
+</server-provisioning>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -44,12 +44,22 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
+        <!-- Needs to kept inline with what the infinispan-server-feature-pack requires -->
+        <version.org.jboss.infinispan-wildfly>13.0.0.Final</version.org.jboss.infinispan-wildfly>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>
             <artifactId>metainf-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Used for the infinispan-server-feature-pack -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-feature-pack</artifactId>
+            <version>${version.org.jboss.infinispan-wildfly}</version>
+            <type>zip</type>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -64,6 +74,25 @@
             </activation>
             <build>
                 <plugins>
+                    <!-- Configure an Infinispan server -->
+                    <plugin>
+                        <groupId>org.wildfly.build</groupId>
+                        <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>provision-infinispan-server</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>test-compile</phase>
+                                <configuration>
+                                    <config-file>infinispan-server-provisioning.xml</config-file>
+                                    <buildName>${basedir}/target/</buildName>
+                                    <server-name>infinispan-server-${version.org.infinispan}</server-name>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Update server profile with shared configuration changes -->
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
@@ -90,30 +119,6 @@
                                 <module.path>${jboss.dist}/modules</module.path>
                             </system-properties>
                         </configuration>
-                    </plugin>
-                    <!-- Unzip Infinispan Server distribution for remote tests -->
-                    <plugin>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack-infinispan-server</id>
-                                <phase>generate-test-resources</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.infinispan.server</groupId>
-                                            <artifactId>infinispan-server-build</artifactId>
-                                            <version>${version.org.infinispan}</version>
-                                            <type>zip</type>
-                                            <outputDirectory>${project.build.directory}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                     <!-- Copy 4 containers based on the shared configuration -->
                     <plugin>


### PR DESCRIPTION
…s are downloaded instead of using a thin provisioned server.

https://issues.jboss.org/browse/WFLY-10770

JBoss Modules was attempting to download dependencies that were not found in the local repository for the `org.infinispan.server:infinispan-server-build` dependency. This causes issues where the JBoss Nexus repository isn't defined in a settings.xml for the user or the user does not use a settings.xml. Instead here we should provision a server to keep Maven itself in charge of downloading dependencies.

Please not this does add a dependency to `org.wildfly:wildfly-feature-pack:13.0.0.Final` as that is what 9.3.1.Final version of the infinispan-server uses. This version parameter was deliberately set in the test pom to hopefully keep the confusion down of why we have 13.0.0.Final defined in WildFly itself.