### PR TITLE
[WFLY-10640] driver-datasource-class-name and driver-xa-datasource-class-name need to be validated when updating

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -910,11 +910,15 @@ public interface ConnectorLogger extends BasicLogger {
     void unexceptedWorkerCompletionError(String errorMessage, @Cause Throwable t);
 
     @Message(id = 114, value = "Failed to load datasource class: %s")
-    IllegalStateException failedToLoadDataSourceClass(String clsName, @Cause Throwable t);
+    OperationFailedException failedToLoadDataSourceClass(String clsName, @Cause Throwable t);
 
     @Message(id = 115, value = "Module for driver [%s] or one of it dependencies is missing: [%s]")
     String missingDependencyInModuleDriver(String moduleName, String missingModule);
 
     @Message(id = 116, value = "Failed to load module for RA [%s] - the module or one of its dependencies is missing [%s]")
     String raModuleNotFound(String moduleName, String missingModule);
+
+    @Message(id = 117, value = "%s is not a valid %s implementation")
+    OperationFailedException notAValidDataSourceClass(String clz, String dsClz);
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceWrongDsClassTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceWrongDsClassTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.sql.Driver;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.JcaMgmtBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the situation when abstract DataSource class is specified when creating a data source.
+ *
+ * @author lgao
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DatasourceWrongDsClassTestCase extends JcaMgmtBase {
+
+    private static final String DEPLOYMENT = "dummydriver";
+
+    @Deployment(name = DEPLOYMENT)
+    public static JavaArchive jdbcArchive() throws Exception {
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, DEPLOYMENT + ".jar");
+        ja.addClasses(DummyDataSource.class, DummyXADataSource.class, TestDriver.class);
+        ja.addAsServiceProviderAndClasses(Driver.class, TestDriver.class);
+        return ja;
+    }
+
+    @Test
+    public void testWrongDSClass() throws Exception {
+        String driverName = DEPLOYMENT + ".jar";
+        ModelNode address = getDataSourceAddress("wrongClsDs");
+        ModelNode operation = getDataSourceOperation(address, "java:/wrongClsDs", driverName, DummyDataSource.class.getName());
+        try {
+            executeOperation(operation);
+            Assert.fail("Not supposed to succeed");
+        } catch (MgmtOperationException e) {
+            ModelNode result = e.getResult();
+            Assert.assertEquals("failed", result.get("outcome").asString());
+            String failDesc = result.get("failure-description").asString();
+            Assert.assertTrue(failDesc.contains("WFLYJCA0117"));
+            return;
+        }
+        Assert.fail("Not supposed to be here");
+    }
+
+    @Test
+    public void testWrongXADSClass() throws Exception {
+        String driverName = DEPLOYMENT + ".jar";
+        ModelNode address = getXADataSourceAddress("wrongXAClsDs");
+        ModelNode operation = getXADataSourceOperation(address, "java:/wrongXAClsDs", driverName, DummyXADataSource.class.getName());
+        try {
+            executeOperation(operation);
+            Assert.fail("Not supposed to succeed");
+        } catch (MgmtOperationException e) {
+            ModelNode result = e.getResult();
+            Assert.assertEquals("failed", result.get("outcome").asString());
+            return;
+        }
+        Assert.fail("Not supposed to be here");
+    }
+
+    private ModelNode getXADataSourceAddress(String xaDsName) {
+        ModelNode address = new ModelNode()
+                .add(SUBSYSTEM, "datasources")
+                .add("xa-data-source", xaDsName);
+        return address;
+    }
+
+    private ModelNode getDataSourceAddress(String dsName) {
+        ModelNode address = new ModelNode()
+                .add(SUBSYSTEM, "datasources")
+                .add("data-source", dsName);
+        return address;
+    }
+
+    private ModelNode getDataSourceOperation(ModelNode address, String jndiName, String driverName, String dsClsName) {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(OP_ADDR).set(address);
+        operation.get("jndi-name").set(jndiName);
+        operation.get("driver-name").set(driverName);
+        operation.get("datasource-class").set(dsClsName);
+        return operation;
+    }
+
+    private ModelNode getXADataSourceOperation(ModelNode address, String jndiName, String driverName, String xaDsClsName) {
+        ModelNode addOp = new ModelNode();
+        addOp.get(OP).set(ADD);
+        addOp.get(OP_ADDR).set(address);
+        addOp.get("jndi-name").set(jndiName);
+        addOp.get("driver-name").set(driverName);
+        addOp.get("xa-datasource-class").set(xaDsClsName);
+
+        ModelNode connProps = new ModelNode();
+        connProps.get(OP).set(ADD);
+        ModelNode connPropAdd = address.add("connection-properties", "url");
+        connProps.get(OP_ADDR).set(connPropAdd);
+        connProps.get("value").set("dummy");
+        List<ModelNode> operationList = new ArrayList<>(Arrays.asList(addOp, connProps));
+        return ModelUtil.createCompositeNode(operationList.toArray(new ModelNode[1]));
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DummyDataSource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DummyDataSource.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import javax.sql.DataSource;
+
+/**
+ * Dummy abstract DataSource, used to verify that it cannot be specified during data source setup.
+ *
+ * @author <a href="mailto:lgao@redhat.com>Lin Gao</a>
+ */
+public abstract class DummyDataSource implements DataSource {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DummyXADataSource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DummyXADataSource.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import javax.sql.XADataSource;
+
+/**
+ * Dummy abstract XADataSource, used to verify that it cannot be specified during xa data source setup.
+ *
+ * @author <a href="mailto:lgao@redhat.com>Lin Gao</a>
+ */
+public abstract class DummyXADataSource implements XADataSource {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Test JDBC driver
+ */
+public class TestDriver implements Driver {
+    /**
+    * {@inheritDoc}
+    */
+    public Connection connect(String url, Properties info) throws SQLException {
+        return null;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public boolean acceptsURL(String url) throws SQLException {
+        return true;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+        Driver driver = DriverManager.getDriver(url);
+        return driver.getPropertyInfo(url, info);
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public int getMajorVersion() {
+        return 1;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public boolean jdbcCompliant() {
+        return false;
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/DriverCfgMetricUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/DriverCfgMetricUnitTestCase.java
@@ -49,8 +49,7 @@ public class DriverCfgMetricUnitTestCase extends JCAMetrictsTestBase {
     public void testDriverAttributes() throws Exception {
         setModel("complex-driver.xml");
         assertEquals("name", readAttribute(baseAddress, "driver-name").asString());
-        assertEquals("DsClass", readAttribute(baseAddress, "driver-datasource-class-name").asString());
-        assertEquals("XaDsClass", readAttribute(baseAddress, "driver-xa-datasource-class-name").asString());
+        assertEquals("org.h2.jdbcx.JdbcDataSource", readAttribute(baseAddress, "driver-xa-datasource-class-name").asString());
         removeDs();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
@@ -3,8 +3,7 @@
         <drivers>
             <driver name="name" module="com.h2database.h2" major-version="1" minor-version="4">
                 <driver-class>org.h2.Driver</driver-class>
-                <datasource-class>DsClass</datasource-class>
-                <xa-datasource-class>XaDsClass</xa-datasource-class>
+                <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
             </driver>
         </drivers>
     </datasources>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-10640

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

Try to check whether the specified `datasource-class` or `xa-datasource-class` is a valid implementation of `javax.sql.DataSource` or `javax.sql.XADataSource` when adding new jdbc driver or adding new (xa-)datasource.


