### PR TITLE
[WFLY-11038] Ensure org.apache.geronimo.specs are excluded from tests

### DIFF
--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -138,6 +138,10 @@
                     <groupId>javax.transaction</groupId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
@@ -177,6 +181,10 @@
                 <exclusion>
                     <artifactId>jta</artifactId>
                     <groupId>javax.transaction</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
                 </exclusion>
                 <exclusion>
                     <artifactId>hibernate-core</artifactId>


### PR DESCRIPTION
This patch is a workaround to avoid failures of Dependency Convergence rule on maven enforcer plugin when the productized version of geronimo-jta_1.1_spec is found in the dependency graph. The maven enforcer plugin should ignore it, but due to a bug in it, it doesn't.

Excluding explicitly from the compatibility test suite avoids the maven enforcer failure.

Jira issue: https://issues.jboss.org/browse/WFLY-11038