### PR TITLE
WFLY-10480 ElytronSecurityDomainContextImpl does not propagate authenticated subject - take 2

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Using_WildFly_Elytron_with_WildFly.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_WildFly_Elytron_with_WildFly.adoc
@@ -198,6 +198,31 @@ for elytron security domain automatically. Like configure with legacy
 security domain, you can configure elytron security domain in deployment
 descriptor or annotation to secure webservice endpoint.
 
+When Elytron security is enabled, JAAS subject or principal can be pushed
+to jbossws-cxf endpoint’s SecurityContext to propagate authenticated
+identity to EJB container. Here is a CXF interceptor example to
+propagate authenticated information to EJB container :
+[source, java]
+----
+public class PropagateSecurityInterceptor extends WSS4JInInterceptor {
+
+   public PropagateSecurityInterceptor() {
+      super();
+      getAfter().add(PolicyBasedWSS4JInInterceptor.class.getName());
+   }
+
+   @Override
+   public void handleMessage(SoapMessage message) throws Fault {
+      ...
+      final Endpoint endpoint = message.getExchange().get(Endpoint.class);
+      final SecurityDomainContext securityDomainContext = endpoint.getSecurityDomainContext();
+      //push subject principal retrieved from CXF to ElytronSecurityDomainContext
+      securityDomainContext.pushSubjectContext(subject, principal, null)
+   }
+
+}
+
+----
 [[legacy-security-subsystem]]
 == Legacy Security Subsystem
 

--- a/pom.xml
+++ b/pom.xml
@@ -336,9 +336,9 @@
         <version.org.jboss.ws.api>1.1.1.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.2.1.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.1.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>5.2.2.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>5.2.3.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
