### PR TITLE
[WFLY-11105] Upgrade WildFly Core 7.0.0.Alpha2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>7.0.0.Alpha1</version.org.wildfly.core>
+        <version.org.wildfly.core>7.0.0.Alpha2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11105

---


## Release Notes - WildFly Core - Version 7.0.0.Alpha2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4094'>WFCORE-4094</a>] -         Upgrade parent pom to 29
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4112'>WFCORE-4112</a>] -         Upgrade CLI to use aesh 1.8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4118'>WFCORE-4118</a>] -         Upgrade WildFly Elytron to 1.7.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4133'>WFCORE-4133</a>] -         Upgrade WildFly Elytron to 1.7.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4134'>WFCORE-4134</a>] -         Upgrade Elytron Web to 1.3.0.CR2
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3386'>WFCORE-3386</a>] -         Add configuration required to support JASPI to the Elytron subsystem and general JASPI integration.
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3404'>WFCORE-3404</a>] -         Performance issue in audit endpoints
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3479'>WFCORE-3479</a>] -         Deploying an empty deployment and adding content later fails in a composite
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3971'>WFCORE-3971</a>] -         Referral mode should be an enumeration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3996'>WFCORE-3996</a>] -         GC logging is not working on Java 9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4002'>WFCORE-4002</a>] -         JDK11 Some security tests fail on closed channel exception
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4098'>WFCORE-4098</a>] -         SimpleMapAttributeDefinition Values Unable to Reference Capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4121'>WFCORE-4121</a>] -         The DomainCommandBuilder does not add modular JDK arguments to the host controler
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4124'>WFCORE-4124</a>] -         The CliCommandBuilder needs add the modular JDK options
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4136'>WFCORE-4136</a>] -         Booting a slave HC fails if the content repository entry for a rollout plan is not present
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4137'>WFCORE-4137</a>] -         Add missing KnownRelease for WildFly 14
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4140'>WFCORE-4140</a>] -         Incorrect resource passed into ExtensionRegistry.remove by ExtensionAddHandler rollback handling
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4141'>WFCORE-4141</a>] -         ServerRootResourceDefininition registers the ServerEnvironment child resource in the wrong place
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4026'>WFCORE-4026</a>] -         Create Version 5 of the Elytron subsystem model and schema.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4079'>WFCORE-4079</a>] -         Fix tests that rely on internationalized loggers not being present
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4105'>WFCORE-4105</a>] -         Create simple tests for scripts
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4119'>WFCORE-4119</a>] -         Add exclusions for org.picketbox
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4126'>WFCORE-4126</a>] -         Remove script tests for shells that require special scripting syntax
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4145'>WFCORE-4145</a>] -         --admin-only might be worth marking as deprecated with ./standalone.sh --help
</li>
</ul>
                                    