### PR TITLE
[WFLY-9106]: Hard-code default values in messaging-activemq subsystem.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
 import javax.management.MBeanServer;
 import javax.sql.DataSource;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.Interceptor;
@@ -281,7 +280,7 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
             server = new ActiveMQServerImpl(configuration,
                     mbs,
                     securityManager);
-            if (ActiveMQDefaultConfiguration.getDefaultClusterPassword().equals(server.getConfiguration().getClusterPassword())) {
+            if (ServerDefinition.CLUSTER_PASSWORD.getDefaultValue().asString().equals(server.getConfiguration().getClusterPassword())) {
                 server.getConfiguration().setClusterPassword(java.util.UUID.randomUUID().toString());
             }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -33,7 +33,6 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.STATIC_C
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
@@ -73,9 +72,12 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBridgeInitialConnectAttempts
+     */
     public static final SimpleAttributeDefinition INITIAL_CONNECT_ATTEMPTS = create("initial-connect-attempts", INT)
             .setRequired(false)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts()))
+            .setDefaultValue(new ModelNode().set(-1))
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
@@ -87,8 +89,11 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBridgeProducerWindowSize
+     */
     public static final SimpleAttributeDefinition PRODUCER_WINDOW_SIZE = create("producer-window-size", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize()))
+            .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
@@ -97,19 +102,25 @@ public class BridgeDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterPassword
+     */
     public static final SimpleAttributeDefinition PASSWORD = create("password", STRING, true)
             .setAllowExpression(true)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultClusterPassword()))
+            .setDefaultValue(new ModelNode("CHANGE ME!!"))
             .setRestartAllServices()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
             .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterUser
+     */
     public static final SimpleAttributeDefinition USER = create("user", STRING)
             .setRequired(false)
             .setAllowExpression(true)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultClusterUser()))
+            .setDefaultValue(new ModelNode("ACTIVEMQ.CLUSTER.ADMIN.USER"))
             .setRestartAllServices()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
@@ -123,25 +134,34 @@ public class BridgeDefinition extends PersistentResourceDefinition {
                     .setAlternatives(PASSWORD.getName())
                     .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#isDefaultBridgeDuplicateDetection
+     */
     public static final SimpleAttributeDefinition USE_DUPLICATE_DETECTION = create("use-duplicate-detection", BOOLEAN)
             .setRequired(false)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.isDefaultBridgeDuplicateDetection()))
+            .setDefaultValue(new ModelNode(true))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBridgeReconnectAttempts
+     */
     public static final SimpleAttributeDefinition RECONNECT_ATTEMPTS = create("reconnect-attempts", INT)
             .setRequired(false)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts()))
+            .setDefaultValue(new ModelNode(-1))
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBridgeConnectSameNode
+     */
     public static final SimpleAttributeDefinition RECONNECT_ATTEMPTS_ON_SAME_NODE = create("reconnect-attempts-on-same-node", INT)
             .setRequired(false)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultBridgeConnectSameNode()))
+            .setDefaultValue(new ModelNode(10))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -37,7 +37,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
@@ -79,8 +78,11 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBroadcastPeriod
+     */
     public static final SimpleAttributeDefinition BROADCAST_PERIOD = create("broadcast-period", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultBroadcastPeriod()))
