### PR TITLE
[WFLY-11207] Remove link to a constant from java doc

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/deployment/SecurityAttachments.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/deployment/SecurityAttachments.java
@@ -36,9 +36,9 @@ public class SecurityAttachments {
      * via jboss-deployment-structure.xml. This allows deployments to disable security, and
      * avoid the overhead of running unneeded security code.
      *
-     * @deprecated Check the presence of {@link org.jboss.as.security.SecuritySubsystemRootResourceDefinition#SECURITY_SUBSYSTEM}
-     * capability instead to avoid classloading dependencies on org.jboss.as.security. If the capability is not in the
-     * capability registry, then we can assume that the security subsystem is not configured.
+     * @deprecated Check the presence of org.wildfly.legacy-security capability instead to avoid classloading
+     * dependencies on org.jboss.as.security. If the capability is not in the capability registry, then we can
+     * assume that the security subsystem is not configured.
      */
     @Deprecated
     public static final AttachmentKey<Boolean> SECURITY_ENABLED = AttachmentKey.create(Boolean.class);


### PR DESCRIPTION
Follows up on: https://github.com/wildfly/wildfly/pull/11757

It fixes the java doc issue.

Jira issue: https://issues.jboss.org/browse/WFLY-11207