-        <version.org.jboss.ws.spi>3.2.1.Final</version.org.jboss.ws.spi>
+        <version.org.jboss.ws.spi>3.2.2.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.2.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jgroups>4.0.13.Final</version.org.jgroups>
@@ -5694,6 +5694,10 @@
                 <artifactId>jbossws-cxf-transports-undertow</artifactId>
                 <version>${version.org.jboss.ws.cxf}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>
                         <artifactId>cxf-rt-frontend-jaxws</artifactId>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/ContextProvider.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/ContextProvider.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+public interface ContextProvider {
+
+   String getEjbCallerPrincipalName();
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/ContextProviderBean.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/ContextProviderBean.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+import javax.annotation.Resource;
+import javax.annotation.security.PermitAll;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+
+@Stateless
+@PermitAll
+@Remote(ContextProvider.class)
+public class ContextProviderBean implements ContextProvider{
+
+     @Resource SessionContext context;
+
+     public String getEjbCallerPrincipalName() {
+        return context.getCallerPrincipal().getName();
+    }
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/SamlSecurityContextInInterceptor.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/SamlSecurityContextInInterceptor.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.common.security.SimplePrincipal;
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.security.DefaultSecurityContext;
+import org.apache.cxf.security.SecurityContext;
+import org.apache.cxf.ws.security.wss4j.PolicyBasedWSS4JInInterceptor;
+import org.apache.cxf.ws.security.wss4j.WSS4JInInterceptor;
+import org.jboss.wsf.spi.deployment.Endpoint;
+import org.jboss.wsf.spi.security.SecurityDomainContext;
+
+import javax.security.auth.Subject;
+import java.security.Principal;
+import java.util.Collections;
+
+public class SamlSecurityContextInInterceptor extends WSS4JInInterceptor {
+
+   public SamlSecurityContextInInterceptor() {
+      super();
+      getAfter().add(PolicyBasedWSS4JInInterceptor.class.getName());
+   }
+
+   @Override
+   public void handleMessage(SoapMessage message) throws Fault {
+      final SecurityContext securityContext = message.get(SecurityContext.class);
+      final Principal principal = securityContext.getUserPrincipal();
+      final String name = principal.getName();
+      final Endpoint endpoint = message.getExchange().get(Endpoint.class);
+      final SecurityDomainContext securityDomainContext = endpoint.getSecurityDomainContext();
+      Principal simplePrincipal = new SimplePrincipal(name);
+      Subject subject = new Subject(false, Collections.singleton(simplePrincipal), Collections.emptySet(), Collections.emptySet());
+      securityDomainContext.pushSubjectContext(subject, simplePrincipal, null);
+      message.put(SecurityContext.class, new DefaultSecurityContext(simplePrincipal, subject));
+   }
+
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-ejb3-elytron.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-ejb3-elytron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss:jboss
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+        xmlns:s="urn:security:1.1"
+        version="3.1" impl-version="2.0">
+    <assembly-descriptor>
+        <s:security>
+            <ejb-name>*</ejb-name>
+            <s:security-domain>ApplicationDomain</s:security-domain>
+        </s:security>
+    </assembly-descriptor>
+</jboss:jboss>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-ejb3.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-ejb3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss:jboss
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+        xmlns:s="urn:security:1.1"
+        version="3.1" impl-version="2.0">
+    <assembly-descriptor>
+        <s:security>
+            <ejb-name>*</ejb-name>
+            <s:security-domain>JBossWS-trust-sts</s:security-domain>
+        </s:security>
+    </assembly-descriptor>
+</jboss:jboss>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-web-elytron.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/jboss-web-elytron.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN" "http://www.jboss.org/j2ee/dtd/jboss-web_4_0.dtd">
+
+<jboss-web>
+    <security-domain>ApplicationDomain</security-domain>
+</jboss-web>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
@@ -1,0 +1,203 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+import static org.junit.Assert.assertEquals;
+import org.apache.commons.io.IOUtils;
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.StringTokenizer;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.Service;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.ws.WrapThreadContextClassLoader;
+import org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for WFLY-10480 with Elytron security domain
+ *
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(WSTrustTestCaseElytronSecuritySetupTask.class)
+public class WSBearerElytronSecurityPropagationTestCase {
+    private static final String BEARER_STS_DEP = "jaxws-samples-wsse-policy-trust-sts-bearer";
+    private static final String BEARER_SERVER_DEP = "jaxws-samples-wsse-policy-trust-bearer";
+    @Rule
+    public TestRule watcher = new WrapThreadContextClassLoaderWatcher();
+    @ArquillianResource
+    private URL serviceURL;
+
+
+    @Deployment(name = BEARER_STS_DEP, testable = false)
+    public static WebArchive createBearerSTSDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_STS_DEP + ".war");
+        archive
+                .setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.jboss.ws.cxf.sts annotations\n"))
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.stsbearer.STSBearerCallbackHandler.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.stsbearer.SampleSTSBearer.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.shared.WSTrustAppUtils.class)
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/bearer-ws-trust-1.4-service.wsdl"), "wsdl/bearer-ws-trust-1.4-service.wsdl")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/stsstore.jks", "classes/stsstore.jks")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/stsKeystore.properties", "classes/stsKeystore.properties")
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/permissions.xml", "permissions.xml")
+                .setWebXML(WSTrustTestCase.class.getPackage(), "WEB-INF/bearer/web.xml");
+        return archive;
+    }
+
+    @Deployment(name = BEARER_SERVER_DEP, testable = false)
+    public static WebArchive createBearerServerDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_SERVER_DEP + ".war");
+        archive
+                .setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        //+ "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl,org.apache.cxf.ws-security\n"))
+                        + "Dependencies: org.apache.cxf.impl,org.apache.cxf,org.jboss.ws.spi,org.jboss.ws.cxf.jbossws-cxf-server,"
+                        + "org.apache.ws.security,org.jboss.ws.jaxws-client\n"))
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHello.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHelloResponse.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerEJBImpl.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SamlSecurityContextInInterceptor.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.ContextProvider.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.ContextProviderBean.class)
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/jboss-web-elytron.xml", "jboss-web.xml")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/jboss-ejb3-elytron.xml", "jboss-ejb3.xml")
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/BearerService.wsdl"), "wsdl/BearerService.wsdl")
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/BearerService_schema1.xsd"), "wsdl/BearerService_schema1.xsd")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/servicestore.jks", "classes/servicestore.jks")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/serviceKeystore.properties", "classes/serviceKeystore.properties");
+        return archive;
+    }
+
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment(BEARER_SERVER_DEP)
+    @WrapThreadContextClassLoader
+    public void testBearer() throws Exception {
+        Bus bus = BusFactory.newInstance().createBus();
+        try {
+            BusFactory.setThreadDefaultBus(bus);
+
+            final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/bearerwssecuritypolicy", "BearerService");
+            Service service = Service.create(new URL(serviceURL + "BearerService?wsdl"), serviceName);
+            BearerIface proxy = (BearerIface) service.getPort(BearerIface.class);
+
+            WSTrustTestUtils.setupWsseAndSTSClientBearer((BindingProvider) proxy, bus);
+            assertEquals("alice&alice", proxy.sayHello());
+
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            bus.shutdown(true);
+        }
+    }
+
+
+    private static String replaceNodeAddress(String resourceName) {
+        String content = null;
+        try {
+            content = IOUtils.toString(WSTrustTestCase.class.getResourceAsStream(resourceName), "UTF-8");
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during replacing node address in resource", e);
+        }
+        return content.replaceAll("@node0@", NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "127.0.0.1")));
+    }
+
+    private static StringAsset createFilteredAsset(String resourceName) {
+        return new StringAsset(replaceNodeAddress(resourceName));
+    }
+    /**
+     * @return comma- or space-separated list of absolute paths to client jars
+     */
+    private String getClientJarPaths() throws IOException {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jaxws-samples-wsse-policy-trust-client.jar");
+        jar.addManifest()
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/clientKeystore.properties", "clientKeystore.properties")
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/clientstore.jks", "clientstore.jks");
+        File jarFile = new File(TestSuiteEnvironment.getTmpDir(), "jaxws-samples-wsse-policy-trust-client.jar");
+        jar.as(ZipExporter.class).exportTo(jarFile, true);
+        return jarFile.getAbsolutePath();
+    }
+    class WrapThreadContextClassLoaderWatcher extends TestWatcher {
+
+        private ClassLoader classLoader = null;
+
+        protected void starting(Description description) {
+            try {
+                final String cjp = getClientJarPaths();
+
+                if (cjp == null || cjp.trim().isEmpty()) {
+                    return;
+                }
+                if (description.getAnnotation(WrapThreadContextClassLoader.class) != null) {
+
+                    classLoader = Thread.currentThread().getContextClassLoader();
+
+                    StringTokenizer st = new StringTokenizer(cjp, ", ");
+                    URL[] archives = new URL[st.countTokens()];
+
+                    for (int i = 0; i < archives.length; i++) {
+                        archives[i] = new File(st.nextToken()).toURI().toURL();
+                    }
+
+                    URLClassLoader cl = new URLClassLoader(archives, classLoader);
+                    Thread.currentThread().setContextClassLoader(cl);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        protected void finished(Description description) {
+
+            if (classLoader != null && description.getAnnotation(WrapThreadContextClassLoader.class) != null) {
+                Thread.currentThread().setContextClassLoader(classLoader);
+            }
+        }
+    }
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerElytronSecurityPropagationTestCase.java
@@ -94,9 +94,7 @@ public class WSBearerElytronSecurityPropagationTestCase {
         WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_SERVER_DEP + ".war");
         archive
                 .setManifest(new StringAsset("Manifest-Version: 1.0\n"
-                        //+ "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl,org.apache.cxf.ws-security\n"))
-                        + "Dependencies: org.apache.cxf.impl,org.apache.cxf,org.jboss.ws.spi,org.jboss.ws.cxf.jbossws-cxf-server,"
-                        + "org.apache.ws.security,org.jboss.ws.jaxws-client\n"))
+                        + "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl\n"))
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHello.class)
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHelloResponse.class)
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface.class)

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
@@ -1,0 +1,202 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+import static org.junit.Assert.assertEquals;
+import org.apache.commons.io.IOUtils;
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.StringTokenizer;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.Service;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.ws.WrapThreadContextClassLoader;
+import org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for WFLY-10480 with legacy security domain
+ *
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(WSTrustTestCaseSecuritySetupTask.class)
+public class WSBearerSecurityPropagationTestCase {
+    private static final String BEARER_STS_DEP = "jaxws-samples-wsse-policy-trust-sts-bearer";
+    private static final String BEARER_SERVER_DEP = "jaxws-samples-wsse-policy-trust-bearer";
+    @Rule
+    public TestRule watcher = new WrapThreadContextClassLoaderWatcher();
+    @ArquillianResource
+    private URL serviceURL;
+
+
+    @Deployment(name = BEARER_STS_DEP, testable = false)
+    public static WebArchive createBearerSTSDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_STS_DEP + ".war");
+        archive
+                .setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.jboss.ws.cxf.sts annotations\n"))
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.stsbearer.STSBearerCallbackHandler.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.stsbearer.SampleSTSBearer.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.shared.WSTrustAppUtils.class)
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/bearer-ws-trust-1.4-service.wsdl"), "wsdl/bearer-ws-trust-1.4-service.wsdl")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/stsstore.jks", "classes/stsstore.jks")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/stsKeystore.properties", "classes/stsKeystore.properties")
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/permissions.xml", "permissions.xml")
+                .setWebXML(WSTrustTestCase.class.getPackage(), "WEB-INF/bearer/web.xml");
+        return archive;
+    }
+
+    @Deployment(name = BEARER_SERVER_DEP, testable = false)
+    public static WebArchive createBearerServerDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_SERVER_DEP + ".war");
+        archive
+                .setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.apache.cxf.impl,org.apache.cxf,org.jboss.ws.spi,org.jboss.ws.cxf.jbossws-cxf-server,"
+                        + "org.apache.ws.security,org.jboss.ws.jaxws-client\n"))
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHello.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHelloResponse.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerEJBImpl.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.SamlSecurityContextInInterceptor.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.ContextProvider.class)
+                .addClass(org.jboss.as.test.integration.ws.wsse.trust.ContextProviderBean.class)
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/jboss-web.xml", "jboss-web.xml")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/BearerService.wsdl"), "wsdl/BearerService.wsdl")
+                .addAsWebInfResource(createFilteredAsset("WEB-INF/wsdl/BearerService_schema1.xsd"), "wsdl/BearerService_schema1.xsd")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/servicestore.jks", "classes/servicestore.jks")
+                .addAsWebInfResource(WSTrustTestCase.class.getPackage(), "WEB-INF/serviceKeystore.properties", "classes/serviceKeystore.properties");
+        return archive;
+    }
+
+
+    @Test
+    @RunAsClient
+    @OperateOnDeployment(BEARER_SERVER_DEP)
+    @WrapThreadContextClassLoader
+    public void testBearer() throws Exception {
+        Bus bus = BusFactory.newInstance().createBus();
+        try {
+            BusFactory.setThreadDefaultBus(bus);
+
+            final QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/bearerwssecuritypolicy", "BearerService");
+            Service service = Service.create(new URL(serviceURL + "BearerService?wsdl"), serviceName);
+            BearerIface proxy = (BearerIface) service.getPort(BearerIface.class);
+
+            WSTrustTestUtils.setupWsseAndSTSClientBearer((BindingProvider) proxy, bus);
+            assertEquals("alice&alice", proxy.sayHello());
+
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            bus.shutdown(true);
+        }
+    }
+
+
+    private static String replaceNodeAddress(String resourceName) {
+        String content = null;
+        try {
+            content = IOUtils.toString(WSTrustTestCase.class.getResourceAsStream(resourceName), "UTF-8");
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during replacing node address in resource", e);
+        }
+        return content.replaceAll("@node0@", NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "127.0.0.1")));
+    }
+
+    private static StringAsset createFilteredAsset(String resourceName) {
+        return new StringAsset(replaceNodeAddress(resourceName));
+    }
+    /**
+     * @return comma- or space-separated list of absolute paths to client jars
+     */
+    private String getClientJarPaths() throws IOException {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jaxws-samples-wsse-policy-trust-client.jar");
+        jar.addManifest()
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/clientKeystore.properties", "clientKeystore.properties")
+                .addAsManifestResource(WSTrustTestCase.class.getPackage(), "META-INF/clientstore.jks", "clientstore.jks");
+        File jarFile = new File(TestSuiteEnvironment.getTmpDir(), "jaxws-samples-wsse-policy-trust-client.jar");
+        jar.as(ZipExporter.class).exportTo(jarFile, true);
+        return jarFile.getAbsolutePath();
+    }
+    class WrapThreadContextClassLoaderWatcher extends TestWatcher {
+
+        private ClassLoader classLoader = null;
+
+        protected void starting(Description description) {
+            try {
+                final String cjp = getClientJarPaths();
+
+                if (cjp == null || cjp.trim().isEmpty()) {
+                    return;
+                }
+                if (description.getAnnotation(WrapThreadContextClassLoader.class) != null) {
+
+                    classLoader = Thread.currentThread().getContextClassLoader();
+
+                    StringTokenizer st = new StringTokenizer(cjp, ", ");
+                    URL[] archives = new URL[st.countTokens()];
+
+                    for (int i = 0; i < archives.length; i++) {
+                        archives[i] = new File(st.nextToken()).toURI().toURL();
+                    }
+
+                    URLClassLoader cl = new URLClassLoader(archives, classLoader);
+                    Thread.currentThread().setContextClassLoader(cl);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        protected void finished(Description description) {
+
+            if (classLoader != null && description.getAnnotation(WrapThreadContextClassLoader.class) != null) {
+                Thread.currentThread().setContextClassLoader(classLoader);
+            }
+        }
+    }
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSBearerSecurityPropagationTestCase.java
@@ -94,8 +94,7 @@ public class WSBearerSecurityPropagationTestCase {
         WebArchive archive = ShrinkWrap.create(WebArchive.class, BEARER_SERVER_DEP + ".war");
         archive
                 .setManifest(new StringAsset("Manifest-Version: 1.0\n"
-                        + "Dependencies: org.apache.cxf.impl,org.apache.cxf,org.jboss.ws.spi,org.jboss.ws.cxf.jbossws-cxf-server,"
-                        + "org.apache.ws.security,org.jboss.ws.jaxws-client\n"))
+                        + "Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl\n"))
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHello.class)
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.SayHelloResponse.class)
                 .addClass(org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface.class)

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
@@ -1,0 +1,136 @@
+package org.jboss.as.test.integration.ws.wsse.trust;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.domain.management.ModelDescriptionConstants.SECURITY_REALM;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+
+public class WSTrustTestCaseElytronSecuritySetupTask implements ServerSetupTask {
+    public static final String HTTPS_SECURITY_REALM_NAME = "jbossws-https-realm";
+    public static final String SECURITY_REALM_NAME = "ApplicationRealm";
+    public static final String SECURITY_DOMAIN_NAME = "ApplicationDomain";
+    public static final String HTTPS_LISTENER_NAME = "jbossws-https-listener";
+
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+        addSecurityRealm(operations);
+        addHttpsListener(operations);
+        addElytronSecurityDomain(operations);
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+        removeHttpsListener(operations);
+        removeSecurityRealm(operations);
+        removeElytronSecurityDomain(operations);
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+        ServerReload.reloadIfRequired(managementClient);
+    }
+    /**
+     * Add https listner like this:
+     * <p/>
+     * /**
+     * <security-realm name="jbws-test-https-realm">
+     * <server-identities>
+     * <ssl>
+     * <keystore path="/path/test.keystore" keystore-password="changeit" alias="tomcat"/>
+     * </ssl>
+     * </server-identities>
+     * </security-realm>
+     */
+    private void addSecurityRealm(List<ModelNode> operations) throws Exception {
+        final ModelNode addOp = createOpNode("core-service=management/security-realm=" + HTTPS_SECURITY_REALM_NAME, ADD);
+        operations.add(addOp);
+        final ModelNode addSslIdentityOp = createOpNode("core-service=management/security-realm=" + HTTPS_SECURITY_REALM_NAME + "/server-identity=ssl", ADD);
+        addSslIdentityOp.get("keystore-path").set(WSTrustTestCaseElytronSecuritySetupTask.class.getResource("test.keystore").getPath());
+        addSslIdentityOp.get("keystore-password").set("changeit");
+        addSslIdentityOp.get("alias").set("tomcat");
+        operations.add(addSslIdentityOp);
+    }
+
+    private void removeSecurityRealm(List<ModelNode> operations) throws Exception {
+        final ModelNode removeOp = createOpNode("core-service=management/security-realm=" + HTTPS_SECURITY_REALM_NAME, REMOVE);
+        operations.add(removeOp);
+    }
+
+    /**
+     * Add https listner like this:
+     * <p/>
+     * <subsystem xmlns="urn:jboss:domain:undertow:3.0"> <server name="default-server"> <https-listener
+     * name="jbws-test-https-listener" socket-binding="https" security-realm="jbws-test-https-realm"/> .... </server> ...
+     * <subsystem>
+     */
+    private void addHttpsListener(List<ModelNode> operations) throws Exception {
+        ModelNode addOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=https2", ADD);
+        addOp.get(PORT).set("8444");
+        operations.add(addOp);
+        addOp = createOpNode("subsystem=undertow/server=default-server/https-listener=" + HTTPS_LISTENER_NAME, ADD);
+        addOp.get(SOCKET_BINDING).set("https2");
+        addOp.get(SECURITY_REALM).set(HTTPS_SECURITY_REALM_NAME);
+        operations.add(addOp);
+    }
+
+    private void removeHttpsListener(List<ModelNode> operations) throws Exception {
+        ModelNode removeOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=https2", REMOVE);
+        operations.add(removeOp);
+        removeOp = createOpNode("subsystem=undertow/server=default-server/https-listener=" + HTTPS_LISTENER_NAME, REMOVE);
+        operations.add(removeOp);
+    }
+
+    private void addElytronSecurityDomain(List<ModelNode> operations) throws Exception {
+        final ModelNode elytronHttpAuthOp = ModelUtil.createOpNode(
+                "subsystem=elytron/http-authentication-factory=application-http-authentication", ADD);
+        elytronHttpAuthOp.get("http-server-mechanism-factory").set("global");
+        elytronHttpAuthOp.get("security-domain").set(SECURITY_DOMAIN_NAME);
+        operations.add(elytronHttpAuthOp);
+
+        final ModelNode addUndertowDomainOp = ModelUtil.createOpNode("subsystem=undertow/application-security-domain="
+                + SECURITY_DOMAIN_NAME, ADD);
+        addUndertowDomainOp.get("http-authentication-factory").set("application-http-authentication");
+        operations.add(addUndertowDomainOp);
+
+        final ModelNode addEJbDomainOp = ModelUtil.createOpNode("subsystem=ejb3/application-security-domain="
+                + SECURITY_DOMAIN_NAME, ADD);
+        addEJbDomainOp.get("security-domain").set(SECURITY_DOMAIN_NAME);
+        operations.add(addEJbDomainOp);
+
+    }
+
+    private void removeElytronSecurityDomain(List<ModelNode> operations) throws Exception {
+        final ModelNode removeUndertowDomainOp = ModelUtil.createOpNode(
+                "subsystem=undertow/application-security-domain=" + SECURITY_DOMAIN_NAME, REMOVE);
+        operations.add(removeUndertowDomainOp);
+        final ModelNode removeEjbDomainOp = ModelUtil.createOpNode(
+                "subsystem=ejb3/application-security-domain=" + SECURITY_DOMAIN_NAME, REMOVE);
+        operations.add(removeEjbDomainOp);
+
+    }
+
+
+}

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseElytronSecuritySetupTask.java
@@ -1,3 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.test.integration.ws.wsse.trust;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseSecuritySetupTask.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCaseSecuritySetupTask.java
@@ -7,6 +7,7 @@ import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServ
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 
 import java.util.ArrayList;
