### PR TITLE
[JBMAR-221] Test checks if default constructor of non-serializable parent POJO is called in deserialization process

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/CacheableObject.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/CacheableObject.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+public class CacheableObject {
+
+    private transient boolean _mutable_one;
+    private transient boolean _mutable_two;
+    private transient boolean _mutable_three;
+
+    public CacheableObject() {
+        this._mutable_one = true;
+        this._mutable_two = false;
+        this._mutable_three = true;
+    }
+
+    public boolean is_mutable_one() {
+        return _mutable_one;
+    }
+
+    public void set_mutable_one(boolean _mutable_one) {
+        this._mutable_one = _mutable_one;
+    }
+
+    public boolean is_mutable_two() {
+        return _mutable_two;
+    }
+
+    public void set_mutable_two(boolean _mutable_two) {
+        this._mutable_two = _mutable_two;
+    }
+
+    public boolean is_mutable_three() {
+        return _mutable_three;
+    }
+
+    public void set_mutable_three(boolean _mutable_three) {
+        this._mutable_three = _mutable_three;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/DefaultConstructorNonSerializedParentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/DefaultConstructorNonSerializedParentTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test checks if default constructor of non-serializable parent POJO is called in deserialization process.
+ * 1. POJO is initialized on client side using it's parent constructor.
+ * 2. One of the fields of the object is set to different value.
+ * 3. Remote stateless EJB is called and the object is used in the EJB call.
+ * 4. Field values received by the server are being checked to see if the default constructor of the non-serializable parent
+ *    was called on EJB server side.
+ * Test for [ JBMAR-221 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DefaultConstructorNonSerializedParentTestCase {
+
+    public static final String DEPLOYMENT = "deployment";
+    public static final String MODULE = "beans";
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(name = DEPLOYMENT, testable = false)
+    public static EnterpriseArchive createDeployment() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, DEPLOYMENT + ".ear");
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE + ".jar");
+        jar.addClasses(HelloBean.class, HelloRemote.class, CacheableObject.class, Response.class, LEContact.class);
+        ear.addAsModule(jar);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "servletDeployment.war");
+        war.addClasses(DefaultConstructorServlet.class, DefaultConstructorNonSerializedParentTestCase.class, HttpRequest.class);
+        war.addAsWebInfResource(DefaultConstructorNonSerializedParentTestCase.class.getPackage(), "WEB-INF/web.xml");
+        war.addAsWebInfResource(DefaultConstructorNonSerializedParentTestCase.class.getPackage(), "WEB-INF/jndi.properties", "classes/jndi.properties");
+        ear.addAsModule(war);
+
+        return ear;
+    }
+
+    @OperateOnDeployment(DEPLOYMENT)
+    @Test
+    public void testDefaultConstructorNonSerializedParent() throws Exception {
+        HttpResponse response = performCall(url);
+        StatusLine statusLine = response.getStatusLine();
+        assertEquals(200, statusLine.getStatusCode());
+    }
+
+    private HttpResponse performCall(URL url) throws Exception {
+        HttpResponse response = null;
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            final String requestURL = url.toExternalForm() + DefaultConstructorServlet.URL_PATTERN;
+            final HttpGet request = new HttpGet(requestURL);
+            response = httpClient.execute(request);
+            HttpEntity entity = response.getEntity();
+            String result = EntityUtils.toString(entity);
+            assertTrue(result.contains("mutable_one:true"));
+            assertTrue(result.contains("mutable_two:false"));
+            assertTrue(result.contains("mutable_three:true"));
+        }
+        return response;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/DefaultConstructorServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/DefaultConstructorServlet.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import org.jboss.logging.Logger;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Writer;
+import java.util.Hashtable;
+import java.util.Properties;
+
+@WebServlet(name = "DefaultConstructorServlet", urlPatterns = DefaultConstructorServlet.URL_PATTERN)
+public class DefaultConstructorServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -6189108351718996259L;
+
+    private static Logger log = Logger.getLogger(DefaultConstructorServlet.class.getName());
+
+    public static final String URL_PATTERN = "DefaultConstructorServlet";
+
+    /**
+     * Test Scenarios:
+     * test-1: _mutable_one defaults to true (set in constructor), we send true on client side
+     * test-2: _mutable_two defaults to false (set in constructor), we send false on client side
+     * test-3: _mutable_three defaults to true (set in constructor), but we change it to false, we send false on client side
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        log.trace("========== doGet method of the DefaultConstructorServlet called ==========");
+
+        Context context = null;
+        HelloRemote remote = null;
+        Response ejbResponse = null;
+
+        boolean init_mutable_one;
+        boolean init_mutable_two;
+        boolean init_mutable_three;
+
+        try {
+            LEContact leContact = new LEContact("test contact");
+
+            leContact.set_mutable_three(false);
+
+            init_mutable_one = leContact.is_mutable_one();
+            init_mutable_two = leContact.is_mutable_two();
+            init_mutable_three = leContact.is_mutable_three();
+            log.trace("Initial mutable_one value on EJB client: " + init_mutable_one + " *****");
+            log.trace("Initial mutable_two value on EJB client: " + init_mutable_two + " *****");
+            log.trace("Initial mutable_three value on EJB client: " + init_mutable_three + " *****");
+
+            context = new InitialContext(loadProperties());
+            String ejbName = getEjb();
+            remote = (HelloRemote) context.lookup(ejbName);
+
+            ejbResponse = remote.hello(leContact);
+
+            log.trace("***** values received on EJB server:" + ejbResponse.getRequestData() + " *****");
+
+            Writer writer = response.getWriter();
+            writer.write(ejbResponse.getRequestData());
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            if (null != context) {
+                try {
+                    context.close();
+                    remote = null;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    public static String getEjb() {
+        final String appName = DefaultConstructorNonSerializedParentTestCase.DEPLOYMENT;
+        final String moduleName = DefaultConstructorNonSerializedParentTestCase.MODULE;
+        final String distinctName = "";
+        final String beanName = HelloBean.class.getSimpleName();
+        final String interfaceName = HelloRemote.class.getName();
+        final String name = "ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName + "!" + interfaceName;
+
+        return name;
+    }
+
+    public Hashtable loadProperties() {
+        Properties prop = new Properties();
+        String propFileName = "jndi.properties";
+        Hashtable jndiProperties = new Hashtable();
+
+        try {
+            InputStream inputStream = getClass().getClassLoader().getResourceAsStream(propFileName);
+            if (inputStream != null) {
+                prop.load(inputStream);
+            } else {
+                throw new FileNotFoundException("property file '" + propFileName + "' not found in the classpath");
+            }
+
+            jndiProperties.put("java.naming.factory.url.pkgs", prop.get("java.naming.factory.url.pkgs"));
+            jndiProperties.put("java.naming.factory.initial", prop.get("java.naming.factory.initial"));
+            jndiProperties.put("java.naming.provider.url", prop.get("java.naming.provider.url"));
+            jndiProperties.put("java.naming.security.principal", prop.get("java.naming.security.principal"));
+            jndiProperties.put("java.naming.security.credentials", prop.get("java.naming.security.credentials"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return jndiProperties;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/HelloBean.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import org.jboss.logging.Logger;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import java.util.Calendar;
+
+@Stateless
+@Remote(HelloRemote.class)
+public class HelloBean implements HelloRemote {
+    private Logger log = Logger.getLogger(this.getClass().getSimpleName());
+
+    public Response hello(LEContact request) {
+        String startProcessing = Calendar.getInstance().getTime().toString();
+        log.trace("------------ EJB Server Side processing message ------------");
+        log.trace("------ Received Data Mutable_One: " + request.is_mutable_one());
+        log.trace("------ Received Data Mutable_Two: " + request.is_mutable_two());
+        log.trace("------ Received Data Mutable_Three: " + request.is_mutable_three());
+
+        Response response = new Response();
+        response.setStartProcessing(startProcessing);
+        response.setRequestData(request.toString());
+        response.setReturnData("Hello Simple EJB: " + request.toString());
+
+        String finishProcessing = Calendar.getInstance().getTime().toString();
+        response.setFinishProcessing(finishProcessing);
+
+        return response;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/HelloRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/HelloRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface HelloRemote {
+
+    Response hello(LEContact request);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/LEContact.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/LEContact.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import java.io.Serializable;
+
+public class LEContact extends CacheableObject implements Serializable {
+
+    private static final long serialVersionUID = 2989987093308217800L;
+
+    private String _name;
+    private int _id;
+
+    public LEContact(final String name) {
+        this._id = 0;
+        this._name = name;
+    }
+
+    public int getId() {
+        return this._id;
+    }
+
+    public void setId(final int id) {
+        this._id = id;
+    }
+
+    public String getName() {
+        return this._name;
+    }
+
+    public void setName(final String name) {
+        this._name = name;
+    }
+
+    public String toString() {
+        return "{\n\t name : " + this.getName() + ",\n" + "\t id : " + this.getId() + " \n" + "\t mutable_one:" + this.is_mutable_one() + " \n" + "\t mutable_two:" + this.is_mutable_two() + "\n"  + "\t mutable_three:" + this.is_mutable_three() + "\n}";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/Response.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/Response.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.serialization.deserialization;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+@XmlRootElement
+public class Response implements Serializable {
+
+    private static final long serialVersionUID = -8034636526599713401L;
+
+    private String requestData;
+    private String returnData;
+    private String startProcessing;
+    private String finishProcessing;
+
+    public String getRequestData() {
+        return requestData;
+    }
+
+    public void setRequestData(String requestData) {
+        this.requestData = requestData;
+    }
+
+    public String getReturnData() {
+        return returnData;
+    }
+
+    public void setReturnData(String returnData) {
+        this.returnData = returnData;
+    }
+
+    public String getStartProcessing() {
+        return startProcessing;
+    }
+
+    public void setStartProcessing(String startProcessing) {
+        this.startProcessing = startProcessing;
+    }
+
+    public String getFinishProcessing() {
+        return finishProcessing;
+    }
+
+    public void setFinishProcessing(String finishProcessing) {
+        this.finishProcessing = finishProcessing;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/WEB-INF/jndi.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/WEB-INF/jndi.properties
@@ -1,0 +1,6 @@
+java.naming.factory.initial=org.jboss.naming.remote.client.InitialContextFactory
+java.naming.factory.url.pkgs=org.jboss.ejb.client.naming
+java.naming.provider.url=http-remoting://localhost:8080
+
+java.naming.security.principal=jboss
+java.naming.security.credentials=password

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/WEB-INF/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/serialization/deserialization/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+  <display-name>default-constructor-ejb-web-client</display-name>
+  <servlet>
+    <servlet-name>DefaultConstructorServlet</servlet-name>
+    <servlet-class>org.jboss.as.test.integration.ejb.stateful.serialization.deserialization.DefaultConstructorServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>DefaultConstructorServlet</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+</web-app>


### PR DESCRIPTION
JIRA issue: [JBMAR-221](https://issues.jboss.org/browse/JBMAR-221)

1. POJO is initialized on client side using it's parent constructor.
2. One of the fields of the object is set to different value.
3. Remote stateless EJB is called and the object is used in the EJB call.
4. Field values received by the server are being checked to see if the default constructor of the non-serializable parent was called on EJB server side.