### PR TITLE
[WFLY-11067]: Use DynamicNameMappers global name mappers instead of lambdas.

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/MailServerDefinition.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailServerDefinition.java
@@ -41,6 +41,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -61,9 +62,7 @@ class MailServerDefinition extends PersistentResourceDefinition {
     static final String CREDENTIAL_STORE_CAPABILITY = "org.wildfly.security.credential-store";
 
     static final RuntimeCapability<Void> SERVER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.mail.session.server", true)
-            .setDynamicNameMapper(path -> new String[]{
-                                  path.getParent().getLastElement().getValue(),
-                                  path.getLastElement().getValue()})
+            .setDynamicNameMapper(DynamicNameMappers.PARENT)
                     .build();
 
     static final SensitivityClassification MAIL_SERVER_SECURITY =

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -50,6 +50,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
@@ -67,7 +68,7 @@ import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 public class BroadcastGroupDefinition extends PersistentResourceDefinition {
 
     public static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq.broadcast-group", true)
-            .setDynamicNameMapper(address -> new String[] { address.getParent().getLastElement().getValue(), address.getLastElement().getValue() })
+            .setDynamicNameMapper(DynamicNameMappers.PARENT)
             .build();
 
     public static final PrimitiveListAttributeDefinition CONNECTOR_REFS = new StringListAttributeDefinition.Builder(CONNECTORS)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -55,9 +56,7 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
     public static final PathElement PATH = PathElement.pathElement(CommonAttributes.DISCOVERY_GROUP);
 
     public static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq.discovery-group", true)
-            .setDynamicNameMapper(path -> new String[]{
-                                            path.getParent().getLastElement().getValue(),
-                                            path.getLastElement().getValue()})
+            .setDynamicNameMapper(DynamicNameMappers.PARENT)
             // WFLY-10518 - only the name of the discovery-group is used for its capability as the resource can be
             // either under server (and it is deprecated) or under the subsystem.
             .build();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AccessLogDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AccessLogDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
@@ -43,10 +44,7 @@ import org.jboss.dmr.ValueExpression;
  */
 class AccessLogDefinition extends PersistentResourceDefinition {
     static final RuntimeCapability<Void> ACCESS_LOG_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_ACCESS_LOG, true, AccessLogService.class)
-              .setDynamicNameMapper(path -> new String[]{
-                      path.getParent().getParent().getLastElement().getValue(),
-                      path.getParent().getLastElement().getValue(),
-                      path.getLastElement().getValue()})
+              .setDynamicNameMapper(DynamicNameMappers.GRAND_PARENT)
               .build();
 
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
@@ -52,9 +53,7 @@ class HostDefinition extends PersistentResourceDefinition {
     static final RuntimeCapability<Void> HOST_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HOST, true, Host.class)
             .addRequirements(Capabilities.CAPABILITY_UNDERTOW)
             //addDynamicRequirements(Capabilities.CAPABILITY_SERVER) -- has no function so don't use it
-            .setDynamicNameMapper(pathElements -> new String[]{
-                    pathElements.getParent().getLastElement().getValue(),
-                    pathElements.getLastElement().getValue()})
+            .setDynamicNameMapper(DynamicNameMappers.PARENT)
             .build();
 
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerDefinition.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.domain.management.SecurityRealm;
@@ -55,9 +56,7 @@ public class HttpInvokerDefinition extends PersistentResourceDefinition {
 
     static final RuntimeCapability<Void> HTTP_INVOKER_HOST_CAPABILITY =
                 RuntimeCapability.Builder.of(CAPABILITY_HTTP_INVOKER_HOST, true, Void.class)
-                        .setDynamicNameMapper(address -> new String[]{
-                                address.getParent().getLastElement().getValue(),
-                                address.getLastElement().getValue()})
+                        .setDynamicNameMapper(DynamicNameMappers.PARENT)
                         //.addDynamicRequirements(Capabilities.CAPABILITY_HOST)
                         .addRequirements(Capabilities.CAPABILITY_HTTP_INVOKER)
                         .build();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -45,10 +46,7 @@ import org.wildfly.extension.undertow.filters.FilterRefDefinition;
 class LocationDefinition extends PersistentResourceDefinition {
     static final RuntimeCapability<Void> LOCATION_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_LOCATION, true, LocationService.class)
             .addRequirements(Capabilities.CAPABILITY_UNDERTOW)
-            .setDynamicNameMapper(path -> new String[]{
-                    path.getParent().getParent().getLastElement().getValue(),
-                    path.getParent().getLastElement().getValue(),
-                    path.getLastElement().getValue()})
+            .setDynamicNameMapper(DynamicNameMappers.GRAND_PARENT)
             .build();
 
     static final AttributeDefinition HANDLER = new SimpleAttributeDefinitionBuilder(Constants.HANDLER, ModelType.STRING)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -80,9 +81,7 @@ public class ReverseProxyHandlerHost extends PersistentResourceDefinition {
 
     private static final RuntimeCapability<Void> REVERSE_PROXY_HOST_RUNTIME_CAPABILITY =
                 RuntimeCapability.Builder.of(CAPABILITY_REVERSE_PROXY_HANDLER_HOST, true, ReverseProxyHostService.class)
-                        .setDynamicNameMapper(path -> new String[]{
-                                            path.getParent().getLastElement().getValue(),
-                                            path.getLastElement().getValue()})
+                        .setDynamicNameMapper(DynamicNameMappers.PARENT)
                         .build();
 
     public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder("outbound-socket-binding", ModelType.STRING, true)


### PR DESCRIPTION
Remove usage of lambdas that have the equivalent function in DynamicNameMappers.

Jira: https://issues.jboss.org/browse/WFLY-11067