### PR TITLE
WFLY-10464 ChannelCommandDispatcher's RequestCorellator bypasses stack configuration including encryption

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
@@ -103,7 +103,7 @@ public class ChannelCommandDispatcherFactory implements AutoCloseableCommandDisp
         this.marshallingContext = config.getMarshallingContext();
         this.timeout = config.getTimeout();
         JChannel channel = config.getChannel();
-        RequestCorrelator correlator = new RequestCorrelator(channel.getProtocolStack().getTransport(), this, channel.getAddress()).setMarshaller(new CommandResponseMarshaller(config));
+        RequestCorrelator correlator = new RequestCorrelator(channel.getProtocolStack(), this, channel.getAddress()).setMarshaller(new CommandResponseMarshaller(config));
         this.dispatcher = new MessageDispatcher()
                 .setChannel(channel)
                 .setRequestHandler(this)


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-10464

Blocker - fixes currently broken scenarios with both SYM_ENCRYPT and ASYM_ENCRYPT, especially for OpenShift cases. Pre-verified by QE in [this](https://jenkins.hosts.mwqe.eng.bos.redhat.com/hudson/view/EAP7/view/EAP7-Clustering_JJB/view/clustering-jobs-http-session-encrypt/job/perflab_eap-7x-failover-http-session-shutdown-dist-async-auth-asymEncrypt/21/) run (now passing 100%).