### PR TITLE
[WFLY-10858] Add RBAC ApplicationTypeAccessConstraintDefinition to ag…

### DIFF
--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
@@ -21,13 +21,23 @@
  */
 package org.wildfly.extension.datasources.agroal;
 
+import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.NONE;
+import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.READ_COMMITTED;
+import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.READ_UNCOMMITTED;
+import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.REPEATABLE_READ;
+import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.SERIALIZABLE;
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+
+import java.util.EnumSet;
+
+import javax.sql.DataSource;
+
 import io.agroal.api.configuration.AgroalConnectionFactoryConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
@@ -38,7 +48,6 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
-import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
@@ -48,12 +57,6 @@ import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.datasources.agroal.logging.AgroalLogger;
-
-import javax.sql.DataSource;
-import java.util.EnumSet;
-
-import static io.agroal.api.configuration.AgroalConnectionFactoryConfiguration.TransactionIsolation.*;
-import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 
 /**
  * Common Definition for the datasource resource
@@ -245,8 +248,8 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
 
     // --- //
 
-    protected AbstractDataSourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler, OperationStepHandler removeHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler);
+    AbstractDataSourceDefinition(Parameters parameters) {
+        super(parameters.setCapabilities(DATA_SOURCE_CAPABILITY));
     }
 
     @Override
@@ -272,11 +275,6 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
 
         // Runtime attributes
         resourceRegistration.registerReadOnlyAttribute(STATISTICS, AbstractDataSourceOperations.STATISTICS_GET_OPERATION);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(DATA_SOURCE_CAPABILITY);
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceDefinition.java
@@ -23,6 +23,8 @@ package org.wildfly.extension.datasources.agroal;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
+import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -62,7 +64,12 @@ class DataSourceDefinition extends AbstractDataSourceDefinition {
     // --- //
 
     private DataSourceDefinition() {
-        super(pathElement("datasource"), getResolver("datasource"), DataSourceOperations.ADD_OPERATION, DataSourceOperations.REMOVE_OPERATION);
+        // TODO The cast to PersistentResourceDefinition.Parameters is a workaround to WFCORE-4040
+        super((Parameters) new Parameters(pathElement("datasource"), getResolver("datasource"))
+                .setAddHandler(DataSourceOperations.ADD_OPERATION)
+                .setRemoveHandler(DataSourceOperations.REMOVE_OPERATION)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(
+                        new ApplicationTypeConfig(AgroalExtension.SUBSYSTEM_NAME, "datasource"))));
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
@@ -56,7 +56,7 @@ class DataSourceOperations {
     private static class DataSourceAdd extends AbstractAddStepHandler {
 
         private DataSourceAdd() {
-            super(DataSourceDefinition.DATA_SOURCE_CAPABILITY, DataSourceDefinition.ATTRIBUTES);
+            super(DataSourceDefinition.ATTRIBUTES);
         }
 
         @Override
@@ -94,10 +94,6 @@ class DataSourceOperations {
     // --- //
 
     private static class DataSourceRemove extends AbstractRemoveStepHandler {
-
-        private DataSourceRemove(){
-            super(DataSourceDefinition.DATA_SOURCE_CAPABILITY);
-        }
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DriverDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DriverDefinition.java
@@ -21,21 +21,23 @@
  */
 package org.wildfly.extension.datasources.agroal;
 
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.PersistentResourceDefinition;
-import org.jboss.as.controller.PrimitiveListAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelType;
-
-import java.util.Collection;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.wildfly.extension.datasources.agroal.AgroalExtension.getResolver;
+
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.PrimitiveListAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
+import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
 
 /**
  * Definition for the driver resource
@@ -71,7 +73,12 @@ class DriverDefinition extends PersistentResourceDefinition {
     // --- //
 
     private DriverDefinition() {
-        super(pathElement("driver"), getResolver("driver"), DriverOperations.ADD_OPERATION, DriverOperations.REMOVE_OPERATION);
+        // TODO The cast to PersistentResourceDefinition.Parameters is a workaround to WFCORE-4040
+        super((Parameters) new Parameters(pathElement("driver"), getResolver("driver"))
+                .setAddHandler(DriverOperations.ADD_OPERATION)
+                .setRemoveHandler(DriverOperations.REMOVE_OPERATION)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(
+                        new ApplicationTypeConfig(AgroalExtension.SUBSYSTEM_NAME, "driver"))));
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceDefinition.java
@@ -21,14 +21,16 @@
  */
 package org.wildfly.extension.datasources.agroal;
 
