### PR TITLE
Revert "Revert WFLY-8066"

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -4,11 +4,11 @@
     <extension-module>org.jboss.as.clustering.jgroups</extension-module>
     <subsystem xmlns="urn:jboss:domain:jgroups:6.0">
         <channels default="ee">
-            <channel name="ee" stack="udp" cluster="ejb"/>
+            <channel name="ee" stack="tcp" cluster="ejb"/>
         </channels>
         <stacks>
             <stack name="tcp">
-                <transport type="TCP" socket-binding="jgroups-tcp"/>
+                <transport type="TCP_NIO2" socket-binding="jgroups-tcp"/>
                 <?TCP-DISCOVERY?>
                 <protocol type="MERGE3"/>
                 <protocol type="FD_SOCK"/>

--- a/galleon-pack/src/main/resources/feature_groups/domain-ec2-full-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/domain-ec2-full-ha.xml
@@ -36,7 +36,7 @@
                 <feature spec="subsystem.jgroups.stack">
                     <param name="stack" value="tcp"/>
                     <feature spec="subsystem.jgroups.stack.transport">
-                        <param name="transport" value="TCP"/>
+                        <param name="transport" value="TCP_NIO2"/>
                         <param name="socket-binding" value="jgroups-tcp"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/domain-ec2-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/domain-ec2-ha.xml
@@ -30,7 +30,7 @@
                 <feature spec="subsystem.jgroups.stack">
                     <param name="stack" value="tcp"/>
                     <feature spec="subsystem.jgroups.stack.transport">
-                        <param name="transport" value="TCP"/>
+                        <param name="transport" value="TCP_NIO2"/>
                         <param name="socket-binding" value="jgroups-tcp"/>
                     </feature>
                     <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/jgroups.xml
+++ b/galleon-pack/src/main/resources/feature_groups/jgroups.xml
@@ -5,7 +5,7 @@
       <feature spec="subsystem.jgroups.stack">
         <param name="stack" value="tcp"/>
         <feature spec="subsystem.jgroups.stack.transport">
-          <param name="transport" value="TCP"/>
+          <param name="transport" value="TCP_NIO2"/>
           <param name="socket-binding" value="jgroups-tcp"/>
         </feature>
         <feature spec="subsystem.jgroups.stack.protocol.MPING">
@@ -87,7 +87,7 @@
       </feature>
       <feature spec="subsystem.jgroups.channel">
         <param name="channel" value="ee"/>
-        <param name="stack" value="udp"/>
+        <param name="stack" value="tcp"/>
         <param name="cluster" value="ejb"/>
       </feature>
     </feature>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-azure-full-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-azure-full-ha.xml
@@ -27,7 +27,7 @@
             <feature spec="subsystem.jgroups.stack">
                 <param name="stack" value="tcp"/>
                 <feature spec="subsystem.jgroups.stack.transport">
-                    <param name="transport" value="TCP"/>
+                    <param name="transport" value="TCP_NIO2"/>
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/standalone-azure-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-azure-ha.xml
@@ -42,7 +42,7 @@
             <feature spec="subsystem.jgroups.stack">
                 <param name="stack" value="tcp"/>
                 <feature spec="subsystem.jgroups.stack.transport">
-                    <param name="transport" value="TCP"/>
+                    <param name="transport" value="TCP_NIO2"/>
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/standalone-ec2-full-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-ec2-full-ha.xml
@@ -27,7 +27,7 @@
             <feature spec="subsystem.jgroups.stack">
                 <param name="stack" value="tcp"/>
                 <feature spec="subsystem.jgroups.stack.transport">
-                    <param name="transport" value="TCP"/>
+                    <param name="transport" value="TCP_NIO2"/>
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/standalone-ec2-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-ec2-ha.xml
@@ -42,7 +42,7 @@
             <feature spec="subsystem.jgroups.stack">
                 <param name="stack" value="tcp"/>
                 <feature spec="subsystem.jgroups.stack.transport">
-                    <param name="transport" value="TCP"/>
+                    <param name="transport" value="TCP_NIO2"/>
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">

--- a/galleon-pack/src/main/resources/feature_groups/standalone-gossip-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-gossip-ha.xml
@@ -15,7 +15,7 @@
             <feature spec="subsystem.jgroups.stack">
                 <param name="stack" value="tcp"/>
                 <feature spec="subsystem.jgroups.stack.transport">
-                    <param name="transport" value="TCP"/>
+                    <param name="transport" value="TCP_NIO2"/>
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">


### PR DESCRIPTION
Reverts wildfly/wildfly#11588

PR to see if the theory on https://github.com/wildfly/wildfly/pull/11588 is correct, and that it causes the clustering errors. 11588 reverts some changes which look like they cause errors on #11586 (which included the same commit) and https://github.com/wildfly/wildfly/pull/11495 is related.

This PR is expected to fail testing