### PR TITLE
[WFLY-11200]:  Messaging-activemq integration code alters the JMS client's enabled protocols via TransportConfiguration

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -369,8 +369,6 @@ public class TransportConfigOperationHandlers {
                 // ARTEMIS-803 Artemis knows that is must not offset the HTTP port when it is used by colocated backups
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, HTTPConnectorDefinition.ENDPOINT.resolveModelAttribute(context, config).asString());
-                // WFLY-9096 support TLSv1.x on IBM Java by default (default for Oracle Java)
-                parameters.putIfAbsent(TransportConstants.ENABLED_PROTOCOLS_PROP_NAME, "TLSv1,TLSv1.1,TLSv1.2");
                 // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
                 parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
                 ModelNode serverNameModelNode = HTTPConnectorDefinition.SERVER_NAME.resolveModelAttribute(context, config);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryService.java
@@ -321,7 +321,7 @@ public class ExternalPooledConnectionFactoryService implements Service<Void> {
                     if (multiple) {
                         connectorParams.append(";");
                     }
-                    connectorParams.append(entry.getKey()).append("=").append(String.valueOf(entry.getValue()).replace(",", "\\,"));
+                    connectorParams.append(entry.getKey()).append("=").append(entry.getValue());
                     multiple = true;
                 }
             }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -363,7 +363,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                     if (multiple) {
                         connectorParams.append(";");
                     }
-                    connectorParams.append(entry.getKey()).append("=").append(String.valueOf(entry.getValue()).replace(",", "\\,"));
+                    connectorParams.append(entry.getKey()).append("=").append(entry.getValue());
                     multiple = true;
                 }
             }


### PR DESCRIPTION
Revert "[WFLY-9096] support TLSv1.x in http-connector on IBM Java" as the real fix is in updating the test suite configuration to allow IBM JDK support for TLSv1.x protocols

This reverts commit d13b4f486536013f65e0c20b1c75843d3e5a0626.

JIRA: https://issues.jboss.org/browse/WFLY-11200