### PR TITLE
[WFLY-10828] Upgrade WildFly Core 6.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.Alpha5</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10828

---


# Release Notes - WildFly Core - Version 6.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3981'>WFCORE-3981</a>] -         Upgrade jboss-logging from 3.3.1.Final to 3.3.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3990'>WFCORE-3990</a>] -         Upgrade Byteman to 4.0.4 for better JDK9+ support
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4003'>WFCORE-4003</a>] -         Upgrade xnio to 3.6.4
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4006'>WFCORE-4006</a>] -         Undertow 2.0.12.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4009'>WFCORE-4009</a>] -         Upgrade VFS to 3.2.13
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4011'>WFCORE-4011</a>] -         Upgrade WildFly Elytron to 1.5.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4013'>WFCORE-4013</a>] -         Upgrade Elytron Web to 1.2.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4016'>WFCORE-4016</a>] -         Upgrade WildFly Elytron to 1.5.3.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4021'>WFCORE-4021</a>] -         Upgrade WildFly Elytron Tool to 1.3.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4019'>WFCORE-4019</a>] -         Add a line to standalone.conf to enable experimental JDK 11 support for ByteBuddy
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-433'>WFCORE-433</a>] -         git backend for loading/storing the configuration XML for wildfly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-2953'>WFCORE-2953</a>] -         Add a socket-handler resource to the logging subsystem
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3970'>WFCORE-3970</a>] -         Add a management operation to allow an Elytron trust-manager to be re-initialized
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3991'>WFCORE-3991</a>] -         read-config-as-features management operation
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3999'>WFCORE-3999</a>] -         Allow registering a custom HTTP handler for management interface
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-37'>WFCORE-37</a>] -         Batching logging profile creation CLI commands can cause errors
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3768'>WFCORE-3768</a>] -         Intermittent failure in SuspendOnSoftKillTestCase
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3797'>WFCORE-3797</a>] -         Logging Subsystem test failures on IBM jdk
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3869'>WFCORE-3869</a>] -         [jdk10] DeletionCollisionTest#testFileLockByRemoveContent failure
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3874'>WFCORE-3874</a>] -         [jdk10] FileSystemDeploymentServiceUnitTestCase#testNoUndeployment failure
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3875'>WFCORE-3875</a>] -         [jdk10] PatchModuleInvalidationWithRenamingFailureTestCase#test failure
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3885'>WFCORE-3885</a>] -         XNIO prints WARNING with JDK10+ if CLI connects to server
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3942'>WFCORE-3942</a>] -         Completion is crashing the console
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3946'>WFCORE-3946</a>] -         Adding an outbound socket binding to the ControllerIntializer requires a dummy socket binding to be added
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3984'>WFCORE-3984</a>] -         WildFly Core TS failures on Java 11 (--add-modules java.se) 
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3988'>WFCORE-3988</a>] -         Domain prints WARNING with JDK10+ during start-up (XNIO illegal reflective access)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3992'>WFCORE-3992</a>] -         InstallationManagerService should not allow duplicate module paths
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3993'>WFCORE-3993</a>] -         Elytron module compilation failure due to &quot;package sun.security.ec does not exist&quot; on IBM jdk
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4007'>WFCORE-4007</a>] -         elytron.KeyStoresTestCase fails on IBM jdk
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4014'>WFCORE-4014</a>] -         Truststore re-initialization not implemented correctly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4015'>WFCORE-4015</a>] -         Ensure the certificate-authority-account create-account operation returns an appropriate message if the account already exists
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4020'>WFCORE-4020</a>] -         Update the staging URL for the Let&#39;s Encrypt certificate-authority
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3519'>WFCORE-3519</a>] -         Add JASPI Module
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3927'>WFCORE-3927</a>] -         Bump logging subsystem schema and model version
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3994'>WFCORE-3994</a>] -         Add HostExcludeResourceDefinition.KnownRelease item for WildFly 13
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4005'>WFCORE-4005</a>] -         Refactor parsing for new elements added to version 4 of the Elytron schema
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4010'>WFCORE-4010</a>] -         Adjust provisioning configs to reduce configuration diff noise
</li>
</ul>
                                    