### PR TITLE
WFLY-10786 HotRodStore throws NPE at runtime if remote cache does not exist

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/InfinispanLogger.java
@@ -25,11 +25,12 @@ package org.jboss.as.clustering.infinispan;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
-import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -134,9 +135,8 @@ public interface InfinispanLogger extends BasicLogger {
     @Message(id = 30, value = "Stopped remote cache container '%s'.")
     void remoteCacheContainerStopped(String remoteCacheContainer);
 
-    @LogMessage(level = WARN)
     @Message(id = 31, value = "Specified HotRod protocol version %s does not support creating caches automatically. Cache named '%s' must be already created on the Infinispan Server!")
-    void remoteCacheMustBeDefined(String protocolVersion, String remoteCacheName);
+    HotRodClientException remoteCacheMustBeDefined(String protocolVersion, String remoteCacheName);
 
     @LogMessage(level = INFO)
     @Message(id = 32, value = "Getting remote cache named '%s'. If it does not exist a new cache will be created from configuration template named '%s'; null value uses default cache configuration on the Infinispan Server.")

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
@@ -22,21 +22,8 @@
 
 package org.jboss.as.clustering.infinispan.subsystem.remote;
 
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_10;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_11;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_12;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_13;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_20;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_21;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_22;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_23;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_24;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_25;
-import static org.infinispan.client.hotrod.ProtocolVersion.PROTOCOL_VERSION_26;
-
 import java.io.IOException;
 import java.util.AbstractMap;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -89,9 +76,8 @@ public class HotRodStore<K, V> implements AdvancedLoadWriteStore<K, V>, Callable
         try {
             ProtocolVersion protocolVersion = remoteCacheContainer.getConfiguration().version();
 
-            // Currently enumerates protocols which do *not* yet support administration calls
-            // TODO update the upstream API to be able to use comparison reliably; ordering is changed in 9.3
-            if (EnumSet.of(PROTOCOL_VERSION_26, PROTOCOL_VERSION_25, PROTOCOL_VERSION_24, PROTOCOL_VERSION_23, PROTOCOL_VERSION_22, PROTOCOL_VERSION_21, PROTOCOL_VERSION_20, PROTOCOL_VERSION_13, PROTOCOL_VERSION_12, PROTOCOL_VERSION_11, PROTOCOL_VERSION_10).contains(protocolVersion)) {
+            // Administration support was introduced in protocol version 2.7
+            if (protocolVersion.compareTo(ProtocolVersion.PROTOCOL_VERSION_27) < 0) {
                 InfinispanLogger.ROOT_LOGGER.remoteCacheMustBeDefined(protocolVersion.toString(), cacheName);
                 this.remoteCache = remoteCacheContainer.getCache(cacheName, false);
             } else {
@@ -101,7 +87,6 @@ public class HotRodStore<K, V> implements AdvancedLoadWriteStore<K, V>, Callable
         } catch (HotRodClientException ex) {
             throw new PersistenceException(ex);
         }
-
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
@@ -78,8 +78,10 @@ public class HotRodStore<K, V> implements AdvancedLoadWriteStore<K, V>, Callable
 
             // Administration support was introduced in protocol version 2.7
             if (protocolVersion.compareTo(ProtocolVersion.PROTOCOL_VERSION_27) < 0) {
-                InfinispanLogger.ROOT_LOGGER.remoteCacheMustBeDefined(protocolVersion.toString(), cacheName);
                 this.remoteCache = remoteCacheContainer.getCache(cacheName, false);
+                if (this.remoteCache == null) {
+                    throw InfinispanLogger.ROOT_LOGGER.remoteCacheMustBeDefined(protocolVersion.toString(), cacheName);
+                }
             } else {
                 InfinispanLogger.ROOT_LOGGER.remoteCacheCreated(cacheName, cacheConfiguration);
                 this.remoteCache = remoteCacheContainer.administration().getOrCreateCache(cacheName, cacheConfiguration);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10786