### PR TITLE
[WFLY-10865] Replace org.wildfly by project.groupId where possible

### DIFF
--- a/datasources-agroal/pom.xml
+++ b/datasources-agroal/pom.xml
@@ -66,11 +66,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-naming</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/opentracing-extension/pom.xml
+++ b/microprofile/opentracing-extension/pom.xml
@@ -40,17 +40,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-microprofile-opentracing-smallrye</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -61,12 +61,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This PR follows up: https://github.com/wildfly/wildfly/pull/10835

Some new subsystems added on this release need this minor tweak.

Jira issue: https://issues.jboss.org/browse/WFLY-10865