### PR TITLE
WFLY-11071 domain="undefined" in JSESSIONIDSSO

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainDefinition.java
@@ -285,7 +285,10 @@ public class ApplicationSecurityDomainDefinition extends PersistentResourceDefin
                 ModelNode ssoModel = resource.getChild(UndertowExtension.PATH_SSO).getModel();
 
                 String cookieName = SingleSignOnDefinition.Attribute.COOKIE_NAME.resolveModelAttribute(context, ssoModel).asString();
-                String domain = SingleSignOnDefinition.Attribute.DOMAIN.resolveModelAttribute(context, ssoModel).asString();
+                String domain = null;
+                if (SingleSignOnDefinition.Attribute.DOMAIN.resolveModelAttribute(context, ssoModel).isDefined()) {
+                    domain = SingleSignOnDefinition.Attribute.DOMAIN.resolveModelAttribute(context, ssoModel).asString();
+                }
                 String path = SingleSignOnDefinition.Attribute.PATH.resolveModelAttribute(context, ssoModel).asString();
                 boolean httpOnly = SingleSignOnDefinition.Attribute.HTTP_ONLY.resolveModelAttribute(context, ssoModel).asBoolean();
                 boolean secure = SingleSignOnDefinition.Attribute.SECURE.resolveModelAttribute(context, ssoModel).asBoolean();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11071

When SSO is enabled and the domain is undefined, the JSESSIONIDSSO cookie has a invalid domain="undefined" as follows:

Set-Cookie: JSESSIONIDSSO=H_xYotFv_g4dUibKUXxkK5zaFx-IESzIHHDvmeEW; path=/; domain=undefined