### PR TITLE
[WFLY-10838] Upgrade to Galleon and WildFly Galleon Plugins 2.0.0.Beta1

### DIFF
--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -22,6 +22,8 @@
 
 <build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly@maven(org.jboss.universe:community-universe):current">
 
+    <include-plugin>false</include-plugin>
+
     <transitive>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>

--- a/pom.xml
+++ b/pom.xml
@@ -173,13 +173,13 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>2.0.0.Alpha4</version.org.jboss.galleon>
+        <version.org.jboss.galleon>2.0.0.Beta1</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>2.0.0.Alpha5</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>2.0.0.Beta1</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->

--- a/servlet-galleon-pack/wildfly-feature-pack-build.xml
+++ b/servlet-galleon-pack/wildfly-feature-pack-build.xml
@@ -21,6 +21,9 @@
   -->
 
 <build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly-servlet@maven(org.jboss.universe:community-universe):current">
+
+    <include-plugin>false</include-plugin>
+
     <dependencies>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10838

include-plugin=false indicates that provisioning plugins (as JARs) should not be included into the feature-packs. In case of wildfly, the plugins are going to be inherited from wildfly-core anyway.