@@ -55,6 +56,7 @@ public class WSTrustTestCaseSecuritySetupTask implements ServerSetupTask {
         updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
         updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+        ServerReload.reloadIfRequired(managementClient);
     }
 
 
@@ -80,7 +82,7 @@ public class WSTrustTestCaseSecuritySetupTask implements ServerSetupTask {
     }
 
     private void removeHttpsListener(List<ModelNode> operations) throws Exception {
-        ModelNode removeOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=https2" + HTTPS_LISTENER_NAME, REMOVE);
+        ModelNode removeOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=https2", REMOVE);
         operations.add(removeOp);
         removeOp = createOpNode("subsystem=undertow/server=default-server/https-listener=" + HTTPS_LISTENER_NAME, REMOVE);
         operations.add(removeOp);

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/bearer/BearerEJBImpl.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/bearer/BearerEJBImpl.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ws.wsse.trust.bearer;
+import org.apache.cxf.annotations.EndpointProperties;
+import org.apache.cxf.annotations.EndpointProperty;
+import org.jboss.as.test.integration.ws.wsse.trust.ContextProvider;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jws.WebService;
+import javax.xml.ws.WebServiceContext;
+
+@WebService
+        (
+                portName = "BearerServicePort",
+                serviceName = "BearerService",
+                wsdlLocation = "WEB-INF/wsdl/BearerService.wsdl",
+                targetNamespace = "http://www.jboss.org/jbossws/ws-extensions/bearerwssecuritypolicy",
+                endpointInterface = "org.jboss.as.test.integration.ws.wsse.trust.bearer.BearerIface"
+        )
+@EndpointProperties(value = {
+        @EndpointProperty(key = "ws-security.signature.properties", value = "serviceKeystore.properties"),
+})
+@org.apache.cxf.interceptor.InInterceptors (interceptors = {"org.jboss.as.test.integration.ws.wsse.trust.SamlSecurityContextInInterceptor" })
+public class BearerEJBImpl implements BearerIface {
+    @Resource
+    WebServiceContext context;
+
+     @EJB
+    ContextProvider ejbContext;
+    public String sayHello() {
+        String wsprincipal =  context.getUserPrincipal().getName();
+        return wsprincipal + "&" + ejbContext.getEjbCallerPrincipalName();
+    }
+}

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
@@ -136,4 +136,10 @@ public class ElytronSecurityDomainContextImpl implements SecurityDomainContext {
         }
         return null;
     }
