### PR TITLE
[WFLY-10873]: Duplicated httpcomponent jars

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
@@ -28,8 +28,6 @@
     </properties>
 
     <resources>
-        <artifact name="${org.apache.httpcomponents:httpclient}"/>
-        <artifact name="${org.apache.httpcomponents:httpcore}"/>
         <artifact name="${org.apache.httpcomponents:httpcore-nio}"/>
         <artifact name="${org.apache.httpcomponents:httpasyncclient}"/>
         <artifact name="${org.apache.httpcomponents:httpmime}"/>
@@ -40,5 +38,6 @@
         <module name="org.apache.commons.codec"/>
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.james.mime4j"/>
+        <module name="org.apache.httpcomponents.core" export="true" services="export" />
     </dependencies>
 </module>


### PR DESCRIPTION
 * Using org.apache.httpcomponents.core module to avoid duplication of http-components jars.

Jira: https://issues.jboss.org/browse/WFLY-10873
https://issues.jboss.org/browse/WFLY-10622