### PR TITLE
WFLY-10736 Increase retry intervals for startup cache operations up to lock acquisition timeout.

### DIFF
--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/retry/RetryingInvoker.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/retry/RetryingInvoker.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ee.infinispan.retry;
+
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.cache.Configuration;
+
+/**
+ * Retrying invoker whose retry intervals are auto-generated based an Infinispan cache configuration.
+ * @author Paul Ferraro
+ */
+public class RetryingInvoker extends org.wildfly.clustering.ee.retry.RetryingInvoker {
+
+    public RetryingInvoker(Cache<?, ?> cache) {
+        super(calculateRetryIntervals(cache.getCacheConfiguration()));
+    }
+
+    private static List<Duration> calculateRetryIntervals(Configuration config) {
+        long timeout = config.locking().lockAcquisitionTimeout();
+        List<Duration> intervals = new LinkedList<>();
+        // Generate exponential back-off intervals
+        for (long interval = timeout; interval > 1; interval /= 10) {
+            intervals.add(0, Duration.ofMillis(interval));
+        }
+        intervals.add(0, Duration.ZERO);
+        return intervals;
+    }
+}

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
@@ -22,7 +22,6 @@
 package org.wildfly.clustering.server.registry;
 
 import java.security.PrivilegedAction;
-import java.time.Duration;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,8 +59,7 @@ import org.jboss.threads.JBossThreadFactory;
 import org.wildfly.clustering.Registration;
 import org.wildfly.clustering.ee.Batch;
 import org.wildfly.clustering.ee.Batcher;
-import org.wildfly.clustering.ee.Invoker;
-import org.wildfly.clustering.ee.retry.RetryingInvoker;
+import org.wildfly.clustering.ee.infinispan.retry.RetryingInvoker;
 import org.wildfly.clustering.group.Node;
 import org.wildfly.clustering.infinispan.spi.distribution.ConsistentHashLocality;
 import org.wildfly.clustering.infinispan.spi.distribution.Locality;
@@ -86,8 +84,6 @@ public class CacheRegistry<K, V> implements Registry<K, V>, CacheEventFilter<Obj
         return WildFlySecurityManager.doUnchecked(action);
     }
 
-    private static final Invoker INVOKER = new RetryingInvoker(Duration.ZERO, Duration.ofMillis(100), Duration.ofSeconds(1));
-
     private final ExecutorService topologyChangeExecutor = Executors.newSingleThreadExecutor(createThreadFactory(this.getClass()));
     private final Map<RegistryListener<K, V>, ExecutorService> listeners = new ConcurrentHashMap<>();
     private final Cache<Address, Map.Entry<K, V>> cache;
@@ -102,7 +98,7 @@ public class CacheRegistry<K, V> implements Registry<K, V>, CacheEventFilter<Obj
         this.group = config.getGroup();
         this.closeTask = closeTask;
         this.entry = new AbstractMap.SimpleImmutableEntry<>(entry);
-        INVOKER.invoke(this::populateRegistry);
+        new RetryingInvoker(this.cache).invoke(this::populateRegistry);
         this.cache.addListener(this, new CacheRegistryFilter(), null);
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10736

Intended to better accommodate kill+restart scenarios.