### PR TITLE
[WFLY-6607]: Broadcast/Discovery group is possible to create with just a name.

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -72,6 +72,7 @@ import static org.jboss.as.messaging.CommonAttributes.POOLED_CONNECTION_FACTORY;
 import static org.jboss.as.messaging.CommonAttributes.REMOTE_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.REMOTE_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.SHARED_STORE;
+import static org.jboss.as.messaging.CommonAttributes.SOCKET_BINDING;
 import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.jboss.dmr.ModelType.EXPRESSION;
@@ -441,8 +442,9 @@ public class MigrateOperation implements OperationStepHandler {
                     }
                 }
             }
-
-            newAddOperations.put(address, newAddOp);
+            if(newAddOp.isDefined()) {
+                newAddOperations.put(address, newAddOp);
+            }
         }
     }
 
@@ -501,6 +503,14 @@ public class MigrateOperation implements OperationStepHandler {
         }
         // These attributes no longer accept expressions in the messaging-activemq subsystem.
         removePropertiesWithExpression(newAddOp, warnings, JGROUPS_CHANNEL.getName(), JGROUPS_STACK.getName());
+        if (!newAddOp.hasDefined(SOCKET_BINDING.getName())) {
+            if(!newAddOp.hasDefined(JGROUPS_CHANNEL.getName())) {
+                warnings.add(ROOT_LOGGER.couldNotMigrateDiscoveryGroup(pathAddress(newAddOp.get(OP_ADDR))));
+                newAddOp.clear();
+            } else {
+                newAddOp.get("jgroups-cluster").set(newAddOp.get(JGROUPS_CHANNEL.getName()));
+            }
+        }
     }
 
     private void migrateBroadcastGroup(ModelNode newAddOp, List<String> warnings) {
@@ -517,6 +527,14 @@ public class MigrateOperation implements OperationStepHandler {
         }
         // These attributes no longer accept expressions in the messaging-activemq subsystem.
         removePropertiesWithExpression(newAddOp, warnings, JGROUPS_CHANNEL.getName(), JGROUPS_STACK.getName());
+        if (!newAddOp.hasDefined(SOCKET_BINDING.getName())) {
+            if(!newAddOp.hasDefined(JGROUPS_CHANNEL.getName())) {
+                warnings.add(ROOT_LOGGER.couldNotMigrateBroadcastGroup(pathAddress(newAddOp.get(OP_ADDR))));
+                newAddOp.clear();
+            } else {
+                newAddOp.get("jgroups-cluster").set(newAddOp.get(JGROUPS_CHANNEL.getName()));
+            }
+        }
     }
 
 

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -819,4 +819,10 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 88, value = "Can not migrate attribute failback-delay to resource %s. Artemis detects failback deterministically and it no longer requires to specify a delay for failback to occur.")
     String couldNotMigrateFailbackDelayAttribute(PathAddress address);
+
+    @Message(id = 89, value = "Can not migrate discovery group %s. as no network configuration is properly defined.")
+    String couldNotMigrateDiscoveryGroup(PathAddress address);
+
+    @Message(id = 90, value = "Can not migrate broadcast group %s. as no network configuration is properly defined.")
+    String couldNotMigrateBroadcastGroup(PathAddress address);
 }

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -820,9 +820,9 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 88, value = "Can not migrate attribute failback-delay to resource %s. Artemis detects failback deterministically and it no longer requires to specify a delay for failback to occur.")
     String couldNotMigrateFailbackDelayAttribute(PathAddress address);
 
-    @Message(id = 89, value = "Can not migrate discovery group %s. as no network configuration is properly defined.")
+    @Message(id = 89, value = "Can not migrate discovery group %s as no network configuration is properly defined.")
     String couldNotMigrateDiscoveryGroup(PathAddress address);
 
