### PR TITLE
[WFLY-9455] suspend WFTC transaction when txnbridge is used

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -71,6 +71,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.narayana.compensations" />
+        <module name="org.wildfly.transaction.client" />
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -65,6 +65,11 @@
         <module name="javax.annotation.api"  export="true" />
         <module name="javax.interceptor.api"  export="true" />
         <module name="org.jboss.weld.spi" />
+        <module name="org.jboss.as.xts" export="true">
+          <imports>
+            <include path="org.jboss.as.xts.txnclient"/>
+          </imports>
+        </module>
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->

--- a/xts/src/main/java/org/jboss/as/xts/XTSHandlerDeploymentProcessor.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSHandlerDeploymentProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.as.xts.jandex.CompensatableAnnotation;
 import org.jboss.as.xts.jandex.EndpointMetaData;
 import org.jboss.as.xts.jandex.OldCompensatableAnnotation;
 import org.jboss.as.xts.jandex.TransactionalAnnotation;
+import org.jboss.as.xts.txnclient.WildflyTransactionClientTxBridgeIntegrationHandler;
 import org.jboss.as.webservices.injection.WSEndpointHandlersMapping;
 import org.jboss.as.webservices.util.ASHelper;
 import org.jboss.as.webservices.util.WSAttachmentKeys;
@@ -59,7 +60,7 @@ import java.util.Set;
 public class XTSHandlerDeploymentProcessor implements DeploymentUnitProcessor {
 
     private static final String TX_BRIDGE_HANDLER = OptionalJaxWSTxInboundBridgeHandler.class.getName();
-
+    private static final String TX_BRIDGE_WFTC_INTEGRATION_HANDLER = WildflyTransactionClientTxBridgeIntegrationHandler.class.getName();
     private static final String TX_CONTEXT_HANDLER = JaxWSHeaderContextProcessor.class.getName();
 
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
@@ -93,6 +94,7 @@ public class XTSHandlerDeploymentProcessor implements DeploymentUnitProcessor {
             final List<String> handlers = new ArrayList<String>();
 
             if (endpointMetaData.isBridgeEnabled()) {
+                handlers.add(TX_BRIDGE_WFTC_INTEGRATION_HANDLER);
                 handlers.add(TX_BRIDGE_HANDLER);
             }
             handlers.add(TX_CONTEXT_HANDLER);

--- a/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
+++ b/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
@@ -24,8 +24,13 @@ package org.jboss.as.xts.logging;
 
 import static org.jboss.logging.Logger.Level.WARN;
 
+import javax.xml.ws.handler.MessageContext;
+
+import static org.jboss.logging.Logger.Level.ERROR;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -110,4 +115,8 @@ public interface XtsAsLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 9, value = "Rejecting call because it is not part of any XTS transaction")
     void rejectingCallBecauseNotPartOfXtsTx();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 10, value = "Cannot get transaction status on handling context %s")
+    void cannotGetTransactionStatus(MessageContext ctx, @Cause Throwable cause);
 }

--- a/xts/src/main/java/org/jboss/as/xts/txnclient/WildflyTransactionClientTxBridgeIntegrationHandler.java
+++ b/xts/src/main/java/org/jboss/as/xts/txnclient/WildflyTransactionClientTxBridgeIntegrationHandler.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.xts.txnclient;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.xml.ws.handler.Handler;
+import javax.xml.ws.handler.MessageContext;
+
+import org.jboss.as.txn.deployment.TransactionRollbackSetupAction;
+import org.jboss.as.xts.XTSHandlerDeploymentProcessor;
+import org.jboss.as.xts.logging.XtsAsLogger;
+import org.wildfly.transaction.client.ContextTransactionManager;
+
+/**
+ * <p>
+ * Handler to integrate the handle message event with WildFly Transaction client (WFTC) SPI.
+ * This handler has to be defined in order to be called after the {@link OptionalJaxWSTxInboundBridgeHandler}.
+ * Check the handler enlistment at {@link XTSHandlerDeploymentProcessor}.
+ * <p>
+ * Importing transaction for incoming WS message is handled by WS integration class: AbstractInvocationHandler
+ * where the interceptor context is filled with the imported transaction.
+ * <p>
+ * When the call leaves eJB there is invoked handler {@link TransactionRollbackSetupAction} verifying existence of the transactions.
+ * At that time the transaction should be suspended. In case of WS call where XTS transaction was imported the suspend
+ * of the transaction is done in XTS handler. This handler is part of the Narayana code and the transaction is thus suspended.
+ * But WFTC stores its own notion about transaction existence and none suspends the WFTC
+ */
+public class WildflyTransactionClientTxBridgeIntegrationHandler implements Handler<MessageContext> {
+
+    @Override
+    public boolean handleMessage(MessageContext messageContext) {
+        final Boolean isOutbound = (Boolean) messageContext.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+
+        try {
+            if (isOutbound != null && isOutbound) {
+                // suspending context before returning to the client
+                if(ContextTransactionManager.getInstance() != null &&
+                        ContextTransactionManager.getInstance().getStatus() != Status.STATUS_NO_TRANSACTION) {
+                    ContextTransactionManager.getInstance().suspend();
+                }
+            }
+        } catch (SystemException se) {
+            XtsAsLogger.ROOT_LOGGER.cannotGetTransactionStatus(messageContext, se);
+        }
+        // continue with message handling
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(MessageContext context) {
+        // do nothing just continue with processing
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+        // no action needed
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9455

As described in the issue the XTS component needs to ensure that on bridging transaction the intermediate layer of wildfly transaction client knows about the fact the transaction was suspended. I consider it just needs to depend on the WFTC. Having new special module seems to me senseless.

Tests are not attached as the behaviour is exposed only by outcome in the logs. If the XTS tests are run it could be checked
`./integration-tests.sh clean install -Dts.noSmoke -Dts.xts -Djboss.dist=$JBOSS_HOME -Dtest=TransactionalTestCase`