+
+    @Override
+    public void cleanupSubjectContext() {
+        currentIdentity.remove();
+    }
+
 }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
@@ -21,7 +21,9 @@
  */
 package org.jboss.as.webservices.security;
 
+import java.security.AccessController;
 import java.security.Principal;
+import java.security.PrivilegedAction;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -91,8 +93,18 @@ public class ElytronSecurityDomainContextImpl implements SecurityDomainContext {
         }
     }
     @Override
-    public void pushSubjectContext(Subject arg0, Principal arg1, Object arg2) {
-
+    public void pushSubjectContext(Subject subject, Principal pincipal, Object credential) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            public Void run() {
+                if (credential != null) {
+                    subject.getPrivateCredentials().add(credential);
+                }
+                SecurityIdentity securityIdentity = SubjectUtil.convertToSecurityIdentity(subject, pincipal, securityDomain,
+                        "ejb");
+                currentIdentity.set(securityIdentity);
+                return null;
+            }
+        });
     }
 
     private SecurityIdentity authenticate(final String username, final String password) {

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/security/ElytronSecurityDomainContextImpl.java
@@ -77,7 +77,6 @@ public class ElytronSecurityDomainContextImpl implements SecurityDomainContext {
             return false;
         }
         SubjectUtil.fromSecurityIdentity(identity, subject);
-        currentIdentity.set(identity);
         return true;
     }
 
