### PR TITLE
[WFLY-11165][WFLY-11166][WFLY-11167][WFLY-11174][WFLY-11177][WFLY-11181] Clarify dependencies on Transaction subsystem

### DIFF
--- a/batch-jberet/pom.xml
+++ b/batch-jberet/pom.xml
@@ -107,6 +107,10 @@
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.transaction</groupId>
+            <artifactId>wildfly-transaction-client</artifactId>
+        </dependency>
 
         <!-- test -->
         <dependency>

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
@@ -40,9 +40,19 @@ public class Capabilities {
     public static final String DATA_SOURCE_CAPABILITY = "org.wildfly.data-source";
 
     /**
+     * Name of the capability that ensures a local provider of transactions is present.
+     * Once its service is started, calls to the getInstance() methods of ContextTransactionManager,
+     * ContextTransactionSynchronizationRegistry and LocalUserTransaction can be made knowing
+     * that the global default TM, TSR and UT will be from that provider.
+     */
+    public static final String LOCAL_TRANSACTION_PROVIDER_CAPABILITY = "org.wildfly.transactions.global-default-local-provider";
+
+    /**
      * A capability for the current batch configuration.
      */
     public static final RuntimeCapability<Void> BATCH_CONFIGURATION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.configuration", false, BatchConfiguration.class)
+            // BatchConfiguration itself doesn't require a TM, but any effective use of it does (BatchEnvironment)
+            .addRequirements(LOCAL_TRANSACTION_PROVIDER_CAPABILITY)
             .build();
 
     /**

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
@@ -43,6 +43,7 @@ import org.wildfly.extension.requestcontroller.RequestController;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.manager.WildFlySecurityManager;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -53,7 +54,6 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
 
     private final InjectedValue<WildFlyArtifactFactory> artifactFactoryInjector = new InjectedValue<>();
     private final InjectedValue<JobExecutor> jobExecutorInjector = new InjectedValue<>();
-    private final InjectedValue<TransactionManager> transactionManagerInjector = new InjectedValue<>();
     private final InjectedValue<RequestController> requestControllerInjector = new InjectedValue<>();
     private final InjectedValue<JobRepository> jobRepositoryInjector = new InjectedValue<>();
     private final InjectedValue<BatchConfiguration> batchConfigurationInjector = new InjectedValue<>();
@@ -86,7 +86,7 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
         }
 
         this.batchEnvironment = new WildFlyBatchEnvironment(artifactFactoryInjector.getValue(),
-                jobExecutor, transactionManagerInjector.getValue(),
+                jobExecutor, ContextTransactionManager.getInstance(),
                 jobRepository, jobXmlResolver);
 
         final RequestController requestController = requestControllerInjector.getOptionalValue();
@@ -118,10 +118,6 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
 
     public InjectedValue<JobExecutor> getJobExecutorInjector() {
         return jobExecutorInjector;
-    }
-
-    public InjectedValue<TransactionManager> getTransactionManagerInjector() {
-        return transactionManagerInjector;
     }
 
     public InjectedValue<RequestController> getRequestControllerInjector() {

--- a/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
+++ b/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/JBeretSubsystemParsingTestCase.java
@@ -126,6 +126,9 @@ public class JBeretSubsystemParsingTestCase extends AbstractBatchTestCase {
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities("org.wildfly.data-source.ExampleDS", "org.wildfly.security.security-domain.ApplicationDomain");
+        return AdditionalInitialization.withCapabilities(
+                "org.wildfly.data-source.ExampleDS",
+                "org.wildfly.security.security-domain.ApplicationDomain",
+                "org.wildfly.transactions.global-default-local-provider");
     }
 }

--- a/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemOperationsTestCase.java
+++ b/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemOperationsTestCase.java
@@ -61,7 +61,7 @@ public class SubsystemOperationsTestCase extends AbstractBatchTestCase {
             @Override
             protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
                 super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
-                registerCapabilities(capabilityRegistry, "org.wildfly.batch.thread.pool.new-job-repo");
+                registerCapabilities(capabilityRegistry, "org.wildfly.batch.thread.pool.new-job-repo", "org.wildfly.transactions.global-default-local-provider");
             }
         };
     }

--- a/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemTransformerTestCase.java
+++ b/batch-jberet/src/test/java/org/wildfly/extension/batch/jberet/SubsystemTransformerTestCase.java
@@ -52,6 +52,11 @@ public class SubsystemTransformerTestCase extends AbstractBatchTestCase {
         return readResource("/security-domain-subsystem.xml");
     }
 
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider");
+    }
+
     @Test
     public void testTransformersEAP700() throws Exception {
         final KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
@@ -63,7 +68,8 @@ public class SubsystemTransformerTestCase extends AbstractBatchTestCase {
         // Add legacy subsystems
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, legacyVersion)
                 .addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-batch-jberet:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-threads:" + controllerVersion.getCoreVersion());
+                .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-threads:" + controllerVersion.getCoreVersion())
+                .configureReverseControllerCheck(createAdditionalInitialization(), null);
         final KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         final KernelServices legacyServices = mainServices.getLegacyServices(legacyVersion);
@@ -76,7 +82,7 @@ public class SubsystemTransformerTestCase extends AbstractBatchTestCase {
     @Test
     public void testFailedTransformersEAP700() throws Exception {
 
-        final KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        final KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         final ModelVersion legacyVersion = ModelVersion.create(1, 1, 0);
 
         final ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_0_0;

--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.transaction</groupId>
+            <artifactId>wildfly-transaction-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cachestore-jdbc</artifactId>
         </dependency>

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheServiceHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheServiceHandler.java
@@ -128,6 +128,9 @@ public class CacheServiceHandler implements ResourceServiceHandler {
     }
 
     private static ServiceName getRecoveryServiceName(OperationContext context) {
-        return context.getCapabilityServiceName(XA_RESOURCE_RECOVERY_REGISTRY.getName(), XAResourceRecoveryRegistry.class);
+        if (context.hasOptionalCapability(XA_RESOURCE_RECOVERY_REGISTRY.getName(), null, null)) {
+            return context.getCapabilityServiceName(XA_RESOURCE_RECOVERY_REGISTRY.getName(), XAResourceRecoveryRegistry.class);
+        }
+        return null;
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheServiceHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheServiceHandler.java
@@ -26,6 +26,7 @@ import static org.jboss.as.clustering.infinispan.subsystem.CacheResourceDefiniti
 import static org.jboss.as.clustering.infinispan.subsystem.CacheResourceDefinition.Attribute.MODULE;
 import static org.jboss.as.clustering.infinispan.subsystem.CacheResourceDefinition.Capability.CACHE;
 import static org.jboss.as.clustering.infinispan.subsystem.CacheResourceDefinition.Capability.CONFIGURATION;
+import static org.jboss.as.clustering.infinispan.subsystem.TransactionResourceDefinition.TransactionRequirement.XA_RESOURCE_RECOVERY_REGISTRY;
 
 import java.util.EnumSet;
 import java.util.ServiceLoader;
@@ -43,6 +44,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.wildfly.clustering.infinispan.spi.service.CacheServiceConfigurator;
 import org.wildfly.clustering.service.IdentityServiceConfigurator;
 import org.wildfly.clustering.service.ServiceNameProvider;
@@ -84,7 +86,7 @@ public class CacheServiceHandler implements ResourceServiceHandler {
         this.configuratorFactory.createServiceConfigurator(cacheAddress).configure(context, model).build(target).install();
 
         new CacheServiceConfigurator<>(CACHE.getServiceName(cacheAddress), containerName, cacheName).configure(context).build(target).install();
-        new XAResourceRecoveryServiceConfigurator(cacheAddress).build(target).install();
+        new XAResourceRecoveryServiceConfigurator(cacheAddress, getRecoveryServiceName(context)).build(target).install();
 
         new BinderServiceConfigurator(InfinispanBindingFactory.createCacheConfigurationBinding(containerName, cacheName), CONFIGURATION.getServiceName(cacheAddress)).build(target).install();
         new BinderServiceConfigurator(InfinispanBindingFactory.createCacheBinding(containerName, cacheName), CACHE.getServiceName(cacheAddress)).build(target).install();
@@ -117,11 +119,15 @@ public class CacheServiceHandler implements ResourceServiceHandler {
         context.removeService(InfinispanBindingFactory.createCacheBinding(containerName, cacheName).getBinderServiceName());
         context.removeService(InfinispanBindingFactory.createCacheConfigurationBinding(containerName, cacheName).getBinderServiceName());
 
-        context.removeService(new XAResourceRecoveryServiceConfigurator(cacheAddress).getServiceName());
+        context.removeService(new XAResourceRecoveryServiceConfigurator(cacheAddress, getRecoveryServiceName(context)).getServiceName());
         context.removeService(CacheComponent.MODULE.getServiceName(cacheAddress));
 
         for (Capability capability : EnumSet.allOf(Capability.class)) {
             context.removeService(capability.getServiceName(cacheAddress));
         }
+    }
+
+    private static ServiceName getRecoveryServiceName(OperationContext context) {
+        return context.getCapabilityServiceName(XA_RESOURCE_RECOVERY_REGISTRY.getName(), XAResourceRecoveryRegistry.class);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionServiceConfigurator.java
@@ -43,12 +43,12 @@ import org.jboss.as.clustering.infinispan.TransactionSynchronizationRegistryProv
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.clustering.service.ServiceConfigurator;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * @author Paul Ferraro
@@ -83,7 +83,13 @@ public class TransactionServiceConfigurator extends ComponentServiceConfigurator
                 break;
             }
             case NON_XA: {
-                this.tsr = builder.requires(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY);
+                this.tsr = new Supplier<TransactionSynchronizationRegistry>() {
+                    @Override
+                    public TransactionSynchronizationRegistry get() {
+                        return ContextTransactionSynchronizationRegistry.getInstance();
+                    }
+                };
+                // fall through
             }
             default: {
                 // Add a service dependency on the void service provided by the

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -70,6 +70,7 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest<Infinis
                 .require(JGroupsRequirement.CHANNEL, "maximal-channel")
                 .require(JGroupsRequirement.CHANNEL_FACTORY, "ee-maximal", "maximal-channel", "maximal-cluster")
                 .require(JGroupsDefaultRequirement.CHANNEL_FACTORY)
+                .require(TransactionResourceDefinition.TransactionRequirement.LOCAL_TRANSACTION_PROVIDER)
                 ;
     }
 

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -71,6 +71,7 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest<Infinis
                 .require(JGroupsRequirement.CHANNEL_FACTORY, "ee-maximal", "maximal-channel", "maximal-cluster")
                 .require(JGroupsDefaultRequirement.CHANNEL_FACTORY)
                 .require(TransactionResourceDefinition.TransactionRequirement.LOCAL_TRANSACTION_PROVIDER)
+                .require(TransactionResourceDefinition.TransactionRequirement.XA_RESOURCE_RECOVERY_REGISTRY)
                 ;
     }
 

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
@@ -155,6 +155,7 @@ public class InfinispanTransformersTestCase extends OperationTestCaseBase {
                 .require(JGroupsRequirement.CHANNEL_FACTORY, "maximal-channel")
                 .require(JGroupsDefaultRequirement.CHANNEL_FACTORY)
                 .require(TransactionResourceDefinition.TransactionRequirement.LOCAL_TRANSACTION_PROVIDER)
+                .require(TransactionResourceDefinition.TransactionRequirement.XA_RESOURCE_RECOVERY_REGISTRY)
                 ;
     }
 

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanTransformersTestCase.java
@@ -154,6 +154,7 @@ public class InfinispanTransformersTestCase extends OperationTestCaseBase {
                 .require(CommonUnaryRequirement.DATA_SOURCE, "ExampleDS")
                 .require(JGroupsRequirement.CHANNEL_FACTORY, "maximal-channel")
                 .require(JGroupsDefaultRequirement.CHANNEL_FACTORY)
+                .require(TransactionResourceDefinition.TransactionRequirement.LOCAL_TRANSACTION_PROVIDER)
                 ;
     }
 

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -70,6 +70,10 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.transaction</groupId>
+            <artifactId>wildfly-transaction-client</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-security</artifactId>
         </dependency>

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectAdminObjectActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectAdminObjectActivatorService.java
@@ -35,7 +35,6 @@ import org.jboss.as.connector.subsystems.jca.JcaSubsystemConfiguration;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.jca.common.api.metadata.common.TransactionSupportEnum;
 import org.jboss.jca.common.api.metadata.resourceadapter.Activation;
 import org.jboss.jca.common.api.metadata.resourceadapter.ConnectionDefinition;
@@ -178,7 +177,7 @@ public class DirectAdminObjectActivatorService implements Service<ContextNames.B
                     */
                     .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class,
                             activator.getCcmInjector()).addDependency(NamingService.SERVICE_NAME)
