### PR TITLE
[WFLY-10939] tests if deployment with taglib-location pointing to jar fails during deployment.

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/TagLibInJarTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/TagLibInJarTestCase.java
@@ -42,6 +42,7 @@ public class TagLibInJarTestCase {
 
     private static final String TLD_INSIDE_RESOURCES = "tld-inside-resources";
     private static final String TLD_OUTSIDE_RESOURCES = "tld-outside-resources";
+    private static final String TLD_INSIDE_JAR = "tld-inside-jar";
     private static final String JAR_NAME = "taglib.jar";
     private static final String JSP = "index.jsp";
     private static final String WEB_FRAGMENT = "web-fragment.xml";
@@ -54,6 +55,10 @@ public class TagLibInJarTestCase {
     @OperateOnDeployment(TLD_INSIDE_RESOURCES)
     private URL urlDep2;
 
+    @ArquillianResource
+    @OperateOnDeployment(TLD_INSIDE_JAR)
+    private URL urlDep3;
+
     @Deployment(name = TLD_OUTSIDE_RESOURCES)
     public static WebArchive deployment1() throws Exception {
         return createDeployment(TLD_OUTSIDE_RESOURCES + ".war", "tlds/taglib.tld");
@@ -64,6 +69,11 @@ public class TagLibInJarTestCase {
         return createDeployment(TLD_INSIDE_RESOURCES + ".war", "resources/tlds/taglib.tld");
     }
 
+    @Deployment(name = TLD_INSIDE_JAR)
+    public static WebArchive deployment3() throws Exception {
+        return createDeployment3(TLD_INSIDE_JAR + ".war");
+    }
+
     private static WebArchive createDeployment(String name, String tldLocation) throws Exception {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JAR_NAME)
                 .addAsManifestResource(TagLibInJarTestCase.class.getPackage(), "taglib.tld", tldLocation)
@@ -71,6 +81,17 @@ public class TagLibInJarTestCase {
                 .addClass(TestTag.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, name)
                 .addAsLibraries(jar)
+                .addAsWebResource(TagLibInJarTestCase.class.getPackage(), JSP, JSP);
+        return war;
+    }
+
+    private static WebArchive createDeployment3(String name) throws Exception {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JAR_NAME)
+                .addAsManifestResource(TagLibInJarTestCase.class.getPackage(), "taglibInJar.tld", "tlds/taglibInJar.tld")
+                .addClass(TestTag.class);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, name)
+                .addAsLibraries(jar)
+                .addAsWebInfResource(TagLibInJarTestCase.class.getPackage(), "web.xml", "web.xml")
                 .addAsWebResource(TagLibInJarTestCase.class.getPackage(), JSP, JSP);
         return war;
     }
@@ -85,6 +106,18 @@ public class TagLibInJarTestCase {
     @OperateOnDeployment(TLD_INSIDE_RESOURCES)
     public void testTldInsideResourcesFolder() throws Exception {
         checkJspAvailable(urlDep2);
+    }
+
+    /**
+     * Tests if deployment with taglib-location pointing to jar fails during deployment phase.
+     * Test passes if the correct response is returned from the JSP.
+     *
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(TLD_INSIDE_JAR)
+    public void testTldInsideJar() throws Exception {
+        checkJspAvailable(urlDep3);
     }
 
     private void checkJspAvailable(URL url) throws Exception {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/taglibInJar.tld
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/taglibInJar.tld
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE taglib
+        PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.1//EN"
+        "http://java.sun.com/j2ee/dtds/web-jsptaglibrary_1_1.dtd">
+
+<taglib>
+    <tlibversion>1.0</tlibversion>
+    <jspversion>1.1</jspversion>
+    <shortname>examples</shortname>
+    <uri>/TestTag</uri>
+    <tag>
+        <name>test</name>
+        <tagclass>org.jboss.as.test.integration.web.jsp.taglib.jar.TestTag</tagclass>
+        <bodycontent>empty</bodycontent>
+    </tag>
+</taglib>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/web.xml
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/jar/web.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-fragment id="WebFragment_ID"
+              version="3.0"
+              xmlns="http://java.sun.com/xml/ns/javaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
+
+    <jsp-config>
+        <taglib>
+            <taglib-uri>/TestTag</taglib-uri>
+            <taglib-location>/WEB-INF/lib/taglib.jar</taglib-location>
+        </taglib>
+    </jsp-config>
+
+    <welcome-file-list>
+        <welcome-file>/index.jsp</welcome-file>
+    </welcome-file-list>
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Test Logon</realm-name>
+    </login-config>
+
+</web-fragment>


### PR DESCRIPTION
Tests if deployment with taglib-location pointing to jar fails during deployment phase.
Test passes if the correct response is returned from the JSP.

Upstream issue: [WFLY-10939](https://issues.jboss.org/browse/WFLY-10939)