### PR TITLE
[WFLY-9955] Compatibility problem: allow a timeout value of "0" to be set

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/transaction/ObjectStoreTypeTestCase.java
@@ -172,6 +172,20 @@ public class ObjectStoreTypeTestCase extends AbstractCliTestBase {
         }
     }
 
+    /**
+     * Test if 0 can be set for default transaction timeout
+     * @throws Exception
+     */
+    @Test
+    public void testSet0ToTransactionTimeout() throws Exception {
+        try {
+            cli.sendLine("/subsystem=transactions:write-attribute(name=default-timeout,value=0)", true);
+            checkAttributeIsAsExpected("default-timeout", "0");
+        } finally {
+            setDefaultObjectStore();
+        }
+    }
+
     private void checkAttributeIsAsExpected(String attributeName, String expectedValue) {
         try {
             cli.sendLine("/subsystem=transactions:read-attribute(name=" + attributeName + ")");


### PR DESCRIPTION
JIRA link [https://issues.jboss.org/browse/WFLY-9955](https://issues.jboss.org/browse/WFLY-9955)

Description: 

Previously we allowed a transaction timeout value of "0" to be set in the transaction subsystem, meaning "no transaction timeout". After the WF 11 changes, we've stopped allowing that value to be set. This behavior should be restored, with "0" translating into some "very large" value.

The transaction team has indicated that using Integer.MAX_VALUE has historically exhibited problems, so a different, smaller-but-still-large value should be used in this case.


