### PR TITLE
WFLY-10638 Eliminate 'Transactional caches are not supported.' log warning from ORM 5.3.* deployments

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -28,7 +28,6 @@
             </cache-container>
             <cache-container name="hibernate" module="org.infinispan.hibernate-cache">
                 <local-cache name="entity">
-                    <transaction mode="NON_XA"/>
                     <object-memory size="10000"/>
                     <expiration max-idle="100000"/>
                 </local-cache>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10638