-import org.jboss.as.controller.AttributeDefinition;
-
-import java.util.Collection;
-
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static org.jboss.as.controller.PathElement.pathElement;
 import static org.wildfly.extension.datasources.agroal.AgroalExtension.getResolver;
+
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
+import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 
 /**
  * Definition for the xa-datasource resource
@@ -44,7 +46,12 @@ class XADataSourceDefinition extends AbstractDataSourceDefinition {
     // --- //
 
     private XADataSourceDefinition() {
-        super(pathElement("xa-datasource"), getResolver("xa-datasource"), XADataSourceOperations.ADD_OPERATION, XADataSourceOperations.REMOVE_OPERATION);
+        // TODO The cast to PersistentResourceDefinition.Parameters is a workaround to WFCORE-4040
+        super((Parameters) new Parameters(pathElement("xa-datasource"), getResolver("xa-datasource"))
+                .setAddHandler(XADataSourceOperations.ADD_OPERATION)
+                .setRemoveHandler(XADataSourceOperations.REMOVE_OPERATION)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(
+                        new ApplicationTypeConfig(AgroalExtension.SUBSYSTEM_NAME, "xa-datasource"))));
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceOperations.java
@@ -59,7 +59,7 @@ class XADataSourceOperations extends AbstractAddStepHandler {
     private static class XADataSourceAdd extends AbstractAddStepHandler {
 
         private XADataSourceAdd() {
-            super(XADataSourceDefinition.DATA_SOURCE_CAPABILITY, XADataSourceDefinition.ATTRIBUTES);
+            super(XADataSourceDefinition.ATTRIBUTES);
         }
 
         @Override
@@ -95,10 +95,6 @@ class XADataSourceOperations extends AbstractAddStepHandler {
     // --- //
 
     private static class XADataSourceRemove extends AbstractRemoveStepHandler {
-
-        private XADataSourceRemove(){
-            super(XADataSourceDefinition.DATA_SOURCE_CAPABILITY);
-        }
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {

--- a/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/PermissionsCoverageTestCase.java
+++ b/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/PermissionsCoverageTestCase.java
@@ -22,12 +22,23 @@
 
 package org.jboss.as.test.integration.mgmt.access;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.test.integration.management.rbac.PermissionsCoverageTestUtil.assertTheEntireDomainTreeHasPermissionsDefined;
+
+import java.io.IOException;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,6 +49,20 @@ import org.junit.runner.RunWith;
 public class PermissionsCoverageTestCase {
     @ContainerResource
     private ManagementClient managementClient;
+
+    @Before
+    public void addAgroal() throws IOException {
+        ModelNode addOp = Util.createAddOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.datasources-agroal"));
+        ModelNode response = managementClient.getControllerClient().execute(addOp);
+        Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+    }
+
+    @After
+    public void removeAgroal() throws IOException {
+        ModelNode removeOp = Util.createRemoveOperation(PathAddress.pathAddress(EXTENSION, "org.wildfly.extension.datasources-agroal"));
+        ModelNode response = managementClient.getControllerClient().execute(removeOp);
+        Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+    }
 
     @Test
     public void testTheEntireDomainTreeHasPermissionsDefined() throws Exception {


### PR DESCRIPTION
…roal

As part of this converted the resource definitions to use Parameters in their constructor and then cleaned up a bit how the datasource capability was registered.

https://issues.jboss.org/browse/WFLY-10858