-                    .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                    .addDependency(ConnectorServices.getLocalTransactionProviderServiceName())
                     .addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
 
 

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
@@ -35,7 +35,6 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SimpleSecurityManagerService;
 import org.jboss.as.security.service.SubjectFactoryService;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.Pool;
 import org.jboss.jca.common.api.metadata.common.TransactionSupportEnum;
@@ -248,7 +247,7 @@ public class DirectConnectionFactoryActivatorService implements org.jboss.msc.se
                     .addDependency(NamingService.SERVICE_NAME)
                     .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
                             activator.getTxIntegrationInjector())
-                    .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                    .addDependency(ConnectorServices.getLocalTransactionProviderServiceName())
                     .addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
 
             if (ActivationSecurityUtil.isLegacySecurityRequired(security)) {

--- a/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
@@ -24,7 +24,6 @@ package org.jboss.as.connector.services.transactionintegration;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
 
-import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.connector.util.ConnectorServices;
@@ -39,6 +38,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.jboss.tm.usertx.UserTransactionRegistry;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * A WorkManager Service.
@@ -47,8 +47,6 @@ import org.jboss.tm.usertx.UserTransactionRegistry;
 public final class TransactionIntegrationService implements Service<TransactionIntegration> {
 
     private volatile TransactionIntegration value;
-
-    private final InjectedValue<TransactionManager> tm = new InjectedValue<TransactionManager>();
 
     private final InjectedValue<TransactionSynchronizationRegistry> tsr = new InjectedValue<TransactionSynchronizationRegistry>();
 
@@ -70,7 +68,7 @@ public final class TransactionIntegrationService implements Service<TransactionI
 
     @Override
     public void start(StartContext context) throws StartException {
-        this.value = new TransactionIntegrationImpl(tm.getValue(), tsr.getValue(), utr.getValue(), terminator.getValue(),
+        this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(), tsr.getValue(), utr.getValue(), terminator.getValue(),
                 rr.getValue());
         ROOT_LOGGER.debugf("Starting JCA TransactionIntegrationService");
     }
@@ -78,10 +76,6 @@ public final class TransactionIntegrationService implements Service<TransactionI
     @Override
     public void stop(StopContext context) {
 
-    }
-
-    public Injector<TransactionManager> getTmInjector() {
-        return tm;
     }
 
     public Injector<TransactionSynchronizationRegistry> getTsrInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
@@ -24,8 +24,6 @@ package org.jboss.as.connector.services.transactionintegration;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
 
-import javax.transaction.TransactionSynchronizationRegistry;
-
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
@@ -39,6 +37,7 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.jboss.tm.usertx.UserTransactionRegistry;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * A WorkManager Service.
@@ -47,8 +46,6 @@ import org.wildfly.transaction.client.ContextTransactionManager;
 public final class TransactionIntegrationService implements Service<TransactionIntegration> {
 
     private volatile TransactionIntegration value;
-
-    private final InjectedValue<TransactionSynchronizationRegistry> tsr = new InjectedValue<TransactionSynchronizationRegistry>();
 
     private final InjectedValue<UserTransactionRegistry> utr = new InjectedValue<UserTransactionRegistry>();
 
@@ -68,7 +65,8 @@ public final class TransactionIntegrationService implements Service<TransactionI
 
     @Override
     public void start(StartContext context) throws StartException {
-        this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(), tsr.getValue(), utr.getValue(), terminator.getValue(),
+        this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(),
+                ContextTransactionSynchronizationRegistry.getInstance(), utr.getValue(), terminator.getValue(),
                 rr.getValue());
         ROOT_LOGGER.debugf("Starting JCA TransactionIntegrationService");
     }
@@ -76,10 +74,6 @@ public final class TransactionIntegrationService implements Service<TransactionI
     @Override
     public void stop(StopContext context) {
 
-    }
-
-    public Injector<TransactionSynchronizationRegistry> getTsrInjector() {
-        return tsr;
     }
 
     public Injector<UserTransactionRegistry> getUtrInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -25,6 +25,7 @@ package org.jboss.as.connector.subsystems.jca;
 
 import static org.jboss.as.connector.subsystems.jca.JcaSubsystemRootDefinition.TRANSACTION_INTEGRATION_CAPABILITY;
 import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 
 import org.jboss.as.connector.deployers.ra.RaDeploymentActivator;
 import org.jboss.as.connector.services.driver.registry.DriverRegistryService;
@@ -76,9 +77,9 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addCapability(TRANSACTION_INTEGRATION_CAPABILITY, tiService)
                 // Ensure the local transaction provider is started
                 .addCapabilityRequirement(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, Void.class)
+                .addCapabilityRequirement(TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY, XAResourceRecoveryRegistry.class, tiService.getRrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, org.jboss.tm.usertx.UserTransactionRegistry.class, tiService.getUtrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, tiService.getTerminatorInjector())
-                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, XAResourceRecoveryRegistry.class, tiService.getRrInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .addAliases(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE)
                 .install();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -25,8 +25,6 @@ package org.jboss.as.connector.subsystems.jca;
 
 import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
 
-import javax.transaction.TransactionSynchronizationRegistry;
-
 import org.jboss.as.connector.deployers.ra.RaDeploymentActivator;
 import org.jboss.as.connector.services.driver.registry.DriverRegistryService;
 import org.jboss.as.connector.services.transactionintegration.TransactionIntegrationService;
@@ -77,7 +75,6 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addService(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, tiService)
                 // Ensure the local transaction provider is started
                 .addDependency(context.getCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, null))
-                .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, tiService.getTsrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, org.jboss.tm.usertx.UserTransactionRegistry.class, tiService.getUtrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, tiService.getTerminatorInjector())
                 .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, XAResourceRecoveryRegistry.class, tiService.getRrInjector())

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -23,7 +23,8 @@
 
 package org.jboss.as.connector.subsystems.jca;
 
-import javax.transaction.TransactionManager;
+import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
+
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.connector.deployers.ra.RaDeploymentActivator;
@@ -74,7 +75,8 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         serviceTarget
                 .addService(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, tiService)
-                .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, tiService.getTmInjector())
+                // Ensure the local transaction provider is started
+                .addDependency(context.getCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, null))
                 .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, tiService.getTsrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, org.jboss.tm.usertx.UserTransactionRegistry.class, tiService.getUtrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, tiService.getTerminatorInjector())

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -24,24 +24,33 @@ package org.jboss.as.connector.subsystems.jca;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
     protected static final PathElement PATH_SUBSYSTEM = PathElement.pathElement(SUBSYSTEM, JcaExtension.SUBSYSTEM_NAME);
+
+    static final RuntimeCapability<Void> TRANSACTION_INTEGRATION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jca.transaction-integration", TransactionIntegration.class)
+            .addRequirements(ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY)
+            .build();
+
     private final boolean registerRuntimeOnly;
 
 
     private JcaSubsystemRootDefinition(final boolean registerRuntimeOnly) {
-        super(PATH_SUBSYSTEM,
-                JcaExtension.getResourceDescriptionResolver(),
-                JcaSubsystemAdd.INSTANCE,
-                JcaSubSystemRemove.INSTANCE);
+        super(new Parameters(PATH_SUBSYSTEM, JcaExtension.getResourceDescriptionResolver())
+                .setAddHandler(JcaSubsystemAdd.INSTANCE)
+                .setRemoveHandler(JcaSubSystemRemove.INSTANCE)
+                .setCapabilities(TRANSACTION_INTEGRATION_CAPABILITY)
+        );
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -22,9 +22,10 @@
 
 package org.jboss.as.connector.subsystems.jca;
 
+import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
-import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -39,7 +40,7 @@ public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
     protected static final PathElement PATH_SUBSYSTEM = PathElement.pathElement(SUBSYSTEM, JcaExtension.SUBSYSTEM_NAME);
 
     static final RuntimeCapability<Void> TRANSACTION_INTEGRATION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jca.transaction-integration", TransactionIntegration.class)
-            .addRequirements(ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY)
+            .addRequirements(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY)
             .build();
 
     private final boolean registerRuntimeOnly;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubSystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubSystemAdd.java
@@ -24,6 +24,7 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ARCHIVE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RESOURCEADAPTER_NAME;
+import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
 
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.connector.util.CopyOnWriteArrayListMultiMap;
@@ -55,6 +56,9 @@ class ResourceAdaptersSubsystemAdd extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+
+        // Cache the TransactionManager service name for use by our runtime services
+        ConnectorServices.registerCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, context.getCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, null));
 
         final Resource subsystemResource = context.readResourceFromRoot(PathAddress.pathAddress(ResourceAdaptersExtension.SUBSYSTEM_PATH));
         ResourceAdaptersSubsystemService service = new ResourceAdaptersSubsystemService();

