### PR TITLE
[WFLY-10930] Eliminate Wildfly Galleon plugin unnecessary configuration from servlet distribution

### DIFF
--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -550,53 +550,8 @@
                         <configuration>
                             <output-dir>${basedir}/target/resources/features</output-dir>
                             <fork-embedded>true</fork-embedded>
-                            <feature-packs>
-                                <feature-pack>
-                                    <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <type>zip</type>
-                                    <extension>zip</extension>
-                                </feature-pack>
-                            </feature-packs>
-                            <standalone-extensions>
-                                <extension>org.jboss.as.deployment-scanner</extension>
-                                <extension>org.jboss.as.ee</extension>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.jboss.as.logging</extension>
-                                <extension>org.jboss.as.naming</extension>
-                                <extension>org.jboss.as.security</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                                <extension>org.wildfly.extension.io</extension>
-                                <extension>org.wildfly.extension.request-controller</extension>
-                                <extension>org.wildfly.extension.security.manager</extension>
-                                <extension>org.wildfly.extension.undertow</extension>
-                                <extension>org.jboss.as.remoting</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                            </standalone-extensions>
-                            <domain-extensions>
-                                <extension>org.jboss.as.ee</extension>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.jboss.as.logging</extension>
-                                <extension>org.jboss.as.naming</extension>
-                                <extension>org.jboss.as.security</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                                <extension>org.wildfly.extension.io</extension>
-                                <extension>org.wildfly.extension.request-controller</extension>
-                                <extension>org.wildfly.extension.undertow</extension>
-                                <extension>org.jboss.as.remoting</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                                <extension>org.wildfly.extension.security.manager</extension>
-                            </domain-extensions>
-                            <host-extensions>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                            </host-extensions>
                         </configuration>
-                        </execution>
+                    </execution>
                     <execution>
                         <id>feature-pack-build</id>
                         <goals>


### PR DESCRIPTION
The removed configuration is no longer valid for this plugin since Galleon wildfly plugins 2.0.0.Final
This configuration does not affect to build, but it should not be there.

Jira issue: https://issues.jboss.org/browse/WFLY-10930

cc: @aloubyansky 