### PR TITLE
[WFLY-10926] More config order fixes

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -7,20 +7,6 @@
             <channel name="ee" stack="udp" cluster="ejb"/>
         </channels>
         <stacks>
-            <stack name="tcp">
-                <transport type="TCP" socket-binding="jgroups-tcp"/>
-                <?TCP-DISCOVERY?>
-                <protocol type="MERGE3"/>
-                <protocol type="FD_SOCK"/>
-                <protocol type="FD_ALL"/>
-                <protocol type="VERIFY_SUSPECT"/>
-                <protocol type="pbcast.NAKACK2"/>
-                <protocol type="UNICAST3"/>
-                <protocol type="pbcast.STABLE"/>
-                <protocol type="pbcast.GMS"/>
-                <?TCP-MULTICAST-FLOW-CONTROL?>
-                <protocol type="FRAG3"/>
-            </stack>
             <stack name="udp">
                 <transport type="UDP" socket-binding="jgroups-udp"/>
                 <?UDP-DISCOVERY?>
@@ -34,6 +20,20 @@
                 <protocol type="pbcast.GMS"/>
                 <protocol type="UFC"/>
                 <?UDP-MULTICAST-FLOW-CONTROL?>
+                <protocol type="FRAG3"/>
+            </stack>
+            <stack name="tcp">
+                <transport type="TCP" socket-binding="jgroups-tcp"/>
+                <?TCP-DISCOVERY?>
+                <protocol type="MERGE3"/>
+                <protocol type="FD_SOCK"/>
+                <protocol type="FD_ALL"/>
+                <protocol type="VERIFY_SUSPECT"/>
+                <protocol type="pbcast.NAKACK2"/>
+                <protocol type="UNICAST3"/>
+                <protocol type="pbcast.STABLE"/>
+                <protocol type="pbcast.GMS"/>
+                <?TCP-MULTICAST-FLOW-CONTROL?>
                 <protocol type="FRAG3"/>
             </stack>
         </stacks>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -45,8 +45,8 @@
                 <param name="buffer-pooling" value="false" />
             </in-vm-acceptor>
 
-            <?DISCOVERY-GROUPS?>
             <?BROADCAST-GROUPS?>
+            <?DISCOVERY-GROUPS?>
             <?CLUSTER-CONNECTIONS?>
 
             <jms-queue name="ExpiryQueue"


### PR DESCRIPTION
Fixes https://github.com/wildfly/wildfly/pull/11604/files#diff-679a9252ceed9b2babbb0460a3840939L47 from #11604, which was wrong.

Also reverts a commit from the previous PR for this issue which was no longer necessary once WFLY-8066 was reverted.

This just fixes the order of elements in the xml configs produced by the legacy build. Minor.

@kabir @jamezp FYI.