### PR TITLE
WFLY-11045 Add sun.jdk as dependency to the GSON module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/google/code/gson/main/module.xml
@@ -25,5 +25,6 @@
 
     <dependencies>
         <module name="javax.sql.api"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11045

This PR fixes the runtime exception thrown when the remote sampling strategy is used and a JSON strategy file is received during the bootstrap of the tracer.

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
