### PR TITLE
[WFLY-10959] Update product.release.version to 15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <product.release.version>${project.version}</product.release.version>
         <product.docs.server.version>14</product.docs.server.version>
         <!-- A short variant of product.release.version used in 'startsWith' tests done by dist verification logic -->
-        <verifier.product.release.version>14.0</verifier.product.release.version>
+        <verifier.product.release.version>15.0</verifier.product.release.version>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>


### PR DESCRIPTION
Update product.release.version to 15.0

WF can't be built without this change:
```
[INFO] ------------------------------------------------------------------------
[INFO] Building WildFly: Distribution 15.0.0.Alpha1-SNAPSHOT
[INFO] ------------------------------------------------------------------------
....
[error] [Verifier] File [/home/mkopecky/git/base/dist/target/wildfly-15.0.0.Alpha1-SNAPSHOT/modules/system/layers/base/org/jboss/as/product/wildfly-full/dir/META-INF/MANIFEST.MF] does not match regexp [JBoss-Product-Release-Version: 14.0]
```

Jira: https://issues.jboss.org/browse/WFLY-10959