### PR TITLE
[WFLY-11222] Fix wrong grep escaping on wsprovide and wsconsume scripts

### DIFF
--- a/feature-pack/src/main/resources/content/bin/wsconsume.sh
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.sh
@@ -85,7 +85,7 @@ if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
 fi
 
 # remove -secmgr from JAVA_OPTS. This flag must reside in a different location
-NEW_SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "-secmgr"`
+NEW_SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "\-secmgr"`
 if [ "x$NEW_SECURITY_MANAGER_SET" != "x" ]; then
     SECMGR="true"
     JAVA_OPTS=`echo $JAVA_OPTS | sed "s/-secmgr//" `

--- a/feature-pack/src/main/resources/content/bin/wsprovide.sh
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.sh
@@ -85,7 +85,7 @@ if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
 fi
 
 # remove -secmgr from JAVA_OPTS. This flag must reside in a different location
-NEW_SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "-secmgr"`
+NEW_SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "\-secmgr"`
 if [ "x$NEW_SECURITY_MANAGER_SET" != "x" ]; then
     SECMGR="true"
     JAVA_OPTS=`echo $JAVA_OPTS | sed "s/-secmgr//" `


### PR DESCRIPTION
Upstream jira: https://issues.jboss.org/browse/WFLY-11222

See also [the discussion on WFLY-10241](https://issues.jboss.org/browse/WFLY-10241?focusedCommentId=13651019&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13651019)

cc: @asoldano, @rsearls, @jamezp 