-    @Message(id = 90, value = "Can not migrate broadcast group %s. as no network configuration is properly defined.")
+    @Message(id = 90, value = "Can not migrate broadcast group %s as no network configuration is properly defined.")
     String couldNotMigrateBroadcastGroup(PathAddress address);
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -152,16 +152,15 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         migrateOp.get(OP_ADDR).add(SUBSYSTEM, SUBSYSTEM_NAME);
 
         ModelNode response = services.executeOperation(migrateOp);
-        System.out.println("Response " + response);
         checkOutcome(response);
 
         ModelNode warnings = response.get(RESULT, "migration-warnings");
         // 6 warnings about broadcast-group attributes that can not be migrated.
         // 2 warnings about broadcast-group attributes not migrated because they have an expression.
-        // 3 warnings about broadcast-group not migrated because they don't have a proper network configuration.
+        // 3 warnings about broadcast-group not migrated because they don't have a proper network configuration (A, B, T).
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about discovery-group attributes not migrated because they have an expression.
-        // 3 warnings about discovery-group not migrated because they don't have a proper network configuration.
+        // 3 warnings about discovery-group not migrated because they don't have a proper network configuration (C, D, U).
         // 3 warnings about interceptors that can not be migrated (for remoting-interceptors, remoting-incoming-interceptors & remoting-outgoing-interceptors attributes)
         // 1 warning about HA migration (attributes have expressions)
         // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -152,19 +152,21 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         migrateOp.get(OP_ADDR).add(SUBSYSTEM, SUBSYSTEM_NAME);
 
         ModelNode response = services.executeOperation(migrateOp);
-
+        System.out.println("Response " + response);
         checkOutcome(response);
 
         ModelNode warnings = response.get(RESULT, "migration-warnings");
         // 6 warnings about broadcast-group attributes that can not be migrated.
         // 2 warnings about broadcast-group attributes not migrated because they have an expression.
+        // 3 warnings about broadcast-group not migrated because they don't have a proper network configuration.
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about discovery-group attributes not migrated because they have an expression.
+        // 3 warnings about discovery-group not migrated because they don't have a proper network configuration.
         // 3 warnings about interceptors that can not be migrated (for remoting-interceptors, remoting-incoming-interceptors & remoting-outgoing-interceptors attributes)
         // 1 warning about HA migration (attributes have expressions)
         // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.
         // 1 warning about use-nio being ignored for netty-throughput remote-connector resource.
-        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 3 + 1 + 1 + 1;
+        int expectedNumberOfWarnings = 6 + 2 + 3 + 5 + 2 + 3 + 3 + 1 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -120,13 +120,16 @@
             <broadcast-group name="groupB">
                 <group-address>224.0.1.105</group-address>
                 <group-port>34567</group-port>
+                <connector-ref>in-vm</connector-ref>
             </broadcast-group>
             <broadcast-group name="groupS">
                 <socket-binding>group-s-binding</socket-binding>
+                <connector-ref>in-vm</connector-ref>
             </broadcast-group>
             <broadcast-group name="groupT">
                 <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
                 <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                <connector-ref>in-vm</connector-ref>
             </broadcast-group>
         </broadcast-groups>
         <discovery-groups>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -28,8 +28,6 @@ import static org.jboss.as.controller.registry.AttributeAccess.Flag.STORAGE_RUNT
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTORS;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_BINDING;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -71,7 +69,7 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final PrimitiveListAttributeDefinition CONNECTOR_REFS = new StringListAttributeDefinition.Builder(CONNECTORS)
-            .setRequired(false)
+            .setRequired(true)
             .setElementValidator(new StringLengthValidator(1))
             .setAttributeParser(AttributeParser.STRING_LIST)
             .setAttributeMarshaller(AttributeMarshaller.STRING_LIST)
@@ -92,6 +90,14 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
 
     @Deprecated public static final SimpleAttributeDefinition JGROUPS_CHANNEL_FACTORY = create(CommonAttributes.JGROUPS_CHANNEL_FACTORY)
             .setCapabilityReference("org.wildfly.clustering.jgroups.channel-factory")
