### PR TITLE
WFLY-11056 Singleton barrier service for @Clustered @MessageDriven EJBs should only start on-demand

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -501,7 +501,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         if (context.hasOptionalCapability(SingletonDefaultRequirement.POLICY.getName(), CLUSTERED_SINGLETON_CAPABILITY.getName(), null)) {
             ServiceBuilder<?> builder = target.addService(SingletonBarrierService.SERVICE_NAME);
             Supplier<SingletonPolicy> policy = builder.requires(context.getCapabilityServiceName(SingletonDefaultRequirement.POLICY.getName(), SingletonDefaultRequirement.POLICY.getType()));
-            builder.setInstance(new SingletonBarrierService(policy)).install();
+            builder.setInstance(new SingletonBarrierService(policy)).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11056

Should be sufficient to workaround https://issues.jboss.org/browse/WFLY-10736