### PR TITLE
[WFLY-11199] Upgrade WildFly Core 7.0.0.Alpha4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>7.0.0.Alpha2</version.org.wildfly.core>
+        <version.org.wildfly.core>7.0.0.Alpha4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
@@ -7523,11 +7523,19 @@
             <repositories>
                 <repository>
                     <id>jboss-staging-repository-group</id>
-                    <name>JBoss Staging Reposiry Group</name>
+                    <name>JBoss Staging Repository Group</name>
                     <url>https://repository.jboss.org/nexus/content/groups/staging/</url>
                     <layout>default</layout>
                 </repository>
             </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jboss-staging-repository-group</id>
+                    <name>JBoss Staging Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/staging/</url>
+                    <layout>default</layout>
+                </pluginRepository>
+            </pluginRepositories>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Add jboss-staging-repository-group to the `<pluginRepositories>` so that
Galleon maven plugin is able to download artifacts from the staging
repository during WildFly Core release process.

JIRA: https://issues.jboss.org/browse/WFLY-11199

---


# Release Notes - WildFly Core - Version 7.0.0.Alpha4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4151'>WFCORE-4151</a>] -         Upgrade jboss-logmanager from 2.1.4.Final to 2.1.5.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4155'>WFCORE-4155</a>] -         Upgrade to Galleon and WildFly Galleon Plugins 2.0.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4167'>WFCORE-4167</a>] -         Upgrade to WildFly Galleon Plugins 2.0.2.Final and properly configure plugin dependencies
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4168'>WFCORE-4168</a>] -         Upgrade WildFly Elytron to 1.7.0.CR3
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4169'>WFCORE-4169</a>] -         Upgrade Elytron Web to 1.3.0.CR3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4096'>WFCORE-4096</a>] -         CLI, replace native support for paging/scrolling/searching with aesh one
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4113'>WFCORE-4113</a>] -         Add a commented line to standalone.conf to show how to use a custom java.security file to override all the Java security properties
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3039'>WFCORE-3039</a>] -         Capability requirement can be lost if two attributes on same resource reference the same capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3952'>WFCORE-3952</a>] -         Unable to run -DallTests -Delytron builds
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4147'>WFCORE-4147</a>] -         (WF15) Wrong JAVA_OPTS propagation, wrong PowerShell GC logging
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4152'>WFCORE-4152</a>] -         HC cannot connect to DC after lost connect with error &quot;WFLYCTL0332: Permission denied\&quot;
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4153'>WFCORE-4153</a>] -         Capability &#39;org.wildfly.nosql.mongo.driver-service&#39; is unknown error thrown on WildFly 14 + current master branch
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4156'>WFCORE-4156</a>] -         Add missing KernelAPIVersion for WildFly 14
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4158'>WFCORE-4158</a>] -         RootSubsystemOperationsTestCase periodically fails on Windows
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4159'>WFCORE-4159</a>] -         WildFly Core Test Suite: Standalone Integration Tests doesn&#39;t compile on JDKs other than Oracle Java 1.8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4164'>WFCORE-4164</a>] -         The read-feature-description requirements output does not include requirements defined via RuntimeCapability.getRequirements
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4146'>WFCORE-4146</a>] -         Check if we can remove .setXmlName in JaspiDefinitions
</li>
</ul>
                                    