### PR TITLE
WFLY-10888 Avoid using deprecated method in TracingCDIExtension.

### DIFF
--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
@@ -34,8 +34,9 @@ import javax.enterprise.inject.spi.ProcessAnnotatedType;
 public class TracingCDIExtension implements Extension {
 
     public void observeBeforeBeanDiscovery(@Observes BeforeBeanDiscovery bbd, BeanManager manager) {
-        bbd.addAnnotatedType(manager.createAnnotatedType(TracerProducer.class));
-        bbd.addAnnotatedType(manager.createAnnotatedType(SmallRyeTracingCDIInterceptor.class));
+        String extensionName = TracingCDIExtension.class.getName();
+        bbd.addAnnotatedType(manager.createAnnotatedType(TracerProducer.class), extensionName + "-" + TracerProducer.class.getName());
+        bbd.addAnnotatedType(manager.createAnnotatedType(SmallRyeTracingCDIInterceptor.class), extensionName + "-" + SmallRyeTracingCDIInterceptor.class.getName());
     }
 
     public void skipTracerBeans(@Observes ProcessAnnotatedType<? extends Tracer> processAnnotatedType) {


### PR DESCRIPTION
JIRA link - https://issues.jboss.org/browse/WFLY-10888

No automated test included, this merely replaces deprecated method with an up-to-date one hence avoiding logging a WARN msg - all current tests passing are verification enough.