### PR TITLE
[WFLY-10816] Replace legacy feature packs by Galleon feature packs in wildfly-testsuite-shared module

### DIFF
--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -41,17 +41,17 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-feature-pack</artifactId>
+            <artifactId>wildfly-galleon-pack</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-servlet-feature-pack</artifactId>
+            <artifactId>wildfly-servlet-galleon-pack</artifactId>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-feature-pack</artifactId>
+            <artifactId>wildfly-core-galleon-pack</artifactId>
             <type>pom</type>
         </dependency>
 


### PR DESCRIPTION
We are still using legacy feature packs in wildfly-testsuite-shared

Jira issue: https://issues.jboss.org/browse/WFLY-10816