### PR TITLE
[WFLY-10842] Upgrade WildFly Core 6.0.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.CR1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-10842

---


# Release Notes - WildFly Core - Version 6.0.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4028'>WFCORE-4028</a>] -         Upgrade WildFly Elytron 1.5.4.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4030'>WFCORE-4030</a>] -         Upgrade to Galleon and WildFly Galleon Plugins 2.0.0.Beta1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4037'>WFCORE-4037</a>] -         Undertow 2.0.13.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4031'>WFCORE-4031</a>] -         Additional test coverage for read-config-as-features
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4022'>WFCORE-4022</a>] -         The key-store obtain-certificate operation currently fails with &quot;Parameter &#39;type&#39; may not be null&quot;
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4024'>WFCORE-4024</a>] -         Manage the xalan test dependency and version from the root pom
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4025'>WFCORE-4025</a>] -         Intermittent errors on RemoteGitRepositoryTestCase.historyAndManagementOperationsTest
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4027'>WFCORE-4027</a>] -         Upgrade xnio to 3.6.5.Final
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4033'>WFCORE-4033</a>] -         use jboss community maven universe instead of galleon1 for wildfly-core-vault-test feature-pack
</li>
</ul>