--- a/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
@@ -267,6 +267,11 @@ public class ConnectorServices {
      */
     public static final String LOCAL_TRANSACTION_PROVIDER_CAPABILITY = "org.wildfly.transactions.global-default-local-provider";
 
+    /**
+     * The capability name for the transaction XAResourceRecoveryRegistry.
+     */
+    public static final String TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY = "org.wildfly.transactions.xa-resource-recovery-registry";
+
     public static ServiceName getLocalTransactionProviderServiceName() {
         synchronized (capabilityServiceNames) {
             return capabilityServiceNames.get(LOCAL_TRANSACTION_PROVIDER_CAPABILITY);

--- a/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
@@ -64,6 +64,8 @@ public class ConnectorServices {
 
     public static final ServiceName BOOTSTRAP_CONTEXT_SERVICE = ServiceName.JBOSS.append("connector", "bootstrapcontext");
 
+    /** @deprecated Use the "org.wildfly.jca.transaction-integration" capability. */
+    @Deprecated
     public static final ServiceName TRANSACTION_INTEGRATION_SERVICE = ServiceName.JBOSS.append("connector",
             "transactionintegration");
 

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -86,7 +86,8 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.withCapabilities(
                 ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName(),
-                ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY);
+                ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY,
+                ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY);
     }
 
     @Test

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -83,7 +84,9 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities(ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName());
+        return AdditionalInitialization.withCapabilities(
+                ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName(),
+                ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY);
     }
 
     @Test

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryService.java
@@ -7,14 +7,12 @@ package org.jboss.as.ejb3.cache.distributable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import javax.transaction.TransactionSynchronizationRegistry;
-
+import org.jboss.as.controller.ServiceNameFactory;
 import org.jboss.as.ejb3.cache.Cache;
 import org.jboss.as.ejb3.cache.CacheFactory;
 import org.jboss.as.ejb3.cache.Contextual;
 import org.jboss.as.ejb3.cache.Identifiable;
 import org.jboss.as.ejb3.cache.StatefulObjectFactory;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -26,6 +24,7 @@ import org.wildfly.clustering.ejb.IdentifierFactory;
 import org.wildfly.clustering.ejb.PassivationListener;
 import org.wildfly.clustering.service.ServiceConfigurator;
 import org.wildfly.clustering.service.SimpleServiceNameProvider;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Service that provides a distributable {@link CacheFactory}.
@@ -38,7 +37,6 @@ public class DistributableCacheFactoryService<K, V extends Identifiable<K> & Con
 
     private final ServiceConfigurator configurator;
     private volatile Supplier<BeanManagerFactory<K, V, Batch>> factory;
-    private volatile Supplier<TransactionSynchronizationRegistry> tsr;
 
     public DistributableCacheFactoryService(ServiceName name, ServiceConfigurator configurator) {
         super(name);
@@ -50,7 +48,12 @@ public class DistributableCacheFactoryService<K, V extends Identifiable<K> & Con
         this.configurator.build(target).install();
         ServiceBuilder<?> builder = target.addService(this.getServiceName());
         this.factory = builder.requires(this.configurator.getServiceName());
-        this.tsr = builder.requires(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY);
+        // Ensure the local transaction provider is started before the cache
+        // This parsing isn't 100% ideal as it's somewhat 'internal' knowledge of the relationship between
+        // capability names and service names. But at this point that relationship really needs to become
+        // a contract anyway
+        ServiceName txServiceName = ServiceNameFactory.parseServiceName("org.wildfly.transactions.global-default-local-provider");
+        builder.requires(txServiceName);
         Consumer<CacheFactory<K, V>> factory = builder.provides(this.getServiceName());
         Service service = Service.newInstance(factory, this);
         return builder.setInstance(service);
@@ -59,6 +62,6 @@ public class DistributableCacheFactoryService<K, V extends Identifiable<K> & Con
     @Override
     public Cache<K, V> createCache(IdentifierFactory<K> identifierFactory, StatefulObjectFactory<V> factory, PassivationListener<V> passivationListener) {
         BeanManager<K, V, Batch> manager = this.factory.get().createBeanManager(identifierFactory, passivationListener, new RemoveListenerAdapter<>(factory));
-        return new DistributableCache<>(manager, factory, this.tsr.get());
+        return new DistributableCache<>(manager, factory, ContextTransactionSynchronizationRegistry.getInstance());
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -60,6 +60,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.transaction.client.LocalUserTransaction;
 
 /**
  * @author Jaikiran Pai
@@ -97,7 +98,6 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final String distinctName;
     private final String policyContextID;
 
-    private final InjectedValue<UserTransaction> userTransactionInjectedValue = new InjectedValue<>();
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPoint = new InjectedValue<>();
     private final InjectedValue<AtomicBoolean> exceptionLoggingEnabled = new InjectedValue<>();
@@ -336,12 +336,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         return moduleName;
     }
 
-    Injector<UserTransaction> getUserTransactionInjector() {
-        return this.userTransactionInjectedValue;
-    }
-
     UserTransaction getUserTransaction() {
-        return this.userTransactionInjectedValue.getValue();
+        return LocalUserTransaction.getInstance();
     }
 
     public Injector<EJBSuspendHandlerService> getEJBSuspendHandlerInjector() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -25,7 +25,6 @@ package org.jboss.as.ejb3.component;
 import javax.ejb.TimerService;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagementType;
-import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
 import java.lang.reflect.Method;
@@ -99,7 +98,6 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final String policyContextID;
 
     private final InjectedValue<UserTransaction> userTransactionInjectedValue = new InjectedValue<>();
-    private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPoint = new InjectedValue<>();
     private final InjectedValue<AtomicBoolean> exceptionLoggingEnabled = new InjectedValue<>();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -25,7 +25,6 @@ package org.jboss.as.ejb3.component;
 import javax.ejb.TimerService;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagementType;
-import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
@@ -99,7 +98,6 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final String distinctName;
     private final String policyContextID;
 
-    private final InjectedValue<TransactionManager> transactionManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<UserTransaction> userTransactionInjectedValue = new InjectedValue<>();
     private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -43,7 +43,6 @@ import javax.ejb.EJBLocalObject;
 import javax.ejb.TimerService;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagementType;
-import javax.transaction.UserTransaction;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.core.security.ServerSecurityManager;
@@ -568,8 +567,6 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                         CapabilityServiceSupport support = context.getDeploymentUnit().getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
                         // add dependency on the local transaction provider
                         serviceBuilder.addDependency(support.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider"));
-                        // add dependency on UserTransaction
-                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, ejbComponentCreateService.getUserTransactionInjector());
                     }
                 });
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -570,8 +570,6 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                         serviceBuilder.addDependency(support.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider"));
                         // add dependency on UserTransaction
                         serviceBuilder.addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, ejbComponentCreateService.getUserTransactionInjector());
-                        // add dependency on TransactionSynchronizationRegistry
-                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY);
                     }
                 });
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -565,8 +565,9 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                 componentConfiguration.getCreateDependencies().add(new DependencyConfigurator<EJBComponentCreateService>() {
                     @Override
                     public void configureDependency(final ServiceBuilder<?> serviceBuilder, final EJBComponentCreateService ejbComponentCreateService) throws DeploymentUnitProcessingException {
-                        // add dependency on transaction manager
-                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER);
+                        CapabilityServiceSupport support = context.getDeploymentUnit().getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
+                        // add dependency on the local transaction provider
+                        serviceBuilder.addDependency(support.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider"));
                         // add dependency on UserTransaction
                         serviceBuilder.addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION, UserTransaction.class, ejbComponentCreateService.getUserTransactionInjector());
                         // add dependency on TransactionSynchronizationRegistry

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -179,8 +179,12 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public static final RuntimeCapability<Void> CLUSTERED_SINGLETON_CAPABILITY =  RuntimeCapability.Builder.of(
             "org.wildfly.ejb3.clustered.singleton", Void.class).build();
 
-    public static final RuntimeCapability<Void> EJB_CAPABILITY =  RuntimeCapability.Builder.of(
-            "org.wildfly.ejb3", Void.class).build();
+    public static final RuntimeCapability<Void> EJB_CAPABILITY =  RuntimeCapability.Builder.of("org.wildfly.ejb3", Void.class)
+            // EJBComponentDescription adds a create dependency on the local tx provider to all components,
+            // so in the absence of relevant finer grained EJB capabilities, we'll say that EJB overall
+            // requires the local provider
+            .addRequirements("org.wildfly.transactions.global-default-local-provider")
+            .build();
 
     //We don't want to actually expose the service, we just want to use optional deps
     public static final RuntimeCapability<Void>  EJB_CLIENT_CONFIGURATOR = RuntimeCapability.Builder.of("org.wildfly.ejb3.remote.client-configurator", Void.class)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
@@ -24,8 +24,6 @@ package org.jboss.as.ejb3.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import javax.transaction.TransactionSynchronizationRegistry;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -36,7 +34,6 @@ import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.ejb3.timerservice.persistence.TimerPersistence;
 import org.jboss.as.ejb3.timerservice.persistence.filestore.FileTimerPersistence;
 import org.jboss.as.server.Services;
-import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.service.ServiceName;
@@ -73,7 +70,6 @@ public class FileDataStoreAdd extends AbstractAddStepHandler {
                 .addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ModuleLoader.class, fileTimerPersistence.getModuleLoader())
                 .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, fileTimerPersistence.getPathManager())
                 .addDependency(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null))
-                .addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, fileTimerPersistence.getTransactionSynchronizationRegistry())
                 .install();
 
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
@@ -24,7 +24,6 @@ package org.jboss.as.ejb3.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -37,7 +36,6 @@ import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.ejb3.timerservice.persistence.TimerPersistence;
 import org.jboss.as.ejb3.timerservice.persistence.filestore.FileTimerPersistence;
 import org.jboss.as.server.Services;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.ModuleLoader;
@@ -74,7 +72,7 @@ public class FileDataStoreAdd extends AbstractAddStepHandler {
         context.getServiceTarget().addService(serviceName, fileTimerPersistence)
                 .addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ModuleLoader.class, fileTimerPersistence.getModuleLoader())
                 .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, fileTimerPersistence.getPathManager())
-                .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, fileTimerPersistence.getTransactionManager())
+                .addDependency(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null))
                 .addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, fileTimerPersistence.getTransactionSynchronizationRegistry())
                 .install();
 

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -177,9 +177,14 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
                 formatArtifact("org.jboss.as:jboss-as-threads:%s", controller), LEGACY_EJB_CLIENT_ARTIFACT);
     }
 
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider", buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain"));
+    }
+
     private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String ... mavenResourceURLs) throws Exception {
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization().withCapabilities(buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain")));
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization());
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, model)

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -37,7 +37,6 @@
         <module name="javax.jms.api" />
         <module name="javax.resource.api"/>
         <module name="org.apache.activemq.artemis"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -51,7 +51,6 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -73,5 +73,6 @@
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.transaction.client"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -37,7 +37,6 @@
         <module name="javax.jms.api"/>
         <module name="javax.transaction.api"/>
         <module name="org.jboss.common-beans"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.staxmapper"/>
         <!-- required to provide high-level JMS CLI commands loaded by the extension -->
         <module name="org.jboss.as.cli" />

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/common/main/module.xml
@@ -38,6 +38,7 @@
         <module name="org.jboss.weld.core" />
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -44,6 +44,7 @@
         <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
+        <module name="org.wildfly.transaction.client"/>
         <module name="javax.transaction.api"/>
     </dependencies>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -41,7 +41,6 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.security"/>
         <module name="org.wildfly.security.elytron-private"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.transaction.client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
@@ -43,7 +43,6 @@
         <module name="javax.validation.api"/>
         <module name="org.hibernate.validator"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
@@ -38,7 +38,6 @@
         <module name="javax.validation.api"/>
         <module name="org.hibernate.validator"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.ironjacamar.impl"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
@@ -59,5 +59,6 @@
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.extension.request-controller"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.wildfly.transaction.client"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/jberet/main/module.xml
@@ -46,7 +46,6 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
@@ -41,7 +41,6 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.metadata.common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -85,6 +85,7 @@
         <module name="org.wildfly.clustering.api"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>
+        <module name="org.wildfly.transaction.client"/>
         <!-- Use the HornetQ client module to create the legacy connection factory and destination resources -->
         <module name="org.hornetq.client" />
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -45,7 +45,6 @@
         <module name="org.apache.activemq.artemis"/>
         <module name="org.apache.activemq.artemis.ra"/>
         <module name="org.jboss.common-beans"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.staxmapper"/>
         <!-- required to provide high-level JMS CLI commands loaded by the extension -->
         <module name="org.jboss.as.cli" />

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
@@ -56,5 +56,7 @@
         <module name="org.picketlink.idm.schema"/>
         <module name="org.picketlink.federation"/>
         <module name="org.picketlink.federation.bindings"/>
+
+        <module name="org.wildfly.transaction.client"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
@@ -36,7 +36,6 @@
         <module name="org.wildfly.extension.undertow"/>
         <module name="org.jboss.as.security"/>
         <module name="org.jboss.as.jpa"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -44,7 +44,6 @@
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.jaxrs"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/transaction/client/main/module.xml
@@ -37,9 +37,12 @@
         <module name="javax.transaction.api"/>
 
         <module name="org.jboss.ejb-client" services="import"/>
-        <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.jts"/>
-        <module name="org.jboss.jts.integration"/>
+        <!-- Not needed if the transaction subsystem is not present to build a JBossLocalTransactionProvider -->
+        <module name="org.jboss.jboss-transaction-spi" optional="true"/>
+        <!-- Not needed if the transaction subsystem is not present to build a JBossLocalTransactionProvider -->
+        <module name="org.jboss.jts" optional="true"/>
+        <!-- Not needed if the transaction subsystem is not present to build a JBossLocalTransactionProvider -->
+        <module name="org.jboss.jts.integration" optional="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.remoting"/>
         <module name="org.jboss.xnio"/>

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -36,10 +36,9 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.transaction.TransactionUtil;
-import org.jboss.as.server.CurrentServiceContainer;
-import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Represents the Extended persistence context injected into a stateful bean.  At bean invocation time,
@@ -277,13 +276,13 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
                 @Override
                 public Object run() {
                     transactionManager = ContextTransactionManager.getInstance();
-                    transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
+                    transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
                     return null;
                 }
             });
         } else {
             transactionManager = ContextTransactionManager.getInstance();
-            transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
+            transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
         }
     }
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -37,9 +37,9 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.transaction.TransactionUtil;
 import org.jboss.as.server.CurrentServiceContainer;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.wildfly.security.manager.WildFlySecurityManager;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * Represents the Extended persistence context injected into a stateful bean.  At bean invocation time,
@@ -276,13 +276,13 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
             AccessController.doPrivileged(new PrivilegedAction<Object>() {
                 @Override
                 public Object run() {
-                    transactionManager = (TransactionManager) CurrentServiceContainer.getServiceContainer().getService(TransactionManagerService.SERVICE_NAME).getValue();
+                    transactionManager = ContextTransactionManager.getInstance();
                     transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
                     return null;
                 }
             });
         } else {
-            transactionManager = (TransactionManager) CurrentServiceContainer.getServiceContainer().getService(TransactionManagerService.SERVICE_NAME).getValue();
+            transactionManager = ContextTransactionManager.getInstance();
             transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
         }
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -41,10 +41,10 @@ import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.jpa.transaction.TransactionUtil;
 import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.server.CurrentServiceContainer;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * Transaction scoped entity manager will be injected into SLSB or SFSB beans.  At bean invocation time, they
@@ -119,7 +119,7 @@ public class TransactionScopedEntityManager extends AbstractEntityManager implem
         in.defaultReadObject();
         final ServiceController<?> controller = currentServiceContainer().getService(JPAServiceNames.getPUServiceName(puScopedName));
         final PersistenceUnitServiceImpl persistenceUnitService = (PersistenceUnitServiceImpl) controller.getService();
-        transactionManager = (TransactionManager) currentServiceContainer().getService(TransactionManagerService.SERVICE_NAME).getValue();
+        transactionManager = ContextTransactionManager.getInstance();
         transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) currentServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
 
         emf = persistenceUnitService.getEntityManagerFactory();

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -41,10 +41,10 @@ import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.jpa.transaction.TransactionUtil;
 import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.server.CurrentServiceContainer;
-import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Transaction scoped entity manager will be injected into SLSB or SFSB beans.  At bean invocation time, they
@@ -120,7 +120,7 @@ public class TransactionScopedEntityManager extends AbstractEntityManager implem
         final ServiceController<?> controller = currentServiceContainer().getService(JPAServiceNames.getPUServiceName(puScopedName));
         final PersistenceUnitServiceImpl persistenceUnitService = (PersistenceUnitServiceImpl) controller.getService();
         transactionManager = ContextTransactionManager.getInstance();
-        transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) currentServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
+        transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
 
         emf = persistenceUnitService.getEntityManagerFactory();
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -51,7 +51,6 @@ import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
-import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -59,6 +58,7 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.value.ImmediateValue;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Represents the PersistenceContext injected into a component.
@@ -153,9 +153,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
             EntityManagerFactory emf = service.getEntityManagerFactory();
             EntityManager entityManager;
             boolean standardEntityManager = ENTITY_MANAGER_CLASS.equals(injectionTypeName);
-            //TODO: change all this to use injections
-            //this is currntly safe, as there is a DUP dependency on the TSR
-            TransactionSynchronizationRegistry tsr = (TransactionSynchronizationRegistry) serviceRegistry.getRequiredService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
+            TransactionSynchronizationRegistry tsr = ContextTransactionSynchronizationRegistry.getInstance();
             TransactionManager transactionManager = ContextTransactionManager.getInstance();
             if (type.equals(PersistenceContextType.TRANSACTION)) {
                 entityManager = new TransactionScopedEntityManager(unitName, properties, emf, synchronizationType, tsr, transactionManager);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -51,7 +51,6 @@ import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
@@ -59,6 +58,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.value.ImmediateValue;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * Represents the PersistenceContext injected into a component.
@@ -75,7 +75,6 @@ public class PersistenceContextInjectionSource extends InjectionSource {
 
     /**
      * Constructor for the PersistenceContextInjectorService
-     *
      * @param type              The persistence context type
      * @param properties        The persistence context properties
      * @param puServiceName     represents the deployed persistence.xml that we are going to use.
@@ -86,7 +85,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
      * @param pu
      * @param jpaDeploymentSettings Optional {@link JPADeploymentSettings} applicable for the persistence context
      */
-    public PersistenceContextInjectionSource(final PersistenceContextType type, final SynchronizationType synchronizationType , final Map properties, final ServiceName puServiceName,
+    public PersistenceContextInjectionSource(final PersistenceContextType type, final SynchronizationType synchronizationType, final Map properties, final ServiceName puServiceName,
                                              final ServiceRegistry serviceRegistry, final String scopedPuName, final String injectionTypeName, final PersistenceUnitMetadata pu, final JPADeploymentSettings jpaDeploymentSettings) {
 
         this.type = type;
@@ -157,7 +156,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
             //TODO: change all this to use injections
             //this is currntly safe, as there is a DUP dependency on the TSR
             TransactionSynchronizationRegistry tsr = (TransactionSynchronizationRegistry) serviceRegistry.getRequiredService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
-            TransactionManager transactionManager = (TransactionManager) serviceRegistry.getRequiredService(TransactionManagerService.SERVICE_NAME).getValue();
+            TransactionManager transactionManager = ContextTransactionManager.getInstance();
             if (type.equals(PersistenceContextType.TRANSACTION)) {
                 entityManager = new TransactionScopedEntityManager(unitName, properties, emf, synchronizationType, tsr, transactionManager);
                 if (ROOT_LOGGER.isDebugEnabled())

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JpaAttachments.java
@@ -27,7 +27,6 @@ import org.jboss.as.jpa.config.PersistenceProviderDeploymentHolder;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.msc.service.ServiceName;
 
-import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 
 /**
@@ -42,7 +41,7 @@ public final class JpaAttachments {
 
     public static final AttachmentKey<ServiceName> PERSISTENCE_UNIT_SERVICE_KEY = AttachmentKey.create(ServiceName.class);
 
-    public static final AttachmentKey<TransactionManager> TRANSACTION_MANAGER = AttachmentKey.create(TransactionManager.class);
+    public static final AttachmentKey<Void> LOCAL_TRANSACTION_PROVIDER = AttachmentKey.create(Void.class);
     public static final AttachmentKey<TransactionSynchronizationRegistry> TRANSACTION_SYNCHRONIZATION_REGISTRY= AttachmentKey.create(TransactionSynchronizationRegistry.class);
 
     /**

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.jpa.processor;
 
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.structure.DeploymentType;
 import org.jboss.as.ee.structure.DeploymentTypeMarker;
 import org.jboss.as.ee.structure.SpecDescriptorPropertyReplacement;
@@ -30,6 +31,7 @@ import org.jboss.as.jpa.config.PersistenceUnitMetadataHolder;
 import org.jboss.as.jpa.config.PersistenceUnitsInApplication;
 import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.puparser.PersistenceUnitXmlParser;
+import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -39,7 +41,6 @@ import org.jboss.as.server.deployment.DeploymentUtils;
 import org.jboss.as.server.deployment.JPADeploymentMarker;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
 import org.jboss.as.server.deployment.module.ResourceRoot;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.metadata.parser.util.NoopXMLResolver;
 import org.jboss.vfs.VirtualFile;
@@ -93,7 +94,8 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
         handleEarDeployment(phaseContext);
         handleJarDeployment(phaseContext);
 
-        phaseContext.addDeploymentDependency(TransactionManagerService.SERVICE_NAME, JpaAttachments.TRANSACTION_MANAGER);
+        CapabilityServiceSupport capabilitySupport = phaseContext.getDeploymentUnit().getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+        phaseContext.addDeploymentDependency(capabilitySupport.getCapabilityServiceName(JPAServiceNames.LOCAL_TRANSACTION_PROVIDER_CAPABILITY), JpaAttachments.LOCAL_TRANSACTION_PROVIDER);
         phaseContext.addDeploymentDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
     }
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -41,7 +41,6 @@ import org.jboss.as.server.deployment.DeploymentUtils;
 import org.jboss.as.server.deployment.JPADeploymentMarker;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
 import org.jboss.as.server.deployment.module.ResourceRoot;
-import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.metadata.parser.util.NoopXMLResolver;
 import org.jboss.vfs.VirtualFile;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
@@ -96,7 +95,6 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
         CapabilityServiceSupport capabilitySupport = phaseContext.getDeploymentUnit().getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         phaseContext.addDeploymentDependency(capabilitySupport.getCapabilityServiceName(JPAServiceNames.LOCAL_TRANSACTION_PROVIDER_CAPABILITY), JpaAttachments.LOCAL_TRANSACTION_PROVIDER);
-        phaseContext.addDeploymentDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
     }
 
     @Override

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -561,7 +561,7 @@ public class PersistenceUnitServiceHandler {
             final PersistenceUnitMetadata pu,
             final PersistenceProvider provider,
             final PersistenceProviderAdaptor adaptor) throws DeploymentUnitProcessingException {
-        TransactionManager transactionManager = deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_MANAGER);
+        TransactionManager transactionManager = ContextTransactionManager.getInstance();
         TransactionSynchronizationRegistry transactionSynchronizationRegistry = deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
         CapabilityServiceSupport capabilitySupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         pu.setClassLoader(classLoader);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -28,12 +28,14 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.jpa.config.ExtendedPersistenceInheritance;
+import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -43,16 +45,31 @@ import org.jboss.dmr.ModelType;
  */
 public class JPADefinition extends SimpleResourceDefinition {
 
+    // This a private capability. Its runtime API or capability service tyoe are subject to change.
+    // See WFLY-7521
+    // Currently it exists to indicate a model dependency from the jpa subsystem to the transactions subsystem
+    private static final RuntimeCapability<Void> JPA_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jpa")
+            .addRequirements(JPAServiceNames.LOCAL_TRANSACTION_PROVIDER_CAPABILITY)
+            .build();
+
     public static final JPADefinition INSTANCE = new JPADefinition(true);
     public static final JPADefinition DEPLOYMENT_INSTANCE = new JPADefinition(false);
 
-
     private JPADefinition(boolean feature) {
-        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME),
+        super(getParameters(feature));
+    }
+
+    private static Parameters getParameters(boolean feature) {
+        Parameters result = new Parameters(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JPAExtension.SUBSYSTEM_NAME),
                 JPAExtension.getResourceDescriptionResolver())
-                .setAddHandler(JPASubSystemAdd.INSTANCE)
-                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
-                .setFeature(feature));
+                .setFeature(feature);
+        if (feature) {
+            result = result.setCapabilities(JPA_CAPABILITY);
+        }
+        // TODO WFLY-11173 add/remove handlers don't make sense on the deployment resource
+        result = result.setAddHandler(JPASubSystemAdd.INSTANCE).setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE);
+
+        return result;
     }
 
     protected static final SimpleAttributeDefinition DEFAULT_DATASOURCE =

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/util/JPAServiceNames.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/util/JPAServiceNames.java
@@ -45,4 +45,11 @@ public class JPAServiceNames {
         return JPA_SERVICE_NAME;
     }
 
+    /**
+     * Name of the capability that ensures a local provider of transactions is present.
+     * Once its service is started, calls to the getInstance() methods of ContextTransactionManager,
+     * ContextTransactionSynchronizationRegistry and LocalUserTransaction can be made knowing
+     * that the global default TM, TSR and UT will be from that provider.
+     */
+    public static final String LOCAL_TRANSACTION_PROVIDER_CAPABILITY = "org.wildfly.transactions.global-default-local-provider";
 }

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.transaction</groupId>
+            <artifactId>wildfly-transaction-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.activemq.artemis.integration</groupId>
             <artifactId>artemis-wildfly-integration</artifactId>
         </dependency>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -122,6 +122,11 @@ public class MessagingServices {
      */
     public static final String LOCAL_TRANSACTION_PROVIDER_CAPABILITY = "org.wildfly.transactions.global-default-local-provider";
 
+    /**
+     * The capability name for the transaction XAResourceRecoveryRegistry.
+     */
+    public static final String TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY = "org.wildfly.transactions.xa-resource-recovery-registry";
+
     public static boolean isSubsystemResource(final OperationContext context) {
         return context.getCurrentAddress().size() > 0 && SUBSYSTEM.equals(context.getCurrentAddress().getParent().getLastElement().getKey());
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
@@ -68,6 +68,10 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     @Override
     protected void performBoottime(final OperationContext context, ModelNode operation, final ModelNode model) throws OperationFailedException {
+
+        // Cache support for capability service name lookups by our services
+        MessagingServices.capabilityServiceSupport = context.getCapabilityServiceSupport();
+
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
             protected void execute(DeploymentProcessorTarget processorTarget) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -55,7 +55,6 @@ import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.Services;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.FlushStrategy;
@@ -305,7 +304,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
     private static ServiceBuilder createServiceBuilder(ServiceTarget serviceTarget, ServiceName serverServiceName, ServiceName serviceName, PooledConnectionFactoryService service) {
         ServiceBuilder serviceBuilder = serviceTarget
                 .addService(serviceName, service)
-                .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                .addDependency(MessagingServices.getCapabilityServiceName(MessagingServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY))
                 .addDependency(serverServiceName, ActiveMQServer.class, service.activeMQServer)
                 .addDependency(ActiveMQActivationService.getServiceName(serverServiceName))
                 .addDependency(JMSServices.getJmsManagerBaseServiceName(serverServiceName))
@@ -474,7 +473,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                             JcaSubsystemConfiguration.class, activator.getConfigInjector())
                     .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class,
                             activator.getCcmInjector()).addDependency(NamingService.SERVICE_NAME)
-                    .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
+                    .addDependency(MessagingServices.getCapabilityServiceName(MessagingServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY))
                     .addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"))
                     .setInitialMode(ServiceController.Mode.PASSIVE).install();
             // Mock the deployment service to allow it to start

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyRecoveryRegistry.java
@@ -23,10 +23,12 @@ package org.wildfly.extension.messaging.activemq.jms;
 
 
 import org.jboss.activemq.artemis.wildfly.integration.recovery.WildFlyActiveMQRegistry;
-import org.jboss.as.txn.service.TxnServices;
+import org.jboss.as.controller.ServiceNameFactory;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.tm.XAResourceRecoveryRegistry;
+import org.wildfly.extension.messaging.activemq.MessagingServices;
 
 /**
  * @author <a href="mailto:andy.taylor@jboss.org">Andy Taylor</a>
@@ -49,8 +51,12 @@ public class WildFlyRecoveryRegistry extends WildFlyActiveMQRegistry {
     }
 
     private static XAResourceRecoveryRegistry getXAResourceRecoveryRegistry() {
+        // This parsing isn't 100% ideal as it's somewhat 'internal' knowledge of the relationship between
+        // capability names and service names. But at this point that relationship really needs to become
+        // a contract anyway
+        ServiceName serviceName = ServiceNameFactory.parseServiceName(MessagingServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY);
         @SuppressWarnings("unchecked")
-        ServiceController<XAResourceRecoveryRegistry> service = (ServiceController<XAResourceRecoveryRegistry>) container.getService(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER);
+        ServiceController<XAResourceRecoveryRegistry> service = (ServiceController<XAResourceRecoveryRegistry>) container.getService(serviceName);
         return service == null ? null : service.getValue();
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
@@ -27,8 +27,6 @@ import static org.jboss.as.server.Services.addServerExecutorDependency;
 
 import java.util.Properties;
 
-import javax.transaction.TransactionManager;
-
 import org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory;
 import org.apache.activemq.artemis.jms.bridge.DestinationFactory;
 import org.apache.activemq.artemis.jms.bridge.JMSBridge;
@@ -46,7 +44,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
@@ -93,8 +90,7 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
                 final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
 
                 final ServiceBuilder<JMSBridge> jmsBridgeServiceBuilder = context.getServiceTarget().addService(bridgeServiceName, bridgeService)
-                        .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER,
-                                TransactionManager.class, bridgeService.getTransactionManagerInjector())
+                        .addDependency(context.getCapabilityServiceName(MessagingServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY, null))
                         .setInitialMode(Mode.ACTIVE);
                 addServerExecutorDependency(jmsBridgeServiceBuilder, bridgeService.getExecutorInjector());
                 if (dependsOnLocalResources(context, model, JMSBridgeDefinition.SOURCE_CONTEXT)) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
 
-import javax.transaction.TransactionManager;
-
 import org.apache.activemq.artemis.jms.bridge.JMSBridge;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -42,6 +40,7 @@ import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 /**
  * Service responsible for JMS Bridges.
@@ -55,7 +54,6 @@ class JMSBridgeService implements Service<JMSBridge> {
     private final InjectedValue<ExecutorService> executorInjector = new InjectedValue<>();
     private final InjectedValue<ExceptionSupplier<CredentialSource, Exception>> sourceCredentialSourceSupplierInjector = new InjectedValue<>();
     private final InjectedValue<ExceptionSupplier<CredentialSource, Exception>> targetCredentialSourceSupplierInjector = new InjectedValue<>();
-    private final InjectedValue<TransactionManager> tmInjector = new InjectedValue<>();
 
     public JMSBridgeService(final String moduleName, final String bridgeName, final JMSBridge bridge) {
         if(bridge == null) {
@@ -72,7 +70,7 @@ class JMSBridgeService implements Service<JMSBridge> {
             @Override
             public void run() {
                 try {
-                    bridge.setTransactionManager(tmInjector.getValue());
+                    bridge.setTransactionManager(ContextTransactionManager.getInstance());
                     startBridge();
 
                     context.complete();
@@ -149,10 +147,6 @@ class JMSBridgeService implements Service<JMSBridge> {
 
     public InjectedValue<ExceptionSupplier<CredentialSource, Exception>> getTargetCredentialSourceSupplierInjector() {
         return targetCredentialSourceSupplierInjector;
-    }
-
-    InjectedValue<TransactionManager> getTransactionManagerInjector() {
-        return tmInjector;
     }
 
     private void setJMSBridgePasswordsFromCredentialSource() {

--- a/picketlink/pom.xml
+++ b/picketlink/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.transaction</groupId>
+            <artifactId>wildfly-transaction-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.naming.ValueManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
@@ -61,7 +60,6 @@ import org.wildfly.extension.picketlink.idm.service.FileIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.JPAIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.PartitionManagerService;
 
-import javax.transaction.TransactionSynchronizationRegistry;
 import java.util.List;
 
 import static org.jboss.as.controller.PathAddress.EMPTY_ADDRESS;
@@ -343,10 +341,6 @@ public class PartitionManagerAddHandler extends AbstractAddStepHandler {
                ContextTransactionManager, ContextTransactionSynchronizationRegistry and LocalUserTransaction
                can be made knowing that the global default TM, TSR and UT will be from that provider. */
             storeServiceBuilder.addDependency(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null));
-
-            storeServiceBuilder
-                .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, storeService
-                    .getTransactionSynchronizationRegistry());
 
             if (jpaDataSourceNode.isDefined()) {
                 storeConfig.dataSourceJndiUrl(toJndiName(jpaDataSourceNode.asString()));

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
@@ -61,7 +61,6 @@ import org.wildfly.extension.picketlink.idm.service.FileIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.JPAIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.PartitionManagerService;
 
-import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import java.util.List;
 
@@ -339,8 +338,11 @@ public class PartitionManagerAddHandler extends AbstractAddStepHandler {
             ServiceBuilder<JPAIdentityStoreService> storeServiceBuilder = context.getServiceTarget()
                 .addService(storeServiceName, storeService);
 
-            storeServiceBuilder.addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER, TransactionManager.class, storeService
-                .getTransactionManager());
+            /* org.wildfly.transactions.global-default-local-provider capability ensures a local provider of
+               transactions is present. Once its service is started, calls to the getInstance() methods of
+               ContextTransactionManager, ContextTransactionSynchronizationRegistry and LocalUserTransaction
+               can be made knowing that the global default TM, TSR and UT will be from that provider. */
+            storeServiceBuilder.addDependency(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null));
 
             storeServiceBuilder
                 .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, storeService

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
@@ -37,6 +37,7 @@ import org.picketlink.idm.spi.IdentityStore;
 import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfiguration;
 import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfigurationBuilder;
 import org.wildfly.extension.picketlink.idm.jpa.transaction.TransactionalEntityManagerHelper;
+import org.wildfly.transaction.client.ContextTransactionManager;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -71,7 +72,6 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     private final JPAStoreSubsystemConfigurationBuilder configurationBuilder;
     private JPAStoreSubsystemConfiguration storeConfig;
     private EntityManagerFactory emf;
-    private final InjectedValue<TransactionManager> transactionManager = new InjectedValue<TransactionManager>();
     private InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistry = new InjectedValue<TransactionSynchronizationRegistry>();
     private TransactionalEntityManagerHelper transactionalEntityManagerHelper;
 
@@ -84,7 +84,7 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
         this.storeConfig = this.configurationBuilder.create();
         this.transactionalEntityManagerHelper = new TransactionalEntityManagerHelper(
             this.transactionSynchronizationRegistry.getValue(),
-            this.transactionManager.getValue());
+            ContextTransactionManager.getInstance());
 
         try {
             configureEntityManagerFactory();
@@ -100,7 +100,7 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
                     EntityManager entityManager = context.getParameter(JPAIdentityStore.INVOCATION_CTX_ENTITY_MANAGER);
 
                     if (entityManager == null || !entityManager.isOpen()) {
-                        context.setParameter(JPAIdentityStore.INVOCATION_CTX_ENTITY_MANAGER, getEntityManager(getTransactionManager().getValue()));
+                        context.setParameter(JPAIdentityStore.INVOCATION_CTX_ENTITY_MANAGER, getEntityManager(ContextTransactionManager.getInstance()));
                     }
                 }
             }
