### PR TITLE
[WFLY-10928] Fix URLs for wildfly-core-feature-pack license

### DIFF
--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -2734,6 +2734,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-galleon-pack</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>wildfly-ee-security</artifactId>
       <licenses>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -594,6 +594,22 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-core-galleon-pack</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-elytron-integration</artifactId>
       <licenses>
         <license>


### PR DESCRIPTION
This patch corrects the URLs used for wildfly-core-galleon-pack licenses ('GNU Lesser General Public License v2.1 or later' and 'Apache License 2.0') changing them from:
- http://repository.jboss.org/licenses/lgpl-2.1.txt
- http://repository.jboss.org/licenses/apache-2.0.txt

To: 

- http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html
- http://www.apache.org/licenses/LICENSE-2.0

The content of the licenses is the same, it only changes the URLs in the same manner as it is done for other artifacts comming from wildfly-core.

Jira issue: https://issues.jboss.org/browse/WFLY-10928
