### PR TITLE
[WFLY-10949] IllegalArgumentException when get jdbc driver info if xa-datasource-class is not defined

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
@@ -96,7 +96,7 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
                         driverNode.get(MODULE_SLOT.getName()).set(driver.getModuleName() != null ? driver.getModuleName().getSlot() : "");
                         driverNode.get(DRIVER_DATASOURCE_CLASS_NAME.getName()).set(
                                 driver.getDataSourceClassName() != null ? driver.getDataSourceClassName() : "");
-                        driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).set(driver.getXaDataSourceClassName());
+                        driverNode.get(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).set(driver.getXaDataSourceClassName() != null ? driver.getXaDataSourceClassName() : "");
 
                     }
                     driverNode.get(DATASOURCE_CLASS_INFO.getName()).set(

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/DataSourceOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/datasource/DataSourceOperationsUnitTestCase.java
@@ -322,6 +322,36 @@ public class DataSourceOperationsUnitTestCase extends DsMgmtTestBase {
         }
     }
 
+    @Test
+    public void testReadJdbcDriver() throws Exception {
+        String h2DriverName = "h2backup";
+        final ModelNode addrAddH2DriverAddr = new ModelNode();
+        addrAddH2DriverAddr.add("subsystem", "datasources").add("jdbc-driver", h2DriverName);
+        final ModelNode addH2DriverOp = new ModelNode();
+        addH2DriverOp.get(OP).set("add");
+        addH2DriverOp.get(OP_ADDR).set(addrAddH2DriverAddr);
+        addH2DriverOp.get("driver-name").set(h2DriverName);
+        addH2DriverOp.get("driver-module-name").set("com.h2database.h2");
+        executeOperation(addH2DriverOp);
+        try {
+            final ModelNode address = new ModelNode();
+            address.add("subsystem", "datasources");
+            address.protect();
+
+            final ModelNode operation = new ModelNode();
+            operation.get(OP).set("get-installed-driver");
+            operation.get(OP_ADDR).set(address);
+            operation.get("driver-name").set(h2DriverName);
+
+            final ModelNode result = executeOperation(operation).get(0);
+            Assert.assertEquals(h2DriverName, result.get("driver-name").asString());
+            Assert.assertEquals("com.h2database.h2", result.get("driver-module-name").asString());
+            Assert.assertEquals("", result.get("driver-xa-datasource-class-name").asString());
+        } finally {
+            remove(addrAddH2DriverAddr);
+        }
+    }
+
     /**
      * AS7-1203 test for missing xa-datasource properties
      *


### PR DESCRIPTION

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

Jira: https://issues.jboss.org/browse/WFLY-10949

Checking whether the `driver-xa-datasource-class-name` is defined when run command:
`/subsystem=datasources:get-installed-driver(driver-name=xxx)`

