### PR TITLE
[WFLY-10818] Exclude org.wildfly transitive dependencies from the wildfly server feature pack used by the clustering tests

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -61,6 +61,12 @@
             <version>${version.org.jboss.infinispan-wildfly}</version>
             <type>zip</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Jira issue: https://issues.jboss.org/browse/WFLY-10818

cc: @jamezp