### PR TITLE
[WFLY-10918] Server dependencies should not contain ironjacamar-spec-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4469,6 +4469,10 @@
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>org.jboss.ironjacamar</groupId>
+                        <artifactId>ironjacamar-spec-api</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss</groupId>
                         <artifactId>jbossxb</artifactId>
                     </exclusion>
@@ -4500,6 +4504,10 @@
                 <artifactId>ironjacamar-core-api</artifactId>
                 <version>${version.org.jboss.ironjacamar}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.ironjacamar</groupId>
+                        <artifactId>ironjacamar-spec-api</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.jboss.integration</groupId>
                         <artifactId>jboss-integration</artifactId>


### PR DESCRIPTION
Exclude ironjacamar-spec-api transitive dependency from the server.

Jira issue: https://issues.jboss.org/browse/WFLY-10918