### PR TITLE
[WFLY-11065] Usage of static fields from java.lang classes as EL expr…

### DIFF
--- a/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jsp/web-app_4_0.xml
+++ b/testsuite/integration/basic/src/test/resources/org/wildfly/test/integration/jsp/web-app_4_0.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd" version="4.0">
+</web-app>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/JspInitializationListener.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/JspInitializationListener.java
@@ -47,7 +47,8 @@ public class JspInitializationListener implements ServletContextListener {
         // if the servlet version is 3.1 or higher, setup a ELResolver which allows usage of static fields java.lang.*
         final ServletContext servletContext = sce.getServletContext();
         final JspApplicationContext jspApplicationContext = JspFactory.getDefaultFactory().getJspApplicationContext(servletContext);
-        if (servletContext.getEffectiveMajorVersion() >= 3 && servletContext.getEffectiveMinorVersion() >= 1) {
+        if (servletContext.getEffectiveMajorVersion() > 3
+                || (servletContext.getEffectiveMajorVersion() == 3 && servletContext.getEffectiveMinorVersion() >= 1)) {
             jspApplicationContext.addELResolver(new ImportedClassELResolver());
         }
         // setup a wrapped JspApplicationContext if there are any EL expression factory wrappers for this servlet context


### PR DESCRIPTION
…essions in JSPs doesn't work for servlet 4.0

 - fix of condition for version check in JspInitializationListener
 - extension of JspELTestCase for Servlet 4.0 and default servlet version with no web.xml

https://issues.jboss.org/browse/WFLY-11065

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.