### PR TITLE
[WFLY-11212] jdbc-driver's datasource-class-info is not a metric

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverDefinition.java
@@ -62,7 +62,7 @@ public class JdbcDriverDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerReadOnlyAttribute(attribute, null);
         }
         if (resourceRegistration.getProcessType().isServer()) {
-            resourceRegistration.registerMetric(DATASOURCE_CLASS_INFO, GetDataSourceClassInfoOperationHandler.INSTANCE);
+            resourceRegistration.registerReadOnlyAttribute(DATASOURCE_CLASS_INFO, GetDataSourceClassInfoOperationHandler.INSTANCE);
         }
     }
 


### PR DESCRIPTION
Register the datasource-class as a read-only runtime attribute

JIRA: https://issues.jboss.org/browse/WFLY-11212