### PR TITLE
[WFLY-10876] Separate the OpenTracing modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger-core/main/module.xml
@@ -14,16 +14,21 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.jaegertracing.jaeger-core">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.jaegertracing:jaeger-core}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="com.google.code.gson"/>
+
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.opentracing-util"/>
+
+        <module name="org.slf4j"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger-thrift/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger-thrift/main/module.xml
@@ -14,16 +14,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.jaegertracing.jaeger-thrift">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.jaegertracing:jaeger-thrift}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="io.jaegertracing.jaeger-core"/>
+
+        <module name="org.slf4j"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-concurrent/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-concurrent/main/module.xml
@@ -14,16 +14,19 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-concurrent">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing.contrib:opentracing-concurrent}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.opentracing-noop"/>
+        <module name="io.opentracing.opentracing-util"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 Red Hat, Inc. and/or its affiliates
-  ~ and other contributors as indicated by the @author tags.
+  ~ Copyright 2018 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~   http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,35 +14,26 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.microprofile.opentracing-smallrye">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-jaxrs2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-microprofile-opentracing-smallrye}"/>
+        <artifact name="${io.opentracing.contrib:opentracing-jaxrs2}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="javax.inject.api"/>
-        <module name="javax.interceptor.api"/>
+        <module name="java.logging"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
 
-        <module name="io.jaegertracing.jaeger-core"/>
-        <module name="io.jaegertracing.jaeger-thrift" services="export"/>
         <module name="io.opentracing.opentracing-api"/>
         <module name="io.opentracing.opentracing-noop"/>
         <module name="io.opentracing.opentracing-util"/>
         <module name="io.opentracing.contrib.opentracing-concurrent"/>
-        <module name="io.opentracing.contrib.opentracing-jaxrs2"/>
-        <module name="io.opentracing.contrib.opentracing-tracerresolver"/>
         <module name="io.opentracing.contrib.opentracing-web-servlet-filter"/>
-        <module name="io.smallrye.opentracing"/>
 
-        <module name="org.apache.thrift"/>
-        <module name="org.jboss.logging"/>
+        <module name="org.eclipse.microprofile.opentracing"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-tracerresolver/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-tracerresolver/main/module.xml
@@ -14,16 +14,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-tracerresolver">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing.contrib:opentracing-tracerresolver}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="javax.annotation.api"/>
+
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.opentracing-util"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-web-servlet-filter/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-web-servlet-filter/main/module.xml
@@ -14,16 +14,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-web-servlet-filter">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing.contrib:opentracing-web-servlet-filter}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="javax.servlet.api" />
+
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.opentracing-util"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-api/main/module.xml
@@ -14,16 +14,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-api">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing:opentracing-api}"/>
     </resources>
-
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-noop/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-noop/main/module.xml
@@ -14,16 +14,17 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-noop">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing:opentracing-noop}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="io.opentracing.opentracing-api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-util/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/opentracing-util/main/module.xml
@@ -14,16 +14,18 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.opentracing-util">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.opentracing:opentracing-util}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.opentracing-noop"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/opentracing/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/opentracing/main/module.xml
@@ -14,16 +14,26 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="com.google.code.gson">
+<module xmlns="urn:jboss:module:1.8" name="io.smallrye.opentracing">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.google.code.gson:gson}"/>
+        <artifact name="${io.smallrye:smallrye-opentracing}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.sql.api"/>
+        <module name="java.logging"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.enterprise.api" />
+        <module name="javax.inject.api"/>
+        <module name="javax.ws.rs.api"/>
+
+        <module name="io.opentracing.opentracing-api"/>
+        <module name="io.opentracing.contrib.opentracing-jaxrs2"/>
+
+        <module name="org.eclipse.microprofile.opentracing"/>
+        <module name="org.wildfly.microprofile.opentracing-smallrye"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
@@ -25,8 +25,11 @@
     </resources>
 
     <dependencies>
+        <module name="javax.api"/> <!-- for javax.naming -->
+
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="javax.enterprise.concurrent.api"/>
         <module name="javax.inject.api"/>
         <module name="javax.interceptor.api"/>
         <module name="javax.servlet.api"/>
@@ -44,6 +47,8 @@
         <module name="io.smallrye.opentracing"/>
 
         <module name="org.apache.thrift"/>