+            .setDefaultValue(new ModelNode(2000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -25,8 +25,8 @@ package org.wildfly.extension.messaging.activemq;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
-import static org.jboss.dmr.ModelType.BIG_DECIMAL;
 import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.DOUBLE;
 import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.OBJECT;
@@ -35,8 +35,8 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.STATIC_C
 
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+
 import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
@@ -87,16 +87,22 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterFailureCheckPeriod
+     */
     public static final SimpleAttributeDefinition CHECK_PERIOD = create("check-period", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterFailureCheckPeriod()))
+            .setDefaultValue(new ModelNode(30000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setMeasurementUnit(MILLISECONDS)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterConnectionTtl
+     */
     public static final SimpleAttributeDefinition CONNECTION_TTL = create("connection-ttl", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterConnectionTtl()))
+            .setDefaultValue(new ModelNode(60000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -123,17 +129,23 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterMessageLoadBalancingType
+     */
     // FIXME WFLY-4587 forward-when-no-consumers == true ? STRICT : ON_DEMAND
     public static final SimpleAttributeDefinition MESSAGE_LOAD_BALANCING_TYPE = create("message-load-balancing-type", STRING)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterMessageLoadBalancingType()))
+            .setDefaultValue(new ModelNode("ON_DEMAND"))
             .setValidator(new EnumValidator<>(MessageLoadBalancingType.class, true, true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterInitialConnectAttempts
+     */
     public static final SimpleAttributeDefinition INITIAL_CONNECT_ATTEMPTS = create("initial-connect-attempts", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts()))
+            .setDefaultValue(new ModelNode(-1))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -141,39 +153,54 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterMaxHops
+     */
     public static final SimpleAttributeDefinition MAX_HOPS = create("max-hops", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterMaxHops()))
+            .setDefaultValue(new ModelNode(1))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterMaxRetryInterval
+     */
     public static final SimpleAttributeDefinition MAX_RETRY_INTERVAL = create("max-retry-interval", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterMaxRetryInterval()))
+            .setDefaultValue(new ModelNode(2000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setMeasurementUnit(MILLISECONDS)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterNotificationAttempts
+     */
     public static final SimpleAttributeDefinition NOTIFICATION_ATTEMPTS = create("notification-attempts",INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterNotificationAttempts()))
+            .setDefaultValue(new ModelNode(2))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterNotificationInterval
+     */
     public static final SimpleAttributeDefinition NOTIFICATION_INTERVAL = create("notification-interval",LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterNotificationInterval()))
+            .setDefaultValue(new ModelNode(1000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBridgeProducerWindowSize
+     */
     public static final SimpleAttributeDefinition PRODUCER_WINDOW_SIZE = create("producer-window-size", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize()))
+            .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
@@ -182,16 +209,22 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterRetryInterval
+     */
     public static final SimpleAttributeDefinition RETRY_INTERVAL = create("retry-interval", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterRetryInterval()))
+            .setDefaultValue(new ModelNode(500L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterReconnectAttempts
+     */
     public static final SimpleAttributeDefinition RECONNECT_ATTEMPTS = create("reconnect-attempts", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts()))
+            .setDefaultValue(new ModelNode(-1))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -199,15 +232,18 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
-    public static final SimpleAttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", BIG_DECIMAL)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterRetryIntervalMultiplier()))
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterRetryIntervalMultiplier
+     */
+    public static final SimpleAttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", DOUBLE)
+            .setDefaultValue(new ModelNode(1.0d))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
     public static final SimpleAttributeDefinition USE_DUPLICATE_DETECTION = create("use-duplicate-detection", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultClusterDuplicateDetection()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -26,13 +26,12 @@ import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
 import static org.jboss.as.controller.registry.AttributeAccess.Flag.RESTART_ALL_SERVICES;
-import static org.jboss.dmr.ModelType.BIG_DECIMAL;
 import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.DOUBLE;
 import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.wildfly.extension.messaging.activemq.jms.Validators.noDuplicateElements;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
@@ -58,9 +57,11 @@ public interface CommonAttributes {
     String ENTRIES = "entries";
     String MODULE = "module";
     String NAME = "name";
-
+    /**
+     * @see ActiveMQClient.DEFAULT_CALL_TIMEOUT
+     */
     AttributeDefinition CALL_TIMEOUT = create("call-timeout", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_CALL_TIMEOUT))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -77,8 +78,11 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD
+     */
     SimpleAttributeDefinition CHECK_PERIOD = create("check-period", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD))
+            .setDefaultValue(new ModelNode(30000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setMeasurementUnit(MILLISECONDS)
@@ -107,8 +111,11 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONNECTION_TTL
+     */
     SimpleAttributeDefinition CONNECTION_TTL = create("connection-ttl", LONG)
-            .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONNECTION_TTL))
+            .setDefaultValue(new ModelNode(60000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
@@ -167,9 +174,11 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_HA
+     */
     SimpleAttributeDefinition HA = create("ha", BOOLEAN)
-            .setDefaultValue(new ModelNode()
-                    .set(ActiveMQClient.DEFAULT_HA))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -206,8 +215,11 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL
+     */
     AttributeDefinition MAX_RETRY_INTERVAL = create("max-retry-interval", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL))
+            .setDefaultValue(new ModelNode(2000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -224,8 +236,11 @@ public interface CommonAttributes {
             .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE
+     */
     AttributeDefinition MIN_LARGE_MESSAGE_SIZE = create("min-large-message-size", INT)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE))
+            .setDefaultValue(new ModelNode(100 * 1024))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
@@ -259,16 +274,22 @@ public interface CommonAttributes {
             .setMaxSize(Integer.MAX_VALUE)
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_RETRY_INTERVAL
+     */
     AttributeDefinition RETRY_INTERVAL = create("retry-interval", LONG)
-            .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_RETRY_INTERVAL))
+            .setDefaultValue(new ModelNode(2000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
-    AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", BIG_DECIMAL)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER))
+    /**
+     * @see ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER
+     */
+    AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", DOUBLE)
+            .setDefaultValue(new ModelNode(1.0d))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -302,10 +323,6 @@ public interface CommonAttributes {
             .setRestartAllServices()
             .build();
 
-    SimpleAttributeDefinition USER = create("user", ModelType.STRING, true)
-            .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterUser()))
-            .build();
 
     String ACCEPTOR = "acceptor";
     String ACCEPTORS = "acceptors";

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -30,8 +30,6 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.SOCKET_B
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
@@ -62,16 +60,22 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
             // either under server (and it is deprecated) or under the subsystem.
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBroadcastRefreshTimeout
+     */
     public static final SimpleAttributeDefinition REFRESH_TIMEOUT = create("refresh-timeout", ModelType.LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultBroadcastRefreshTimeout()))
+            .setDefaultValue(new ModelNode(10000))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT
+     */
     public static final SimpleAttributeDefinition INITIAL_WAIT_TIMEOUT = create("initial-wait-timeout", ModelType.LONG)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT))
+            .setDefaultValue(new ModelNode(10000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DivertDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DivertDefinition.java
@@ -29,7 +29,6 @@ import static org.jboss.dmr.ModelType.STRING;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
@@ -65,8 +64,11 @@ public class DivertDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultDivertExclusive
+     */
     public static final SimpleAttributeDefinition EXCLUSIVE = create("exclusive", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultDivertExclusive()))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -31,7 +31,6 @@ import static org.jboss.dmr.ModelType.STRING;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
@@ -53,17 +52,23 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultGroupingHandlerTimeout
+     */
     public static final SimpleAttributeDefinition TIMEOUT = create("timeout", LONG)
-            .setDefaultValue(new ModelNode(1L * ActiveMQDefaultConfiguration.getDefaultGroupingHandlerTimeout()))
+            .setDefaultValue(new ModelNode(5000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultGroupingHandlerGroupTimeout
+     */
     public static final SimpleAttributeDefinition GROUP_TIMEOUT = create("group-timeout", LONG)
             // FIXME Cast to a long until Artemis type is fixed
-            .setDefaultValue(new ModelNode(1L * ActiveMQDefaultConfiguration.getDefaultGroupingHandlerGroupTimeout()))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -71,8 +76,11 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultGroupingHandlerReaperPeriod
+     */
     public static final SimpleAttributeDefinition REAPER_PERIOD = create("reaper-period", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultGroupingHandlerReaperPeriod()))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -88,7 +88,14 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.EXTERNAL
  * Domain extension that integrates Apache ActiveMQ 6.
  *
  * <dl>
- *   <dt><strong>Current</strong> - WildFly 12</dt>
+ * <dt><strong>Current</strong> - WildFly 14</dt>
+ *   <dd>
+ *     <ul>
+ *       <li>XML namespace: urn:jboss:domain:messaging-activemq:4.0
+ *       <li>Management model: 4.0.0
+ *     </ul>
+ *   </dd>
+ *   <dt>WildFly 12</dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging-activemq:3.0

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -116,7 +116,6 @@ import java.util.function.Supplier;
 import javax.management.MBeanServer;
 import javax.sql.DataSource;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.Interceptor;
@@ -484,15 +483,21 @@ class ServerAdd extends AbstractAddStepHandler {
         final JournalType journalType = JournalType.valueOf(JOURNAL_TYPE.resolveModelAttribute(context, model).asString());
         configuration.setJournalType(journalType);
 
-        // AIO Journal
-        configuration.setJournalBufferSize_AIO(JOURNAL_BUFFER_SIZE.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalBufferSizeAio()));
-        configuration.setJournalBufferTimeout_AIO(JOURNAL_BUFFER_TIMEOUT.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalBufferTimeoutAio()));
-        configuration.setJournalMaxIO_AIO(JOURNAL_MAX_IO.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalMaxIoAio()));
-        // NIO Journal
-        configuration.setJournalBufferSize_NIO(JOURNAL_BUFFER_SIZE.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalBufferSizeNio()));
-        configuration.setJournalBufferTimeout_NIO(JOURNAL_BUFFER_TIMEOUT.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalBufferTimeoutNio()));
-        configuration.setJournalMaxIO_NIO(JOURNAL_MAX_IO.resolveModelAttribute(context, model).asInt(ActiveMQDefaultConfiguration.getDefaultJournalMaxIoNio()));
-        //
+        ModelNode value = JOURNAL_BUFFER_SIZE.resolveModelAttribute(context, model);
+        if(value.isDefined()) {
+            configuration.setJournalBufferSize_AIO(value.asInt());
+            configuration.setJournalBufferSize_NIO(value.asInt());
+        }
+        value = JOURNAL_BUFFER_TIMEOUT.resolveModelAttribute(context, model);
+        if(value.isDefined()) {
+            configuration.setJournalBufferTimeout_AIO(value.asInt());
+            configuration.setJournalBufferTimeout_NIO(value.asInt());
+        }
+        value = JOURNAL_MAX_IO.resolveModelAttribute(context, model);
+        if(value.isDefined()) {
+            configuration.setJournalMaxIO_AIO(value.asInt());
+            configuration.setJournalMaxIO_NIO(value.asInt());
+        }
         configuration.setJournalCompactMinFiles(JOURNAL_COMPACT_MIN_FILES.resolveModelAttribute(context, model).asInt());
         configuration.setJournalCompactPercentage(JOURNAL_COMPACT_PERCENTAGE.resolveModelAttribute(context, model).asInt());
         configuration.setJournalFileSize(JOURNAL_FILE_SIZE.resolveModelAttribute(context, model).asInt());

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -38,8 +38,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.jboss.as.controller.AttributeDefinition;
@@ -76,10 +77,13 @@ import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFacto
  */
 public class ServerDefinition extends PersistentResourceDefinition {
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterPassword
+     */
     public static final SimpleAttributeDefinition CLUSTER_PASSWORD = create("cluster-password", ModelType.STRING, true)
             .setAttributeGroup("cluster")
             .setXmlName("password")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterPassword()))
