### PR TITLE
[WFLY-11232] Upgrade jboss-ejb-client from 4.0.11 to 4.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.11.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.12.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.2.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.1.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11232

<h1>Release Notes for EJB Client Library 4.0.12.Final</h1>
<hr />

<h2>Bug</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/EJBCLIENT-310">EJBCLIENT-310</a> ] Naming provider is lost on deserialization</li>
</ul>