### PR TITLE
WFLY-10847 Set one tracer instance per WAR sub-deployment in EAR deployments

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.microprofile.opentracing;
 
+import org.jboss.as.ee.structure.DeploymentType;
+import org.jboss.as.ee.structure.DeploymentTypeMarker;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -43,6 +45,10 @@ public class TracingDependencyProcessor implements DeploymentUnitProcessor {
     }
 
     private void addDependencies(DeploymentUnit deploymentUnit) {
+        if (DeploymentTypeMarker.isType(DeploymentType.EAR, deploymentUnit)) {
+            return;
+        }
+
         ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         ModuleLoader moduleLoader = Module.getBootModuleLoader();
 

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
@@ -44,14 +44,14 @@ public interface TracingExtensionLogger extends BasicLogger {
     void processingDeployment();
 
     @LogMessage(level = DEBUG)
-    @Message(id = 4, value = "The deployment does not have CDI enabled. Skipping MicroProfile OpenTracing integration.")
+    @Message(id = 3, value = "The deployment does not have CDI enabled. Skipping MicroProfile OpenTracing integration.")
     void noCdiDeployment();
 
     @LogMessage(level = DEBUG)
-    @Message(id = 6, value = "Deriving service name based on the deployment unit's name: %s")
+    @Message(id = 4, value = "Deriving service name based on the deployment unit's name: %s")
     void serviceNameDerivedFromDeploymentUnit(String serviceName);
 
     @LogMessage(level = DEBUG)
-    @Message(id = 7, value = "Registering the TracerInitializer filter")
+    @Message(id = 5, value = "Registering the TracerInitializer filter")
     void registeringTracerInitializer();
 }

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingExtensionLogger.java
@@ -44,16 +44,8 @@ public interface TracingExtensionLogger extends BasicLogger {
     void processingDeployment();
 
     @LogMessage(level = DEBUG)
-    @Message(id = 3, value = "Registering SmallRye CDI Extension")
-    void registeringCDIExtension();
-
-    @LogMessage(level = DEBUG)
     @Message(id = 4, value = "The deployment does not have CDI enabled. Skipping MicroProfile OpenTracing integration.")
     void noCdiDeployment();
-
-    @LogMessage(level = DEBUG)
-    @Message(id = 5, value = "Registering MicroProfile OpenTracing JAX-RS integration")
-    void registeringJaxRs();
 
     @LogMessage(level = DEBUG)
     @Message(id = 6, value = "Deriving service name based on the deployment unit's name: %s")

--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -40,6 +40,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-jaxrs2</artifactId>
         </dependency>

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingLogger.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingLogger.java
@@ -51,15 +51,11 @@ public interface TracingLogger extends BasicLogger {
     @Message(id = 4, value = "Registering %s as the OpenTracing Tracer")
     void registeringTracer(String message);
 
-    @LogMessage(level = DEBUG)
-    @Message(id = 5, value = "CDI events are not supported for this deployment. Possible configuration issues? Skipping MicroProfile OpenTracing integration.")
-    void noCdiEventSupport();
+    @LogMessage(level = WARN)
+    @Message(id = 5, value = "No tracer available to JAX-RS. Skipping MicroProfile OpenTracing configuration for JAX-RS")
+    void noTracerAvailable();
 
     @LogMessage(level = DEBUG)
     @Message(id = 6, value = "Extra Tracer bean found: %s. Vetoing it, please use TracerResolver to specify a custom tracer to use.")
     void extraTracerBean(String clazz);
-
-    @LogMessage(level = WARN)
-    @Message(id = 7, value = "Multiple tracer resolvers found. Cannot properly determine which one to use.")
-    void multipleTracerResolvers();
 }

--- a/microprofile/opentracing-smallrye/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/microprofile/opentracing-smallrye/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.wildfly.microprofile.opentracing.smallrye.TracingCDIExtension

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/EarOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/EarOpenTracingTestCase.java
@@ -21,10 +21,6 @@
  */
 package org.jboss.as.test.integration.microprofile.opentracing;
 
-import static org.wildfly.test.integration.microprofile.config.smallrye.HttpUtils.getContent;
-
-import java.net.URL;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -43,9 +39,12 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.wildfly.test.integration.microprofile.config.smallrye.HttpUtils.getContent;
 
 /**
  * Test verifying the assumption that different services inside single EAR have different tracers.
@@ -75,13 +74,11 @@ public class EarOpenTracingTestCase {
         return ear;
     }
 
-    @Ignore("Unignore when https://issues.jboss.org/browse/WFWIP-104") // TODO
     @Test
     public void testEarServicesUseDifferentTracers() throws Exception {
         testHttpInvokation();
     }
 
-    @Ignore("Unignore when https://issues.jboss.org/browse/WFWIP-104") // TODO
     @Test
     public void testEarServicesUseDifferentTracersAfterReload() throws Exception {
         //TODO the tracer instance is same after reload as before it - check whether this is correct or no

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/ResourceTracedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/ResourceTracedTestCase.java
@@ -17,8 +17,10 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.microprofile.opentracing.smallrye.TracerInitializer;
 
 import javax.inject.Inject;
+import javax.servlet.ServletContext;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
@@ -29,6 +31,9 @@ public class ResourceTracedTestCase {
 
     @ArquillianResource
     private URL url;
+
+    @Inject
+    ServletContext servletContext;
 
     @Deployment
     public static Archive<?> deploy() {
@@ -57,6 +62,10 @@ public class ResourceTracedTestCase {
         performCall("opentracing/traced");
 
         Assert.assertEquals(1, mockTracer.finishedSpans().size());
+        Assert.assertEquals(
+                (servletContext.getContextPath() + ".war").substring(1),
+                servletContext.getInitParameter(TracerInitializer.SMALLRYE_OPENTRACING_SERVICE_NAME)
+        );
     }
 
     private void performCall(String path) throws Exception {


### PR DESCRIPTION
See https://issues.jboss.org/browse/WFLY-10847

This PR changes the MicroProfile OpenTracing subsystem to add the tracer to the servlet context, so that it can be correctly consumed without CDI by the JAX-RS components. We are now also skipping the subsystem for EAR deployments, installing it only on sub-deployments.

These two changes are required to fix WFLY-10847, which was always delivering the same tracer instance created by the last deployment to all deployments in the EAR.

cc @mjurc

- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>