### PR TITLE
[WFLY-9978] Legacy security domain with resource adapter test case

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jms/resourceadapter/LegacySecurityDomainRAServerSetupTask.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jms/resourceadapter/LegacySecurityDomainRAServerSetupTask.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.jms.resourceadapter;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ *
+ * Server setup task for test LegacySecurityDomainRATestCase.
+ * Configures legacy security domain and resource adapter.
+ *
+ * @author Daniel Cihak
+ */
+public class LegacySecurityDomainRAServerSetupTask extends SnapshotRestoreSetupTask {
+
+    @Override
+    public void doSetup(ManagementClient managementClient, String s) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+
+        // /subsystem=resource-adapters/resource-adapter=generic-jms-ra:add(module=org.jboss.genericjms,transaction-support=LocalTransaction)
+        ModelNode addResourceAdapter = createOpNode("subsystem=resource-adapters/resource-adapter=generic-jms-ra", ADD);
+        addResourceAdapter.get("module").set("org.jboss.genericjms");
+        addResourceAdapter.get("transaction-support").set("LocalTransaction");
+        operations.add(addResourceAdapter);
+
+        // //subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA:add(class-name=org.jboss.resource.adapter.jms.JmsManagedConnectionFactory,jndi-name=java:/jms/TibcoEmsLocalTxFactory,enabled=true,use-ccm=true,min-pool-size=0,max-pool-size=20,pool-prefill=false,pool-use-strict-min=false,flush-strategy=FailingConnectionOnly,security-domain-and-application=TibcoEmsRealm)
+        ModelNode addConnectionDefinitions = createOpNode("subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA", ADD);
+        addConnectionDefinitions.get("class-name").set("org.jboss.resource.adapter.jms.JmsManagedConnectionFactory");
+        addConnectionDefinitions.get("jndi-name").set("java:/jms/TibcoEmsLocalTxFactory");
+        addConnectionDefinitions.get("enabled").set(true);
+        addConnectionDefinitions.get("use-ccm").set(true);
+        addConnectionDefinitions.get("min-pool-size").set(0);
+        addConnectionDefinitions.get("max-pool-size").set(20);
+        addConnectionDefinitions.get("pool-prefill").set(false);
+        addConnectionDefinitions.get("pool-use-strict-min").set(false);
+        addConnectionDefinitions.get("flush-strategy").set("FailingConnectionOnly");
+        addConnectionDefinitions.get("security-domain-and-application").set("TibcoEmsRealm");
+        operations.add(addConnectionDefinitions);
+
+        // /subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=ConnectionFactory:add(value=QueueConnectionFactory)
+        ModelNode addConfigProperty1 = createOpNode("subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=ConnectionFactory", ADD);
+        addConfigProperty1.get("value").set("QueueConnectionFactory");
+        operations.add(addConfigProperty1);
+
+        // /subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=SessionDefaultType:add(value=javax.jms.Queue)
+        ModelNode addConfigProperty2 = createOpNode("subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=SessionDefaultType", ADD);
+        addConfigProperty2.get("value").set("javax.jms.Queue");
+        operations.add(addConfigProperty2);
+
+        // /subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=JndiParameters:add(value=java.naming.factory.initial=com.tibco.tibjms.naming.TibjmsInitialContextFactory;java.naming.provider.url=tcp:/xxxxx)
+        ModelNode addConfigProperty3 = createOpNode("subsystem=resource-adapters/resource-adapter=generic-jms-ra/connection-definitions=GenericJmsXA/config-properties=JndiParameters", ADD);
+        addConfigProperty3.get("value").set("java.naming.factory.initial=com.tibco.tibjms.naming.TibjmsInitialContextFactory;java.naming.provider.url=tcp:/xxxxx");
+        operations.add(addConfigProperty3);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jms/resourceadapter/LegacySecurityDomainRATestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jms/resourceadapter/LegacySecurityDomainRATestCase.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.jms.resourceadapter;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Test configures legacy security domain and resource adapter.
+ * Test tries to start sever several times and checks it does not fail during the startup.
+ * Test for [ WFLY-9978 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(LegacySecurityDomainRAServerSetupTask.class)
+@RunAsClient
+public class LegacySecurityDomainRATestCase {
+
+    private static final Logger LOG = Logger.getLogger(LegacySecurityDomainRATestCase.class);
+    private static final String DEPLOYMENT = "deployment";
+    private static final String CONTAINER = "jbossas-with-remote-outbound-connection-non-clustered";
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(name = DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(CONTAINER)
+    public static WebArchive createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
+        war.addClass(LegacySecurityDomainRATestCase.class);
+        return war;
+    }
+
+    @Test
+    public void testRepeatedlyStartServerWithLegacySecurityDomain() {
+        for (int i = 0; i <= 20; i++) {
+            PrintStream oldOut = System.out;
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                System.setOut(new PrintStream(baos));
+                controller.start(CONTAINER);
+                LOG.trace("===appserver started===");
+                deployer.deploy(DEPLOYMENT);
+                LOG.trace("===deployment deployed===");
+                try {
+                    if (controller.isStarted(CONTAINER)) {
+                        System.setOut(oldOut);
+                        String output = new String(baos.toByteArray());
+                        Assert.assertFalse(output, output.contains("ERROR"));
+                        Assert.assertFalse(output, output.contains("MSC000001"));
+                    } else {
+                        fail("Container " + CONTAINER + " could not be started.");
+                    }
+                } finally {
+                    deployer.undeploy(DEPLOYMENT);
+                    controller.stop(CONTAINER);
+                }
+            } finally {
+                System.setOut(oldOut);
+            }
+        }
+    }
+
+    @After
+    public void stopContainer() {
+        if (controller.isStarted(CONTAINER)) {
+            deployer.undeploy(DEPLOYMENT);
+        }
+        if (controller.isStarted(CONTAINER)) {
+            controller.stop(CONTAINER);
+        }
+    }
+}


### PR DESCRIPTION
Test configures legacy security domain and resource adapter and tries to start server several times and checks it does not fail during the startup.

Automated test for upstream issue: [WFLY-9978](https://issues.jboss.org/browse/WFLY-9978)