### PR TITLE
[WFLY-10954] Failing OnOffOpenTracingTestCase on IBM java

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
@@ -145,7 +145,10 @@ public class OnOffOpenTracingTestCase {
             // Perform request to the deployment on server where OpenTracing is disabled. Deployment must not have a Tracer instance available.
             // Actually 500 internal server error is responded with NoClassDefFoundError.
             response = Utils.makeCall(requestUri, 500);
-            Assert.assertTrue(response.contains("java.lang.NoClassDefFoundError: Lio/opentracing/Tracer"));
+            Assert.assertTrue(
+                    "HTTP response did not contain expected exception indicating that opentracing Tracer is not available.",
+                    response.matches("(?s).*java\\.lang\\.NoClassDefFoundError: L*io.opentracing.Tracer.*"));
+            // really dots because openjdk uses '/' whereas ibmjdk uses '.'      ---^        ---^
         } finally {
             opentracingSubsystem(ModelDescriptionConstants.ADD, managementClient.getControllerClient());
         }


### PR DESCRIPTION
 - Fixed matching expression to successfully match also on IBM JDK.

https://issues.jboss.org/browse/WFLY-10954

The OnOffOpenTracingTestCase fails with IBM java due to the different stack trace output compared to the OpenJDK/OracleJDK. In the test there is checked
```
java.lang.NoClassDefFoundError: Lio/opentracing/Tracer
```
but IBM java provides slightly different variation
```
java.lang.NoClassDefFoundError: io.opentracing.Tracer
```
in the stacktrace.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.