+        <module name="org.eclipse.microprofile.opentracing"/>
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.resteasy.resteasy-jaxrs"/>
     </dependencies>
 </module>

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
@@ -31,12 +31,22 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 
 public class TracingDependencyProcessor implements DeploymentUnitProcessor {
-    public static final ModuleIdentifier MP_OT_MODULE = ModuleIdentifier.create("org.eclipse.microprofile.opentracing");
-    public static final ModuleIdentifier WF_OT_MODULE = ModuleIdentifier.create("org.wildfly.microprofile.opentracing-smallrye");
+    private static final String[] MODULES = {
+            "io.jaegertracing.jaeger-core",
+            "io.jaegertracing.jaeger-thrift",
+            "io.opentracing.contrib.opentracing-tracerresolver",
+            "io.opentracing.opentracing-api",
+            "io.opentracing.opentracing-util",
+            "org.eclipse.microprofile.opentracing",
+    };
+
+    private static final String[] EXPORTED_MODULES = {
+            "io.smallrye.opentracing",
+            "org.wildfly.microprofile.opentracing-smallrye",
+    };
 
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) {
@@ -51,9 +61,12 @@ public class TracingDependencyProcessor implements DeploymentUnitProcessor {
 
         ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
         ModuleLoader moduleLoader = Module.getBootModuleLoader();
-
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, MP_OT_MODULE, false, true, true, false));
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, WF_OT_MODULE, false, true, true, false));
+        for (String module : MODULES) {
+            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, false, true, false));
+        }
+        for (String module : EXPORTED_MODULES) {
+            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, true, true, false));
+        }
     }
 
     @Override

--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -90,6 +90,11 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.microprofile.opentracing.smallrye;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedExecutorService;
+import io.smallrye.opentracing.SmallRyeClientTracingFeature;
+import org.eclipse.microprofile.opentracing.ClientTracingRegistrarProvider;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.ws.rs.client.ClientBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class WildFlyClientTracingRegistrarProvider implements ClientTracingRegistrarProvider {
+    @Override
+    public ClientBuilder configure(ClientBuilder clientBuilder) {
+        ExecutorService executorService;
+
+        try {
+            executorService = InitialContext.doLookup("java:comp/DefaultManagedExecutorService");
+        } catch (NamingException e) {
+            executorService = Executors.newFixedThreadPool(10);
+        }
+
+        return configure(clientBuilder, executorService);
+    }
+
+    @Override
+    public ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService) {
+        Tracer tracer = CDI.current().select(Tracer.class).get();
+
+        ResteasyClientBuilder resteasyClientBuilder = (ResteasyClientBuilder) clientBuilder;
+        return resteasyClientBuilder
+                .asyncExecutor(new TracedExecutorService(executorService, tracer))
+                .register(new SmallRyeClientTracingFeature(tracer));
+    }
+}

--- a/microprofile/opentracing-smallrye/src/main/resources/META-INF/services/org.eclipse.microprofile.opentracing.ClientTracingRegistrarProvider
+++ b/microprofile/opentracing-smallrye/src/main/resources/META-INF/services/org.eclipse.microprofile.opentracing.ClientTracingRegistrarProvider
@@ -1,0 +1,1 @@
+org.wildfly.microprofile.opentracing.smallrye.WildFlyClientTracingRegistrarProvider

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/SimpleRestClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/SimpleRestClientTestCase.java
@@ -1,0 +1,89 @@
+package org.jboss.as.test.integration.microprofile.opentracing;
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerFactory;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.eclipse.microprofile.opentracing.ClientTracingRegistrar;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.microprofile.opentracing.application.MockTracerFactory;
+import org.jboss.as.test.integration.microprofile.opentracing.application.OpenTracingApplication;
+import org.jboss.as.test.integration.microprofile.opentracing.application.TracedEndpoint;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.net.URL;
+import java.util.List;
+
+@RunWith(Arquillian.class)
+public class SimpleRestClientTestCase {
+    @Inject
+    Tracer tracer;
+
+    @ArquillianResource
+    URL url;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        war.addClass(SimpleRestClientTestCase.class);
+
+        war.addClass(OpenTracingApplication.class);
+        war.addClass(TracedEndpoint.class);
+        war.addClass(MockTracerFactory.class);
+
+        war.addPackage(MockTracer.class.getPackage());
+        war.addAsServiceProvider(TracerFactory.class, MockTracerFactory.class);
+
+        war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @Test
+    public void clientRequestSpanJoinsServer() {
+        // sanity checks
+        Assert.assertNotNull(tracer);
+        Assert.assertTrue(tracer instanceof MockTracer);
+
+        // test
+        // the first span
+        try (Scope ignored = tracer.buildSpan("existing-span").startActive(true)) {
+
+            // the second span is the client request, as a child of `existing-span`
+            Client restClient = ClientTracingRegistrar.configure(ClientBuilder.newBuilder()).build();
+
+            // the third span is the traced endpoint, child of the client request
+            String targetUrl = url.toString() + "opentracing/traced";
+            WebTarget target = restClient.target(targetUrl);
+
+            try (Response response = target.request().get()) {
+                // just a sanity check
+                Assert.assertEquals(200, response.getStatus());
+            }
+        }
+
+        // verify
+        MockTracer mockTracer = (MockTracer) tracer;
+        List<MockSpan> spans = mockTracer.finishedSpans();
+        Assert.assertEquals(3, spans.size());
+        long traceId = spans.get(0).context().traceId();
+        for (MockSpan span : spans) {
+            // they should all belong to the same trace
+            Assert.assertEquals(traceId, span.context().traceId());
+        }
+    }
+
+}


### PR DESCRIPTION
See #11572 for the original version of this PR.

As part of running the TCK for #11572, I realized that the REST client tracing was missing, as the TCK implemented this code itself. As such, this PR extends the original by implementing this REST client tracing.

- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