+            .setDefaultValue(new ModelNode("CHANGE ME!!"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
@@ -96,18 +100,24 @@ public class ServerDefinition extends PersistentResourceDefinition {
                     .setAlternatives(CLUSTER_PASSWORD.getName())
                     .build();
 
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultClusterUser
+     */
     public static final SimpleAttributeDefinition CLUSTER_USER = create("cluster-user", ModelType.STRING)
             .setAttributeGroup("cluster")
             .setXmlName("user")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultClusterUser()))
+            .setDefaultValue(new ModelNode("ACTIVEMQ.CLUSTER.ADMIN.USER"))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAccessConstraint(MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET)
             .build();
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultScheduledThreadPoolMaxSize
+     */
     public static final AttributeDefinition SCHEDULED_THREAD_POOL_MAX_SIZE = create("scheduled-thread-pool-max-size", INT)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
+            .setDefaultValue(new ModelNode(5))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -136,8 +146,11 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .addAccessConstraint(MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET)
             .setCapabilityReference(Capabilities.ELYTRON_DOMAIN_CAPABILITY, Capabilities.ACTIVEMQ_SERVER_CAPABILITY)
             .build();
+     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultThreadPoolMaxSize
+     */
     public static final AttributeDefinition THREAD_POOL_MAX_SIZE = create("thread-pool-max-size", INT)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
+            .setDefaultValue(new ModelNode(30))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -151,8 +164,11 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultWildcardRoutingEnabled
+     */
     public static final SimpleAttributeDefinition WILD_CARD_ROUTING_ENABLED = create("wild-card-routing-enabled", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultWildcardRoutingEnabled()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -183,18 +199,24 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalCompactMinFiles
+     */
     public static final SimpleAttributeDefinition JOURNAL_COMPACT_MIN_FILES = create("journal-compact-min-files", INT)
             .setAttributeGroup("journal")
             .setXmlName("compact-min-files")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalCompactMinFiles()))
+            .setDefaultValue(new ModelNode(10))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalCompactPercentage
+     */
     public static final SimpleAttributeDefinition JOURNAL_COMPACT_PERCENTAGE = create("journal-compact-percentage", INT)
             .setAttributeGroup("journal")
             .setXmlName("compact-percentage")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalCompactPercentage()))
+            .setDefaultValue(new ModelNode(30))
             .setMeasurementUnit(PERCENTAGE)
             .setValidator(new IntRangeValidator(0, 100, true, true))
             .setRequired(false)
@@ -212,12 +234,14 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setCapabilityReference(Capabilities.DATA_SOURCE_CAPABILITY, Capabilities.ACTIVEMQ_SERVER_CAPABILITY)
             .setRestartAllServices()
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultBindingsTableName
+     */
     public static final SimpleAttributeDefinition JOURNAL_BINDINGS_TABLE  = create("journal-bindings-table", STRING)
             .setAttributeGroup("journal")
             .setXmlName("bindings-table")
             .setRequired(false)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultBindingsTableName()))
+            .setDefaultValue(new ModelNode("BINDINGS"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -231,21 +255,25 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setDeprecated(VERSION_3_0_0)
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultLargeMessagesTableName
+     */
     public static final SimpleAttributeDefinition JOURNAL_LARGE_MESSAGES_TABLE  = create("journal-large-messages-table", STRING)
             .setAttributeGroup("journal")
             .setXmlName("large-messages-table")
             .setRequired(false)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultLargeMessagesTableName()))
+            .setDefaultValue(new ModelNode("LARGE_MESSAGES"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMessageTableName
+     */
     public static final SimpleAttributeDefinition JOURNAL_MESSAGES_TABLE = create("journal-messages-table", STRING)
             .setAttributeGroup("journal")
             .setXmlName("messages-table")
             .setRequired(false)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMessageTableName()))
