### PR TITLE
[WFLY-10951] allowing a SSLException with SocketException cause

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslNeedClientAuthTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ssl/UndertowTwoWaySslNeedClientAuthTestCase.java
@@ -32,7 +32,10 @@ import java.net.MalformedURLException;
 import java.net.SocketException;
 import java.net.URISyntaxException;
 import java.net.URL;
+
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
+
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.codehaus.plexus.util.FileUtils;
@@ -140,6 +143,9 @@ public class UndertowTwoWaySslNeedClientAuthTestCase {
         } catch (SSLHandshakeException | SocketException e) {
             // expected
             return;
+        } catch (SSLException e) {
+            if (e.getCause() instanceof SocketException) return; // expected
+            throw new IllegalStateException("Unexpected SSLException", e);
         } catch (IOException | URISyntaxException ex) {
             throw new IllegalStateException("Unable to request server root over HTTPS", ex);
         }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -41,6 +41,7 @@ import java.net.SocketException;
 import java.net.URL;
 import java.util.Locale;
 
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.servlet.http.HttpServletResponse;
@@ -292,6 +293,10 @@ public class HTTPSWebConnectorTestCase {
                 //depending on the OS and the version of HTTP client in use any one of these exceptions may be thrown
                 //in particular the SocketException gets thrown on Windows
                 // OK
+            } catch (SSLException e) {
+                if (! (e.getCause() instanceof SocketException)) { // OK
+                    throw e;
+                }
             }
 
             try {
@@ -299,6 +304,10 @@ public class HTTPSWebConnectorTestCase {
                 fail("Untrusted client should not be authenticated.");
             } catch (SSLHandshakeException |SSLPeerUnverifiedException | SocketException e) {
                 // OK
+            } catch (SSLException e) {
+                if (! (e.getCause() instanceof SocketException)) { // OK
+                    throw e;
+                }
             }
 
             try {
@@ -306,6 +315,10 @@ public class HTTPSWebConnectorTestCase {
                 fail("Untrusted client should not be authenticated.");
             } catch (SSLHandshakeException |SSLPeerUnverifiedException | SocketException e) {
                 // OK
+            } catch (SSLException e) {
+                if (! (e.getCause() instanceof SocketException)) { // OK
+                    throw e;
+                }
             }
 
         } finally {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10951
(subtask of https://issues.jboss.org/browse/WFLY-10812 )

elytron testsuite failures on JDK-11:
* UndertowTwoWaySslNeedClientAuthTestCase produce a bit different SSLException on JDK-11