### PR TITLE
WFLY-10630 HttpSessionListener.sessionDestroyed() not called if session invalidated in another WAR

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
@@ -50,6 +50,7 @@ public class DistributableSessionManagerFactory implements io.undertow.servlet.a
 
     private final SessionManagerFactory<LocalSessionContext, Batch> factory;
     private final DistributableSessionManagerConfiguration config;
+    private final SessionListeners listeners = new SessionListeners();
 
     public DistributableSessionManagerFactory(SessionManagerFactory<LocalSessionContext, Batch> factory, DistributableSessionManagerConfiguration config) {
         this.factory = factory;
@@ -62,8 +63,7 @@ public class DistributableSessionManagerFactory implements io.undertow.servlet.a
         boolean statisticsEnabled = info.getMetricsCollector() != null;
         RecordableInactiveSessionStatistics inactiveSessionStatistics = statisticsEnabled ? new RecordableInactiveSessionStatistics() : null;
         IdentifierFactory<String> factory = new IdentifierFactoryAdapter(info.getSessionIdGenerator());
-        SessionListeners listeners = new SessionListeners();
-        SessionExpirationListener expirationListener = new UndertowSessionExpirationListener(deployment, listeners);
+        SessionExpirationListener expirationListener = new UndertowSessionExpirationListener(deployment, this.listeners);
         SessionManagerConfiguration configuration = new SessionManagerConfiguration() {
             @Override
             public ServletContext getServletContext() {
@@ -102,6 +102,6 @@ public class DistributableSessionManagerFactory implements io.undertow.servlet.a
             }
         });
         RecordableSessionManagerStatistics statistics = (inactiveSessionStatistics != null) ? new DistributableSessionManagerStatistics(manager, inactiveSessionStatistics, this.config.getMaxActiveSessions()) : null;
-        return new DistributableSessionManager(info.getDeploymentName(), manager, listeners, statistics);
+        return new DistributableSessionManager(info.getDeploymentName(), manager, this.listeners, statistics);
     }
 }


### PR DESCRIPTION
Affects session sharing across WARs within an EAR.
https://issues.jboss.org/browse/WFLY-10630