### PR TITLE
Upgrade WildFly Core from 6.0.1.Final to 6.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
<h2>Bug</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/WFCORE-4086">WFCORE-4086</a> ] Starting an embedded server with older versions of WildFly Core results in a NoSuchMethodException</li>
</ul>