+            .setDefaultValue(new ModelNode("MESSAGES"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -261,12 +289,14 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultPageStoreTableName
+     */
     public static final SimpleAttributeDefinition JOURNAL_PAGE_STORE_TABLE  = create("journal-page-store-table", STRING)
             .setAttributeGroup("journal")
             .setXmlName("page-store-table")
             .setRequired(false)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultPageStoreTableName()))
+            .setDefaultValue(new ModelNode("PAGE_STORE"))
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
@@ -318,11 +348,13 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalFileSize
+     */
     public static final SimpleAttributeDefinition JOURNAL_FILE_SIZE = create("journal-file-size", LONG)
             .setAttributeGroup("journal")
             .setXmlName("file-size")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalFileSize()))
+            .setDefaultValue(new ModelNode(10485760L))
             .setMeasurementUnit(BYTES)
             .setValidator(new LongRangeValidator(1024, Long.MAX_VALUE, true, true))
             .setRequired(false)
@@ -337,15 +369,22 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalMinFiles
+     */
     public static final SimpleAttributeDefinition JOURNAL_MIN_FILES = create("journal-min-files", INT)
             .setAttributeGroup("journal")
             .setXmlName("min-files")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalMinFiles()))
+            .setDefaultValue(new ModelNode(2))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .setValidator(new IntRangeValidator(2, true, true))
             .build();
+    /**
+     * This is different from currant Artemis default value.
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalPoolFiles
+     */
     public static final SimpleAttributeDefinition JOURNAL_POOL_FILES = create("journal-pool-files", INT)
             .setAttributeGroup("journal")
             .setXmlName("pool-files")
@@ -356,18 +395,24 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setValidator(InfiniteOrPositiveValidators.INT_INSTANCE)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultJournalSyncNonTransactional
+     */
     public static final SimpleAttributeDefinition JOURNAL_SYNC_NON_TRANSACTIONAL = create("journal-sync-non-transactional", BOOLEAN)
             .setAttributeGroup("journal")
             .setXmlName("sync-non-transactional")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultJournalSyncNonTransactional()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultJournalSyncTransactional
+     */
     public static final SimpleAttributeDefinition JOURNAL_SYNC_TRANSACTIONAL = create("journal-sync-transactional", BOOLEAN)
             .setAttributeGroup("journal")
             .setXmlName("sync-transactional")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultJournalSyncTransactional()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -382,73 +427,100 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setValidator(new EnumValidator<>(JournalType.class, true, true, JournalType.ASYNCIO, JournalType.NIO))
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultJournalLogWriteRate
+     */
     public static final SimpleAttributeDefinition LOG_JOURNAL_WRITE_RATE = create("log-journal-write-rate", BOOLEAN)
             .setAttributeGroup("journal")
             .setXmlName("log-write-rate")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultJournalLogWriteRate()))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultConnectionTtlOverride
+     */
     public static final SimpleAttributeDefinition CONNECTION_TTL_OVERRIDE = create("connection-ttl-override", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultConnectionTtlOverride()))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultAsyncConnectionExecutionEnabled
+     */
     public static final SimpleAttributeDefinition ASYNC_CONNECTION_EXECUTION_ENABLED = create("async-connection-execution-enabled", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultAsyncConnectionExecutionEnabled()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMessageCounterMaxDayHistory
+     */
     public static final SimpleAttributeDefinition MESSAGE_COUNTER_MAX_DAY_HISTORY = create("message-counter-max-day-history", INT)
             .setAttributeGroup("statistics")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMessageCounterMaxDayHistory()))
+            .setDefaultValue(new ModelNode(10))
             .setMeasurementUnit(DAYS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMessageCounterSamplePeriod
+     */
     public static final SimpleAttributeDefinition MESSAGE_COUNTER_SAMPLE_PERIOD = create("message-counter-sample-period", LONG)
             .setAttributeGroup("statistics")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMessageCounterSamplePeriod()))
+            .setDefaultValue(new ModelNode(10000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultTransactionTimeout
+     */
     public static final SimpleAttributeDefinition TRANSACTION_TIMEOUT = create("transaction-timeout", LONG)
             .setAttributeGroup("transaction")
             .setXmlName("timeout")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultTransactionTimeout()))
+            .setDefaultValue(new ModelNode(300000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultTransactionTimeoutScanPeriod
+     */
     public static final SimpleAttributeDefinition TRANSACTION_TIMEOUT_SCAN_PERIOD = create("transaction-timeout-scan-period", LONG)
             .setAttributeGroup("transaction")
             .setXmlName("scan-period")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultTransactionTimeoutScanPeriod()))
+            .setDefaultValue(new ModelNode(1000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMessageExpiryScanPeriod
+     */
     public static final SimpleAttributeDefinition MESSAGE_EXPIRY_SCAN_PERIOD = create("message-expiry-scan-period", LONG)
             .setAttributeGroup("message-expiry")
             .setXmlName("scan-period")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMessageExpiryScanPeriod()))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMessageExpiryThreadPriority
+     */
     public static final SimpleAttributeDefinition MESSAGE_EXPIRY_THREAD_PRIORITY = create("message-expiry-thread-priority", INT)
             .setAttributeGroup("message-expiry")
             .setXmlName("thread-priority")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMessageExpiryThreadPriority()))
+            .setDefaultValue(new ModelNode(3))
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(new IntRangeValidator(Thread.MIN_PRIORITY, Thread.MAX_PRIORITY, true, true))
@@ -478,71 +550,94 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .setDeprecated(VERSION_3_0_0)
             .build();
-
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultServerDumpInterval
+     */
     public static final SimpleAttributeDefinition SERVER_DUMP_INTERVAL = create("server-dump-interval", LONG)
             .setAttributeGroup("debug")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultServerDumpInterval()))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMemoryMeasureInterval
+     */
     public static final SimpleAttributeDefinition MEMORY_MEASURE_INTERVAL = create("memory-measure-interval", LONG)
             .setAttributeGroup("debug")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMemoryMeasureInterval()))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMemoryWarningThreshold
+     */
     public static final SimpleAttributeDefinition MEMORY_WARNING_THRESHOLD = create("memory-warning-threshold", INT)
             .setAttributeGroup("debug")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMemoryWarningThreshold()))
