### PR TITLE
WFLY-10784 Introduce Phase.CLEANUP based Weld processor to end initia…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/EjbService.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/EjbService.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.optionalComponent.cleanup;
+
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Singleton
+@Startup
+public class EjbService {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/StandardServletAsyncWebRequest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/StandardServletAsyncWebRequest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.optionalComponent.cleanup;
+
+import java.io.IOException;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class StandardServletAsyncWebRequest implements AsyncListener {
+
+    /**
+     * just to make non-default constructor - this is against spec and will blow up
+     */
+    public StandardServletAsyncWebRequest(HttpServletRequest request, HttpServletResponse response) {
+    }
+
+    @Override
+    public void onStartAsync(AsyncEvent event) throws IOException {
+    }
+
+    @Override
+    public void onError(AsyncEvent event) throws IOException {
+    }
+
+    @Override
+    public void onTimeout(AsyncEvent event) throws IOException {
+    }
+
+    @Override
+    public void onComplete(AsyncEvent event) throws IOException {
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/WeldCleanupWithOptionalWebComponentTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/optionalComponent/cleanup/WeldCleanupWithOptionalWebComponentTest.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.weld.optionalComponent.cleanup;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that Weld cleanup is not causing deployment errors for composite deployment with optional web component.
+ *
+ * @see WFLY-10784
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class WeldCleanupWithOptionalWebComponentTest {
+
+    @Deployment(name = "ear", testable = false)
+    public static Archive<?> ear() {
+        // create faulty WAR
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "WebComponentsIntegrationTestCase.war");
+        war.addAsLibraries(
+            ShrinkWrap.create(JavaArchive.class, "module.jar").addClass(StandardServletAsyncWebRequest.class));
+
+        // create EJB JAR
+        JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "ejb.jar").addClass(EjbService.class);
+
+        // add all to EAR
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "WebComponentsIntegrationTestCase.ear");
+        ear.addAsModule(war);
+        ear.addAsModule(ejb);
+        return ear;
+    }
+
+    @Test
+    @RunAsClient
+    public void testEar() {
+        // no-op the ability to deploy without error is the test here
+    }
+
+}

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldStartCompletionService.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldStartCompletionService.java
@@ -21,8 +21,15 @@
  */
 package org.jboss.as.weld;
 
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -31,10 +38,14 @@ import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
- * This service calls {@link Bootstrap#endInitialization()}, i.e. places the container into a state where it can service requests. It is started after all EE
- * components are installed which allows Weld to perform efficient cleanup and further optimizations after bootstrap.
+ * This service calls {@link Bootstrap#endInitialization()}, i.e. places the container into a state where it can service
+ * requests.
+ *
+ * Its start is delayed after all EE components are installed which allows Weld to perform efficient cleanup and further
+ * optimizations after bootstrap.
  *
  * @author Martin Kouba
+ * @author Matej Novotny
  * @see WeldStartService
  */
 public class WeldStartCompletionService implements Service<WeldStartCompletionService> {
@@ -42,21 +53,59 @@ public class WeldStartCompletionService implements Service<WeldStartCompletionSe
     public static final ServiceName SERVICE_NAME = ServiceNames.WELD_START_COMPLETION_SERVICE_NAME;
 
     private final InjectedValue<WeldBootstrapService> bootstrap = new InjectedValue<WeldBootstrapService>();
+    private final InjectedValue<ExecutorService> executorService = new InjectedValue<ExecutorService>();
 
     private final ClassLoader classLoader;
+    private final List<ServiceController> serviceControllers;
 
-    public WeldStartCompletionService(ClassLoader classLoader) {
+    private final AtomicBoolean runOnce = new AtomicBoolean();
+
+    public WeldStartCompletionService(ClassLoader classLoader, List<ServiceController> serviceControllers) {
         this.classLoader = classLoader;
+        this.serviceControllers = serviceControllers;
     }
 
     @Override
     public void start(final StartContext context) throws StartException {
-        ClassLoader oldTccl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        if (!runOnce.compareAndSet(false, true)) {
+            // we only execute this once, if there is a restart, WeldStartService initiates re-deploy hence we do nothing here
+            return;
+        }
+
+        final ExecutorService executor = executorService.getValue();
+        final Runnable task = new Runnable() {
+            // we want to execute StabilityMonitor.awaitStability() in a different thread so that this is non-blocking
+            @Override
+            public void run() {
+                StabilityMonitor monitor = new StabilityMonitor();
+                for (ServiceController controller : serviceControllers) {
+                    monitor.addController(controller);
+                }
+                try {
+                    monitor.awaitStability();
+                } catch (InterruptedException ex) {
+                    context.failed(new StartException(ex));
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ex);
+                } finally {
+                    monitor.clear();
+                }
+                ClassLoader oldTccl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+                try {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+                    bootstrap.getValue().getBootstrap().endInitialization();
+                } finally {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
+                    context.complete();
+                }
+            }
+        };
         try {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            bootstrap.getValue().getBootstrap().endInitialization();
+            executor.execute(task);
+        } catch (RejectedExecutionException e) {
+            task.run();
         } finally {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
+            context.asynchronous();
         }
     }
 
@@ -72,6 +121,10 @@ public class WeldStartCompletionService implements Service<WeldStartCompletionSe
 
     public InjectedValue<WeldBootstrapService> getBootstrap() {
         return bootstrap;
+    }
+
+    public InjectedValue<ExecutorService> getServerExecutor() {
+        return executorService;
     }
 
 }

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldStartService.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldStartService.java
@@ -71,7 +71,7 @@ public class WeldStartService implements Service<WeldStartService> {
          * Weld service restarts are not supported. Therefore, if we detect that Weld is being restarted we
          * trigger restart of the entire deployment.
          */
-        if (runOnce.get()) {
+        if (!runOnce.compareAndSet(false,true)) {
             ServiceController<?> controller = context.getController().getServiceContainer().getService(deploymentServiceName);
             controller.addListener(new LifecycleListener() {
                 @Override
@@ -85,7 +85,6 @@ public class WeldStartService implements Service<WeldStartService> {
             controller.setMode(Mode.NEVER);
             return;
         }
-        runOnce.set(true);
 
         ClassLoader oldTccl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
@@ -46,6 +46,7 @@ import org.jboss.as.weld.deployment.processors.WeldBeanManagerServiceProcessor;
 import org.jboss.as.weld.deployment.processors.WeldComponentIntegrationProcessor;
 import org.jboss.as.weld.deployment.processors.WeldConfigurationProcessor;
 import org.jboss.as.weld.deployment.processors.WeldDependencyProcessor;
+import org.jboss.as.weld.deployment.processors.WeldDeploymentCleanupProcessor;
 import org.jboss.as.weld.deployment.processors.WeldDeploymentProcessor;
 import org.jboss.as.weld.deployment.processors.WeldImplicitDeploymentProcessor;
 import org.jboss.as.weld.deployment.processors.WeldPortableExtensionProcessor;
@@ -107,6 +108,8 @@ class WeldSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_COMPONENT_INTEGRATION, new WeldComponentIntegrationProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_WELD_DEPLOYMENT, new WeldDeploymentProcessor(checkJtsEnabled(context)));
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_WELD_BEAN_MANAGER, new WeldBeanManagerServiceProcessor());
+                // note that we want to go one step before Phase.CLEANUP_EE because we use metadata that it then cleans up
+                processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.CLEANUP, Phase.CLEANUP_EE - 1, new WeldDeploymentCleanupProcessor());
 
                 // Add additional deployment processors
                 ServiceLoader<DeploymentUnitProcessorProvider> processorProviders = ServiceLoader.load(DeploymentUnitProcessorProvider.class,

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentCleanupProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentCleanupProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.weld.deployment.processors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.Services;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.weld.WeldBootstrapService;
+import org.jboss.as.weld.WeldStartCompletionService;
+import org.jboss.as.weld.WeldStartService;
+import org.jboss.as.weld.util.Utils;
+import org.jboss.modules.Module;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * A processor which takes care of after boot cleanup for Weld. The idea is to invoke
+ * {@code org.jboss.weld.bootstrap.WeldStartup.endInitialization()} after all EE components are installed.
+ *
+ * This allows Weld to do metadata cleanup on unused items.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class WeldDeploymentCleanupProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final DeploymentUnit parent = Utils.getRootDeploymentUnit(deploymentUnit);
+        final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+        final ServiceTarget serviceTarget = phaseContext.getServiceTarget();
+
+        // obtain service names
+        ServiceName weldStartCompletionServiceName = parent.getServiceName().append(WeldStartCompletionService.SERVICE_NAME);
+        ServiceName weldBootstrapServiceName = parent.getServiceName().append(WeldBootstrapService.SERVICE_NAME);
+        ServiceName weldStartServiceName = parent.getServiceName().append(WeldStartService.SERVICE_NAME);
+
+        // if it is not Weld deployment, we skip it
+        if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
+            return;
+        }
+
+        // only register this on top level deployments
+        if (deploymentUnit.getParent() != null) {
+            return;
+        }
+
+        // extract all service controllers and store them as attachment for WeldDeploymentCleanupProcessor to use
+        List<ServiceController> serviceControllers = new ArrayList<>();
+
+        // add controllers from top level deployment
+        for (ServiceName serviceName : getComponentStartServiceNames(deploymentUnit)) {
+            ServiceController<?> controller = deploymentUnit.getServiceRegistry().getService(serviceName);
+            if (controller != null) {
+                serviceControllers.add(controller);
+            }
+        }
+
+        // add controllers from sub-deployments
+        final List<DeploymentUnit> subDeployments = deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS);
+        for (DeploymentUnit sub : subDeployments) {
+            ServiceRegistry registry = sub.getServiceRegistry();
+            List<ServiceName> componentStartServiceNames = getComponentStartServiceNames(sub);
+
+            for (ServiceName name : componentStartServiceNames) {
+                ServiceController<?> serviceController = registry.getService(name);
+                if (serviceController != null) {
+                    serviceControllers.add(serviceController);
+                }
+            }
+        }
+
+        // pass on service controllers so that we can do StabilityMonitor.awaitStability() on those with our service
+        // we also add dependency on our WeldBootstrapService and WeldStartService to ensure this goes after them
+        WeldStartCompletionService weldStartCompletionService = new WeldStartCompletionService(module.getClassLoader(), serviceControllers);
+        ServiceBuilder<WeldStartCompletionService> weldStartCompletionServiceBuilder = serviceTarget
+            .addService(weldStartCompletionServiceName, weldStartCompletionService)
+            .addDependency(weldBootstrapServiceName, WeldBootstrapService.class, weldStartCompletionService.getBootstrap())
+            .addDependency(Services.JBOSS_SERVER_EXECUTOR, ExecutorService.class, weldStartCompletionService.getServerExecutor())
+            .addDependency(weldStartServiceName);
+        weldStartCompletionServiceBuilder.install();
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+        // no-op
+    }
+
+    private List<ServiceName> getComponentStartServiceNames(DeploymentUnit deploymentUnit) {
+        List<ServiceName> serviceNames = new ArrayList<>();
+        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
+        if (eeModuleDescription == null) {
+            return serviceNames;
+        }
+        for (ComponentDescription component : eeModuleDescription.getComponentDescriptions()) {
+            serviceNames.add(component.getStartServiceName());
+        }
+        return serviceNames;
+    }
+}

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -36,8 +36,6 @@ import java.util.concurrent.ExecutorService;
 
 import javax.enterprise.inject.spi.Extension;
 
-import org.jboss.as.ee.component.ComponentDescription;
-import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.naming.JavaNamespaceSetup;
 import org.jboss.as.ee.weld.WeldDeploymentMarker;
 import org.jboss.as.naming.deployment.ContextNames;
@@ -56,7 +54,6 @@ import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.weld.ServiceNames;
 import org.jboss.as.weld.WeldBootstrapService;
-import org.jboss.as.weld.WeldStartCompletionService;
 import org.jboss.as.weld.WeldStartService;
 import org.jboss.as.weld.deployment.BeanDeploymentArchiveImpl;
 import org.jboss.as.weld.deployment.BeanDeploymentModule;
@@ -123,7 +120,6 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         //add a dependency on the weld service to web deployments
         final ServiceName weldBootstrapServiceName = parent.getServiceName().append(WeldBootstrapService.SERVICE_NAME);
         ServiceName weldStartServiceName = parent.getServiceName().append(WeldStartService.SERVICE_NAME);
-        ServiceName weldStartCompletionServiceName = parent.getServiceName().append(WeldStartCompletionService.SERVICE_NAME);
         deploymentUnit.addToAttachmentList(Attachments.WEB_DEPENDENCIES, weldStartServiceName);
 
         final Set<ServiceName> dependencies = new HashSet<ServiceName>();
@@ -286,27 +282,6 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         }
 
         startService.install();
