### PR TITLE
[WFLY-10958] Fix verifier and docs version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,9 +135,9 @@
         <servlet.dist.product.release.name>WildFly Servlet</servlet.dist.product.release.name>
         <servlet.dist.product.slot>wildfly-web</servlet.dist.product.slot>
         <product.release.version>${project.version}</product.release.version>
-        <product.docs.server.version>14</product.docs.server.version>
+        <product.docs.server.version>15</product.docs.server.version>
         <!-- A short variant of product.release.version used in 'startsWith' tests done by dist verification logic -->
-        <verifier.product.release.version>14.0</verifier.product.release.version>
+        <verifier.product.release.version>15.0</verifier.product.release.version>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>


### PR DESCRIPTION
 After each new release the product.docs.server.version and verifier.product.release.version properties should be changed as well.

Jira issue: https://issues.jboss.org/browse/WFLY-10958