### PR TITLE
[WFLY-10927] Clean up servlet feature-pack config

### DIFF
--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -463,21 +463,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>wildfly-config-gen</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>wildfly-feature-spec-gen</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>wildfly-galleon-plugins</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>xalan</groupId>
             <artifactId>serializer</artifactId>
         </dependency>

--- a/servlet-galleon-pack/wildfly-feature-pack-build.xml
+++ b/servlet-galleon-pack/wildfly-feature-pack-build.xml
@@ -82,52 +82,20 @@
         <feature-group name="host-slave"/>
     </config>
 
-    <plugins>
-        <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>
-    </plugins>
-    <resources>
-        <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
-    </resources>
-
     <generate-feature-specs>
         <extensions>
             <standalone>
-                <extension>org.jboss.as.deployment-scanner</extension>
                 <extension>org.jboss.as.ee</extension>
-                <extension>org.jboss.as.jmx</extension>
-                <extension>org.jboss.as.logging</extension>
                 <extension>org.jboss.as.naming</extension>
                 <extension>org.jboss.as.security</extension>
-                <extension>org.wildfly.extension.core-management</extension>
-                <extension>org.wildfly.extension.elytron</extension>
-                <extension>org.wildfly.extension.io</extension>
-                <extension>org.wildfly.extension.request-controller</extension>
-                <extension>org.wildfly.extension.security.manager</extension>
                 <extension>org.wildfly.extension.undertow</extension>
-                <extension>org.jboss.as.remoting</extension>
-                <extension>org.wildfly.extension.discovery</extension>
             </standalone>
             <domain>
                 <extension>org.jboss.as.ee</extension>
-                <extension>org.jboss.as.jmx</extension>
-                <extension>org.jboss.as.logging</extension>
                 <extension>org.jboss.as.naming</extension>
                 <extension>org.jboss.as.security</extension>
-                <extension>org.wildfly.extension.core-management</extension>
-                <extension>org.wildfly.extension.elytron</extension>
-                <extension>org.wildfly.extension.io</extension>
-                <extension>org.wildfly.extension.request-controller</extension>
                 <extension>org.wildfly.extension.undertow</extension>
-                <extension>org.jboss.as.remoting</extension>
-                <extension>org.wildfly.extension.discovery</extension>
-                <extension>org.wildfly.extension.security.manager</extension>
             </domain>
-            <host>
-                <extension>org.jboss.as.jmx</extension>
-                <extension>org.wildfly.extension.core-management</extension>
-                <extension>org.wildfly.extension.discovery</extension>
-                <extension>org.wildfly.extension.elytron</extension>
-            </host>
         </extensions>
     </generate-feature-specs>
 </build>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10927

Now that WildFly Core feature-pack is built with WFGP 2.0.0.Final, servlet feature-pack can be cleaned up by removing bits that are now available in WildFly Core feature-pack that include:
- the expected version of the provisioning plugin and the config-gen jar;
- list of extensions from WildFly Core to generate feature specs.