### PR TITLE
WFLY-10783 Prevent port conflicts at runtime when running with migrated JGroups/Infinispan configuration

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
@@ -447,6 +447,14 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
                 }
             }
         }
+
+        // Set default port_range for pre-WF11 schemas
+        if (!this.schema.since(JGroupsSchema.VERSION_5_0)) {
+            String portRangeProperty = "port_range";
+            if (!operation.hasDefined(AbstractProtocolResourceDefinition.Attribute.PROPERTIES.getName(), portRangeProperty)) {
+                operation.get(AbstractProtocolResourceDefinition.Attribute.PROPERTIES.getName()).get(portRangeProperty).set("50");
+            }
+        }
     }
 
     private void parseSocketProtocol(XMLExtendedStreamReader reader, PathAddress stackAddress, Map<PathAddress, ModelNode> operations) throws XMLStreamException {

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -56,7 +56,7 @@
         interval="15000"
         timeout="60000"
         timeout_check_interval="5000"/>
-    <FD_SOCK port_range="0"/>
+    <FD_SOCK/>
     <VERIFY_SUSPECT timeout="5000"/>
     <pbcast.NAKACK2
         xmit_interval="100"


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10783

To mainain configuration compatibility, set original port_range value when parsing schemas prior to WF11.
Otherwise, migrated configuration containing facbricated channels, will encounter port conflicts at runtime, as the shared transport feature on which it previously relied no longer exists.