### PR TITLE
[WFLY-11185] Transaction subsystem only optionally depends on io.unde…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -46,7 +46,6 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.msc"/>
@@ -58,11 +57,20 @@
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="org.jboss.jandex"/>
-        <module name="org.jboss.remoting"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.narayana.compensations"/>
+        <module name="org.wildfly.security.manager"/>
+
+        <!-- Only used if the org.wildfly.undertow.http-invoker capability is present,
+             in which case this module will also be present.
+             TODO Work out how to mark http-client.transaction as 'passive' so we
+             can make it optional here but have it provisioned if http is available
+        -->
         <module name="io.undertow.core"/>
         <module name="org.wildfly.http-client.transaction" />
-        <module name="org.wildfly.security.manager"/>
+
+        <!-- Only used if the org.jboss.remoting.endpoint capability is present,
+             in which case this module will also be present. -->
+        <module name="org.jboss.remoting" optional="true"/>
     </dependencies>
 </module>

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -53,7 +53,6 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
-import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.ServerEnvironment;
@@ -120,6 +119,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
     static final TransactionSubsystemAdd INSTANCE = new TransactionSubsystemAdd();
 
     private static final String UNDERTOW_HTTP_INVOKER_CAPABILITY_NAME = "org.wildfly.undertow.http-invoker";
+    private static final String REMOTING_ENDPOINT_CAPABILITY_NAME = "org.wildfly.remoting.endpoint";
 
     private TransactionSubsystemAdd() {
         super(TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY);
@@ -435,11 +435,11 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .setInitialMode(Mode.ACTIVE)
                 .install();
 
-        if (context.hasOptionalCapability("org.wildfly.remoting.endpoint", TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY.getName(),null)) {
+        if (context.hasOptionalCapability(REMOTING_ENDPOINT_CAPABILITY_NAME, TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY.getName(),null)) {
             final RemotingTransactionServiceService remoteTransactionServiceService = new RemotingTransactionServiceService();
             context.getServiceTarget().addService(TxnServices.JBOSS_TXN_REMOTE_TRANSACTION_SERVICE, remoteTransactionServiceService)
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, remoteTransactionServiceService.getLocalTransactionContextInjector())
-                .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class, remoteTransactionServiceService.getEndpointInjector())
+                .addDependency(context.getCapabilityServiceName(REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class), Endpoint.class, remoteTransactionServiceService.getEndpointInjector())
                 .setInitialMode(Mode.LAZY)
                 .install();
         }


### PR DESCRIPTION
…rtow.core and org.jboss.remoting. Doesn't need org.jboss.as.remoting at all.

https://issues.jboss.org/browse/WFLY-11185