### PR TITLE
[WFLY-10711] Support Eclipse MicroProfile Health

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
@@ -1,0 +1,86 @@
+[[MicroProfile_Health_SmallRye]]
+= MicroProfile Health Subsystem Configuration
+
+Support for https://microprofile.io/project/eclipse/microprofile-health[Eclipse MicroProfile Health] is provided by
+ the _microprofile-health-smallrye_ subsystem.
+
+[[required-extension]]
+== Required Extension
+
+This extension is included in the standalone configurations included in the
+WildFly distribution.
+
+You can also add the extension to a configuration without it either by adding
+an `<extension module="org.wildfly.extension.microprofile.health-smallrye"/>`
+element to the xml or by using the following CLI operation:
+
+[source,ruby]
+----
+[standalone@localhost:9990 /]/extension=org.wildfly.extension.microprofile.health-smallrye:add
+----
+
+== Management Operation
+
+The healthiness of the application server can be queried by calling the `check`:
+
+[source]
+----
+[standalone@localhost:9990 /] /subsystem=microprofile-health-smallrye:check
+{
+    "outcome" => "success", <1>
+    "result" => {
+        "outcome" => "UP", <2>
+        "checks" => []
+    }
+}
+----
+<1> this `outcome` means that the management operation is successful
+<2> this `outcome` corresponds to the health check, `UP` if the application server is healthy, `DOWN` else.
+
+== HTTP Endpoint
+
+The Health HTTP endpoint is accessible on WildFly HTTP management interface http://localhost:9990/health[http://localhost:9990/health].
+
+Secured access to the HTTP endpoint is controlled by the `security-enabled` attribute of the `/subsystem=microprofile-health-smallrye` resource.
+If it is set to `true`, the HTTP client must be authenticated.
+
+If the application server is healthy, it will return a `200 OK` response:
+
+---
+$ curl -v http://localhost:9990/health
+< HTTP/1.1 200 OK
+...
+{"outcome":"UP","checks":[]}
+---
+
+If the application server (and its deployment) is not healthy, it returns `503 Service Unavailable`
+
+----
+$ curl -v http://localhost:9990/health
+< HTTP/1.1 503 Service Unavailable
+...
+{"outcome":"DOWN","checks":[{"name":"myFailingProbe","state":"DOWN","data":{"foo":"bar"}}]}
+----
+
+If security has been enabled, the HTTP client must pass the credentials corresponding to a management user
+created by the `add-user` script. For example:
+
+---
+$ curl -v --digest -u myadminuser:myadminpassword http://localhost:9990/health
+< HTTP/1.1 200 OK
+...
+{"outcome":"UP","checks":[]}
+---
+
+If the authentication fails, the  server will reply with a `401 NOT AUTHORIZED` response.
+
+== Component Reference
+
+The Eclipse MicroProfile Health is implemented by the SmallRye Health project.
+
+****
+
+* https://microprofile.io/project/eclipse/microprofile-health[Eclipse MicroProfile Health]
+* http://github.com/smallrye/smallrye-health/[SmallRye Health]
+
+****

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2831,7 +2831,40 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-health</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-health-smallrye</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+        <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mod_cluster-extension</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -88,6 +88,7 @@
                 <extension module="org.wildfly.extension.ee-security"/>
                 <extension module="org.wildfly.extension.elytron"/>
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing" />
             </excluded-extensions>
         </host-exclude>
@@ -99,6 +100,7 @@
                 <extension module="org.wildfly.extension.ee-security"/>
                 <extension module="org.wildfly.extension.elytron"/>
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing" />
             </excluded-extensions>
         </host-exclude>
@@ -107,6 +109,7 @@
             <excluded-extensions>
                 <extension module="org.wildfly.extension.ee-security"/>
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing" />
             </excluded-extensions>
         </host-exclude>
@@ -115,18 +118,18 @@
             <excluded-extensions>
                 <extension module="org.wildfly.extension.ee-security"/>
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing" />
             </excluded-extensions>
         </host-exclude>
-        <!--
         <host-exclude name="WildFly13.0">
             <host-release id="WildFly13.0"/>
             <excluded-extensions>
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing" />
             </excluded-extensions>
         </host-exclude>
-        -->
     </host-excludes>
 
 </domain>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -25,9 +25,10 @@
         <subsystem>jsf.xml</subsystem>
         <subsystem>jsr77.xml</subsystem>
         <subsystem>mail.xml</subsystem>
-        <subsystem>microprofile-config-smallrye.xml</subsystem>
-        <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem supplement="ha">messaging-activemq.xml</subsystem>
+        <subsystem>microprofile-config-smallrye.xml</subsystem>
+        <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem supplement="${mod_cluster.supplement}">mod_cluster.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -24,9 +24,10 @@
         <subsystem>jsf.xml</subsystem>
         <subsystem>jsr77.xml</subsystem>
         <subsystem>mail.xml</subsystem>
