### PR TITLE
[WFLY-10811] Removing unnecessary --illegal-access & --add-exports fr…

### DIFF
--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -75,7 +75,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -89,7 +89,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -81,7 +81,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/galleon-pack/src/main/resources/feature_groups/host-master.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host-master.xml
@@ -7,7 +7,7 @@
         <param name="host" value="master"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
         </feature>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/host-slave.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host-slave.xml
@@ -10,7 +10,7 @@
         <param name="host" value="slave"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
         </feature>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/host.xml
+++ b/galleon-pack/src/main/resources/feature_groups/host.xml
@@ -10,7 +10,7 @@
         <param name="host" value="master"/>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
         </feature>
         <feature spec="host.server-config">
             <param name="server-config" value="server-two"/>

--- a/pom.xml
+++ b/pom.xml
@@ -6989,7 +6989,6 @@
                     --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
                     --add-modules=java.se</modular.jdk.args>
             </properties>
-
         </profile>
         <profile>
             <id>docs</id>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -75,7 +75,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -92,7 +92,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -84,7 +84,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-master.xml
@@ -33,7 +33,7 @@
             <param name="jvm" value="default"/>
             <param name="heap-size" value="64m"/>
             <param name="max-heap-size" value="256m"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
             <unset param="environment-variables"/>
         </feature>
     </feature>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host-slave.xml
@@ -9,7 +9,7 @@
                     <param name="jvm" value="default"/>
                     <param name="heap-size" value="64m"/>
                     <param name="max-heap-size" value="256m"/>
-                    <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+                    <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
                     <unset param="environment-variables"/>
                 </feature>
             </include>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/host.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/host.xml
@@ -13,7 +13,7 @@
         </feature>
         <feature spec="host.jvm">
             <param name="jvm" value="default"/>
-            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;,&quot;--add-exports=java.base/sun.nio.ch=ALL-UNNAMED&quot;]"/>
+            <param name="jvm-options" value="[&quot;-server&quot;,&quot;-XX:MetaspaceSize=96m&quot;,&quot;-XX:MaxMetaspaceSize=256m&quot;]"/>
         </feature>
         <feature spec="host.server-config">
             <param name="server-config" value="server-two"/>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -77,8 +77,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -77,8 +77,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -73,8 +73,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -79,8 +79,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -92,8 +92,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -75,8 +75,6 @@
             <heap size="64m" max-size="256m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -58,8 +58,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -67,8 +67,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -95,8 +95,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -92,8 +92,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -90,8 +90,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -73,8 +73,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -100,8 +100,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -78,8 +78,6 @@
             <heap size="64m" max-size="256m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -112,8 +112,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -109,8 +109,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="-ea"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--illegal-access=permit"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -113,8 +113,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -67,8 +67,6 @@
           <heap size="64m" max-size="128m"/>
            <jvm-options>
                <option value="-ea"/>
-               <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--illegal-access=permit"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-7-1-0.xml
@@ -81,7 +81,6 @@
                 <option value="-server"/>
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
-                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
             </jvm-options>
         </jvm>
     </jvms>


### PR DESCRIPTION
…om host configs.

https://issues.jboss.org/browse/WFLY-10811

This separates out one of the commits from #11612 from the other script-related commit. The other commit is still being discussed/tested but that should not prevent us removing unneeded cruft from our standard config files, which the commit here does.