### PR TITLE
[WFWIP-108] Add jboss.api=private to new MP-OpenTracing modules

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
@@ -1,8 +1,8 @@
 [[MicroProfile_OpenTracing SmallRye]]
 = MicroProfile OpenTracing Subsystem Configuration
 
-Support for https://microprofile.io/project/eclipse/microprofile-opentracing[Eclipse MicroProfile OpenTracing] is provided by
- the _microprofile-opentracing-smallrye_ subsystem.
+Support for https://microprofile.io/project/eclipse/microprofile-opentracing[Eclipse MicroProfile OpenTracing] is
+provided as a Tech Preview feature by the _microprofile-opentracing-smallrye_ subsystem.
 
 [[required-extension]]
 == Required Extension
@@ -45,6 +45,9 @@ possible by setting system properties or environment variables. If a more comple
 WARNING: by default, the Jaeger Client Java has a probabilistic sampling strategy, set to 0.001, meaning that only
 approximately one in one thousand traces will be sampled. To sample every request, set the environment variable
 `JAEGER_SAMPLER_TYPE` to `const` and `JAEGER_SAMPLER_PARAM` to `1`.
+
+WARNING: the supported configuration options for this Tech Preview feature, particularly those related to configuring
+the Jaeger Java Client tracer, may change in incompatible ways in a future release.
 
 By default, the service name used with the Jaeger Client is derived from the deployment's name, which is usually the
 WAR file name.

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing/main/module.xml
@@ -16,6 +16,10 @@
   ~ limitations under the License.
   -->
 <module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.opentracing">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${org.wildfly:wildfly-microprofile-opentracing-extension}"/>
     </resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
@@ -16,6 +16,10 @@
   ~ limitations under the License.
   -->
 <module xmlns="urn:jboss:module:1.8" name="org.wildfly.microprofile.opentracing-smallrye">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${org.wildfly:wildfly-microprofile-opentracing-smallrye}"/>
 

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -7,7 +7,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/wildfly</property>
-            <property name="javaVmArguments">${server.jvm.args} -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n</property>
+            <property name="javaVmArguments">${server.jvm.args}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFWIP-108

This PR adds the property `jboss.api=private` to the new modules from #11454, as well as a couple of minor fixes that weren't blockers for that PR.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
