### PR TITLE
[WFLY-11144] Remove the seemingly unneeded javax.rmi.api dep from jav…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -28,7 +28,6 @@
         <module name="javax.api" />
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 
     <resources>


### PR DESCRIPTION
…ax.ejb.api

https://issues.jboss.org/browse/WFLY-11144

This needs review by someone familiar with javax.ejb.api... which David Lloyd has done via his comment on the JIRA. :)