+            .build();
+
+    public static final SimpleAttributeDefinition JGROUPS_CLUSTER = create(CommonAttributes.JGROUPS_CLUSTER)
+            .setRequired(true)
+            .build();
+
+    public static final SimpleAttributeDefinition SOCKET_BINDING = create(CommonAttributes.SOCKET_BINDING)
+            .setRequired(true)
             .build();
 
     public static final SimpleAttributeDefinition JGROUPS_CHANNEL = create(CommonAttributes.JGROUPS_CHANNEL)
@@ -149,12 +155,10 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
         final Set<String> availableConnectors =  getAvailableConnectors(context,operation);
         final List<ModelNode> operationAddress = operation.get(ModelDescriptionConstants.ADDRESS).asList();
         final String broadCastGroup = operationAddress.get(operationAddress.size()-1).get(CommonAttributes.BROADCAST_GROUP).asString();
-        if(connectorRefs.isDefined()) {
-            for(ModelNode connectorRef:connectorRefs.asList()){
-                final String connectorName = connectorRef.asString();
-                if(!availableConnectors.contains(connectorName)){
-                    throw MessagingLogger.ROOT_LOGGER.wrongConnectorRefInBroadCastGroup(broadCastGroup, connectorName, availableConnectors);
-                }
+        for (ModelNode connectorRef : connectorRefs.asList()) {
+            final String connectorName = connectorRef.asString();
+            if (!availableConnectors.contains(connectorName)) {
+                throw MessagingLogger.ROOT_LOGGER.wrongConnectorRefInBroadCastGroup(broadCastGroup, connectorName, availableConnectors);
             }
         }
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -70,6 +70,7 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
 
     public static final PrimitiveListAttributeDefinition CONNECTOR_REFS = new StringListAttributeDefinition.Builder(CONNECTORS)
             .setRequired(true)
+            .setMinSize(1)
             .setElementValidator(new StringLengthValidator(1))
             .setAttributeParser(AttributeParser.STRING_LIST)
             .setAttributeMarshaller(AttributeMarshaller.STRING_LIST)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -65,4 +65,11 @@ public class Capabilities {
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/management/path-manager/capability.adoc">documentation</a>
      */
     static final String PATH_MANAGER_CAPABILITY = "org.wildfly.management.path-manager";
+
+    /**
+     * The capability for the SocketBinding capability
+     *
+     * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/network/socket-binding/capability.adoc">documentation</a>
+     */
+    static final String SOCKET_BINDING_CAPABILITY = "org.wildfly.network.socket-binding";
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -24,11 +24,11 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_BINDING;
 
 import java.util.Arrays;
 import java.util.Collection;
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
@@ -36,6 +36,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.capability.DynamicNameMappers;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -104,7 +105,7 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     protected DiscoveryGroupDefinition(final boolean registerRuntimeOnly, final boolean subsystemResource) {
-        super(new Parameters(PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.DISCOVERY_GROUP))
+        super(new SimpleResourceDefinition.Parameters(PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.DISCOVERY_GROUP))
                 .setAddHandler(DiscoveryGroupAdd.INSTANCE)
                 .setRemoveHandler(DiscoveryGroupRemove.INSTANCE));
         this.registerRuntimeOnly = registerRuntimeOnly;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -89,6 +89,14 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
             .setCapabilityReference(ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getName())
             .build();
 
+    public static final SimpleAttributeDefinition JGROUPS_CLUSTER = create(CommonAttributes.JGROUPS_CLUSTER)
+            .setRequired(true)
+            .build();
+
+    public static final SimpleAttributeDefinition SOCKET_BINDING = create(CommonAttributes.SOCKET_BINDING)
+            .setRequired(true)
+            .build();
+
     public static final AttributeDefinition[] ATTRIBUTES = { JGROUPS_CHANNEL_FACTORY, JGROUPS_CHANNEL, JGROUPS_CLUSTER, SOCKET_BINDING,
             REFRESH_TIMEOUT, INITIAL_WAIT_TIMEOUT
     };

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -31,8 +31,13 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CO
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
 
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
 import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
@@ -330,17 +335,31 @@ public class MessagingSubsystemParser_1_0 extends PersistentResourceXMLParser {
                                                         .addAttributes(
                                                                 CommonAttributes.SOCKET_BINDING,
                                                                 BroadcastGroupDefinition.JGROUPS_CHANNEL_FACTORY,
-                                                                CommonAttributes.JGROUPS_CHANNEL,
                                                                 BroadcastGroupDefinition.BROADCAST_PERIOD,
-                                                                BroadcastGroupDefinition.CONNECTOR_REFS))
+                                                                BroadcastGroupDefinition.CONNECTOR_REFS)
+                                                        .addAttribute(DiscoveryGroupDefinition.JGROUPS_CHANNEL, new AttributeParser() {
+                                                                @Override
+                                                                public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+                                                                    ModelNode paramVal = parse(attribute, value, reader);
+                                                                    operation.get(attribute.getName()).set(paramVal);
+                                                                    operation.get(DiscoveryGroupDefinition.JGROUPS_CLUSTER.getName()).set(paramVal);
+                                                                }
+                                                            }))
                                         .addChild(
                                                 builder(DiscoveryGroupDefinition.PATH)
                                                         .addAttributes(
                                                                 CommonAttributes.SOCKET_BINDING,
                                                                 DiscoveryGroupDefinition.JGROUPS_CHANNEL_FACTORY,
-                                                                CommonAttributes.JGROUPS_CHANNEL,
                                                                 DiscoveryGroupDefinition.REFRESH_TIMEOUT,
-                                                                DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT))
+                                                                DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT)
+                                                        .addAttribute(DiscoveryGroupDefinition.JGROUPS_CHANNEL, new AttributeParser() {
+                                                                @Override
+                                                                public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+                                                                    ModelNode paramVal = parse(attribute, value, reader);
+                                                                    operation.get(attribute.getName()).set(paramVal);
+                                                                    operation.get(DiscoveryGroupDefinition.JGROUPS_CLUSTER.getName()).set(paramVal);
+                                                                }
+                                                            }))
                                         .addChild(
                                                 builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
                                                         .addAttributes(

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_2_0.java
@@ -31,8 +31,13 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CO
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
 
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
 import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
 import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
@@ -344,17 +349,31 @@ public class MessagingSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                                 .addAttributes(
                                                         CommonAttributes.SOCKET_BINDING,
                                                         BroadcastGroupDefinition.JGROUPS_CHANNEL_FACTORY,
-                                                        CommonAttributes.JGROUPS_CHANNEL,
                                                         BroadcastGroupDefinition.BROADCAST_PERIOD,
-                                                        BroadcastGroupDefinition.CONNECTOR_REFS))
+                                                        BroadcastGroupDefinition.CONNECTOR_REFS)
+                                                .addAttribute(DiscoveryGroupDefinition.JGROUPS_CHANNEL, new AttributeParser() {
+                                                    @Override
+                                                    public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+                                                        ModelNode paramVal = parse(attribute, value, reader);
+                                                        operation.get(attribute.getName()).set(paramVal);
+                                                        operation.get(DiscoveryGroupDefinition.JGROUPS_CLUSTER.getName()).set(paramVal);
+                                                    }
+                                                }))
                                 .addChild(
                                         builder(DiscoveryGroupDefinition.PATH)
                                                 .addAttributes(
                                                         CommonAttributes.SOCKET_BINDING,
                                                         DiscoveryGroupDefinition.JGROUPS_CHANNEL_FACTORY,
-                                                        CommonAttributes.JGROUPS_CHANNEL,
                                                         DiscoveryGroupDefinition.REFRESH_TIMEOUT,
-                                                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT))
+                                                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT)
+                                                .addAttribute(DiscoveryGroupDefinition.JGROUPS_CHANNEL, new AttributeParser() {
+                                                    @Override
+                                                    public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+                                                        ModelNode paramVal = parse(attribute, value, reader);
+                                                        operation.get(attribute.getName()).set(paramVal);
+                                                        operation.get(DiscoveryGroupDefinition.JGROUPS_CLUSTER.getName()).set(paramVal);
+                                                    }
+                                                }))
                                 .addChild(
                                         builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
                                                 .addAttributes(

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_4_0_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_4_0_TestCase.java
@@ -107,6 +107,7 @@ public class MessagingActiveMQSubsystem_4_0_TestCase extends AbstractSubsystemBa
         return super.standardSubsystemTest(configId, false);
     }
 
+
     /////////////////////////////////////////
     //  Tests for HA Policy Configuration  //
     /////////////////////////////////////////

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
@@ -170,7 +170,8 @@
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
-                         socket-binding="group-s-binding"/>
+                         socket-binding="group-s-binding"
+                         connectors="in-vm"/>
 
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_2_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_2_0.xml
@@ -181,7 +181,8 @@
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
-                         socket-binding="group-s-binding"/>
+                         socket-binding="group-s-binding"
+                         connectors="in-vm"/>
 
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_3_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_3_0.xml
@@ -181,7 +181,8 @@
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
-                         socket-binding="group-s-binding"/>
+                         socket-binding="group-s-binding"
+                         connectors="in-vm"/>
 
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_3_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_3_0_reject_transform.xml
@@ -80,7 +80,8 @@
 
         <broadcast-group name="groupT"
                          jgroups-channel="ee"
-                         jgroups-cluster="activemq-cluster"/>
+                         jgroups-cluster="activemq-cluster"
+                         connectors="http"/>
 
         <discovery-group name="groupU"
                          jgroups-channel="ee"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_4_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_4_0.xml
@@ -321,7 +321,8 @@
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
-                         socket-binding="group-s-binding"/>
+                         socket-binding="group-s-binding"
+                         connectors="http netty"/>
 
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_4_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_4_0_reject_transform.xml
@@ -136,7 +136,8 @@
 
         <broadcast-group name="groupT"
                          jgroups-channel="ee"
-                         jgroups-cluster="activemq-cluster"/>
+                         jgroups-cluster="activemq-cluster"
+                         connectors="http"/>
 
         <discovery-group name="groupU"
                          jgroups-channel="ee"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_5_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_5_0.xml
@@ -27,6 +27,7 @@
 
     <discovery-group name="client-discovery-group-1"
                      socket-binding="group-t-binding"/>
+
     <discovery-group name="client-discovery-group-2"
                      jgroups-channel="ee"
                      jgroups-cluster="activemq-cluster"
@@ -321,10 +322,12 @@
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
-                         socket-binding="group-s-binding"/>
+                         socket-binding="group-s-binding"
+                         connectors="http netty"/>
 
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>
+
         <discovery-group name="groupU"
                          jgroups-channel="ee"
                          jgroups-cluster="activemq-cluster"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_5_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_5_0_reject_transform.xml
@@ -136,7 +136,9 @@
 
         <broadcast-group name="groupT"
                          jgroups-channel="ee"
-                         jgroups-cluster="activemq-cluster"/>
+                         jgroups-cluster="activemq-cluster"
+                         connectors="http"/>
+
 
         <discovery-group name="groupU"
                          jgroups-channel="ee"


### PR DESCRIPTION
     * [WFLY-11005]: Requires connectors for broadcast-group resource.
     * Making jgroups-cluster and socket-bindings required for DiscoveryGroups and BroadcasrGroups.
     * Fixing migration

Requires https://github.com/wildfly/wildfly/pull/11678

Jira: https://issues.jboss.org/browse/WFLY-6607
Jira: https://issues.jboss.org/browse/WFLY-11005