+            .setDefaultValue(new ModelNode(25))
             .setMeasurementUnit(PERCENTAGE)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultSecurityInvalidationInterval
+     */
     public static final SimpleAttributeDefinition SECURITY_INVALIDATION_INTERVAL = create("security-invalidation-interval", LONG)
             .setAttributeGroup("security")
             .setXmlName("invalidation-interval")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultSecurityInvalidationInterval()))
+            .setDefaultValue(new ModelNode(10000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultSecurityEnabled
+     */
     public static final SimpleAttributeDefinition SECURITY_ENABLED = create("security-enabled", BOOLEAN)
             .setAttributeGroup("security")
             .setXmlName("enabled")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultSecurityEnabled()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(MessagingExtension.MESSAGING_SECURITY_SENSITIVE_TARGET)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultPersistenceEnabled
+     */
     public static final SimpleAttributeDefinition PERSISTENCE_ENABLED = create("persistence-enabled", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultPersistenceEnabled()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultManagementNotificationAddress
+     */
     public static final SimpleAttributeDefinition MANAGEMENT_NOTIFICATION_ADDRESS = create("management-notification-address", ModelType.STRING)
             .setAttributeGroup("management")
             .setXmlName("notification-address")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultManagementNotificationAddress().toString()))
+            .setDefaultValue(new ModelNode("activemq.notifications"))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(MessagingExtension.MESSAGING_MANAGEMENT_SENSITIVE_TARGET)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultManagementAddress
+     */
     public static final SimpleAttributeDefinition MANAGEMENT_ADDRESS = create("management-address", ModelType.STRING)
             .setAttributeGroup("management")
             .setXmlName("address")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultManagementAddress().toString()))
+            .setDefaultValue(new ModelNode(new SimpleString("activemq.management").toString()))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -557,49 +652,70 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .addAccessConstraint(MessagingExtension.MESSAGING_MANAGEMENT_SENSITIVE_TARGET)
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJmxDomain
+     */
     public static final SimpleAttributeDefinition JMX_DOMAIN = create("jmx-domain", ModelType.STRING)
             .setAttributeGroup("management")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJmxDomain()))
+            .setDefaultValue(new ModelNode("org.apache.activemq.artemis"))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .addAccessConstraint(MessagingExtension.MESSAGING_MANAGEMENT_SENSITIVE_TARGET)
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultPersistIdCache
+     */
     public static final SimpleAttributeDefinition PERSIST_ID_CACHE = create("persist-id-cache", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultPersistIdCache()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultPersistDeliveryCountBeforeDelivery
+     */
     public static final SimpleAttributeDefinition PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY = create("persist-delivery-count-before-delivery", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultPersistDeliveryCountBeforeDelivery()))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultIdCacheSize
+     */
     public static final SimpleAttributeDefinition ID_CACHE_SIZE = create("id-cache-size", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultIdCacheSize()))
+            .setDefaultValue(new ModelNode(20000))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMaxConcurrentPageIo
+     */
     public static final SimpleAttributeDefinition PAGE_MAX_CONCURRENT_IO = create("page-max-concurrent-io", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMaxConcurrentPageIo()))
+            .setDefaultValue(new ModelNode(5))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultCreateBindingsDir
+     */
     public static final SimpleAttributeDefinition CREATE_BINDINGS_DIR = create("create-bindings-dir", BOOLEAN)
             .setAttributeGroup("journal")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultCreateBindingsDir()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultCreateJournalDir
+     */
     public static final SimpleAttributeDefinition CREATE_JOURNAL_DIR = create("create-journal-dir", BOOLEAN)
             .setAttributeGroup("journal")
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultCreateJournalDir()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAAttributes.java
@@ -29,7 +29,6 @@ import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -44,23 +43,31 @@ import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
  */
 public class HAAttributes {
-
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultAllowAutoFailback
+     */
     public static final SimpleAttributeDefinition ALLOW_FAILBACK = create("allow-failback", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultAllowAutoFailback()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultHapolicyBackupPortOffset
+     */
     public static final SimpleAttributeDefinition BACKUP_PORT_OFFSET = create("backup-port-offset", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyBackupPortOffset()))
+            .setDefaultValue(new ModelNode(100))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultHapolicyBackupRequestRetries
+     */
     public static final SimpleAttributeDefinition BACKUP_REQUEST_RETRIES = create("backup-request-retries", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetries()))
+            .setDefaultValue(new ModelNode(-1))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -68,8 +75,11 @@ public class HAAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultHapolicyBackupRequestRetryInterval
+     */
     public static final SimpleAttributeDefinition BACKUP_REQUEST_RETRY_INTERVAL = create("backup-request-retry-interval", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetryInterval()))
+            .setDefaultValue(new ModelNode(5000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -97,8 +107,11 @@ public class HAAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultFailoverOnServerShutdown
+     */
     public static final SimpleAttributeDefinition FAILOVER_ON_SERVER_SHUTDOWN = create("failover-on-server-shutdown", ModelType.BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultFailoverOnServerShutdown()))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -110,37 +123,52 @@ public class HAAttributes {
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultInitialReplicationSyncTimeout
+     */
     public static final SimpleAttributeDefinition INITIAL_REPLICATION_SYNC_TIMEOUT = create("initial-replication-sync-timeout", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultInitialReplicationSyncTimeout()))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultHapolicyMaxBackups
+     */
     public static final SimpleAttributeDefinition MAX_BACKUPS = create("max-backups", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultHapolicyMaxBackups()))
+            .setDefaultValue(new ModelNode(1))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultMaxSavedReplicatedJournalsSize
+     */
     public static final SimpleAttributeDefinition MAX_SAVED_REPLICATED_JOURNAL_SIZE = create("max-saved-replicated-journal-size", INT)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize()))
+            .setDefaultValue(new ModelNode(2))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultHapolicyRequestBackup
+     */
     public static final SimpleAttributeDefinition REQUEST_BACKUP = create("request-backup", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultHapolicyRequestBackup()))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#isDefaultRestartBackup
+     */
     public static final SimpleAttributeDefinition RESTART_BACKUP = create("restart-backup", BOOLEAN)
