### PR TITLE
[WFLY-10943] Upgrade to Hibernate ORM 5.3.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
-        <version.org.hibernate>5.3.5.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.4.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.3.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.13.Final</version.org.hibernate.validator>


### PR DESCRIPTION
 * https://issues.jboss.org/browse/WFLY-10943

Note that ORM is not pushed to JBoss Nexus but to Bintray and then synced to Central. I forced the sync to Central and it's supposed to be synced but I can't find it yet in the Central UI.

Hopefully, CI will be able to get it.