@@ -117,10 +117,6 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     @Override
     public JPAIdentityStoreService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
-    }
-
-    public InjectedValue<TransactionManager> getTransactionManager() {
-        return this.transactionManager;
     }
 
     public InjectedValue<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistry() {

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
@@ -29,7 +29,6 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.InjectedValue;
 import org.picketlink.idm.jpa.internal.JPAIdentityStore;
 import org.picketlink.idm.spi.ContextInitializer;
 import org.picketlink.idm.spi.IdentityContext;
@@ -38,6 +37,7 @@ import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfiguratio
 import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfigurationBuilder;
 import org.wildfly.extension.picketlink.idm.jpa.transaction.TransactionalEntityManagerHelper;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -47,7 +47,6 @@ import javax.persistence.Persistence;
 import javax.persistence.metamodel.EntityType;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
-import javax.transaction.TransactionSynchronizationRegistry;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
@@ -72,7 +71,6 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     private final JPAStoreSubsystemConfigurationBuilder configurationBuilder;
     private JPAStoreSubsystemConfiguration storeConfig;
     private EntityManagerFactory emf;
-    private InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistry = new InjectedValue<TransactionSynchronizationRegistry>();
     private TransactionalEntityManagerHelper transactionalEntityManagerHelper;
 
     public JPAIdentityStoreService(JPAStoreSubsystemConfigurationBuilder configurationBuilder) {
@@ -83,7 +81,7 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     public void start(StartContext startContext) throws StartException {
         this.storeConfig = this.configurationBuilder.create();
         this.transactionalEntityManagerHelper = new TransactionalEntityManagerHelper(
-            this.transactionSynchronizationRegistry.getValue(),
+            ContextTransactionSynchronizationRegistry.getInstance(),
             ContextTransactionManager.getInstance());
 
         try {
@@ -117,10 +115,6 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     @Override
     public JPAIdentityStoreService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
-    }
-
-    public InjectedValue<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistry() {
-        return this.transactionSynchronizationRegistry;
     }
 
     private void configureEntityManagerFactory() {

--- a/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemAdd.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemAdd.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.extension.rts;
 
+import static org.wildfly.extension.rts.RTSSubsystemDefinition.XA_RESOURCE_RECOVERY_CAPABILITY;
+
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -28,7 +30,6 @@ import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
-import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -83,7 +84,7 @@ final class RTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final ServiceBuilder<InboundBridgeService> inboundBridgeServiceBuilder = context
                 .getServiceTarget()
                 .addService(RTSSubsystemExtension.INBOUND_BRIDGE, inboundBridgeService)
-                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER)
+                .addDependency(context.getCapabilityServiceName(XA_RESOURCE_RECOVERY_CAPABILITY, null))
                 .addDependency(RTSSubsystemExtension.PARTICIPANT);
 
         inboundBridgeServiceBuilder

--- a/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemDefinition.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemDefinition.java
@@ -25,6 +25,7 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelType;
@@ -36,6 +37,13 @@ import org.wildfly.extension.rts.configuration.Attribute;
  *
  */
 public final class RTSSubsystemDefinition extends SimpleResourceDefinition {
+
+    static final String XA_RESOURCE_RECOVERY_CAPABILITY = "org.wildfly.transactions.xa-resource-recovery-registry";
+    /** Private capability that currently just represents the existence of the subsystem */
+    private static final RuntimeCapability<Void> RTS_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.rts")
+            .addRequirements(XA_RESOURCE_RECOVERY_CAPABILITY)
+            .build();
+
     public static final RTSSubsystemDefinition INSTANCE = new RTSSubsystemDefinition();
 
     protected static final SimpleAttributeDefinition SERVER =
@@ -60,10 +68,11 @@ public final class RTSSubsystemDefinition extends SimpleResourceDefinition {
                     .build();
 
     private RTSSubsystemDefinition() {
-        super(RTSSubsystemExtension.SUBSYSTEM_PATH,
-                RTSSubsystemExtension.getResourceDescriptionResolver(null),
-                RTSSubsystemAdd.INSTANCE,
-                RTSSubsystemRemove.INSTANCE);
+        super(new Parameters(RTSSubsystemExtension.SUBSYSTEM_PATH, RTSSubsystemExtension.getResourceDescriptionResolver(null))
+                .setAddHandler(RTSSubsystemAdd.INSTANCE)
+                .setRemoveHandler(RTSSubsystemRemove.INSTANCE)
+                .setCapabilities(RTS_CAPABILITY)
+        );
     }
 
     @Override

--- a/rts/src/test/java/org/wildfly/extension/rts/RTSSubsystemTestCase.java
+++ b/rts/src/test/java/org/wildfly/extension/rts/RTSSubsystemTestCase.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.rts;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.junit.Test;
 
 /**
@@ -56,5 +57,10 @@ public class RTSSubsystemTestCase extends AbstractSubsystemBaseTest {
     @Override
     public void testSchemaOfSubsystemTemplates() throws Exception {
         super.testSchemaOfSubsystemTemplates();
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.xa-resource-recovery-registry");
     }
 }

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -49,7 +49,6 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.transactions" optional="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.web"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/module.xml
@@ -35,7 +35,6 @@
         <module name="javax.validation.api"/>
         <module name="org.hibernate.validator"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.ironjacamar.api"/>
         <module name="org.jboss.logging"/>

--- a/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
@@ -92,7 +92,7 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
         final UserTransactionBindingService userTransactionBindingService = new UserTransactionBindingService("UserTransaction");
         serviceTarget.addService(userTransactionServiceName, userTransactionBindingService)
             .addDependency(UserTransactionAccessControlService.SERVICE_NAME, UserTransactionAccessControlService.class,userTransactionBindingService.getUserTransactionAccessControlServiceInjector())
-            .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class,
+            .addDependency(UserTransactionService.INTERNAL_SERVICE_NAME, UserTransaction.class,
                     new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()))
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, userTransactionBindingService.getNamingStoreInjector())
             .install();
@@ -101,7 +101,7 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
         final ServiceName transactionSynchronizationRegistryName = contextServiceName.append("TransactionSynchronizationRegistry");
         BinderService transactionSyncBinderService = new BinderService("TransactionSynchronizationRegistry");
         serviceTarget.addService(transactionSynchronizationRegistryName, transactionSyncBinderService)
-            .addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class,
+            .addDependency(TransactionSynchronizationRegistryService.INTERNAL_SERVICE_NAME, TransactionSynchronizationRegistry.class,
                     new ManagedReferenceInjector<TransactionSynchronizationRegistry>(transactionSyncBinderService.getManagedObjectInjector()))
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, transactionSyncBinderService.getNamingStoreInjector())
             .install();

--- a/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionLeakRollbackProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionLeakRollbackProcessor.java
@@ -47,7 +47,7 @@ public class TransactionLeakRollbackProcessor implements DeploymentUnitProcessor
         final ServiceName serviceName = deploymentUnit.getServiceName().append(SERVICE_NAME);
         final TransactionRollbackSetupAction service = new TransactionRollbackSetupAction(serviceName);
         phaseContext.getServiceTarget().addService(serviceName, service)
-                .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, service.getTransactionManager())
+                .addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, TransactionManager.class, service.getTransactionManager())
                 .install();
 
         deploymentUnit.addToAttachmentList(Attachments.WEB_SETUP_ACTIONS, service);

--- a/transactions/src/main/java/org/jboss/as/txn/ee/concurrency/EEConcurrencyContextHandleFactoryProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/ee/concurrency/EEConcurrencyContextHandleFactoryProcessor.java
@@ -52,7 +52,7 @@ public class EEConcurrencyContextHandleFactoryProcessor implements DeploymentUni
             @Override
             public void configure(DeploymentPhaseContext context, ComponentDescription description, final ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
                 final TransactionLeakContextHandleFactory transactionLeakContextHandleFactory = new TransactionLeakContextHandleFactory();
-                context.addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, transactionLeakContextHandleFactory);
+                context.addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, TransactionManager.class, transactionLeakContextHandleFactory);
                 configuration.getConcurrentContext().addFactory(transactionLeakContextHandleFactory);
             }
         };

--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaRecoveryManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaRecoveryManagerService.java
@@ -65,6 +65,9 @@ import com.arjuna.orbportability.internal.utils.PostInitLoader;
  */
 public class ArjunaRecoveryManagerService implements Service<RecoveryManagerService> {
 
+    /** @deprecated Use the "org.wildfly.transactions.xa-resource-recovery-registry" capability */
+    @Deprecated
+    @SuppressWarnings("deprecation")
     public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER;
 
     private final InjectedValue<ORB> orbInjector = new InjectedValue<ORB>();

--- a/transactions/src/main/java/org/jboss/as/txn/service/LocalTransactionContextService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/LocalTransactionContextService.java
@@ -23,6 +23,7 @@
 package org.jboss.as.txn.service;
 
 import static java.security.AccessController.doPrivileged;
+import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.LOCAL_PROVIDER_CAPABILITY;
 
 import java.security.PrivilegedAction;
 
@@ -66,6 +67,13 @@ public final class LocalTransactionContextService implements Service<LocalTransa
             LocalTransactionContext.getContextManager().setGlobalDefault(transactionContext);
             return null;
         });
+
+        // Install the void service required by capability org.wildfly.transactions.global-default-local-provider
+        // so other capabilities that require it can start their services after this capability
+        // has completed its work.
+        context.getChildTarget().addService(LOCAL_PROVIDER_CAPABILITY.getCapabilityServiceName())
+                .setInstance(Service.NULL)
+                .install();
     }
 
     public void stop(final StopContext context) {

--- a/transactions/src/main/java/org/jboss/as/txn/service/TransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TransactionManagerService.java
@@ -51,7 +51,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class TransactionManagerService extends AbstractService<TransactionManager> {
 
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.ContextTransactionManager to obtain a TransactionManager reference. */
+    @Deprecated
     public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN_TRANSACTION_MANAGER;
+    /** Non-deprecated service name only for use within the subsystem */
+    @SuppressWarnings("deprecation")
+    public static final ServiceName INTERNAL_SERVICE_NAME = TxnServices.JBOSS_TXN_TRANSACTION_MANAGER;
 
     private InjectedValue<UserTransactionRegistry> registryInjector = new InjectedValue<>();
 
@@ -60,7 +66,7 @@ public class TransactionManagerService extends AbstractService<TransactionManage
 
     public static ServiceController<TransactionManager> addService(final ServiceTarget target) {
         final TransactionManagerService service = new TransactionManagerService();
-        ServiceBuilder<TransactionManager> serviceBuilder = target.addService(SERVICE_NAME, service);
+        ServiceBuilder<TransactionManager> serviceBuilder = target.addService(INTERNAL_SERVICE_NAME, service);
         // This is really a dependency on the global context.  TODO: Break this later; no service is needed for TM really
         serviceBuilder.addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT);
         serviceBuilder.addDependency(UserTransactionRegistryService.SERVICE_NAME, UserTransactionRegistry.class, service.registryInjector);

--- a/transactions/src/main/java/org/jboss/as/txn/service/TransactionSynchronizationRegistryService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TransactionSynchronizationRegistryService.java
@@ -36,7 +36,13 @@ import org.jboss.msc.value.InjectedValue;
  * @author Stuart Douglas
  */
 public class TransactionSynchronizationRegistryService extends AbstractService<TransactionSynchronizationRegistry> {
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry to obtain a TransactionSynchronizationRegistry reference. */
+    @Deprecated
     public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY;
+    /** Non-deprecated service name only for use within the subsystem */
+    @SuppressWarnings("deprecation")
+    public static final ServiceName INTERNAL_SERVICE_NAME = TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY;
 
     private final InjectedValue<com.arjuna.ats.jbossatx.jta.TransactionManagerService> injectedArjunaTM = new InjectedValue<com.arjuna.ats.jbossatx.jta.TransactionManagerService>();
 
@@ -46,7 +52,7 @@ public class TransactionSynchronizationRegistryService extends AbstractService<T
 
     public static ServiceController<TransactionSynchronizationRegistry> addService(final ServiceTarget target) {
         TransactionSynchronizationRegistryService service = new TransactionSynchronizationRegistryService();
-        ServiceBuilder<TransactionSynchronizationRegistry> serviceBuilder = target.addService(SERVICE_NAME, service);
+        ServiceBuilder<TransactionSynchronizationRegistry> serviceBuilder = target.addService(INTERNAL_SERVICE_NAME, service);
         serviceBuilder.addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT);
         serviceBuilder.addDependency(ArjunaTransactionManagerService.SERVICE_NAME, com.arjuna.ats.jbossatx.jta.TransactionManagerService.class, service.injectedArjunaTM);
         return serviceBuilder.install();

--- a/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
@@ -47,12 +47,21 @@ public final class TxnServices {
 
     public static final ServiceName JBOSS_TXN_ARJUNA_RECOVERY_MANAGER = JBOSS_TXN.append("ArjunaRecoveryManager");
 
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.ContextTransactionManager to obtain a TransactionManager reference. */
+    @Deprecated
     public static final ServiceName JBOSS_TXN_TRANSACTION_MANAGER = JBOSS_TXN.append("TransactionManager");
 
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.LocalTransactionContext to obtain a UserTransaction reference. */
+    @Deprecated
     public static final ServiceName JBOSS_TXN_USER_TRANSACTION = JBOSS_TXN.append("UserTransaction");
 
     public static final ServiceName JBOSS_TXN_USER_TRANSACTION_REGISTRY = JBOSS_TXN.append("UserTransactionRegistry");
 
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry to obtain a TransactionSynchronizationRegistry reference. */
+    @Deprecated
     public static final ServiceName JBOSS_TXN_SYNCHRONIZATION_REGISTRY = JBOSS_TXN.append("TransactionSynchronizationRegistry");
 
     public static final ServiceName JBOSS_TXN_JTA_ENVIRONMENT = JBOSS_TXN.append("JTAEnvironment");

--- a/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
@@ -45,6 +45,8 @@ public final class TxnServices {
 
     public static final ServiceName JBOSS_TXN_ARJUNA_TRANSACTION_MANAGER = JBOSS_TXN.append("ArjunaTransactionManager");
 
+    /** @deprecated Use the "org.wildfly.transactions.xa-resource-recovery-registry" capability */
+    @Deprecated
     public static final ServiceName JBOSS_TXN_ARJUNA_RECOVERY_MANAGER = JBOSS_TXN.append("ArjunaRecoveryManager");
 
     /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider

--- a/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/UserTransactionService.java
@@ -38,7 +38,13 @@ import org.wildfly.transaction.client.LocalUserTransaction;
  * @since 29-Oct-2010
  */
 public class UserTransactionService extends AbstractService<UserTransaction> {
+    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
+     *              and org.wildfly.transaction.client.LocalTransactionContext to obtain a UserTransaction reference. */
+    @Deprecated
     public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN_USER_TRANSACTION;
+    /** Non-deprecated service name only for use within the subsystem */
+    @SuppressWarnings("deprecation")
+    public static final ServiceName INTERNAL_SERVICE_NAME = TxnServices.JBOSS_TXN_USER_TRANSACTION;
 
     private static final UserTransactionService INSTANCE = new UserTransactionService();
 
@@ -46,7 +52,7 @@ public class UserTransactionService extends AbstractService<UserTransaction> {
     }
 
     public static ServiceController<UserTransaction> addService(final ServiceTarget target) {
-        ServiceBuilder<UserTransaction> serviceBuilder = target.addService(SERVICE_NAME, INSTANCE);
+        ServiceBuilder<UserTransaction> serviceBuilder = target.addService(INTERNAL_SERVICE_NAME, INSTANCE);
         serviceBuilder.addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT);
         return serviceBuilder.install();
     }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -122,7 +122,6 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
     private static final String REMOTING_ENDPOINT_CAPABILITY_NAME = "org.wildfly.remoting.endpoint";
 
     private TransactionSubsystemAdd() {
-        super(TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY);
     }
 
     @Override

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -274,7 +274,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final BinderService tmBinderService = new BinderService("TransactionManager");
         final ServiceBuilder<ManagedReferenceFactory> tmBuilder = context.getServiceTarget().addService(ContextNames.JBOSS_CONTEXT_SERVICE_NAME.append("TransactionManager"), tmBinderService);
         tmBuilder.addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, tmBinderService.getNamingStoreInjector());
-        tmBuilder.addDependency(TransactionManagerService.SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
+        tmBuilder.addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
             @Override
             public void inject(final javax.transaction.TransactionManager value) throws InjectionException {
                 tmBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
@@ -290,7 +290,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final BinderService tmLegacyBinderService = new BinderService("TransactionManager");
         final ServiceBuilder<ManagedReferenceFactory> tmLegacyBuilder = context.getServiceTarget().addService(ContextNames.JAVA_CONTEXT_SERVICE_NAME.append("TransactionManager"), tmLegacyBinderService);
         tmLegacyBuilder.addDependency(ContextNames.JAVA_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, tmLegacyBinderService.getNamingStoreInjector());
-        tmLegacyBuilder.addDependency(TransactionManagerService.SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
+        tmLegacyBuilder.addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, javax.transaction.TransactionManager.class, new Injector<javax.transaction.TransactionManager>() {
             @Override
             public void inject(final javax.transaction.TransactionManager value) throws InjectionException {
                 tmLegacyBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
@@ -306,7 +306,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final BinderService tsrBinderService = new BinderService("TransactionSynchronizationRegistry");
         final ServiceBuilder<ManagedReferenceFactory> tsrBuilder = context.getServiceTarget().addService(ContextNames.JBOSS_CONTEXT_SERVICE_NAME.append("TransactionSynchronizationRegistry"), tsrBinderService);
         tsrBuilder.addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, tsrBinderService.getNamingStoreInjector());
-        tsrBuilder.addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, new Injector<TransactionSynchronizationRegistry>() {
+        tsrBuilder.addDependency(TransactionSynchronizationRegistryService.INTERNAL_SERVICE_NAME, TransactionSynchronizationRegistry.class, new Injector<TransactionSynchronizationRegistry>() {
             @Override
             public void inject(final TransactionSynchronizationRegistry value) throws InjectionException {
                 tsrBinderService.getManagedObjectInjector().inject(new ValueManagedReferenceFactory(new ImmediateValue<Object>(value)));
@@ -328,14 +328,14 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final ServiceBuilder<ManagedReferenceFactory> utBuilder = context.getServiceTarget().addService(ContextNames.JBOSS_CONTEXT_SERVICE_NAME.append("UserTransaction"), userTransactionBindingService);
         utBuilder.addDependency(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, userTransactionBindingService.getNamingStoreInjector())
                 .addDependency(UserTransactionAccessControlService.SERVICE_NAME, UserTransactionAccessControlService.class, userTransactionBindingService.getUserTransactionAccessControlServiceInjector())
-                .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class,
+                .addDependency(UserTransactionService.INTERNAL_SERVICE_NAME, UserTransaction.class,
                         new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()));
         utBuilder.install();
 
         // install the EE Concurrency transaction setup provider's service
         final TransactionSetupProviderService transactionSetupProviderService = new TransactionSetupProviderService();
         context.getServiceTarget().addService(ConcurrentServiceNames.TRANSACTION_SETUP_PROVIDER_SERVICE_NAME, transactionSetupProviderService)
-                .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, transactionSetupProviderService.getTransactionManagerInjectedValue())
+                .addDependency(TransactionManagerService.INTERNAL_SERVICE_NAME, TransactionManager.class, transactionSetupProviderService.getTransactionManagerInjectedValue())
                 .install();
     }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -27,6 +27,7 @@ import static org.jboss.as.txn.subsystem.CommonAttributes.JDBC_STORE_DATASOURCE;
 import static org.jboss.as.txn.subsystem.CommonAttributes.JTS;
 import static org.jboss.as.txn.subsystem.CommonAttributes.USE_JOURNAL_STORE;
 import static org.jboss.as.txn.subsystem.CommonAttributes.USE_JDBC_STORE;
+import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -38,6 +39,7 @@ import javax.transaction.UserTransaction;
 import io.undertow.server.handlers.PathHandler;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -413,14 +415,26 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
     }
 
     private void performRecoveryEnvBoottime(OperationContext context, ModelNode model, final boolean jts, List<ServiceName> deps) throws OperationFailedException {
+        CapabilityServiceTarget serviceTarget = context.getCapabilityServiceTarget();
+
         //recovery environment
         final String recoveryBindingName = TransactionSubsystemRootResourceDefinition.BINDING.resolveModelAttribute(context, model).asString();
         final String recoveryStatusBindingName = TransactionSubsystemRootResourceDefinition.STATUS_BINDING.resolveModelAttribute(context, model).asString();
         final boolean recoveryListener = TransactionSubsystemRootResourceDefinition.RECOVERY_LISTENER.resolveModelAttribute(context, model).asBoolean();
 
         final ArjunaRecoveryManagerService recoveryManagerService = new ArjunaRecoveryManagerService(recoveryListener, jts);
-        final ServiceBuilder<RecoveryManagerService> recoveryManagerServiceServiceBuilder = context.getServiceTarget()
-                .addService(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, recoveryManagerService);
+        final ServiceBuilder<RecoveryManagerService> recoveryManagerServiceServiceBuilder = serviceTarget
+                .addCapability(XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY, recoveryManagerService)
+                .addCapabilityRequirement("org.wildfly.network.socket-binding", SocketBinding.class, recoveryManagerService.getRecoveryBindingInjector(), recoveryBindingName)
+                .addCapabilityRequirement("org.wildfly.network.socket-binding", SocketBinding.class, recoveryManagerService.getStatusBindingInjector(), recoveryStatusBindingName)
+                .addCapabilityRequirement("org.wildfly.management.socket-binding-manager", SocketBindingManager.class, recoveryManagerService.getBindingManager())
+                .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, recoveryManagerService.getSuspendControllerInjector())
+                .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT)
+                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_OBJECTSTORE_ENVIRONMENT)
+                .addAliases(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER)
+                .setInitialMode(ServiceController.Mode.ACTIVE);
+
+
         // add dependency on JTA environment bean
         for (final ServiceName dep : deps) {
             recoveryManagerServiceServiceBuilder.addDependency(dep);
@@ -428,17 +442,17 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         // Register WildFly transaction services - TODO: this should eventually be separated from the Narayana subsystem
         final LocalTransactionContextService localTransactionContextService = new LocalTransactionContextService();
-        context.getServiceTarget().addService(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, localTransactionContextService)
+        serviceTarget.addService(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, localTransactionContextService)
                 .addDependency(TxnServices.JBOSS_TXN_EXTENDED_JBOSS_XA_TERMINATOR, ExtendedJBossXATerminator.class, localTransactionContextService.getExtendedJBossXATerminatorInjector())
                 .addDependency(TxnServices.JBOSS_TXN_ARJUNA_TRANSACTION_MANAGER, com.arjuna.ats.jbossatx.jta.TransactionManagerService.class, localTransactionContextService.getTransactionManagerInjector())
-                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER, XAResourceRecoveryRegistry.class, localTransactionContextService.getXAResourceRecoveryRegistryInjector())
+                .addDependency(XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY.getCapabilityServiceName(), XAResourceRecoveryRegistry.class, localTransactionContextService.getXAResourceRecoveryRegistryInjector())
                 .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, localTransactionContextService.getServerEnvironmentInjector())
                 .setInitialMode(Mode.ACTIVE)
                 .install();
 
         if (context.hasOptionalCapability(REMOTING_ENDPOINT_CAPABILITY_NAME, TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY.getName(),null)) {
             final RemotingTransactionServiceService remoteTransactionServiceService = new RemotingTransactionServiceService();
-            context.getServiceTarget().addService(TxnServices.JBOSS_TXN_REMOTE_TRANSACTION_SERVICE, remoteTransactionServiceService)
+            serviceTarget.addService(TxnServices.JBOSS_TXN_REMOTE_TRANSACTION_SERVICE, remoteTransactionServiceService)
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, remoteTransactionServiceService.getLocalTransactionContextInjector())
                 .addDependency(context.getCapabilityServiceName(REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class), Endpoint.class, remoteTransactionServiceService.getEndpointInjector())
                 .setInitialMode(Mode.LAZY)
@@ -447,7 +461,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         if(context.hasOptionalCapability(UNDERTOW_HTTP_INVOKER_CAPABILITY_NAME, TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY.getName(), null)) {
             final TransactionRemoteHTTPService remoteHTTPService = new TransactionRemoteHTTPService();
-            context.getServiceTarget().addService(TxnServices.JBOSS_TXN_HTTP_REMOTE_TRANSACTION_SERVICE, remoteHTTPService)
+            serviceTarget.addService(TxnServices.JBOSS_TXN_HTTP_REMOTE_TRANSACTION_SERVICE, remoteHTTPService)
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, remoteHTTPService.getLocalTransactionContextInjectedValue())
                 .addDependency(context.getCapabilityServiceName(UNDERTOW_HTTP_INVOKER_CAPABILITY_NAME, PathHandler.class), PathHandler.class, remoteHTTPService.getPathHandlerInjectedValue())
                     .install();
@@ -456,7 +470,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final String nodeIdentifier = TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.resolveModelAttribute(context, model).asString();
         // install JTA environment bean service
         final JTAEnvironmentBeanService jtaEnvironmentBeanService = new JTAEnvironmentBeanService(nodeIdentifier);
-        context.getServiceTarget().addService(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, jtaEnvironmentBeanService)
+        serviceTarget.addService(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, jtaEnvironmentBeanService)
                 .setInitialMode(Mode.ACTIVE)
                 .install();
 
@@ -480,29 +494,20 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
             extendedJBossXATerminatorService = new ExtendedJBossXATerminatorService(terminator);
         }
 
-        context.getServiceTarget().addService(TxnServices.JBOSS_TXN_XA_TERMINATOR, xaTerminatorService)
+        serviceTarget.addService(TxnServices.JBOSS_TXN_XA_TERMINATOR, xaTerminatorService)
                 .setInitialMode(Mode.ACTIVE).install();
-        context.getServiceTarget()
+        serviceTarget
                 .addService(TxnServices.JBOSS_TXN_EXTENDED_JBOSS_XA_TERMINATOR, extendedJBossXATerminatorService)
                 .setInitialMode(Mode.ACTIVE).install();
 
         final JBossContextXATerminatorService contextXATerminatorService = new JBossContextXATerminatorService();
-        context.getServiceTarget()
+        serviceTarget
                 .addService(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, contextXATerminatorService)
                 .addDependency(TxnServices.JBOSS_TXN_XA_TERMINATOR, JBossXATerminator.class, contextXATerminatorService.getJBossXATerminatorInjector())
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, contextXATerminatorService.getLocalTransactionContextInjector())
                 .setInitialMode(Mode.ACTIVE).install();
 
-
-        recoveryManagerServiceServiceBuilder
-                .addDependency(SocketBinding.JBOSS_BINDING_NAME.append(recoveryBindingName), SocketBinding.class, recoveryManagerService.getRecoveryBindingInjector())
-                .addDependency(SocketBinding.JBOSS_BINDING_NAME.append(recoveryStatusBindingName), SocketBinding.class, recoveryManagerService.getStatusBindingInjector())
-                .addDependency(SocketBindingManager.SOCKET_BINDING_MANAGER, SocketBindingManager.class, recoveryManagerService.getBindingManager())
-                .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, recoveryManagerService.getSuspendControllerInjector())
-                .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT)
-                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_OBJECTSTORE_ENVIRONMENT)
-                .setInitialMode(ServiceController.Mode.ACTIVE)
-                .install();
+        recoveryManagerServiceServiceBuilder.install();
     }
 
     private void performCoordinatorEnvBoottime(OperationContext context, ModelNode coordEnvModel, final boolean jts) throws OperationFailedException {
@@ -535,7 +540,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, UserTransactionRegistry.class, transactionManagerService.getUserTransactionRegistry())
                 .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT)
                 .addDependency(TxnServices.JBOSS_TXN_ARJUNA_OBJECTSTORE_ENVIRONMENT)
-                .addDependency(TxnServices.JBOSS_TXN_ARJUNA_RECOVERY_MANAGER)
+                .addDependency(XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY.getCapabilityServiceName())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
     }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRemove.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRemove.java
