### PR TITLE
[WFLY-10860] jdbc-network-timeout value is in seconds

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -577,7 +577,6 @@ class ServerAdd extends AbstractAddStepHandler {
         long networkTimeout = SECONDS.toMillis(JOURNAL_JDBC_NETWORK_TIMEOUT.resolveModelAttribute(context, model).asInt());
         // ARTEMIS-1493: Artemis API is not correct. the value must be in millis but it requires an int instead of a long.
         storageConfiguration.setJdbcNetworkTimeout((int)networkTimeout);
-        storageConfiguration.setJdbcNetworkTimeout(JOURNAL_JDBC_NETWORK_TIMEOUT.resolveModelAttribute(context, model).asInt());
         ModelNode databaseNode = JOURNAL_DATABASE.resolveModelAttribute(context, model);
         final String database = databaseNode.isDefined() ? databaseNode.asString() : null;
         try {


### PR DESCRIPTION
The removed line was a leftover from a previous merge conflict
resolution.

JIRA: https://issues.jboss.org/browse/WFLY-10860
