### PR TITLE
WFLY-10830 -  WFLY-10831 - Upgrade Hibernate ORM to 5.3.5.Final and ByteBuddy to 1.8.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
         <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bouncycastle>1.56</version.org.bouncycastle>
-        <version.org.bytebuddy>1.8.15</version.org.bytebuddy>
+        <version.org.bytebuddy>1.8.17</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.8</version.org.codehaus.jettison>
         <version.org.cryptacular>1.2.0</version.org.cryptacular>

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
-        <version.org.hibernate>5.3.4.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.5.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.4.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.3.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.12.Final</version.org.hibernate.validator>


### PR DESCRIPTION
* https://issues.jboss.org/browse/WFLY-10830 - Upgrade to Hibernate ORM 5.3.5.Final
* https://issues.jboss.org/browse/WFLY-10831 - Upgrade to ByteBuddy 1.8.17