### PR TITLE
WFLY-10341 Enable EclipseLink integration tests for Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.rest.client.api>1.0.1</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.1</version.org.eclipse.yasson>
-        <version.org.eclipselink.version>2.7.1</version.org.eclipselink.version>
+        <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/EclipseLinkSharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/EclipseLinkSharedModuleProviderTestCase.java
@@ -37,14 +37,13 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * @author Scott Marlow
  */
-@Ignore("WFLY-10177")
+
 @RunWith(Arquillian.class)
 public class EclipseLinkSharedModuleProviderTestCase {
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10341
This change improves our JDK 10 testing to include EcliseLink (also seems to help with JDK11 build 11-ea+25 as well).