### PR TITLE
[WFLY-11128] added ref to jboss-modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -71,5 +71,6 @@
         <module name="org.apache.commons.beanutils"/>
         <module name="javax.wsdl4j.api" />
         <module name="org.bouncycastle" />
+        <module name="org.jboss.modules"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11128
Added jboss-module reference in jaxws-client module.xml to resolve classNotFound Exception
to org.jboss.modules.ModuleLoadException.
