### PR TITLE
[WFLY-10914] Adding backward compatible option for ldaps connection

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLDAPServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLDAPServerSetupTask.java
@@ -304,7 +304,8 @@ public class LdapExtLDAPServerSetupTask implements ServerSetupTask {
          */
         @Override
         protected SystemProperty[] getSystemProperties() {
-            return new SystemProperty[]{new DefaultSystemProperty("javax.net.ssl.trustStore", KEYSTORE_FILE.getAbsolutePath())};
+            return new SystemProperty[]{new DefaultSystemProperty("javax.net.ssl.trustStore", KEYSTORE_FILE.getAbsolutePath()),
+                    new DefaultSystemProperty("com.sun.jndi.ldap.object.disableEndpointIdentification","")};
         }
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionClientCertTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionClientCertTestCase.java
@@ -67,6 +67,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
 import org.jboss.as.test.integration.security.common.AbstractSecurityRealmsServerSetupTask;
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.ManagedCreateTransport;
 import org.jboss.as.test.integration.security.common.Utils;
@@ -148,6 +149,7 @@ public class OutboundLdapConnectionClientCertTestCase {
     private final LDAPServerSetupTask ldapsSetup = new LDAPServerSetupTask();
     private final SecurityRealmsSetup realmsSetup = new SecurityRealmsSetup();
     private final SecurityDomainsSetup domainsSetup = new SecurityDomainsSetup();
+    private final SystemPropertiesSetup systemPropertiesSetup = new SystemPropertiesSetup();
     private static boolean serverConfigured = false;
 
     @ArquillianResource
@@ -194,6 +196,7 @@ public class OutboundLdapConnectionClientCertTestCase {
         ldapsSetup.startLdapServer();
         realmsSetup.setup(mgmtClient, CONTAINER);
         domainsSetup.setup(mgmtClient, CONTAINER);
+        systemPropertiesSetup.setup(mgmtClient, CONTAINER);
     }
 
     private void createTempKS(final String keystoreFilename, final File keystoreFile) throws IOException {
@@ -210,6 +213,7 @@ public class OutboundLdapConnectionClientCertTestCase {
         realmsSetup.tearDown(mgmtClient, CONTAINER);
         ldapsSetup.shutdownLdapServer();
         domainsSetup.tearDown(mgmtClient, CONTAINER);
+        systemPropertiesSetup.tearDown(mgmtClient, CONTAINER);
     }
 
     @Deployment(name = LDAPS_AUTHN_SD_ALWAYS, managed = false, testable = false)
@@ -400,6 +404,20 @@ public class OutboundLdapConnectionClientCertTestCase {
                     )
                     .build();
             return new SecurityRealm[]{sslConfRealm, ldapsAuthRealmAlways, ldapsAuthRealmSometimes};
+        }
+    }
+
+    /**
+     * This setup task disables hostname verification truststore file.
+     */
+    static class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+
+        /**
+         * @see org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask#getSystemProperties()
+         */
+        @Override
+        protected SystemProperty[] getSystemProperties() {
+            return new SystemProperty[]{new DefaultSystemProperty("com.sun.jndi.ldap.object.disableEndpointIdentification","")};
         }
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
@@ -67,6 +67,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
 import org.jboss.as.test.integration.security.common.AbstractSecurityRealmsServerSetupTask;
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.ManagedCreateTransport;
 import org.jboss.as.test.integration.security.common.Utils;
@@ -144,6 +145,7 @@ public class OutboundLdapConnectionTestCase {
     private final LDAPServerSetupTask ldapsSetup = new LDAPServerSetupTask();
     private final SecurityRealmsSetup realmsSetup = new SecurityRealmsSetup();
     private final SecurityDomainsSetup domainsSetup = new SecurityDomainsSetup();
+    private final SystemPropertiesSetup systemPropertiesSetup = new SystemPropertiesSetup();
     private static boolean serverConfigured = false;
 
     @ArquillianResource
@@ -190,6 +192,7 @@ public class OutboundLdapConnectionTestCase {
         ldapsSetup.startLdapServer();
         realmsSetup.setup(mgmtClient, CONTAINER);
         domainsSetup.setup(mgmtClient, CONTAINER);
+        systemPropertiesSetup.setup(mgmtClient, CONTAINER);
     }
 
     private void createTempKS(final String keystoreFilename, final File keystoreFile) throws IOException {
@@ -206,6 +209,7 @@ public class OutboundLdapConnectionTestCase {
         realmsSetup.tearDown(mgmtClient, CONTAINER);
         ldapsSetup.shutdownLdapServer();
         domainsSetup.tearDown(mgmtClient, CONTAINER);
+        systemPropertiesSetup.tearDown(mgmtClient, CONTAINER);
     }
 
     @Deployment(name = LDAPS_AUTHN_SD, managed = false, testable = false)
@@ -331,6 +335,20 @@ public class OutboundLdapConnectionTestCase {
                     .authorization(new Authorization.Builder().path("application-roles.properties")
                     .relativeTo("jboss.server.config.dir").build()).build();
             return new SecurityRealm[]{sslConfRealm, ldapsAuthRealm};
+        }
+    }
+
+    /**
+     * This setup task disables hostname verification truststore file.
+     */
+    static class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+
+        /**
+         * @see org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask#getSystemProperties()
+         */
+        @Override
+        protected SystemProperty[] getSystemProperties() {
+            return new SystemProperty[]{new DefaultSystemProperty("com.sun.jndi.ldap.object.disableEndpointIdentification","")};
         }
     }
 


### PR DESCRIPTION
[WFLY-10914] Adding backward compatible option -Dcom.sun.jndi.ldap.object.disableEndpointIdentification

For LDAPS connections host verification check was added by default. This option reverts previous behaviour. For details see https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html#JDK-8200666

https://issues.jboss.org/browse/WFLY-10914

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.