@@ -85,8 +84,11 @@ public class ElytronSecurityDomainContextImpl implements SecurityDomainContext {
         final SecurityIdentity ci = currentIdentity.get();
         if (ci != null) {
             //there is no security constrains in servlet and directly with jaas
-            ci.runAs(action);
-            currentIdentity.set(null);
+            try {
+                ci.runAs(action);
+            } finally {
+                currentIdentity.remove();
+            }
         } else {
             //undertow's ElytronRunAsHandler will propagate the SecurityIndentity to SecurityDomain and directly run this action
             action.call();

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
@@ -17,18 +17,26 @@ package org.jboss.as.webservices.util;
  * limitations under the License.
  */
 import java.security.AccessController;
+import java.security.KeyPair;
 import java.security.Principal;
+import java.security.PrivateKey;
 import java.security.PrivilegedAction;
+import java.security.PublicKey;
 import java.security.acl.Group;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.crypto.SecretKey;
 import javax.security.auth.Subject;
 
 import org.wildfly.security.auth.principal.NamePrincipal;
+import org.wildfly.security.auth.server.IdentityCredentials;
+import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
+import org.wildfly.security.authz.Roles;
 import org.wildfly.security.credential.Credential;
 import org.wildfly.security.credential.KeyPairCredential;
 import org.wildfly.security.credential.PasswordCredential;
@@ -37,7 +45,7 @@ import org.wildfly.security.credential.SecretKeyCredential;
 import org.wildfly.security.credential.X509CertificateChainPrivateCredential;
 import org.wildfly.security.credential.X509CertificateChainPublicCredential;
 import org.wildfly.security.manager.WildFlySecurityManager;
-
+import org.wildfly.security.password.Password;
 /**
  * Utilities for dealing with {@link Subject}.
  *
@@ -119,6 +127,54 @@ public final class SubjectUtil {
                 return null;
             });
         }
+    }
+
+    public static SecurityIdentity convertToSecurityIdentity(Subject subject, Principal principal, SecurityDomain domain,
+            String roleCategory) {
+        SecurityIdentity identity = domain.createAdHocIdentity(principal);
+        // convert subject Group
+        Set<String> roles = new HashSet<>();
+        for (Principal prin : subject.getPrincipals()) {
+            if (prin instanceof Group && "Roles".equalsIgnoreCase(prin.getName())) {
+                Enumeration<? extends Principal> enumeration = ((Group) prin).members();
+                while (enumeration.hasMoreElements()) {
+                    roles.add(enumeration.nextElement().getName());
+                }
+            }
+        }
+        identity.withRoleMapper(roleCategory, (rolesToMap) -> Roles.fromSet(roles));
+        // convert public credentials
+        IdentityCredentials publicCredentials = IdentityCredentials.NONE;
+        for (Object credential : subject.getPublicCredentials()) {
+            if (credential instanceof PublicKey) {
+                publicCredentials = publicCredentials.withCredential(new PublicKeyCredential((PublicKey) credential));
+            } else if (credential instanceof X509Certificate) {
+                publicCredentials = publicCredentials.withCredential(new X509CertificateChainPublicCredential(
+                        (X509Certificate) credential));
+            } else if (credential instanceof Credential) {
+                publicCredentials = publicCredentials.withCredential((Credential) credential);
+            }
+        }
+        identity.withPublicCredentials(publicCredentials);
+
+        // convert private credentials
+        IdentityCredentials privateCredentials = IdentityCredentials.NONE;
+        for (Object credential : subject.getPrivateCredentials()) {
+            if (credential instanceof Password) {
+                privateCredentials = privateCredentials.withCredential(new PasswordCredential((Password) credential));
+            } else if (credential instanceof SecretKey) {
+                privateCredentials = privateCredentials.withCredential(new SecretKeyCredential((SecretKey) credential));
+            } else if (credential instanceof KeyPair) {
+                privateCredentials = privateCredentials.withCredential(new KeyPairCredential((KeyPair) credential));
+            } else if (credential instanceof PrivateKey) {
+                privateCredentials = privateCredentials.withCredential(new X509CertificateChainPrivateCredential(
+                        (PrivateKey) credential));
+            } else if (credential instanceof Credential) {
+                privateCredentials = privateCredentials.withCredential((Credential) credential);
+            }
+        }
+        identity.withPrivateCredentials(privateCredentials);
+        return identity;
     }
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10480
This PR includes:

*  Fix to propagate authenticated subject to elytron security domain context
*  Tests for this issue
*  Community doc

This replaces #11497
