### PR TITLE
[WFLY-11112]: WildFly intermittently fails to add pooled-connection-factory but it still got registered after.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -921,4 +921,11 @@ public interface ConnectorLogger extends BasicLogger {
     @Message(id = 117, value = "%s is not a valid %s implementation")
     OperationFailedException notAValidDataSourceClass(String clz, String dsClz);
 
+    @LogMessage(level = INFO)
+    @Message(id = 118, value = "Binding connection factory named %s to alias %s")
+    void bindingAlias(String jndiName, String alias);
+
+    @LogMessage(level = INFO)
+    @Message(id = 119, value = "Unbinding connection factory named %s to alias %s")
+    void unbindingAlias(String jndiName, String alias);
 }

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
@@ -26,6 +26,9 @@ import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTO
 
 import java.io.File;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -68,6 +71,7 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
 
     private CommonDeployment deploymentMD;
     private ContextNames.BindInfo bindInfo;
+    private final List<String> jndiAliases = new ArrayList<>();
     private boolean createBinderService = true;
 
     public ResourceAdapterActivatorService(final Connector cmd, final Activation activation, ClassLoader cl,
@@ -81,9 +85,9 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
     }
 
     public ContextNames.BindInfo getBindInfo(String jndi) {
-        if (bindInfo != null)
+        if (bindInfo != null) {
             return bindInfo;
-
+        }
         return ContextNames.bindInfoFor(jndi);
     }
 
@@ -91,6 +95,20 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
         this.bindInfo = bindInfo;
     }
 
+    public void addJndiAlias(String alias) {
+        this.jndiAliases.add(alias);
+    }
+
+    public void addJndiAliases(Collection<String> aliases) {
+        this.jndiAliases.addAll(aliases);
+    }
+
+    @Override
+    public Collection<String> getJndiAliases() {
+        return Collections.unmodifiableList(this.jndiAliases);
+    }
+
+    @Override
     public boolean isCreateBinderService() {
         return createBinderService;
     }

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
@@ -26,6 +26,8 @@ import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTO
 
 import java.io.File;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -186,6 +188,11 @@ public final class ResourceAdapterDeploymentService extends AbstractResourceAdap
         } finally {
             context.asynchronous();
         }
+    }
+
+    @Override
+    public Collection<String> getJndiAliases() {
+        return Collections.emptyList();
     }
 
     /**

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
@@ -29,6 +29,8 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.connector.metadata.deployment.ResourceAdapterDeployment;
@@ -146,6 +148,11 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
     @Override
     public void stop(StopContext context) {
         stopAsync(context, raName, deploymentServiceName);
+    }
+
+    @Override
+    public Collection<String> getJndiAliases() {
+        return Collections.emptyList();
     }
 
     public CommonDeployment getRaxmlDeployment() {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -174,6 +174,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
     private Map<String, SocketBinding> socketBindings = new HashMap<String, SocketBinding>();
     private InjectedValue<ActiveMQServer> activeMQServer = new InjectedValue<>();
     private BindInfo bindInfo;
+    private List<String> jndiAliases;
     private final boolean pickAnyConnectors;
     private String txSupport;
     private int minPoolSize;
@@ -187,7 +188,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
     private InjectedValue<ExceptionSupplier<CredentialSource, Exception>> credentialSourceSupplier = new InjectedValue<>();
 
 
-    public PooledConnectionFactoryService(String name, List<String> connectors, String discoveryGroupName, String serverName, String jgroupsChannelName, List<PooledConnectionFactoryConfigProperties> adapterParams, BindInfo bindInfo, String txSupport, int minPoolSize, int maxPoolSize, String managedConnectionPoolClassName, Boolean enlistmentTrace) {
+    public PooledConnectionFactoryService(String name, List<String> connectors, String discoveryGroupName, String serverName, String jgroupsChannelName, List<PooledConnectionFactoryConfigProperties> adapterParams, BindInfo bindInfo, List<String> jndiAliases, String txSupport, int minPoolSize, int maxPoolSize, String managedConnectionPoolClassName, Boolean enlistmentTrace) {
         this.name = name;
         this.connectors = connectors;
         this.discoveryGroupName = discoveryGroupName;
@@ -195,6 +196,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
         this.jgroupsChannelName = jgroupsChannelName;
         this.adapterParams = adapterParams;
         this.bindInfo = bindInfo;
+        this.jndiAliases = new ArrayList<>(jndiAliases);
         createBinderService = true;
         this.txSupport = txSupport;
         this.minPoolSize = minPoolSize;
@@ -212,6 +214,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
         this.jgroupsChannelName = jgroupsChannelName;
         this.adapterParams = adapterParams;
         this.bindInfo = bindInfo;
+        this.jndiAliases = Collections.emptyList();
         this.createBinderService = false;
         this.txSupport = txSupport;
         this.minPoolSize = minPoolSize;
@@ -263,6 +266,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                                       String jgroupsChannelName,
                                       List<PooledConnectionFactoryConfigProperties> adapterParams,
                                       BindInfo bindInfo,
+                                      List<String> jndiAliases,
                                       String txSupport,
                                       int minPoolSize,
                                       int maxPoolSize,
@@ -274,7 +278,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
         ServiceName serviceName = JMSServices.getPooledConnectionFactoryBaseServiceName(serverServiceName).append(name);
         PooledConnectionFactoryService service = new PooledConnectionFactoryService(name,
                 connectors, discoveryGroupName, serverName, jgroupsChannelName, adapterParams,
-                bindInfo, txSupport, minPoolSize, maxPoolSize, managedConnectionPoolClassName, enlistmentTrace);
+                bindInfo, jndiAliases, txSupport, minPoolSize, maxPoolSize, managedConnectionPoolClassName, enlistmentTrace);
 
         installService0(context, serverServiceName, serviceName, service, model);
         return service;
@@ -449,6 +453,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                     PooledConnectionFactoryService.class.getClassLoader(), name);
             activator.setBindInfo(bindInfo);
             activator.setCreateBinderService(createBinderService);
+            activator.addJndiAliases(jndiAliases);
 
             ServiceController<ResourceAdapterDeployment> controller =
                     Services.addServerExecutorDependency(


### PR DESCRIPTION
Adding JNDI aliases in the same step as the JNDI main name when adding a PooledConnectionFactory.

Jira: https://issues.jboss.org/browse/WFLY-11112