### PR TITLE
[WFLY-10811] Adding required modular jdk params to all configs.

### DIFF
--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -79,6 +79,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -89,6 +89,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -85,6 +85,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/galleon-pack/src/main/resources/feature_groups/host-master.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host-master.xml
@@ -7,7 +7,7 @@
         <param name="host" value="master"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
         </feature>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/host-slave.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host-slave.xml
@@ -10,7 +10,7 @@
         <param name="host" value="slave"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
         </feature>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/host.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host.xml
@@ -10,7 +10,7 @@
         <param name="host" value="master"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
         </feature>
         <feature spec="host.server-config">
             <param name="server-config" value="server-two"/>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -79,6 +79,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -92,6 +92,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -88,6 +88,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
@@ -30,7 +30,7 @@
             <param name="jvm" value="default"/>
             <param name="heap-size" value="64m"/>
             <param name="max-heap-size" value="256m"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
             <unset param="environment-variables"/>
         </feature>
     </feature>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
@@ -9,7 +9,7 @@
                     <param name="jvm" value="default"/>
                     <param name="heap-size" value="64m"/>
                     <param name="max-heap-size" value="256m"/>
-                    <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+                    <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
                     <unset param="environment-variables"/>
                 </feature>
             </include>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host.xml
@@ -13,7 +13,7 @@
         </feature>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;,&quot;--add-modules=java.se&quot;,&quot;--illegal-access=permit&quot;]"/>
         </feature>
         <feature spec="host.server-config">
             <param name="server-config" value="server-two"/>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -79,6 +79,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -79,6 +79,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -75,6 +75,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -81,6 +81,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -94,6 +94,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -77,6 +77,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -60,6 +60,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -69,6 +69,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -97,6 +97,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -94,6 +94,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -87,11 +87,12 @@
 
  	<jvms>
  	   <jvm name="default">
-          <heap size="64m" max-size="128m"/>
+           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -75,6 +75,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -102,6 +102,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -80,6 +80,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -114,6 +114,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -111,6 +111,7 @@
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                 <option value="--illegal-access=permit"/>
+                <option value="--add-modules=java.se"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -115,6 +115,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -69,6 +69,7 @@
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
                <option value="--illegal-access=permit"/>
+               <option value="--add-modules=java.se"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
@@ -82,6 +82,8 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
+                <option value="--add-modules=java.se"/>
+                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>


### PR DESCRIPTION
Adding --add-modules=java.se and --illegal-access=permit options to all configs.
These options are necessary to function properly on JDK 9, 10 and 11.
This pull request addresses the following issue:
https://issues.jboss.org/browse/WFLY-10811
