### PR TITLE
WFLY-8066 Update stack of default channel to tcp. Update tcp stack to use TCP_NIO2.

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -4,7 +4,7 @@
     <extension-module>org.jboss.as.clustering.jgroups</extension-module>
     <subsystem xmlns="urn:jboss:domain:jgroups:6.0">
         <channels default="ee">
-            <channel name="ee" stack="udp" cluster="ejb"/>
+            <channel name="ee" stack="tcp" cluster="ejb"/>
         </channels>
         <stacks>
             <stack name="udp">

--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -23,7 +23,7 @@
                 <protocol type="FRAG3"/>
             </stack>
             <stack name="tcp">
-                <transport type="TCP" socket-binding="jgroups-tcp"/>
+                <transport type="TCP_NIO2" socket-binding="jgroups-tcp"/>
                 <?TCP-DISCOVERY?>
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-8066

Moving default channel to tcp stack makes sense now given that:
* the majority of our caches no longer use replication
* TCP performs on par with UDP unicasts.
* Clustering testsuite already uses tcp stack
* tcp stack is the default on OpenShift.

Additionally, stress tests indicate a ~40% improvement to request throughput under load for distributed web applications in stress tests using TCP_NIO2 vs TCP - and should also reduce state transfer duration.