### PR TITLE
WFLY-11010 Document 2lc/JTA integration properties and add better detection of ehcache/JTA platform Class use

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
@@ -894,6 +894,10 @@ to avoid the IllegalStateException, so they don't have to change their
 application right away (for compatibility purposes). This hint may be
 deprecated in a future release. See WFLY-7108 for more details. Defaults
 to false.
+
+|wildfly.jpa.regionfactory |Only applies to Hibernate ORM 5.3+, set to false to disable automatic use of Infinispan as second level cache (hibernate.cache.region.factory_class).
+
+|wildfly.jpa.jtaplatform |Only applies to Hibernate ORM 5.3+, set to false to disable automatic configuring of the JTA integration platform (hibernate.transaction.jta.platform).
 |=======================================================================
 
 [[determine-the-persistence-provider-module]]

--- a/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/HibernatePersistenceProviderAdaptor.java
+++ b/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/HibernatePersistenceProviderAdaptor.java
@@ -49,6 +49,7 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
     private volatile Platform platform;
     private static final String SHARED_CACHE_MODE = "javax.persistence.sharedCache.mode";
     private static final String NONE = SharedCacheMode.NONE.name();
+    private static final String UNSPECIFIED = SharedCacheMode.UNSPECIFIED.name();
     private static final String HIBERNATE_EXTENDED_BEANMANAGER = "org.hibernate.jpa.event.spi.jpa.ExtendedBeanManager";
 
     @Override
@@ -103,7 +104,9 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
         // check if 2lc is explicitly disabled which takes precedence over other settings
         boolean sharedCacheDisabled = SharedCacheMode.NONE.equals(pu.getSharedCacheMode())
                 ||
-                NONE.equals(sharedCacheMode);
+                NONE.equals(sharedCacheMode) ||
+                SharedCacheMode.UNSPECIFIED.equals(pu.getSharedCacheMode()) ||
+                UNSPECIFIED.equals(sharedCacheMode);
         if (!sharedCacheDisabled &&
                 (null == properties.getProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE) ||
                         Boolean.parseBoolean(properties.getProperty(AvailableSettings.USE_SECOND_LEVEL_CACHE))))
@@ -116,6 +119,7 @@ public class HibernatePersistenceProviderAdaptor implements PersistenceProviderA
                     SHARED_CACHE_MODE,
                     sharedCacheMode,
                     pu.getSharedCacheMode().toString());
+            pu.setSharedCacheMode(SharedCacheMode.NONE);  // ensure that Hibernate doesn't try to use the 2lc for UNSPECIFIED
         }
     }
 

--- a/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/service/ServiceContributorImpl.java
+++ b/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/service/ServiceContributorImpl.java
@@ -16,6 +16,8 @@
  */
 package org.jboss.as.jpa.hibernate5.service;
 
+import static org.jboss.as.jpa.hibernate5.JpaLogger.JPA_LOGGER;
+
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceContributor;
 
@@ -28,23 +30,36 @@ import org.hibernate.service.spi.ServiceContributor;
 public class ServiceContributorImpl implements ServiceContributor {
     private static final String CONTROLJTAINTEGRATION = "wildfly.jpa.jtaplatform"; // these properties are documented in org.jboss.as.jpa.config.Configuration
     private static final String CONTROL2LCINTEGRATION = "wildfly.jpa.regionfactory";
+    private static final String TRANSACTION_PLATFORM = "hibernate.transaction.jta.platform";
+    private static final String EHCACHE = "ehcache";
+    private static final String HIBERNATE_REGION_FACTORY_CLASS = "hibernate.cache.region.factory_class";
 
     @Override
     public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
         // note that the following deprecated getSettings() is agreed to be replaced with method that returns immutable copy of configuration settings.
         final Object jtaPlatformInitiatorEnabled = serviceRegistryBuilder.getSettings().getOrDefault(CONTROLJTAINTEGRATION, true);
 
-        if (jtaPlatformInitiatorEnabled == null ||
+        if (serviceRegistryBuilder.getSettings().get(TRANSACTION_PLATFORM) != null) {
+            // applications that already specify the transaction platform property which will override the WildFlyCustomJtaPlatform.
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute application configured the JTA Platform to be used instead of WildFlyCustomJtaPlatform (%s=%s)",
+                    TRANSACTION_PLATFORM, serviceRegistryBuilder.getSettings().get(TRANSACTION_PLATFORM));
+        } else if (jtaPlatformInitiatorEnabled == null ||
                 (jtaPlatformInitiatorEnabled instanceof Boolean && ((Boolean) jtaPlatformInitiatorEnabled).booleanValue()) ||
                 Boolean.parseBoolean(jtaPlatformInitiatorEnabled.toString())) {
+            // use WildFlyCustomJtaPlatform unless they explicitly set wildfly.jpa.jtaplatform to false.
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute application will use WildFlyCustomJtaPlatform");
             serviceRegistryBuilder.addInitiator(new WildFlyCustomJtaPlatformInitiator());
         }
 
         final Object regionFactoryInitiatorEnabled = serviceRegistryBuilder.getSettings().getOrDefault(CONTROL2LCINTEGRATION, true);
-
-        if (regionFactoryInitiatorEnabled == null ||
+        final Object regionFactory = serviceRegistryBuilder.getSettings().get(HIBERNATE_REGION_FACTORY_CLASS);
+        if ((regionFactory instanceof String) && (((String) regionFactory)).contains(EHCACHE)) {
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute application is using Ehcache via regionFactory=%s",
+                    regionFactory);
+        } else if (regionFactoryInitiatorEnabled == null ||
                 (regionFactoryInitiatorEnabled instanceof Boolean && ((Boolean) regionFactoryInitiatorEnabled).booleanValue()) ||
                 Boolean.parseBoolean(regionFactoryInitiatorEnabled.toString())) {
+            JPA_LOGGER.tracef("ServiceContributorImpl#contribute adding ORM initiator for 2lc region factory");
             serviceRegistryBuilder.addInitiator(new WildFlyCustomRegionFactoryInitiator());
         }
     }

