### PR TITLE
[WFLY-10827] Exclude hornetq-journal dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3878,6 +3878,12 @@
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-commons</artifactId>
                 <version>${version.org.hornetq}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hornetq</groupId>
+                        <artifactId>hornetq-journal</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -3890,6 +3896,12 @@
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-jms-client</artifactId>
                 <version>${version.org.hornetq}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hornetq</groupId>
+                        <artifactId>hornetq-journal</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>


### PR DESCRIPTION
Exclude org.hornetq:hornet-journal transitive dependency.
There is no longer any HornetQ runtime in WildFly and these transitive
dependencies are not required by the legacy messaging subsystem (which
still reference a few HornetQ API interfaces or enums).

JIRA: https://issues.jboss.org/browse/WFLY-10827