### PR TITLE
Upgrade to wildfly-core 6.0.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.CR2</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.CR3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION

---
# Release Notes - WildFly Core - Version 6.0.0.CR4

<h2>Bug</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-3831">WFCORE-3831</a> ] jboss-cli.ps1 script doesn't return exit value correctly</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4034">WFCORE-4034</a> ] RuntimeException when call key-store=ks:revoke-certificate</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4042">WFCORE-4042</a> ] "filter-spec" attribute of socket-handler contains non existent "filter" alternative</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4045">WFCORE-4045</a> ] Make ExtensibleHttpManagement.addManagementHandler() return error code 500</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4051">WFCORE-4051</a> ] KeyManagementException: FIPS mode: only SunJSSE TrustManagers may be used</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4057">WFCORE-4057</a> ] Add missing dependencies on org.apache.httpcomponents.core module</li>
</ul>

<h2>Component Upgrade</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-3620">WFCORE-3620</a> ] Upgrade log4j-jboss-logmanager from 1.1.4.Final to 1.1.5.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4038">WFCORE-4038</a> ] Upgrade WildFly Elytron to 1.5.5.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4052">WFCORE-4052</a> ] Upgrade WildFly Elytron to 1.6.0.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4053">WFCORE-4053</a> ] Upgrade Elytron Web to 1.2.3.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4054">WFCORE-4054</a> ] Upgrade WildFly Elytron Tool to 1.4.0.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4056">WFCORE-4056</a> ] Upgrade MSC to 1.4.3.Final</li>
</ul>

<h2>Enhancement</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4040">WFCORE-4040</a> ] Deprecate PersistentResourceDefinition.Parameters, remove all uses</li>
</ul>