-        <subsystem>microprofile-config-smallrye.xml</subsystem>
-        <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem>messaging-activemq.xml</subsystem>
+        <subsystem>microprofile-config-smallrye.xml</subsystem>
+        <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>
         <subsystem>remoting.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -24,6 +24,7 @@
         <subsystem>jsf.xml</subsystem>
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
+        <subsystem>microprofile-health-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem supplement="${mod_cluster.supplement}">mod_cluster.xml</subsystem>
         <subsystem>naming.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -23,6 +23,7 @@
         <subsystem>jsf.xml</subsystem>
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
+        <subsystem>microprofile-health-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="io.smallrye.health">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${io.smallrye:smallrye-health}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.eclipse.microprofile.health.api"/>
+        <module name="javax.enterprise.api" />
+        <module name="javax.annotation.api" />
+        <module name="javax.json.api" />
+    </dependencies>
+</module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/health/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/health/api/main/module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.health.api">
+    <resources>
+        <artifact name="${org.eclipse.microprofile.health:microprofile-health-api}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+    </dependencies>
+</module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.health-smallrye">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:wildfly-microprofile-health-smallrye}"/>
+    </resources>
+
+    <dependencies>
+        <module name="io.smallrye.health" />
+        <module name="io.undertow.core"/>
+        <module name="javax.api"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.eclipse.microprofile.health.api"/>
+        <module name="org.jboss.as.weld" />
+        <module name="org.jboss.as.ee" />
+        <module name="javax.enterprise.api" />
+        <module name="javax.annotation.api" />
+    </dependencies>
+</module>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -186,6 +186,7 @@
                                 <extension>org.wildfly.extension.io</extension>
                                 <extension>org.wildfly.extension.messaging-activemq</extension>
                                 <extension>org.wildfly.extension.microprofile.config-smallrye</extension>
+                                <extension>org.wildfly.extension.microprofile.health-smallrye</extension>
                                 <extension>org.wildfly.extension.microprofile.opentracing</extension>
                                 <extension>org.wildfly.extension.picketlink</extension>
                                 <extension>org.wildfly.extension.request-controller</extension>
@@ -228,6 +229,7 @@
                                 <extension>org.wildfly.extension.io</extension>
                                 <extension>org.wildfly.extension.messaging-activemq</extension>
                                 <extension>org.wildfly.extension.microprofile.config-smallrye</extension>
+                                <extension>org.wildfly.extension.microprofile.health-smallrye</extension>
                                 <extension>org.wildfly.extension.microprofile.opentracing</extension>
                                 <extension>org.wildfly.extension.picketlink</extension>
                                 <extension>org.wildfly.extension.request-controller</extension>
@@ -1444,6 +1446,17 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-health</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-opentracing</artifactId>
             <exclusions>
                 <exclusion>
@@ -1724,6 +1737,17 @@
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -3118,6 +3142,17 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-microprofile-config-smallrye</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-health-smallrye</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/galleon-pack/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/galleon-pack/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -7,20 +7,25 @@
 
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly10.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly10.1"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly11.0"/>
         <param name="host-release" value="WildFly11.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly12.0"/>
         <param name="host-release" value="WildFly12.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly13.0"/>
+        <param name="host-release" value="WildFly13.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/health.xml
+++ b/galleon-pack/src/main/resources/feature_groups/health.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="health" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.microprofile-health-smallrye">
+      <param name="security-enabled" value="false"/>
+    </feature>
+</feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-ha.xml
@@ -21,9 +21,11 @@
     <feature-group name="management-audit"/>
     <feature-group name="management-interfaces"/>
     <feature-group name="access-control"/>
+    <feature-group name="health"/>
 
     <origin name="org.wildfly:wildfly-servlet-galleon-pack">
         <feature-group name="standalone-profile"/>
     </origin>
     <feature-group name="basic-ha-profile"/>
+
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
@@ -6,5 +6,6 @@
     </origin>
 
     <feature-group name="basic-profile"/>