--- a/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/service/WildFlyCustomRegionFactoryInitiator.java
+++ b/jpa/hibernate5_3/src/main/java/org/jboss/as/jpa/hibernate5/service/WildFlyCustomRegionFactoryInitiator.java
@@ -18,6 +18,7 @@ package org.jboss.as.jpa.hibernate5.service;
 
 import static org.hibernate.cfg.AvailableSettings.JPA_SHARED_CACHE_MODE;
 import static org.hibernate.cfg.AvailableSettings.USE_SECOND_LEVEL_CACHE;
+import static org.jboss.as.jpa.hibernate5.JpaLogger.JPA_LOGGER;
 
 import java.util.Map;
 
@@ -36,23 +37,30 @@ public class WildFlyCustomRegionFactoryInitiator extends RegionFactoryInitiator 
     private static final String V53_INFINISPAN_REGION_FACTORY = "org.infinispan.hibernate.cache.v53.InfinispanRegionFactory";
     private static final String UNSPECIFIED = "UNSPECIFIED";
     private static final String NONE = "NONE";
+
     @Override
     protected RegionFactory resolveRegionFactory(Map configurationValues, ServiceRegistryImplementor registry) {
         final Object useSecondLevelCache = configurationValues.get(USE_SECOND_LEVEL_CACHE);
         final String jpaSharedCodeModeValue = configurationValues.get(JPA_SHARED_CACHE_MODE) != null ? configurationValues.get(JPA_SHARED_CACHE_MODE).toString() : UNSPECIFIED;
-
+        final Object regionFactory = configurationValues.get(HIBERNATE_REGION_FACTORY_CLASS);
 
         // treat Hibernate 2lc as off, if not specified.
         // Note that Hibernate 2lc in 5.1.x, defaults to disabled, so this code is only needed in 5.3.x+.
         if(Boolean.parseBoolean((String)useSecondLevelCache)) {
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory using %s for 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    V53_INFINISPAN_REGION_FACTORY, useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
             configurationValues.put(HIBERNATE_REGION_FACTORY_CLASS, V53_INFINISPAN_REGION_FACTORY);
             return super.resolveRegionFactory(configurationValues, registry);
         } else if(UNSPECIFIED.equals(jpaSharedCodeModeValue)
              || NONE.equals(jpaSharedCodeModeValue)) {
             // explicitly disable 2lc cache
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory not using a 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
             return NoCachingRegionFactory.INSTANCE;
         }
         else {
+            JPA_LOGGER.tracef("WildFlyCustomRegionFactoryInitiator#resolveRegionFactory using %s for 2lc, useSecondLevelCache=%s, jpaSharedCodeModeValue=%s, regionFactory=%s",
+                    V53_INFINISPAN_REGION_FACTORY, useSecondLevelCache,jpaSharedCodeModeValue, regionFactory);
             configurationValues.put(HIBERNATE_REGION_FACTORY_CLASS, V53_INFINISPAN_REGION_FACTORY);
             return super.resolveRegionFactory(configurationValues, registry);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11010

This addresses an issue reported by a community user, where they couldn't find "wildfly.jpa.regionfactory" in our WF14 documentation.  The fix includes both a documentation update, as well as better detection of Ehcache 2lc and other custom Hibernate transaction configuration settings (hibernate.transaction.jta.platform).