### PR TITLE
WFLY-11169 Default ASYM_ENCRYPT asym_keylength is considered breakable

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -58,6 +58,9 @@
         timeout_check_interval="5000"/>
     <FD_SOCK/>
     <VERIFY_SUSPECT timeout="5000"/>
+    <ASYM_ENCRYPT
+        asym_keylength="2048"
+    />
     <pbcast.NAKACK2
         xmit_interval="100"
         xmit_table_num_rows="50"


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-11169