### PR TITLE
WFLY-10795 Non-Elytron SSL configuration won't establish secure channel between worker and balancer

### DIFF
--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemServiceHandler.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemServiceHandler.java
@@ -72,7 +72,7 @@ class ModClusterSubsystemServiceHandler implements ResourceServiceHandler {
                 String proxyName = proxyResource.getName();
                 PathAddress proxyAddress = context.getCurrentAddress().append(ProxyConfigurationResourceDefinition.pathElement(proxyName));
                 adapterNames.add(proxyName);
-                ModelNode proxyModel = proxyResource.getModel();
+                ModelNode proxyModel = Resource.Tools.readModel(proxyResource);
 
                 ServiceTarget target = context.getServiceTarget();
                 ProxyConfigurationServiceConfigurator configurationBuilder = new ProxyConfigurationServiceConfigurator(proxyAddress);

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ProxyConfigurationServiceConfigurator.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ProxyConfigurationServiceConfigurator.java
@@ -287,9 +287,9 @@ import org.wildfly.clustering.service.SupplierDependency;
             }
             node = PASSWORD.resolveModelAttribute(context, sslModel);
             if (node.isDefined()) {
-                String str = node.toString();
-                sslConfiguration.setSslTrustStorePassword(str);
-                sslConfiguration.setSslKeyStorePassword(str);
+                String password = node.asString();
+                sslConfiguration.setSslTrustStorePassword(password);
+                sslConfiguration.setSslKeyStorePassword(password);
             }
             node = CERTIFICATE_KEY_FILE.resolveModelAttribute(context, sslModel);
             if (node.isDefined()) {

--- a/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_3_0.xml
+++ b/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_3_0.xml
@@ -76,5 +76,14 @@
             <custom-load-metric class="SomeFakeLoadMetricClass3"
                                 weight="${modcluster.custom-load-metric.weight:5}"/>
         </dynamic-load-provider>
+        <!-- The legacy SSL resource cannot be used in conjunction with Elytron SSL context in runtime,
+         but this is fine for the parsing test -->
+        <ssl ca-certificate-file="${modcluster.ca-certificate-file:/home/rhusar/client-keystore.jks}"
+             ca-revocation-url="${modcluster.ca-revocation-url:/home/rhusar/revocations}"
+             certificate-key-file="${modcluster.certificate-key-file:/home/rhusar/client-keystore.jks}"
+             cipher-suite="${modcluster.cipher-suite:SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA}"
+             key-alias="${modcluster.key-alias:mykeyalias}"
+             password="${modcluster.password:mypassword}"
+             protocol="${modcluster.protocol:TLSv1}"/>
     </mod-cluster-config>
 </subsystem>

--- a/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_4_0.xml
+++ b/mod_cluster/extension/src/test/resources/org/wildfly/extension/mod_cluster/subsystem_4_0.xml
@@ -81,5 +81,12 @@
     <proxy name="other"
            connector="default">
         <simple-load-provider factor="${modcluster.simple-load-provider.factor:15}"/>
+        <ssl ca-certificate-file="${modcluster.ca-certificate-file:/home/rhusar/client-keystore.jks}"
+             ca-revocation-url="${modcluster.ca-revocation-url:/home/rhusar/revocations}"
+             certificate-key-file="${modcluster.certificate-key-file:/home/rhusar/client-keystore.jks}"
+             cipher-suite="${modcluster.cipher-suite:SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA,SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA,SSL_RSA_WITH_3DES_EDE_CBC_SHA}"
+             key-alias="${modcluster.key-alias:mykeyalias}"
+             password="${modcluster.password:mypassword}"
+             protocol="${modcluster.protocol:TLSv1}"/>
     </proxy>
 </subsystem>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-10795 Non-Elytron SSL configuration won't establish secure channel between worker and balancer
https://issues.jboss.org/browse/WFLY-10836 mod_cluster uses wrong password for credential stores (regression after removing lambdas)
https://issues.jboss.org/browse/WFLY-10834 Load provider settings is not taken into account in mod_cluster subsystem