@@ -34,8 +34,7 @@ class TransactionSubsystemRemove extends ReloadRequiredRemoveStepHandler {
 
     static final TransactionSubsystemRemove INSTANCE = new TransactionSubsystemRemove();
 
-    public TransactionSubsystemRemove() {
-        super(TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY);
+    private TransactionSubsystemRemove() {
     }
 
     /**

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -53,6 +53,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.txn.logging.TransactionLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.wildfly.transaction.client.ContextTransactionManager;
 
 import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
@@ -72,6 +73,9 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
     /** Capability that indicates a local TransactionManager provider is present. */
     public static final RuntimeCapability<Void> LOCAL_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.transactions.global-default-local-provider", Void.class)
             .build();
+    static final RuntimeCapability<Void> XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.transactions.xa-resource-recovery-registry", XAResourceRecoveryRegistry.class)
+                    .build();
 
     //recovery environment
     public static final SimpleAttributeDefinition BINDING = new SimpleAttributeDefinitionBuilder(CommonAttributes.BINDING, ModelType.STRING, false)
@@ -262,7 +266,8 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                 TransactionExtension.getResourceDescriptionResolver())
                 .setAddHandler(TransactionSubsystemAdd.INSTANCE)
                 .setRemoveHandler(TransactionSubsystemRemove.INSTANCE)
-                .setCapabilities(TRANSACTION_CAPABILITY, LOCAL_PROVIDER_CAPABILITY)
+                .setCapabilities(TRANSACTION_CAPABILITY, LOCAL_PROVIDER_CAPABILITY,
+                        XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY)
                 // Configuring these is not required as these are defaulted based on our add/remove handler types
                 //OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES
         );

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -69,6 +69,10 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
     static final RuntimeCapability<Void> TRANSACTION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.transactions")
             .build();
 
