### PR TITLE
Fix for WFLY-10890, CLI client in jconsole doesn't work with JDK11

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jconsole.bat
+++ b/feature-pack/src/main/resources/content/bin/jconsole.bat
@@ -50,10 +50,20 @@ set "CLASSPATH=%CLASSPATH%;%JBOSS_HOME%\bin\client\jboss-cli-client.jar"
 
 rem echo %CLASSPATH%
 
-if "%*" == "" (
-    "%JAVA_HOME%\bin\jconsole.exe" "-J-Djava.class.path=%CLASSPATH%"
+"%JAVA_HOME%\bin\java.exe" --add-modules=java.se -version >nul 2>&1 && (set MODULAR_JDK=true) || (set MODULAR_JDK=false)
+
+if "%MODULAR_JDK%" == "true" (
+ if "%*" == "" (
+    "%JAVA_HOME%\bin\jconsole.exe" "-J--add-modules=jdk.unsupported" "-J-Djava.class.path=%CLASSPATH%"
+ ) else (
+    "%JAVA_HOME%\bin\jconsole.exe" "-J--add-modules=jdk.unsupported" "-J-Djava.class.path=%CLASSPATH%" %*
+ )   
 ) else (
+ if "%*" == "" (
+    "%JAVA_HOME%\bin\jconsole.exe" "-J-Djava.class.path=%CLASSPATH%"
+ ) else (
     "%JAVA_HOME%\bin\jconsole.exe" "-J-Djava.class.path=%CLASSPATH%" %*
+ )
 )
 
 :END

--- a/feature-pack/src/main/resources/content/bin/jconsole.ps1
+++ b/feature-pack/src/main/resources/content/bin/jconsole.ps1
@@ -13,17 +13,24 @@ if (!$JAVA_HOME){
 
 $CLASSPATH= "$JAVA_HOME\lib\jconsole.jar;$JAVA_HOME\lib\tools.jar;$JBOSS_HOME\bin\client\jboss-cli-client.jar"
 
-$PROG_ARGS = @("-J-Djava.class.path=$CLASSPATH")
+& $JAVA_HOME\bin\java.exe --add-modules=java.se -version 2> $nul
+
+if ($LASTEXITCODE -eq 0) {
+ $PROG_ARGS= @("-J--add-modules=jdk.unsupported", "-J-Djava.class.path=$CLASSPATH")
+} else {
+ $PROG_ARGS = @("-J-Djava.class.path=$CLASSPATH")
+}
+
 if ($ARGS){
-	$PROG_ARGS += $ARGS
+ $PROG_ARGS += $ARGS
 }
 
 echo $PROG_ARGS
 
 try{
-	pushd $JBOSS_HOME
-	& $JAVA_HOME\bin\jconsole.exe $PROG_ARGS
+    pushd $JBOSS_HOME
+    & $JAVA_HOME\bin\jconsole.exe $PROG_ARGS
 }finally{
-	popd
-	Env-Clean-Up
+    popd
+    Env-Clean-Up
 }

--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -72,11 +72,18 @@ if $cygwin; then
     JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
 fi
 
-CLASSPATH=$JAVA_HOME/lib/jconsole.jar
-CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
-CLASSPATH=$CLASSPATH:./bin/client/jboss-cli-client.jar
-
-echo CLASSPATH $CLASSPATH
-
 cd "$JBOSS_HOME"
-$JAVA_HOME/bin/jconsole -J-Djava.class.path="$CLASSPATH" "$@"
+
+"$JAVA_HOME/bin/java" --add-modules=java.se -version > /dev/null 2>&1 && MODULAR_JDK=true || MODULAR_JDK=false
+
+if [ "$MODULAR_JDK" = "true" ]; then
+  $JAVA_HOME/bin/jconsole -J--add-modules=jdk.unsupported -J-Djava.class.path=./bin/client/jboss-cli-client.jar "$@"
+else
+  CLASSPATH=$JAVA_HOME/lib/jconsole.jar
+  CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
+  CLASSPATH=$CLASSPATH:./bin/client/jboss-cli-client.jar
+
+  echo CLASSPATH $CLASSPATH
+
+  $JAVA_HOME/bin/jconsole -J-Djava.class.path="$CLASSPATH" "$@"
+fi


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFLY-10890
Fixed jconsole.bat, jconsole.sh and  jconsole.ps1
NB: The jconsole context is modular, when running with JConsole class in the classpath the problem doesn't show up.