-            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.isDefaultRestartBackup()))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreMasterDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreMasterDefinition.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
-import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
 /**
@@ -55,7 +54,7 @@ public class SharedStoreMasterDefinition extends PersistentResourceDefinition {
     ));
 
     public static final SharedStoreMasterDefinition INSTANCE = new SharedStoreMasterDefinition(MessagingExtension.SHARED_STORE_MASTER_PATH, false);
-    public static final SharedStoreMasterDefinition CONFIGURATION_INSTANCE = new SharedStoreMasterDefinition(PathElement.pathElement(CommonAttributes.CONFIGURATION, CommonAttributes.MASTER), true);
+    public static final SharedStoreMasterDefinition CONFIGURATION_INSTANCE = new SharedStoreMasterDefinition(MessagingExtension.CONFIGURATION_MASTER_PATH, true);
 
 
     private SharedStoreMasterDefinition(PathElement path, boolean allowSibling) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAdd.java
@@ -30,7 +30,6 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA;
 
 import java.util.List;
 
-import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.api.jms.JMSFactoryType;
 import org.apache.activemq.artemis.jms.server.JMSServerManager;
 import org.apache.activemq.artemis.jms.server.config.ConnectionFactoryConfiguration;
@@ -86,7 +85,7 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
 
         final ConnectionFactoryConfiguration config = new ConnectionFactoryConfigurationImpl()
                 .setName(name)
-                .setHA(ActiveMQClient.DEFAULT_HA)
+                .setHA(false)
                 .setBindings(entries.toArray(new String[entries.size()]));
 
         config.setHA(HA.resolveModelAttribute(context, model).asBoolean());

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttribute.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttribute.java
@@ -69,6 +69,7 @@ public class ConnectionFactoryAttribute {
         switch (attributeDefinition.getType()) {
             case BOOLEAN:
                 return Boolean.class.getName();
+            case DOUBLE:
             case BIG_DECIMAL:
                 return Double.class.getName();
             case LONG:

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -25,8 +25,8 @@ import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.PER_SECOND;
-import static org.jboss.dmr.ModelType.BIG_DECIMAL;
 import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.DOUBLE;
 import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
@@ -37,6 +37,7 @@ import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttr
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.apache.activemq.artemis.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
@@ -55,43 +56,61 @@ import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
 public interface ConnectionFactoryAttributes {
 
     interface Common {
+    /**
+     * @see ActiveMQClient.DEFAULT_AUTO_GROUP
+     */
         AttributeDefinition AUTO_GROUP = SimpleAttributeDefinitionBuilder.create("auto-group", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_AUTO_GROUP))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE
+     */
         AttributeDefinition BLOCK_ON_ACKNOWLEDGE = SimpleAttributeDefinitionBuilder.create("block-on-acknowledge", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_BLOCK_ON_DURABLE_SEND
+     */
         AttributeDefinition BLOCK_ON_DURABLE_SEND = SimpleAttributeDefinitionBuilder.create("block-on-durable-send", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_BLOCK_ON_DURABLE_SEND))
+                .setDefaultValue(new ModelNode(true))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND
+     */
         AttributeDefinition BLOCK_ON_NON_DURABLE_SEND = SimpleAttributeDefinitionBuilder.create("block-on-non-durable-send", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT
+     */
         AttributeDefinition CACHE_LARGE_MESSAGE_CLIENT = SimpleAttributeDefinitionBuilder.create("cache-large-message-client", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD
+     */
         AttributeDefinition CLIENT_FAILURE_CHECK_PERIOD =SimpleAttributeDefinitionBuilder.create("client-failure-check-period", LONG)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD))
+                .setDefaultValue(new ModelNode(30000L))
                 .setMeasurementUnit(MILLISECONDS)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -99,15 +118,21 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_COMPRESS_LARGE_MESSAGES
+     */
         AttributeDefinition COMPRESS_LARGE_MESSAGES = SimpleAttributeDefinitionBuilder.create("compress-large-messages", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_COMPRESS_LARGE_MESSAGES))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE
+     */
         AttributeDefinition CONFIRMATION_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("confirmation-window-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE))
+                .setDefaultValue(new ModelNode(-1))
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -116,15 +141,21 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME
+     */
         AttributeDefinition CONNECTION_LOAD_BALANCING_CLASS_NAME = SimpleAttributeDefinitionBuilder.create("connection-load-balancing-policy-class-name", STRING)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME))
+                .setDefaultValue(new ModelNode(RoundRobinConnectionLoadBalancingPolicy.class.getCanonicalName()))
                 .setRequired(false)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONNECTION_TTL
+     */
         AttributeDefinition CONNECTION_TTL = new SimpleAttributeDefinitionBuilder("connection-ttl", LONG)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONNECTION_TTL))
+                .setDefaultValue(new ModelNode(60000L))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
@@ -140,8 +171,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONSUMER_MAX_RATE
+     */
         AttributeDefinition CONSUMER_MAX_RATE = SimpleAttributeDefinitionBuilder.create("consumer-max-rate", INT)
-                .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_CONSUMER_MAX_RATE))
+                .setDefaultValue(new ModelNode(-1))
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -150,8 +184,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE
+     */
         AttributeDefinition CONSUMER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("consumer-window-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE))
+                .setDefaultValue(new ModelNode(1024 * 1024))
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -182,8 +219,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
+     */
         AttributeDefinition DUPS_OK_BATCH_SIZE = SimpleAttributeDefinitionBuilder.create("dups-ok-batch-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_ACK_BATCH_SIZE))
+                .setDefaultValue(new ModelNode(1024 * 1024))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
@@ -198,8 +238,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION
+     */
         AttributeDefinition FAILOVER_ON_INITIAL_CONNECTION = SimpleAttributeDefinitionBuilder.create("failover-on-initial-connection", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
@@ -219,31 +262,43 @@ public interface ConnectionFactoryAttributes {
                 .setMeasurementUnit(BYTES)
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL
+     */
         AttributeDefinition MAX_RETRY_INTERVAL = SimpleAttributeDefinitionBuilder.create("max-retry-interval", LONG)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL))
+                .setDefaultValue(new ModelNode(2000L))
                 .setMeasurementUnit(MILLISECONDS)
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE
+     */
         AttributeDefinition MIN_LARGE_MESSAGE_SIZE = SimpleAttributeDefinitionBuilder.create("min-large-message-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE))
+                .setDefaultValue(new ModelNode().set(100 * 1024))
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE
+     */
         AttributeDefinition PRE_ACKNOWLEDGE = SimpleAttributeDefinitionBuilder.create("pre-acknowledge", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE))
+                .setDefaultValue(new ModelNode(false))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_PRODUCER_MAX_RATE
+     */
         AttributeDefinition PRODUCER_MAX_RATE = SimpleAttributeDefinitionBuilder.create("producer-max-rate", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_PRODUCER_MAX_RATE))
+                .setDefaultValue(new ModelNode(-1))
                 .setMeasurementUnit(PER_SECOND)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -252,8 +307,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_PRODUCER_WINDOW_SIZE
+     */
         AttributeDefinition PRODUCER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("producer-window-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_PRODUCER_WINDOW_SIZE))
+                .setDefaultValue(new ModelNode(64 * 1024))
                 .setMeasurementUnit(BYTES)
                 .setRequired(false)
                 .setAllowExpression(true)
@@ -265,30 +323,42 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
-        AttributeDefinition RECONNECT_ATTEMPTS = create("reconnect-attempts", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_RECONNECT_ATTEMPTS))
+        /**
+         * @see ActiveMQClient.DEFAULT_RECONNECT_ATTEMPTS
+         */
+        SimpleAttributeDefinition RECONNECT_ATTEMPTS = create("reconnect-attempts", INT)
+                .setDefaultValue(new ModelNode(0))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQClient.DEFAULT_RETRY_INTERVAL
+         */
         AttributeDefinition RETRY_INTERVAL = SimpleAttributeDefinitionBuilder.create("retry-interval", LONG)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_RETRY_INTERVAL))