+    /** Capability that indicates a local TransactionManager provider is present. */
+    public static final RuntimeCapability<Void> LOCAL_PROVIDER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.transactions.global-default-local-provider", Void.class)
+            .build();
+
     //recovery environment
     public static final SimpleAttributeDefinition BINDING = new SimpleAttributeDefinitionBuilder(CommonAttributes.BINDING, ModelType.STRING, false)
             .setValidator(new StringLengthValidator(1))
@@ -258,7 +262,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                 TransactionExtension.getResourceDescriptionResolver())
                 .setAddHandler(TransactionSubsystemAdd.INSTANCE)
                 .setRemoveHandler(TransactionSubsystemRemove.INSTANCE)
-                .setCapabilities(TRANSACTION_CAPABILITY)
+                .setCapabilities(TRANSACTION_CAPABILITY, LOCAL_PROVIDER_CAPABILITY)
                 // Configuring these is not required as these are defaulted based on our add/remove handler types
                 //OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES
         );

--- a/weld/common/src/main/java/org/jboss/as/weld/ServiceNames.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/ServiceNames.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.weld;
 
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.msc.service.ServiceName;
 
@@ -38,6 +40,15 @@ public final class ServiceNames {
 
     public static ServiceName beanManagerServiceName(final DeploymentUnit deploymentUnit) {
         return deploymentUnit.getServiceName().append(BEAN_MANAGER_SERVICE_NAME);
+    }
+
+    public static ServiceName capabilityServiceName(final DeploymentUnit deploymentUnit, final String baseCapabilityName, final String... dynamicParts) {
+        CapabilityServiceSupport capabilityServiceSupport = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
+        if (dynamicParts == null || dynamicParts.length == 0) {
+            return capabilityServiceSupport.getCapabilityServiceName(baseCapabilityName);
+        } else {
+            return capabilityServiceSupport.getCapabilityServiceName(baseCapabilityName, dynamicParts);
+        }
     }
 
 }

