### PR TITLE
[WFLY-10857] Don't register runtime-only agroal attributes and ops on profile resources

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverDefinition.java
@@ -61,7 +61,9 @@ public class JdbcDriverDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : Constants.JDBC_DRIVER_ATTRIBUTES) {
             resourceRegistration.registerReadOnlyAttribute(attribute, null);
         }
-        resourceRegistration.registerMetric(DATASOURCE_CLASS_INFO, GetDataSourceClassInfoOperationHandler.INSTANCE);
+        if (resourceRegistration.getProcessType().isServer()) {
+            resourceRegistration.registerMetric(DATASOURCE_CLASS_INFO, GetDataSourceClassInfoOperationHandler.INSTANCE);
+        }
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
@@ -271,7 +271,9 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
         }
 
         // Runtime attributes
-        resourceRegistration.registerReadOnlyAttribute(STATISTICS, AbstractDataSourceOperations.STATISTICS_GET_OPERATION);
+        if (resourceRegistration.getProcessType().isServer()) {
+            resourceRegistration.registerReadOnlyAttribute(STATISTICS, AbstractDataSourceOperations.STATISTICS_GET_OPERATION);
+        }
     }
 
     @Override
@@ -282,11 +284,13 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
-        resourceRegistration.registerOperationHandler(FLUSH_ALL, AbstractDataSourceOperations.FLUSH_ALL_OPERATION);
-        resourceRegistration.registerOperationHandler(FLUSH_GRACEFUL, AbstractDataSourceOperations.FLUSH_GRACEFUL_OPERATION);
-        resourceRegistration.registerOperationHandler(FLUSH_INVALID, AbstractDataSourceOperations.FLUSH_INVALID_OPERATION);
-        resourceRegistration.registerOperationHandler(FLUSH_IDLE, AbstractDataSourceOperations.FLUSH_IDLE_OPERATION);
-        resourceRegistration.registerOperationHandler(RESET_STATISTICS, AbstractDataSourceOperations.RESET_STATISTICS_OPERATION);
-        resourceRegistration.registerOperationHandler(TEST_CONNECTION, AbstractDataSourceOperations.TEST_CONNECTION_OPERATION);
+        if (resourceRegistration.getProcessType().isServer()) {
+            resourceRegistration.registerOperationHandler(FLUSH_ALL, AbstractDataSourceOperations.FLUSH_ALL_OPERATION);
+            resourceRegistration.registerOperationHandler(FLUSH_GRACEFUL, AbstractDataSourceOperations.FLUSH_GRACEFUL_OPERATION);
+            resourceRegistration.registerOperationHandler(FLUSH_INVALID, AbstractDataSourceOperations.FLUSH_INVALID_OPERATION);
+            resourceRegistration.registerOperationHandler(FLUSH_IDLE, AbstractDataSourceOperations.FLUSH_IDLE_OPERATION);
+            resourceRegistration.registerOperationHandler(RESET_STATISTICS, AbstractDataSourceOperations.RESET_STATISTICS_OPERATION);
+            resourceRegistration.registerOperationHandler(TEST_CONNECTION, AbstractDataSourceOperations.TEST_CONNECTION_OPERATION);
+        }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10857

This is meant to follow-up on #11176 which is as yet unmerged but I expect to be merged soon. It includes the commits from there but really only the last commit is for this issue.