+                .setDefaultValue(new ModelNode(2000L))
                 .setMeasurementUnit(MILLISECONDS)
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
-        AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", BIG_DECIMAL)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER))
+        /**
+         * @see ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER
+         */
+        AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", DOUBLE)
+                .setDefaultValue(new ModelNode(1.0d))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQDefaultConfiguration#getDefaultScheduledThreadPoolMaxSize
+         */
         AttributeDefinition SCHEDULED_THREAD_POOL_MAX_SIZE = SimpleAttributeDefinitionBuilder.create("scheduled-thread-pool-max-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
+                .setDefaultValue(new ModelNode(5))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -296,8 +366,11 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQDefaultConfiguration#getDefaultThreadPoolMaxSize
+         */
         AttributeDefinition THREAD_POOL_MAX_SIZE = SimpleAttributeDefinitionBuilder.create("thread-pool-max-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
+                .setDefaultValue(new ModelNode(30))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -305,15 +378,21 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQClient.DEFAULT_ACK_BATCH_SIZE
+         */
         AttributeDefinition TRANSACTION_BATCH_SIZE = SimpleAttributeDefinitionBuilder.create("transaction-batch-size", INT)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_ACK_BATCH_SIZE))
+                .setDefaultValue(new ModelNode(1024 * 1024))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQClient.DEFAULT_USE_GLOBAL_POOLS
+         */
         AttributeDefinition USE_GLOBAL_POOLS = SimpleAttributeDefinitionBuilder.create("use-global-pools", BOOLEAN)