-
-        // Defer invocation of WeldBootstrap.endInitialization() until all EE components are started
-        WeldStartCompletionService weldStartCompletionService = new WeldStartCompletionService(module.getClassLoader());
-
-        ServiceBuilder<WeldStartCompletionService> weldStartCompletionServiceBuilder = serviceTarget
-                .addService(weldStartCompletionServiceName, weldStartCompletionService)
-                .addDependency(weldBootstrapServiceName, WeldBootstrapService.class, weldStartCompletionService.getBootstrap())
-                .addDependency(weldStartServiceName).addDependencies(getComponentStartServiceNames(deploymentUnit));
-        for (DeploymentUnit sub : subDeployments) {
-            weldStartCompletionServiceBuilder.addDependencies(getComponentStartServiceNames(sub));
-        }
-        weldStartCompletionServiceBuilder.install();
-    }
-
-    private List<ServiceName> getComponentStartServiceNames(DeploymentUnit deploymentUnit) {
-        List<ServiceName> dependencies = new ArrayList<>();
-        final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
-        for (ComponentDescription component : eeModuleDescription.getComponentDescriptions()) {
-            dependencies.add(component.getStartServiceName());
-        }
-        return dependencies;
     }
 
     private List<ServiceName> getJNDISubsytemDependencies() {


### PR DESCRIPTION
…lization. Use StabilityMonitor to delay invocation.

JIRA issue - https://issues.jboss.org/browse/WFLY-10784

In short - Weld cleanup was done by declaring service dependency on other services which could fail whole deployment if there was a faulty optional web component. This approach uses additional DUP with `StabilityMonitor`.

Automated test is included.