--- a/weld/transactions/src/main/java/org/jboss/as/weld/deployment/processor/TransactionsBootstrapDependencyInstaller.java
+++ b/weld/transactions/src/main/java/org/jboss/as/weld/deployment/processor/TransactionsBootstrapDependencyInstaller.java
@@ -21,10 +21,7 @@
  */
 package org.jboss.as.weld.deployment.processor;
 
-import javax.transaction.UserTransaction;
-
 import org.jboss.as.server.deployment.DeploymentUnit;
-import org.jboss.as.txn.service.UserTransactionService;
 import org.jboss.as.weld.ServiceNames;
 import org.jboss.as.weld.services.bootstrap.WeldTransactionServices;
 import org.jboss.as.weld.spi.BootstrapDependencyInstaller;
@@ -46,7 +43,7 @@ public class TransactionsBootstrapDependencyInstaller implements BootstrapDepend
         serviceTarget.addService(weldTransactionServiceName, weldTransactionServices)
                 // Ensure the local transaction provider is started before we start
                 .addDependency(ServiceNames.capabilityServiceName(deploymentUnit, "org.wildfly.transactions.global-default-local-provider"))
-                .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class, weldTransactionServices.getInjectedTransaction()).install();
+                .install();
 
         return weldTransactionServiceName;
     }

