### PR TITLE
[WFLY-10978] Add the com.squareup.okhttp3 module dependency to the io…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/jaegertracing/jaeger/main/module.xml
@@ -28,6 +28,7 @@
 
     <dependencies>
         <module name="com.google.code.gson"/>
+        <module name="com.squareup.okhttp3"/>
 
         <module name="io.opentracing.opentracing-api"/>
         <module name="io.opentracing.opentracing-util"/>


### PR DESCRIPTION
….jaegertracing.jaeger-thrift module.

https://issues.jboss.org/browse/WFLY-10978