+    <feature-group name="health"/>
 
 </feature-group-spec>

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>14.0.0.Beta2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-microprofile-health-smallrye</artifactId>
+
+    <name>WildFly: MicroProfile Health Extension With SmallRye</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-weld</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/CheckOperation.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/CheckOperation.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import io.smallrye.health.SmallRyeHealth;
+import io.smallrye.health.SmallRyeHealthReporter;
+import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * Management operation that returns the DMR representation of the MicroProfile Health Check JSON payload.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class CheckOperation extends AbstractRuntimeOnlyHandler {
+
+    private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("check", MicroProfileHealthExtension.getResourceDescriptionResolver(MicroProfileHealthExtension.SUBSYSTEM_NAME))
+            .setRuntimeOnly()
+            .setReplyType(ModelType.OBJECT)
+            .setReplyValueType(ModelType.OBJECT)
+            .build();
+
+    static void register(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerOperationHandler(DEFINITION, new CheckOperation());
+    }
+
+    private CheckOperation() {
+    }
+
+    @Override
+    protected void executeRuntimeStep(OperationContext context, ModelNode operation) {
+        ServiceName serviceName = context.getCapabilityServiceName(MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_CAPABILITY, SmallRyeHealthReporter.class);
+        SmallRyeHealthReporter reporter = (SmallRyeHealthReporter) context.getServiceRegistry(false).getService(serviceName).getValue();
+
+        SmallRyeHealth health = reporter.getHealth();
+        ModelNode result = ModelNode.fromJSONString(health.getPayload().toString());
+        context.getResult().set(result);
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthContextService.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthContextService.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import java.util.function.Supplier;
+
+import io.smallrye.health.SmallRyeHealth;
+import io.smallrye.health.SmallRyeHealthReporter;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.server.mgmt.domain.ExtensibleHttpManagement;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class HealthContextService implements Service {
+
+    private static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("extension", "health", "context");
+    private static final String CONTEXT_NAME = "health";
+
+    private final Supplier<ExtensibleHttpManagement> extensibleHttpManagement;
+    private final boolean securityEnabled;
+    private final Supplier<SmallRyeHealthReporter> healthReporter;
+
+
+    static void install(OperationContext context, boolean securityEnabled) {
+        ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(SERVICE_NAME);
+
+        Supplier<ExtensibleHttpManagement> extensibleHttpManagement = serviceBuilder.requires(context.getCapabilityServiceName(MicroProfileHealthSubsystemDefinition.HTTP_EXTENSIBILITY_CAPABILITY, ExtensibleHttpManagement.class));
+        Supplier<SmallRyeHealthReporter> healthReporter = serviceBuilder.requires(context.getCapabilityServiceName(MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_CAPABILITY, SmallRyeHealthReporter.class));
+
+        Service healthContextService = new HealthContextService(extensibleHttpManagement, securityEnabled, healthReporter);
+
+        serviceBuilder.setInstance(healthContextService)
+                .install();
+    }
+
+    HealthContextService(Supplier<ExtensibleHttpManagement> extensibleHttpManagement, boolean securityEnabled, Supplier<SmallRyeHealthReporter> healthReporter) {
+        this.extensibleHttpManagement = extensibleHttpManagement;
+        this.securityEnabled = securityEnabled;
+        this.healthReporter = healthReporter;
+    }
+
+    @Override
+    public void start(StartContext context) {
+        // access to the /health endpoint is unsecured
+        extensibleHttpManagement.get().addManagementHandler(CONTEXT_NAME, securityEnabled,
+                new HealthCheckHandler(healthReporter.get()));
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        extensibleHttpManagement.get().removeContext(CONTEXT_NAME);
+    }
+
+    private class HealthCheckHandler implements HttpHandler {
+        private final SmallRyeHealthReporter healthReporter;
+
+        public HealthCheckHandler(SmallRyeHealthReporter healthReporter) {
+            this.healthReporter = healthReporter;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) {
+            final SmallRyeHealth health = healthReporter.getHealth();
+            exchange.setStatusCode(health.isDown() ? 503 : 200)
+                    .getResponseHeaders().add(Headers.CONTENT_TYPE, "application/json");
+            exchange.getResponseSender().send(health.getPayload().toString());
+        }
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthContextService.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthContextService.java
@@ -42,7 +42,7 @@ import org.jboss.msc.service.StopContext;
  */
 public class HealthContextService implements Service {
 
-    private static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("extension", "health", "context");
+    static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("extension", "health", "context");
     private static final String CONTEXT_NAME = "health";
 
     private final Supplier<ExtensibleHttpManagement> extensibleHttpManagement;

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthReporterService.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/HealthReporterService.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import static org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_CAPABILITY;
+
+import io.smallrye.health.ResponseProvider;
+import io.smallrye.health.SmallRyeHealthReporter;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class HealthReporterService implements Service<SmallRyeHealthReporter> {
+
+    private SmallRyeHealthReporter healthReporter;
+
+    static void install(OperationContext context) {
+        context.getCapabilityServiceTarget()
+                .addCapability(RuntimeCapability.Builder.of(HEALTH_REPORTER_CAPABILITY, SmallRyeHealthReporter.class).build(),
+                        new HealthReporterService())
+                .install();
+    }
+
+    private HealthReporterService() {
+    }
+
+    @Override
+    public void start(StartContext context) {
+        HealthCheckResponse.setResponseProvider(new ResponseProvider());
+        this.healthReporter = new SmallRyeHealthReporter();
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        this.healthReporter = null;
+        HealthCheckResponse.setResponseProvider(null);
+    }
+
+    @Override
+    public SmallRyeHealthReporter getValue() {
+        return healthReporter;
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthExtension.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthExtension.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthExtension implements Extension {
+
+    static final String EXTENSION_NAME = "org.wildfly.extension.microprofile.health.smallrye";
+
+    /**
+     * The name of our subsystem within the model.
+     */
+    public static final String SUBSYSTEM_NAME = "microprofile-health-smallrye";
+
+    protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+
+    private static final String RESOURCE_NAME = MicroProfileHealthExtension.class.getPackage().getName() + ".LocalDescriptions";
+
+    protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_1_0_0;
+
+    private static final MicroProfileHealthParser_1_0 CURRENT_PARSER = new MicroProfileHealthParser_1_0();
+
+    static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {
+        return getResourceDescriptionResolver(true, keyPrefix);
+
+    }
+
+    static ResourceDescriptionResolver getResourceDescriptionResolver(final boolean useUnprefixedChildTypes, final String... keyPrefix) {
+        StringBuilder prefix = new StringBuilder();
+        for (String kp : keyPrefix) {
+            if (prefix.length() > 0){
+                prefix.append('.');
+            }
+            prefix.append(kp);
+        }
+        return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, MicroProfileHealthExtension.class.getClassLoader(), true, useUnprefixedChildTypes);
+    }
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        subsystem.registerXMLElementWriter(CURRENT_PARSER);
+
+        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new MicroProfileHealthSubsystemDefinition());
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileHealthParser_1_0.NAMESPACE, CURRENT_PARSER);
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthParser_1_0.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthParser_1_0.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthParser_1_0 extends PersistentResourceXMLParser {
+    /**
+     * The name space used for the {@code subsystem} element
+     */
+    public static final String NAMESPACE = "urn:wildfly:microprofile-health-smallrye:1.0";
+
+    private static final PersistentResourceXMLDescription xmlDescription;
+
+    static {
+        xmlDescription = builder(MicroProfileHealthExtension.SUBSYSTEM_PATH, NAMESPACE)
+                .addAttribute(MicroProfileHealthSubsystemDefinition.SECURITY_ENABLED)
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return xmlDescription;
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemAdd.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemAdd.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import static org.jboss.as.controller.OperationContext.Stage.RUNTIME;
+import static org.jboss.as.server.deployment.Phase.DEPENDENCIES;
+import static org.jboss.as.server.deployment.Phase.POST_MODULE;
+
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.server.AbstractDeploymentChainStep;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.microprofile.health._private.MicroProfileHealthLogger;
+import org.wildfly.extension.microprofile.health.deployment.DependencyProcessor;
+import org.wildfly.extension.microprofile.health.deployment.DeploymentProcessor;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+class MicroProfileHealthSubsystemAdd extends AbstractBoottimeAddStepHandler {
+
+    public static final int PRIORITY = 0x4000;
+
+    MicroProfileHealthSubsystemAdd() {
+        super(MicroProfileHealthSubsystemDefinition.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performBoottime(context, operation, model);
+
+        context.addStep(new AbstractDeploymentChainStep() {
+            public void execute(DeploymentProcessorTarget processorTarget) {
+                processorTarget.addDeploymentProcessor(MicroProfileHealthExtension.SUBSYSTEM_NAME, DEPENDENCIES, PRIORITY, new DependencyProcessor());
+                processorTarget.addDeploymentProcessor(MicroProfileHealthExtension.SUBSYSTEM_NAME, POST_MODULE, PRIORITY, new DeploymentProcessor());
+            }
+        }, RUNTIME);
+
+        final boolean securityEnabled = MicroProfileHealthSubsystemDefinition.SECURITY_ENABLED.resolveModelAttribute(context, model).asBoolean();
+        HealthReporterService.install(context);
+        HealthContextService.install(context, securityEnabled);
+
+        MicroProfileHealthLogger.LOGGER.activatingSubsystem();
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 
 import io.smallrye.health.SmallRyeHealthReporter;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -42,14 +41,14 @@ import org.jboss.msc.service.ServiceName;
 public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDefinition {
 
     static final String HEALTH_REPORTER_CAPABILITY = "org.wildlfy.microprofile.health.reporter";
-    private static final RuntimeCapability<Void> HEALTH_REPORTER_RUNTIME_CAPABILITY =
+    static final RuntimeCapability<Void> HEALTH_REPORTER_RUNTIME_CAPABILITY =
             RuntimeCapability.Builder.of(HEALTH_REPORTER_CAPABILITY, SmallRyeHealthReporter.class)
                     .build();
 
     public static final ServiceName HEALTH_REPORTER_SERVICE = ServiceName.parse(HEALTH_REPORTER_CAPABILITY);
 
     static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
-    private static final RuntimeCapability<Void> EXTENSION_CAPABILITY = RuntimeCapability.Builder.of(MicroProfileHealthExtension.EXTENSION_NAME)
+    static final RuntimeCapability<Void> EXTENSION_CAPABILITY = RuntimeCapability.Builder.of(MicroProfileHealthExtension.EXTENSION_NAME)
             .addRequirements(HTTP_EXTENSIBILITY_CAPABILITY)
             .build();
 
@@ -65,7 +64,7 @@ public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDef
         super(new Parameters(MicroProfileHealthExtension.SUBSYSTEM_PATH,
                 MicroProfileHealthExtension.getResourceDescriptionResolver(MicroProfileHealthExtension.SUBSYSTEM_NAME))
                 .setAddHandler(new MicroProfileHealthSubsystemAdd())
-                .setRemoveHandler(new ModelOnlyRemoveStepHandler())
+                .setRemoveHandler(new MicroProfileHealthSubsystemRemove())
                 .setCapabilities(HEALTH_REPORTER_RUNTIME_CAPABILITY, EXTENSION_CAPABILITY));
     }
 

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.smallrye.health.SmallRyeHealthReporter;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDefinition {
+
+    static final String HEALTH_REPORTER_CAPABILITY = "org.wildlfy.microprofile.health.reporter";
+    private static final RuntimeCapability<Void> HEALTH_REPORTER_RUNTIME_CAPABILITY =
+            RuntimeCapability.Builder.of(HEALTH_REPORTER_CAPABILITY, SmallRyeHealthReporter.class)
+                    .build();
+
+    public static final ServiceName HEALTH_REPORTER_SERVICE = ServiceName.parse(HEALTH_REPORTER_CAPABILITY);
+
+    static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
+    private static final RuntimeCapability<Void> EXTENSION_CAPABILITY = RuntimeCapability.Builder.of(MicroProfileHealthExtension.EXTENSION_NAME)
+            .addRequirements(HTTP_EXTENSIBILITY_CAPABILITY)
+            .build();
+
+    static final AttributeDefinition SECURITY_ENABLED = SimpleAttributeDefinitionBuilder.create("security-enabled", ModelType.BOOLEAN)
+            .setDefaultValue(new ModelNode(true))
+            .setRequired(false)
+            .setRestartAllServices()
+            .setAllowExpression(true)
+            .build();
+    static final AttributeDefinition[] ATTRIBUTES = { SECURITY_ENABLED };
+
+    protected MicroProfileHealthSubsystemDefinition() {
+        super(new Parameters(MicroProfileHealthExtension.SUBSYSTEM_PATH,
+                MicroProfileHealthExtension.getResourceDescriptionResolver(MicroProfileHealthExtension.SUBSYSTEM_NAME))
+                .setAddHandler(new MicroProfileHealthSubsystemAdd())
+                .setRemoveHandler(new ModelOnlyRemoveStepHandler())
+                .setCapabilities(HEALTH_REPORTER_RUNTIME_CAPABILITY, EXTENSION_CAPABILITY));
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(ATTRIBUTES);
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+
+        CheckOperation.register(resourceRegistration);
+    }
+
+
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemRemove.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemRemove.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import static org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_SERVICE;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthSubsystemRemove extends AbstractRemoveStepHandler {
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performRuntime(context, operation, model);
+
+        context.removeService(HealthContextService.SERVICE_NAME);
+        context.removeService(HEALTH_REPORTER_SERVICE);
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/_private/MicroProfileHealthLogger.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health._private;
+
+import static org.jboss.logging.Logger.Level.INFO;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Log messages for WildFly microprofile-health-smallrye Extension.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@MessageLogger(projectCode = "WFLYHEALTH", length = 4)
+public interface MicroProfileHealthLogger extends BasicLogger {
+    /**
+     * A logger with the category {@code org.wildfly.extension.batch}.
+     */
+    MicroProfileHealthLogger LOGGER = Logger.getMessageLogger(MicroProfileHealthLogger.class, "org.wildfly.extension.microprofile.health.smallrye");
+
+    /**
+     * Logs an informational message indicating the naming subsystem is being activated.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 1, value = "Activating Eclipse MicroProfile Health Subsystem")
+    void activatingSubsystem();
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/CDIExtension.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/CDIExtension.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health.deployment;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeShutdown;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.Unmanaged;
+import javax.enterprise.inject.spi.Unmanaged.UnmanagedInstance;
+import javax.enterprise.inject.spi.WithAnnotations;
+
+import io.smallrye.health.SmallRyeHealthReporter;
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.wildfly.extension.microprofile.health._private.MicroProfileHealthLogger;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+public class CDIExtension implements Extension {
+
+    private final SmallRyeHealthReporter healthReporter;
+    private List<AnnotatedType<? extends HealthCheck>> delegates = new ArrayList<>();
+    private Collection<UnmanagedInstance<HealthCheck>> healthCheckInstances = new ArrayList<>();
+
+    public CDIExtension(SmallRyeHealthReporter healthReporter) {
+        this.healthReporter = healthReporter;
+    }
+
+    /**
+     * Discover all classes that implements HealthCheckProcedure
+     */
+    public void observeResources(@Observes @WithAnnotations({Health.class})  ProcessAnnotatedType<? extends HealthCheck> event) {
+        AnnotatedType<? extends HealthCheck> annotatedType = event.getAnnotatedType();
+        Class<? extends HealthCheck> javaClass = annotatedType.getJavaClass();
+        MicroProfileHealthLogger.LOGGER.infof("Discovered health check procedure %s", javaClass);
+        delegates.add(annotatedType);
+    }
+
+    /**
+     * Instantiates <em>unmanaged instances</em> of HealthCheckProcedure and
+     * handle manually their CDI creation lifecycle.
+     * Add them to the {@link SmallRyeHealthReporter}.
+     */
+    private void afterDeploymentValidation(@Observes final AfterDeploymentValidation avd, BeanManager bm) {
+        for (AnnotatedType delegate : delegates) {
+            try {
+                Unmanaged<HealthCheck> unmanagedHealthCheck = new Unmanaged<HealthCheck>(bm, delegate.getJavaClass());
+                UnmanagedInstance<HealthCheck> healthCheckInstance = unmanagedHealthCheck.newInstance();
+                HealthCheck healthCheck =  healthCheckInstance.produce().inject().postConstruct().get();
+                healthCheckInstances.add(healthCheckInstance);
+                healthReporter.addHealthCheck(healthCheck);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to register health bean", e);
+            }
+        }
+    }
+
+    /**
+     * Called when the deployment is undeployed.
+     *
+     * Remove all the instances of {@link HealthCheck} from the {@link SmallRyeHealthReporter}.
+     * Handle manually their CDI destroy lifecycle.
+     */
+    public void close(@Observes final BeforeShutdown bs) {
+        healthCheckInstances.forEach(healthCheck -> {
+            healthReporter.removeHealthCheck(healthCheck.get());
+            healthCheck.preDestroy().dispose();
+        });
+        healthCheckInstances.clear();
+    }
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DependencyProcessor.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DependencyProcessor.java
@@ -1,0 +1,36 @@
+package org.wildfly.extension.microprofile.health.deployment;
+
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Add dependencies required by deployment unit to access the Config API (programmatically or using CDI).
+ */
+public class DependencyProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+
+        addModuleDependencies(deploymentUnit);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    private void addModuleDependencies(DeploymentUnit deploymentUnit) {
+        final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+        final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.eclipse.microprofile.health.api", false, false, true, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "io.smallrye.health", false, false, true, false));
+    }
+
+}

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health.deployment;
+
+import io.smallrye.health.SmallRyeHealthReporter;
+import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
+import org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition;
+
+/**
+ */
+public class DeploymentProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
+            final SmallRyeHealthReporter healthReporter = (SmallRyeHealthReporter) phaseContext.getServiceRegistry().getService(MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_SERVICE).getValue();
+
+            WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit);
+            extensions.registerExtensionInstance(new CDIExtension(healthReporter), deploymentUnit);
+        }
+
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+
+    }
+}

--- a/microprofile/health-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
+++ b/microprofile/health-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.wildfly.extension.microprofile.health.MicroProfileHealthExtension

--- a/microprofile/health-smallrye/src/main/resources/org/wildfly/extension/microprofile/health/LocalDescriptions.properties
+++ b/microprofile/health-smallrye/src/main/resources/org/wildfly/extension/microprofile/health/LocalDescriptions.properties
@@ -1,0 +1,5 @@
+microprofile-health-smallrye=WildFly Extension for Eclipse MicroProfile Health With SmallRye
+microprofile-health-smallrye.add=Add the subsystem
+microprofile-health-smallrye.remove=Remove the subsystem
+microprofile-health-smallrye.check=Check the healthiness of the application server and its deployments
+microprofile-health-smallrye.security-enabled=True if authentication is required to access the HTTP endpoint on the HTTP management interface.

--- a/microprofile/health-smallrye/src/main/resources/schema/wildfly-microprofile-health-smallrye_1_0.xsd
+++ b/microprofile/health-smallrye/src/main/resources/schema/wildfly-microprofile-health-smallrye_1_0.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:wildfly:microprofile-health-smallrye:1.0"
+           xmlns="urn:wildfly:microprofile-health-smallrye:1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:attribute name="security-enabled" type="xs:boolean" default="true" />
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/microprofile/health-smallrye/src/main/resources/subsystem-templates/microprofile-health-smallrye.xml
+++ b/microprofile/health-smallrye/src/main/resources/subsystem-templates/microprofile-health-smallrye.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.wildfly.extension.microprofile.health-smallrye</extension-module>
+    <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:1.0" security-enabled="false">
+    </subsystem>
+</config>

--- a/microprofile/health-smallrye/src/test/java/org/wildfly/extension/microprofile/health/Subsystem_1_0_ParsingTestCase.java
+++ b/microprofile/health-smallrye/src/test/java/org/wildfly/extension/microprofile/health/Subsystem_1_0_ParsingTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.health;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
+
+    public Subsystem_1_0_ParsingTestCase() {
+        super(MicroProfileHealthExtension.SUBSYSTEM_NAME, new MicroProfileHealthExtension());
+    }
+
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem_1_0.xml");
+    }
+
+    @Override
+    protected String[] getSubsystemTemplatePaths() throws IOException {
+        return new String[] {
+                "/subsystem-templates/microprofile-health-smallrye.xml"
+        };
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws IOException {
+        return "schema/wildfly-microprofile-health-smallrye_1_0.xsd";
+    }
+
+    protected Properties getResolvedProperties() {
+        return System.getProperties();
+    }
+
+
+
+}

--- a/microprofile/health-smallrye/src/test/resources/org/wildfly/extension/microprofile/health/subsystem_1_0.xml
+++ b/microprofile/health-smallrye/src/test/resources/org/wildfly/extension/microprofile/health/subsystem_1_0.xml
@@ -1,0 +1,1 @@
+<subsystem xmlns="urn:wildfly:microprofile-health-smallrye:1.0" security-enabled="${security-enabled:true}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,9 @@
         <module>mail</module>
         <module>messaging-activemq</module>
         <module>microprofile/config-smallrye</module>
-        <module>microprofile/opentracing-smallrye</module>
+        <module>microprofile/health-smallrye</module>
         <module>microprofile/opentracing-extension</module>
+        <module>microprofile/opentracing-smallrye</module>
         <module>mod_cluster</module>
         <module>naming</module>
         <module>picketlink</module>
@@ -164,13 +165,13 @@
         <server.output.dir.prefix>wildfly</server.output.dir.prefix>
         <!-- Version suffix that is appended to directories. Default is the maven GAV version but this can be edited to use a short form version -->
         <server.output.dir.version>${project.version}</server.output.dir.version>
-        
+
         <!-- Surefire args -->
         <surefire.extra.args></surefire.extra.args>
         <surefire.jpda.args></surefire.jpda.args>
         <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=256m ${surefire.jpda.args} ${surefire.extra.args} ${surefire.jacoco.args}</surefire.system.args>
         <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
-        
+
         <!-- use older version of checkstyle as otherwise lots of checks fail -->
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
@@ -237,6 +238,7 @@
         <version.io.opentracing.servlet>0.1.0</version.io.opentracing.servlet>
         <version.io.reactivex.rxjava>2.1.16</version.io.reactivex.rxjava>
         <version.io.smallrye.smallrye-config>1.3.3</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.3.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -280,6 +282,7 @@
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
+        <version.org.eclipse.microprofile.health.api>1.0</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.opentracing>1.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.0.1</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.1</version.org.eclipse.yasson>
@@ -478,7 +481,7 @@
                 <artifactId>jipijapa-hibernate5-legacy</artifactId>
                 <version>${project.version}</version>
             </dependency>
- 
+
            <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>jipijapa-hibernate5-3-legacy</artifactId>
@@ -869,6 +872,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-microprofile-config-smallrye</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>wildfly-microprofile-health-smallrye</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -1457,6 +1466,12 @@
                         <artifactId>javax.annotation-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-health</artifactId>
+                <version>${version.io.smallrye.smallrye-health}</version>
             </dependency>
 
             <dependency>
@@ -3620,6 +3635,12 @@
                 <groupId>org.eclipse.microprofile.config</groupId>
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${version.org.eclipse.microprofile.config.api}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.health</groupId>
+                <artifactId>microprofile-health-api</artifactId>
+                <version>${version.org.eclipse.microprofile.health.api}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthCheckOperationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthCheckOperationTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthCheckOperationTestCase extends MicroProfileHealthTestBase{
+
+    void checkGlobalOutcome(ManagementClient managementClient, boolean mustBeUP, String probeName) throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "microprofile-health-smallrye");
+        ModelNode checkOp = getEmptyOperation("check", address);
+
+        ModelNode response = managementClient.getControllerClient().execute(checkOp);
+
+        final String opOutcome = response.get("outcome").asString();
+        assertEquals("success", opOutcome);
+
+        ModelNode result = response.get("result");
+        assertEquals(mustBeUP? "UP" : "DOWN", result.get("outcome").asString());
+
+        if (probeName != null) {
+            for (ModelNode check : result.get("checks").asList()) {
+                if (probeName.equals(check.get("name").asString())) {
+                    // probe name found
+                    // global outcome is driven by this probe state
+                    assertEquals(mustBeUP? "UP" : "DOWN", check.get("state").asString());
+                    return;
+                }
+            }
+            fail("Probe named " + probeName + " not found in " + result);
+        }
+
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthHTTPEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthHTTPEndpointTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.as.arquillian.container.ManagementClient;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileHealthHTTPEndpointTestCase extends MicroProfileHealthTestBase{
+
+    void checkGlobalOutcome(ManagementClient managementClient, boolean mustBeUP, String probeName) throws IOException {
+
+        final String healthURL = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/health";
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+
+            CloseableHttpResponse resp = client.execute(new HttpGet(healthURL));
+            assertEquals(mustBeUP ? 200 : 503, resp.getStatusLine().getStatusCode());
+
+            String content = getContent(resp);
+            resp.close();
+
+            try (
+                    JsonReader jsonReader = Json.createReader(new StringReader(content))
+            ) {
+                JsonObject payload = jsonReader.readObject();
+                String outcome = payload.getString("outcome");
+                assertEquals(mustBeUP ? "UP": "DOWN", outcome);
+
+                if (probeName != null) {
+                    for (JsonValue check : payload.getJsonArray("checks")) {
+                        if (probeName.equals(check.asJsonObject().getString("name"))) {
+                            // probe name found
+                            assertEquals(mustBeUP ? "UP" : "DOWN", check.asJsonObject().getString("state"));
+                            return;
+                        }
+                    }
+                    fail("Probe named " + probeName + " not found in " + content);
+                }
+            }
+        }
+    }
+
+    public static String getContent(HttpResponse response) throws IOException {
+        try (InputStream stream = response.getEntity().getContent()){
+            StringBuilder builder = new StringBuilder();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
+            char[] buff = new char[512];
+            int read;
+            while ((read = reader.read(buff)) != -1) {
+                builder.append(buff, 0, read);
+            }
+            return builder.toString();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthTestBase.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public abstract class MicroProfileHealthTestBase {
+
+    abstract void checkGlobalOutcome(ManagementClient managementClient, boolean mustBeUP, String probeName) throws IOException;
+
+    @Deployment(name = "MicroProfileHealthTestCase", managed = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthTestCase.war")
+                .addClasses(TestApplication.class, TestApplication.Resource.class, MyProbe.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Test
+    @InSequence(1)
+    public void testHealthCheckBeforeDeployment() throws Exception {
+        checkGlobalOutcome(managementClient, true, null);
+
+        // deploy the archive
+        deployer.deploy("MicroProfileHealthTestCase");
+    }
+
+    @Test
+    @InSequence(2)
+    @OperateOnDeployment("MicroProfileHealthTestCase")
+    public void testHealthCheckAfterDeployment(@ArquillianResource URL url) throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+
+            checkGlobalOutcome(managementClient, true, "myProbe");
+
+            HttpPost request = new HttpPost(url + "microprofile/myApp");
+            List<NameValuePair> nvps = new ArrayList<NameValuePair>();
+            nvps.add(new BasicNameValuePair("up", "false"));
+            request.setEntity(new UrlEncodedFormEntity(nvps));
+
+            CloseableHttpResponse response = client.execute(request);
+            System.out.println("response = " + response);
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            checkGlobalOutcome(managementClient, false, "myProbe");
+        }
+    }
+
+    @Test
+    @InSequence(3)
+    public void testHealthCheckAfterUndeployment() throws Exception {
+
+        deployer.undeploy("MicroProfileHealthTestCase");
+
+        checkGlobalOutcome(managementClient, true, null);
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MyProbe.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MyProbe.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import org.eclipse.microprofile.health.Health;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@Health
+public class MyProbe implements HealthCheck {
+
+    static boolean up = true;
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named("myProbe")
+                .state(up)
+                .build();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/TestApplication.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@ApplicationPath("/microprofile")
+public class TestApplication extends Application {
+
+    @Path("/myApp")
+    public static class Resource {
+
+        @POST
+        @Produces("text/plain")
+        public Response changeProbeOutcome(@FormParam("up") boolean up) {
+            MyProbe.up = up;
+            return Response.ok().build();
+        }
+    }
+
+}


### PR DESCRIPTION
* add microprofile-smallrye-health extension
* the MicroProfile Health implementation is provided by smallrye-health
  1.0.2
* Healthiness can be queried by:
  * the `check` operation on the `/subsystem=microprofile-health-smallrye` resource
  * the HTTP endpoint http://localhost:9990/health

The HTTP endpoint is attached to WildFly HTTP management interface.
It secure access is controlled by the `security-enabled` attribute.
Default value i set to `true` (i.e. authentication is required) but the
attribute is set to `false` in the standalone configuration.

JIRA: https://issues.jboss.org/browse/WFLY-10711
Proposal: https://github.com/wildfly/wildfly-proposals/pull/105

This PR has a downstream dependency on WFCORE-3999 that has been submitted in https://github.com/wildfly/wildfly-core/pull/3427

----
Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [x] Pull Request requires a change to the documentation
- [x] Documentation have been updated accordingly
- [x] Tests were added to cover changes

For new features ensure as well:
- [x] Analysis was done
- [x] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.