### PR TITLE
[WFLY-10906]:Fix roleMapper is lost in SecurityIndentity

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/SubjectUtil.java
@@ -142,7 +142,6 @@ public final class SubjectUtil {
                 }
             }
         }
-        identity.withRoleMapper(roleCategory, (rolesToMap) -> Roles.fromSet(roles));
         // convert public credentials
         IdentityCredentials publicCredentials = IdentityCredentials.NONE;
         for (Object credential : subject.getPublicCredentials()) {
@@ -174,6 +173,10 @@ public final class SubjectUtil {
             }
         }
         identity.withPrivateCredentials(privateCredentials);
+        if (!roles.isEmpty()) {
+            // identity.withRoleMapper will create NEW identity instance instead of set this roleMapper to identity
+            return identity.withRoleMapper(roleCategory, (rolesToMap) -> Roles.fromSet(roles));
+        }
         return identity;
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10906
These regression failures are simply caused by the roleMapper is lost in converted SecurityIdentity from subject : identity.withRoleMapper doesn't set roleMapper in the current identity and its returns does. 