-                .setDefaultValue(new ModelNode().set(ActiveMQClient.DEFAULT_USE_GLOBAL_POOLS))
+                .setDefaultValue(new ModelNode(true))
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
@@ -411,10 +490,13 @@ public interface ConnectionFactoryAttributes {
                 .setRestartAllServices()
                 .build();
 
+        /**
+         * @see ActiveMQClient.INITIAL_CONNECT_ATTEMPTS
+         */
         SimpleAttributeDefinition INITIAL_CONNECT_ATTEMPTS = SimpleAttributeDefinitionBuilder.create("initial-connect-attempts", INT)
                 .setRequired(false)
                 .setAllowExpression(true)
-                .setDefaultValue(new ModelNode(ActiveMQClient.INITIAL_CONNECT_ATTEMPTS))
+                .setDefaultValue(new ModelNode(1))
                 .setRestartAllServices()
                 .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
@@ -32,17 +32,17 @@ import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.PER_SECOND;
-import static org.jboss.dmr.ModelType.BIG_DECIMAL;
 import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.DOUBLE;
 import static org.jboss.dmr.ModelType.INT;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.jboss.dmr.ModelType.STRING;
 
 import java.util.Arrays;
 import java.util.Collection;
-
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+
 import org.hornetq.api.core.client.HornetQClient;
 import org.hornetq.api.jms.JMSFactoryType;
 import org.jboss.as.controller.AttributeDefinition;
@@ -67,43 +67,61 @@ import org.wildfly.extension.messaging.activemq.jms.Validators;
  */
 public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinition {
 
+    /**
+     * @see HornetQClient.DEFAULT_AUTO_GROUP
+     */
     public static final AttributeDefinition AUTO_GROUP = SimpleAttributeDefinitionBuilder.create("auto-group", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_AUTO_GROUP))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE
+     */
     public static final AttributeDefinition BLOCK_ON_ACKNOWLEDGE = SimpleAttributeDefinitionBuilder.create("block-on-acknowledge", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_BLOCK_ON_DURABLE_SEND
+     */
     public static final AttributeDefinition BLOCK_ON_DURABLE_SEND = SimpleAttributeDefinitionBuilder.create("block-on-durable-send", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_BLOCK_ON_DURABLE_SEND))
+            .setDefaultValue(new ModelNode(true))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND
+     */
     public static final AttributeDefinition BLOCK_ON_NON_DURABLE_SEND = SimpleAttributeDefinitionBuilder.create("block-on-non-durable-send", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT
+     */
     public static final AttributeDefinition CACHE_LARGE_MESSAGE_CLIENT = SimpleAttributeDefinitionBuilder.create("cache-large-message-client", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD
+     */
     public static final AttributeDefinition CLIENT_FAILURE_CHECK_PERIOD =SimpleAttributeDefinitionBuilder.create("client-failure-check-period", LONG)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
@@ -111,15 +129,21 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES
+     */
     public static final AttributeDefinition COMPRESS_LARGE_MESSAGES = SimpleAttributeDefinitionBuilder.create("compress-large-messages", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE
+     */
     public static final AttributeDefinition CONFIRMATION_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("confirmation-window-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE))
+            .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
@@ -128,15 +152,21 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME
+     */
     public static final AttributeDefinition CONNECTION_LOAD_BALANCING_CLASS_NAME = SimpleAttributeDefinitionBuilder.create("connection-load-balancing-policy-class-name", STRING)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME))
+            .setDefaultValue(new ModelNode("org.hornetq.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy"))
             .setRequired(false)
             .setAllowExpression(false)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CONNECTION_TTL
+     */
     public static final AttributeDefinition CONNECTION_TTL = new SimpleAttributeDefinitionBuilder("connection-ttl", LONG)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CONNECTION_TTL))
+            .setDefaultValue(new ModelNode(60000L))
             .setRequired(false)
             .setAllowExpression(true)
             .setValidator(InfiniteOrPositiveValidators.LONG_INSTANCE)
@@ -144,8 +174,11 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CONSUMER_MAX_RATE
+     */
     public static final AttributeDefinition CONSUMER_MAX_RATE = SimpleAttributeDefinitionBuilder.create("consumer-max-rate", INT)
-            .setDefaultValue(new ModelNode(HornetQClient.DEFAULT_CONSUMER_MAX_RATE))
+            .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
@@ -154,16 +187,22 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE
+     */
     public static final AttributeDefinition CONSUMER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("consumer-window-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE))
+            .setDefaultValue(new ModelNode(1024 * 1024))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_ACK_BATCH_SIZE
+     */
     public static final AttributeDefinition DUPS_OK_BATCH_SIZE = SimpleAttributeDefinitionBuilder.create("dups-ok-batch-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_ACK_BATCH_SIZE))
+            .setDefaultValue(new ModelNode(1024 * 1024))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -186,8 +225,11 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION
+     */
     public static final AttributeDefinition FAILOVER_ON_INITIAL_CONNECTION = SimpleAttributeDefinitionBuilder.create("failover-on-initial-connection", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -206,45 +248,63 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.INITIAL_CONNECT_ATTEMPTS
+     */
     public static final AttributeDefinition INITIAL_CONNECT_ATTEMPTS = SimpleAttributeDefinitionBuilder.create("initial-connect-attempts", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.INITIAL_CONNECT_ATTEMPTS))
+            .setDefaultValue(new ModelNode(1))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_INITIAL_MESSAGE_PACKET_SIZE
+     */
     public static final AttributeDefinition INITIAL_MESSAGE_PACKET_SIZE = SimpleAttributeDefinitionBuilder.create("initial-message-packet-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_INITIAL_MESSAGE_PACKET_SIZE))
+            .setDefaultValue(new ModelNode(1500))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_MAX_RETRY_INTERVAL
+     */
     public static final AttributeDefinition MAX_RETRY_INTERVAL = SimpleAttributeDefinitionBuilder.create("max-retry-interval", LONG)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_MAX_RETRY_INTERVAL))
+            .setDefaultValue(new ModelNode(2000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE
+     */
     public static final AttributeDefinition MIN_LARGE_MESSAGE_SIZE = SimpleAttributeDefinitionBuilder.create("min-large-message-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE))
+            .setDefaultValue(new ModelNode(100 * 1024))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_PRE_ACKNOWLEDGE
+     */
     public static final AttributeDefinition PRE_ACKNOWLEDGE = SimpleAttributeDefinitionBuilder.create("pre-acknowledge", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_PRE_ACKNOWLEDGE))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_PRODUCER_MAX_RATE
+     */
     public static final AttributeDefinition PRODUCER_MAX_RATE = SimpleAttributeDefinitionBuilder.create("producer-max-rate", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_PRODUCER_MAX_RATE))
+            .setDefaultValue(new ModelNode(-1))
             .setMeasurementUnit(PER_SECOND)
             .setRequired(false)
             .setAllowExpression(true)
@@ -253,8 +313,11 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_PRODUCER_WINDOW_SIZE
+     */
     public static final AttributeDefinition PRODUCER_WINDOW_SIZE = SimpleAttributeDefinitionBuilder.create("producer-window-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_PRODUCER_WINDOW_SIZE))
+            .setDefaultValue(new ModelNode(64 * 1024))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
@@ -262,30 +325,42 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .build();
 
 
+    /**
+     * @see HornetQClient.DEFAULT_RECONNECT_ATTEMPTS
+     */
     public static final AttributeDefinition RECONNECT_ATTEMPTS = create("reconnect-attempts", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_RECONNECT_ATTEMPTS))
+            .setDefaultValue(new ModelNode(0))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient.DEFAULT_RETRY_INTERVAL
+     */
     public static final AttributeDefinition RETRY_INTERVAL = SimpleAttributeDefinitionBuilder.create("retry-interval", LONG)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_RETRY_INTERVAL))
+            .setDefaultValue(new ModelNode(2000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
-    public static final AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", BIG_DECIMAL)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER))
+    /**
+     * @see HornetQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER
+     */
+    public static final AttributeDefinition RETRY_INTERVAL_MULTIPLIER = create("retry-interval-multiplier", DOUBLE)
+            .setDefaultValue(new ModelNode(1.0d))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultScheduledThreadPoolMaxSize
+     */
     public static final AttributeDefinition SCHEDULED_THREAD_POOL_MAX_SIZE = SimpleAttributeDefinitionBuilder.create("scheduled-thread-pool-max-size", INT)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize()))
+            .setDefaultValue(new ModelNode(5))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -293,8 +368,11 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#getDefaultThreadPoolMaxSize
+     */
     public static final AttributeDefinition THREAD_POOL_MAX_SIZE = SimpleAttributeDefinitionBuilder.create("thread-pool-max-size", INT)
-            .setDefaultValue(new ModelNode().set(ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize()))
+            .setDefaultValue(new ModelNode(30))
             .setRequired(false)
             .setAllowExpression(true)
             .setCorrector(InfiniteOrPositiveValidators.NEGATIVE_VALUE_CORRECTOR)
@@ -330,8 +408,11 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see ActiveMQClient.DEFAULT_CALL_TIMEOUT
+     */
     public static final AttributeDefinition CALL_TIMEOUT = create("call-timeout", LONG)
-            .setDefaultValue(new ModelNode(ActiveMQClient.DEFAULT_CALL_TIMEOUT))
+            .setDefaultValue(new ModelNode(30000L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)


### PR DESCRIPTION
Replacing ActiveMQClient., ActiveMQDefaultConfiguration default values usage by hardcoded values in the messaging subsystem.

JIRA: https://issues.jboss.org/browse/WFLY-9106
