### PR TITLE
[WFLY-10976] Eliminate Artemis deprecation notices when our standard configs boot

### DIFF
--- a/galleon-pack/src/main/resources/feature_groups/messaging-activemq-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/messaging-activemq-ha.xml
@@ -5,6 +5,7 @@
         <feature spec="subsystem.messaging-activemq.server">
             <param name="server" value="default"/>
             <param name="cluster-password" value="${jboss.messaging.cluster.password:CHANGE ME!!}"/>
+            <param name="journal-pool-files" value="10"/>
             <feature spec="subsystem.messaging-activemq.server.address-setting">
                 <param name="address-setting" value="#"/>
                 <param name="dead-letter-address" value="jms.queue.DLQ"/>

--- a/galleon-pack/src/main/resources/feature_groups/messaging-activemq.xml
+++ b/galleon-pack/src/main/resources/feature_groups/messaging-activemq.xml
@@ -3,6 +3,7 @@
     <feature spec="subsystem.messaging-activemq">
         <feature spec="subsystem.messaging-activemq.server">
             <param name="server" value="default"/>
+            <param name="journal-pool-files" value="10"/>
             <feature spec="subsystem.messaging-activemq.server.http-connector">
                 <param name="http-connector" value="http-connector"/>
                 <param name="socket-binding" value="http"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -528,7 +528,7 @@ class ServerAdd extends AbstractAddStepHandler {
         configuration.setThreadPoolMaxSize(THREAD_POOL_MAX_SIZE.resolveModelAttribute(context, model).asInt());
         configuration.setTransactionTimeout(TRANSACTION_TIMEOUT.resolveModelAttribute(context, model).asLong());
         configuration.setTransactionTimeoutScanPeriod(TRANSACTION_TIMEOUT_SCAN_PERIOD.resolveModelAttribute(context, model).asLong());
-        configuration.setWildcardRoutingEnabled(WILD_CARD_ROUTING_ENABLED.resolveModelAttribute(context, model).asBoolean());
+        configuration.getWildcardConfiguration().setRoutingEnabled(WILD_CARD_ROUTING_ENABLED.resolveModelAttribute(context, model).asBoolean());
 
         processStorageConfiguration(context, model, configuration);
         addHAPolicyConfiguration(context, configuration, model);

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
@@ -9,7 +9,8 @@
             <cluster password="${jboss.messaging.cluster.password:CHANGE ME!!}" />
             <journal type="ASYNCIO"
                      file-size="102400"
-                     min-files="2" />
+                     min-files="2"
+                     pool-files="10"/>
 
             <shared-store-master />
 

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -7,6 +7,8 @@
         <server name="default">
             <?CLUSTERED?>
 
+            <journal pool-files="10"/>
+
             <security-setting name="#">
                 <role name="guest"
                       send="true"

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -158,9 +158,9 @@ public abstract class BuildConfigurationTestBase {
                 BufferedWriter writer = Files.newBufferedWriter(file.toPath())) {
             String line = reader.readLine();
             while (line != null) {
-                if (line.contains("<security-setting name=\"#\">")) { //super duper hackish, just IO optimization
-                    writer.write("        <journal type=\"NIO\" file-size=\"1024\" />");
-                    writer.newLine();
+
+                if (line.contains("<journal pool-files=\"10\"/>")) { //super duper hackish, just IO optimization
+                    line = "        <journal type=\"NIO\" file-size=\"1024\" pool-files=\"10\"/>";
                 }
 
                 int start = line.indexOf("java.net.preferIPv4Stack");


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10976

1) Use non-deprecated Artemis API for enabling wildcard routing.

2) In our standard config files use value of '10' for 'journal-pool-files'. We don't use the default value of -1 as that causes Artemis to log a WARN. We don't change the default value as that's an API change. (We might consider that for future releases.) I use '10' because that's the value that Artemis put in their broker.xml as part of the ARTEMIS-1628 change[1] that introduced the WARN. I put no further thought into the value than that.
    
[1] https://github.com/apache/activemq-artemis/pull/1803