### PR TITLE
WFLY-10839 RetryingInvoker fails with millisecond timeouts | WFLY-10840 CacheServiceProviderRegistry interval too large

### DIFF
--- a/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/retry/RetryingInvoker.java
+++ b/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/retry/RetryingInvoker.java
@@ -57,7 +57,7 @@ public class RetryingInvoker implements Invoker {
                 Thread.yield();
             } else {
                 try {
-                    Thread.sleep(delay.toMillis(), delay.getNano());
+                    Thread.sleep(delay.toMillis(), delay.getNano() % 1_000_000);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }

--- a/clustering/ee/spi/src/test/java/org/wildfly/clustering/ee/retry/RetryingInvokerTestCase.java
+++ b/clustering/ee/spi/src/test/java/org/wildfly/clustering/ee/retry/RetryingInvokerTestCase.java
@@ -46,7 +46,7 @@ public class RetryingInvokerTestCase {
         Object expected = new Object();
         ExceptionSupplier<Object, Exception> action = mock(ExceptionSupplier.class);
 
-        Invoker invoker = new RetryingInvoker(Duration.ZERO, Duration.ZERO);
+        Invoker invoker = new RetryingInvoker(Duration.ZERO, Duration.ofMillis(1));
 
         when(action.get()).thenReturn(expected);
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
@@ -85,7 +85,7 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
         return WildFlySecurityManager.doUnchecked(action);
     }
 
-    private static final Invoker INVOKER = new RetryingInvoker(Duration.ZERO, Duration.ofMillis(100), Duration.ofSeconds(500));
+    private static final Invoker INVOKER = new RetryingInvoker(Duration.ZERO, Duration.ofMillis(100), Duration.ofSeconds(1));
 
     final Batcher<? extends Batch> batcher;
     private final ConcurrentMap<T, Map.Entry<Listener, ExecutorService>> listeners = new ConcurrentHashMap<>();


### PR DESCRIPTION
Jiras
https://issues.jboss.org/browse/WFLY-10839
https://issues.jboss.org/browse/WFLY-10840
