### PR TITLE
[WFLY-10908] Upgrade Hibernate Validator to 6.0.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <version.org.hibernate>5.3.5.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.4.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.3.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.12.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.13.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>9.3.1.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>


### PR DESCRIPTION
 * https://issues.jboss.org/browse/WFLY-10908

The details about the changes are in the issue mentioned above.