### PR TITLE
[WFLY-11039] Upgrade WildFly Core 7.0.0.Alpha1

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:8.0">
+<domain xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="master">
+<host xmlns="urn:jboss:domain:9.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0">
+<host xmlns="urn:jboss:domain:9.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="master">
+<host xmlns="urn:jboss:domain:9.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:8.0">
+<server xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:8.0">
+<server xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:8.0">
+<server xmlns="urn:jboss:domain:9.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>6.0.2.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>7.0.0.Alpha1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:8.0">
+<domain xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="master">
+<host xmlns="urn:jboss:domain:9.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0">
+<host xmlns="urn:jboss:domain:9.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="master">
+<host xmlns="urn:jboss:domain:9.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:8.0">
+<server xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0"
+<domain xmlns="urn:jboss:domain:9.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0">
+<domain xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0"
+<domain xmlns="urn:jboss:domain:9.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0">
+<domain xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0">
+<domain xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="failover-h1">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="failover-h2">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="failover-h3">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="master">
+<host xmlns="urn:jboss:domain:9.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="slave">
 
     <management>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:8.0" name="slave">
+<host xmlns="urn:jboss:domain:9.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="slave">
 
     <paths>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,9 +20,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:8.0"
+<host xmlns="urn:jboss:domain:9.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:8.0 wildfly-config_8_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:9.0 wildfly-config_9_0.xsd"
       name="master">
 
     <paths>

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:8.0">
+<server xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:8.0"
+<domain xmlns="urn:jboss:domain:9.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:8.0">
+<host name="master" xmlns="urn:jboss:domain:9.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:8.0">
+<host name="master" xmlns="urn:jboss:domain:9.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11039

---


# Release Notes - WildFly Core - Version 7.0.0.Alpha1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4101'>WFCORE-4101</a>] -         Upgrade MSC to 1.4.4.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4107'>WFCORE-4107</a>] -         Upgrade MSC to 1.4.5.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4111'>WFCORE-4111</a>] -         Upgrade WildFly Elytron to 1.6.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4088'>WFCORE-4088</a>] -         Propose several DynamicNameMappers to be reused
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3180'>WFCORE-3180</a>] -         ElytronSubsystemMessages uses double quotes to surround string literals
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4074'>WFCORE-4074</a>] -         InterdependentDeploymentTestCase fail intermittently
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4075'>WFCORE-4075</a>] -         Proper cleanup of InterdependentDeploymentTestCase
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4078'>WFCORE-4078</a>] -         TimeZone is not correctly taken into account when checking certification expiration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4081'>WFCORE-4081</a>] -         SocketHandlerTestCase.testTlsSocket fails on IBM JDK
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4082'>WFCORE-4082</a>] -         Fix common.sh setDefaultModularJvmOptions() to grep all function arguments
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4083'>WFCORE-4083</a>] -         org.apache.httpcomponents.core requires org.apache.commons.codec
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4090'>WFCORE-4090</a>] -         CredentialReference doesn&#39;t work with the new MSC API
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4092'>WFCORE-4092</a>] -         ModifiableKeyStoreDecorator is public
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4099'>WFCORE-4099</a>] -         Prevent failures due to MSC-240 in &#39;critical&#39; code
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4102'>WFCORE-4102</a>] -         ModelPersistenceTestCase fails when running after ReadConfigAsFeaturesStandaloneTestCase
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4085'>WFCORE-4085</a>] -         Update subsystem and core-model tests to use WF14
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4109'>WFCORE-4109</a>] -         Bump the kernel management API version to 9.0.0 and the xsd to 9.0
</li>
</ul>
                                    