### PR TITLE
Upgrade wildfly-core from 6.0.0.CR4 to 6.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.0.CR4</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
# 6.0.0.Final Release Notes

<hr />

<h2>Bug</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-3962">WFCORE-3962</a> ] Starting WFLY scripts with JDK 11 blows up with ModuleNotFoundException java.se</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4000">WFCORE-4000</a> ] Domain tests fail on JDK11 because of missing java.se module</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4039">WFCORE-4039</a> ] Fix JvmOptionsBuilderFactory JDK decision logic</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4049">WFCORE-4049</a> ] Deactivate modular jdk properties we used in the past for workarounds.</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4065">WFCORE-4065</a> ] Minor discrepancies between galleon build output and legacy build output</li>
</ul>

<h2>Task</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4066">WFCORE-4066</a> ] Avoid overriding galleon pack properties when core-feature-pack-licenses.html is created</li>
</ul>

<h2>Component Upgrade</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4070">WFCORE-4070</a> ] Upgrade jboss-vfs to 3.2.14.Final</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4068">WFCORE-4068</a> ] Upgrade JBoss Modules to 1.8.6</li>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4073">WFCORE-4073</a> ] Upgrade JBoss Marshalling to 2.0.6.Final</li>
</ul>
