### PR TITLE
[WFLY-10938] Avoid overriding galleon pack properties when feature pack licenses html files are created

### DIFF
--- a/galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -2,6 +2,6 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/full-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/full-licenses.xsl" src="docs/licenses/full-feature-pack-licenses.xml" output="docs/licenses/full-feature-pack-licenses.html"/>
+    <transform stylesheet="docs/licenses/full-licenses.xsl" src="docs/licenses/full-feature-pack-licenses.xml" output="docs/licenses/full-feature-pack-licenses.html" feature-pack-properties="true"/>
     <delete path="docs/licenses/full-licenses.xsl"/>
 </tasks>

--- a/servlet-galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -2,6 +2,6 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/servlet-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/servlet-licenses.xsl" src="docs/licenses/servlet-feature-pack-licenses.xml" output="docs/licenses/servlet-feature-pack-licenses.html"/>
+    <transform stylesheet="docs/licenses/servlet-licenses.xsl" src="docs/licenses/servlet-feature-pack-licenses.xml" output="docs/licenses/servlet-feature-pack-licenses.html" feature-pack-properties="true"/>
     <delete path="docs/licenses/servlet-licenses.xsl"/>
 </tasks>


### PR DESCRIPTION
Counterpart PR on wildfly full for https://github.com/wildfly/wildfly-core/pull/3485
It will protect the properties used by the tasks that create the licenses html files so they are not overridden by any feature pack that depends on any wildfly-full feature packs.

jira issue: https://issues.jboss.org/browse/WFLY-10938