--- a/weld/transactions/src/main/java/org/jboss/as/weld/deployment/processor/TransactionsBootstrapDependencyInstaller.java
+++ b/weld/transactions/src/main/java/org/jboss/as/weld/deployment/processor/TransactionsBootstrapDependencyInstaller.java
@@ -21,12 +21,11 @@
  */
 package org.jboss.as.weld.deployment.processor;
 
-import javax.transaction.TransactionManager;
 import javax.transaction.UserTransaction;
 
 import org.jboss.as.server.deployment.DeploymentUnit;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.UserTransactionService;
+import org.jboss.as.weld.ServiceNames;
 import org.jboss.as.weld.services.bootstrap.WeldTransactionServices;
 import org.jboss.as.weld.spi.BootstrapDependencyInstaller;
 import org.jboss.msc.service.ServiceName;
@@ -45,7 +44,8 @@ public class TransactionsBootstrapDependencyInstaller implements BootstrapDepend
         final ServiceName weldTransactionServiceName = deploymentUnit.getServiceName().append(WeldTransactionServices.SERVICE_NAME);
 
         serviceTarget.addService(weldTransactionServiceName, weldTransactionServices)
-                .addDependency(TransactionManagerService.SERVICE_NAME, TransactionManager.class, weldTransactionServices.getInjectedTransactionManager())
+                // Ensure the local transaction provider is started before we start
+                .addDependency(ServiceNames.capabilityServiceName(deploymentUnit, "org.wildfly.transactions.global-default-local-provider"))
                 .addDependency(UserTransactionService.SERVICE_NAME, UserTransaction.class, weldTransactionServices.getInjectedTransaction()).install();
 
         return weldTransactionServiceName;

--- a/weld/transactions/src/main/java/org/jboss/as/weld/services/bootstrap/WeldTransactionServices.java
+++ b/weld/transactions/src/main/java/org/jboss/as/weld/services/bootstrap/WeldTransactionServices.java
@@ -33,9 +33,9 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.InjectedValue;
 import org.jboss.weld.transaction.spi.TransactionServices;
 import org.wildfly.transaction.client.ContextTransactionManager;
+import org.wildfly.transaction.client.LocalUserTransaction;
 
 /**
  * Service that implements welds {@link TransactionServices}
@@ -50,8 +50,6 @@ public class WeldTransactionServices implements TransactionServices, Service<Wel
 
     public static final ServiceName SERVICE_NAME = ServiceNames.WELD_TRANSACTION_SERVICES_SERVICE_NAME;
 
-    private final InjectedValue<UserTransaction> injectedTransaction = new InjectedValue<UserTransaction>();
-
     private final boolean jtsEnabled;
 
     public WeldTransactionServices(final boolean jtsEnabled) {
@@ -60,7 +58,7 @@ public class WeldTransactionServices implements TransactionServices, Service<Wel
 
     @Override
     public UserTransaction getUserTransaction() {
-        return injectedTransaction.getValue();
+        return LocalUserTransaction.getInstance();
     }
 
     @Override
@@ -115,10 +113,6 @@ public class WeldTransactionServices implements TransactionServices, Service<Wel
     @Override
     public WeldTransactionServices getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
-    }
-
-    public InjectedValue<UserTransaction> getInjectedTransaction() {
-        return injectedTransaction;
     }
 
 }


### PR DESCRIPTION
A whole lot of stuff but all generally about creating capabilities for the most commonly used services provided by the transactions subsystem, and then having other subsystems require those capabilities, thus:

1) Allowing config validation (i.e. ensure the tx subsystem is present, can't be removed etc.)
2) Allow Galleon to understand the config relationship so it can ensure features are present.
3) Remove unneeded module dependencies or make them optional if they are only needed if a capability is present.

https://issues.jboss.org/browse/WFLY-11165
https://issues.jboss.org/browse/WFLY-11166
https://issues.jboss.org/browse/WFLY-11167
https://issues.jboss.org/browse/WFLY-11177
https://issues.jboss.org/browse/WFLY-11181

Also a start on https://issues.jboss.org/browse/WFLY-11174. Creates a JCA capability, which depends on some TX capabilities, but doesn't actually convert other code to use it yet.

Requires a core upgrade with https://github.com/wildfly/wildfly-core/pull/3554