### PR TITLE
[WFCORE-4132] Tests LogManager still works without any error after setting the "encoding" attribute on the file handler

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/LogManagerEncodingAttributeServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/LogManagerEncodingAttributeServerSetupTask.java
@@ -1,0 +1,68 @@
+package org.jboss.as.test.integration.logging;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.cli.Util.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.client.helpers.ClientConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ * Server setup task for test LogManagerEncodingAttributeTestCase.
+ * Sets "encoding" attribute on the file handler.
+ *
+ * @author Daniel Cihak
+ */
+public class LogManagerEncodingAttributeServerSetupTask implements ServerSetupTask {
+
+    public static PrintStream oldOut;
+    public static ByteArrayOutputStream baos;
+
+    @Override
+    public final void setup(ManagementClient managementClient, String containerId) throws Exception {
+        oldOut = System.out;
+        baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+
+        List<ModelNode> operations = new ArrayList<>();
+        // /subsystem=logging/periodic-rotating-file-handler=FILE:write-attribute(name=encoding,value=UTF-8)
+        ModelNode setLoggingAttribute = createOpNode("subsystem=logging/periodic-rotating-file-handler=FILE", WRITE_ATTRIBUTE_OPERATION);
+        setLoggingAttribute.get(ClientConstants.NAME).set("encoding");
+        setLoggingAttribute.get(ClientConstants.VALUE).set("UTF-8");
+        operations.add(setLoggingAttribute);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+        // /subsystem=logging/periodic-rotating-file-handler=FILE:undefine-attribute(name=encoding)
+        ModelNode undefineLoggingAttribute = createOpNode("subsystem=logging/periodic-rotating-file-handler=FILE", UNDEFINE_ATTRIBUTE_OPERATION);
+        undefineLoggingAttribute.get(ClientConstants.NAME).set("encoding");
+        operations.add(undefineLoggingAttribute);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/LogManagerEncodingAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/LogManagerEncodingAttributeTestCase.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test checks if the LogManager won't throw "java.io.IOException: Stream Closed" or any other error after
+ * setting the "encoding" attribute on the file handler (file-handler, periodic-rotating-file-handler,
+ * size-rotating-file-handler and periodic-size-rotating-file-handler).
+ *
+ * Automated test for [ WFLY-8946 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(LogManagerEncodingAttributeServerSetupTask.class)
+@RunAsClient
+public class LogManagerEncodingAttributeTestCase {
+
+    private static final String DEPLOYMENT = "deployment";
+
+    @Deployment(name = DEPLOYMENT)
+    public static WebArchive createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
+        war.addClass(LogManagerEncodingAttributeTestCase.class);
+        return war;
+    }
+
+    @Test
+    public void testLogManagerEncodingAttribute() {
+    }
+
+    @AfterClass
+    public static void after() {
+        try {
+            System.setOut(LogManagerEncodingAttributeServerSetupTask.oldOut);
+            String output = new String(LogManagerEncodingAttributeServerSetupTask.baos.toByteArray());
+            Assert.assertFalse(output, output.contains("ERROR"));
+            Assert.assertFalse(output, output.contains("java.io.IOException: Stream Closed"));
+        } finally {
+            System.setOut(LogManagerEncodingAttributeServerSetupTask.oldOut);
+        }
+    }
+}


### PR DESCRIPTION
Test checks if the LogManager won't throw "java.io.IOException: Stream Closed" or any other error after setting the "encoding" attribute on the file handler (file-handler, periodic-rotating-file-handler, size-rotating-file-handler and periodic-size-rotating-file-handler).

Upstream JIRA issue: [WFCORE-4132](https://issues.jboss.org/browse/WFCORE-4132)