### PR TITLE
[WFLY-11195] The org.jboss.xts module only require org.jboss.as.xts i…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -65,7 +65,13 @@
         <module name="javax.annotation.api"  export="true" />
         <module name="javax.interceptor.api"  export="true" />
         <module name="org.jboss.weld.spi" />
-        <module name="org.jboss.as.xts" export="true">
+
+        <!-- This dependency is required only if the
+             xts subsystem is present. If it is the
+             subsystem may configure the deployment such
+             that this module will need to use classes from
+             the subsystem module.-->
+        <module name="org.jboss.as.xts" export="true" optional="true">
           <imports>
             <include path="org.jboss.as.xts.txnclient"/>
           </imports>


### PR DESCRIPTION
…f the subsystem is loaded.

https://issues.jboss.org/browse/WFLY-11195

This will allow Galleon to break a dependency chain whereby use of the org.jboss.as.transactions module (fairly common) leads to a dependency on the WS subsystem module (and then on to all its deps.)

org.jboss.as.transactions->org.jboss.narayana.compensations->org.jboss.xts->org.jboss.as.xts->org.jboss.as.webservices.server.integration 
