### PR TITLE
Upgrade wildfly-core from 6.0.0.CR3 to 6.0.0.CR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.CR3</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.CR4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
For some reason the version 6.0.0.CR4 seems to mostly disappeared from JIRA. I couldn't do a release notes report, however here is a query for the JIRA's https://issues.jboss.org/browse/WFCORE-4064?jql=project%20%3D%20WFCORE%20AND%20fixVersion%20%3D%206.0.0.CR4.