### PR TITLE
WFLY-11018 Upgrade JGroups to 4.0.15.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.org.jboss.ws.spi>3.2.2.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.6.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jdom>1.1.3</version.org.jdom>
-        <version.org.jgroups>4.0.13.Final</version.org.jgroups>
+        <version.org.jgroups>4.0.15.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.2.0.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.6.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11018

Contains fix for https://issues.jboss.org/browse/JGRP-2294
which is the underlying cause of https://issues.jboss.org/browse/ISPN-9517
which is the underlying cause of https://issues.jboss.org/browse/WFLY-10736