### PR TITLE
[WFLY-11092] xts logger fails to compile on jdk11 as javax package was removed from jdk

### DIFF
--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.jboss.spec.javax.xml.ws</groupId>
             <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
+++ b/xts/src/main/java/org/jboss/as/xts/logging/XtsAsLogger.java
@@ -23,9 +23,6 @@
 package org.jboss.as.xts.logging;
 
 import static org.jboss.logging.Logger.Level.WARN;
-
-import javax.xml.ws.handler.MessageContext;
-
 import static org.jboss.logging.Logger.Level.ERROR;
 
 import org.jboss.logging.BasicLogger;
@@ -35,6 +32,7 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.msc.service.StartException;
+import javax.xml.ws.handler.MessageContext;
 
 /**
  * Date: 05.11.2011
@@ -119,4 +117,5 @@ public interface XtsAsLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 10, value = "Cannot get transaction status on handling context %s")
     void cannotGetTransactionStatus(MessageContext ctx, @Cause Throwable cause);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11092