### PR TITLE
WFLY-11214 - Implement transaction recovery in datasources-agroal

### DIFF
--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
@@ -125,9 +125,8 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
 
     static final SimpleAttributeDefinition USERNAME_ATTRIBUTE = create("username", ModelType.STRING)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
-            .addAlternatives("elytron-domain")
+            .addAlternatives("authentication-context")
             .setAllowExpression(true)
-            .setAttributeGroup("security")
             .setRequired(false)
             .setRestartAllServices()
             .setValidator(new StringLengthValidator(1))
@@ -137,7 +136,6 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
             .addAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
             .setAllowExpression(true)
-            .setAttributeGroup("security")
             .setRequired(false)
             .setRequires(USERNAME_ATTRIBUTE.getName())
             .setRestartAllServices()
@@ -153,7 +151,6 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(true, true)
                                                                                          .addAlternatives(PASSWORD_ATTRIBUTE.getName())
-                                                                                         .setAttributeGroup("security")
                                                                                          .build();
 
     static final PropertiesAttributeDefinition CONNECTION_PROPERTIES_ATTRIBUTE = new PropertiesAttributeDefinition.Builder("connection-properties", true)

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalExtension.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalExtension.java
@@ -45,7 +45,9 @@ public class AgroalExtension implements Extension {
 
     public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append(SUBSYSTEM_NAME);
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 0, 0);
+    static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
+    static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_2_0_0;
 
     private static final String RESOURCE_NAME = AgroalExtension.class.getPackage().getName() + ".LocalDescriptions";
 
@@ -60,6 +62,7 @@ public class AgroalExtension implements Extension {
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, AgroalNamespace.AGROAL_1_0.getUriString(), AgroalSubsystemParser_1_0.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, AgroalNamespace.AGROAL_2_0.getUriString(), AgroalSubsystemParser_2_0.INSTANCE);
     }
 
     @Override
@@ -68,6 +71,6 @@ public class AgroalExtension implements Extension {
         ManagementResourceRegistration registration = subsystem.registerSubsystemModel(AgroalSubsystemDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        subsystem.registerXMLElementWriter(AgroalSubsystemParser_1_0.INSTANCE);
+        subsystem.registerXMLElementWriter(AgroalSubsystemParser_2_0.INSTANCE);
     }
 }

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalNamespace.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalNamespace.java
@@ -33,9 +33,10 @@ enum AgroalNamespace {
 
     UNKNOWN(null), // must be first
 
-    AGROAL_1_0("urn:jboss:domain:datasources-agroal:1.0");
+    AGROAL_1_0("urn:jboss:domain:datasources-agroal:1.0"),
+    AGROAL_2_0("urn:jboss:domain:datasources-agroal:2.0");
 
-    public static final AgroalNamespace CURRENT = AGROAL_1_0;
+    public static final AgroalNamespace CURRENT = AGROAL_2_0;
 
     private static final Map<String, AgroalNamespace> MAP;
 

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalSubsystemParser_2_0.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalSubsystemParser_2_0.java
@@ -33,14 +33,14 @@ import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
  *
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  */
-class AgroalSubsystemParser_1_0 extends PersistentResourceXMLParser {
+class AgroalSubsystemParser_2_0 extends PersistentResourceXMLParser {
 
-    static final AgroalSubsystemParser_1_0 INSTANCE = new AgroalSubsystemParser_1_0();
+    static final AgroalSubsystemParser_2_0 INSTANCE = new AgroalSubsystemParser_2_0();
 
     private static final PersistentResourceXMLDescription XML_DESCRIPTION;
 
     static {
-        PersistentResourceXMLBuilder subsystemXMLBuilder = builder(AgroalSubsystemDefinition.INSTANCE.getPathElement(), AgroalNamespace.AGROAL_1_0.getUriString());
+        PersistentResourceXMLBuilder subsystemXMLBuilder = builder(AgroalSubsystemDefinition.INSTANCE.getPathElement(), AgroalNamespace.AGROAL_2_0.getUriString());
 
         PersistentResourceXMLBuilder datasourceXMLBuilder = builder(DataSourceDefinition.INSTANCE.getPathElement());
         for (AttributeDefinition attributeDefinition : DataSourceDefinition.ATTRIBUTES) {
@@ -49,7 +49,7 @@ class AgroalSubsystemParser_1_0 extends PersistentResourceXMLParser {
         subsystemXMLBuilder.addChild(datasourceXMLBuilder);
 
         PersistentResourceXMLBuilder xaDatasourceXMLBuilder = builder(XADataSourceDefinition.INSTANCE.getPathElement());
-        for (AttributeDefinition attributeDefinition : XADataSourceDefinition.ATTRIBUTES_1_0) {
+        for (AttributeDefinition attributeDefinition : XADataSourceDefinition.ATTRIBUTES_2_0) {
             xaDatasourceXMLBuilder.addAttribute(attributeDefinition);
         }
         subsystemXMLBuilder.addChild(xaDatasourceXMLBuilder);
@@ -64,7 +64,7 @@ class AgroalSubsystemParser_1_0 extends PersistentResourceXMLParser {
         XML_DESCRIPTION = subsystemXMLBuilder.build();
     }
 
-    private AgroalSubsystemParser_1_0() {
+    private AgroalSubsystemParser_2_0() {
     }
 
     @Override

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalTransformers.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalTransformers.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.datasources.agroal;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.description.AttributeTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
+
+import static org.wildfly.extension.datasources.agroal.AgroalExtension.VERSION_1_0_0;
+import static org.wildfly.extension.datasources.agroal.AgroalExtension.VERSION_2_0_0;
+import static org.wildfly.extension.datasources.agroal.XADataSourceDefinition.*;
+
+/**
+ * Defines an extension to provide DataSources based on the Agroal project
+ *
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public class AgroalTransformers implements ExtensionTransformerRegistration {
+
+    @Override
+    public String getSubsystemName() {
+        return AgroalExtension.SUBSYSTEM_NAME;
+    }
+
+    @Override
+    public void registerTransformers(SubsystemTransformerRegistration subsystemRegistration) {
+        ChainedTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemRegistration.getCurrentSubsystemVersion());
+
+        transformers_2_0_0(builder);
+
+        builder.buildAndRegister(subsystemRegistration, new ModelVersion[] { VERSION_1_0_0, VERSION_2_0_0 });
+    }
+
+    private void transformers_2_0_0(ChainedTransformationDescriptionBuilder parentBuilder) {
+        AttributeTransformationDescriptionBuilder attributeBuilder = parentBuilder.createBuilder(VERSION_2_0_0, VERSION_1_0_0).getAttributeBuilder();
+
+        attributeBuilder.setDiscard(DiscardAttributeChecker.UNDEFINED, RECOVERY_USERNAME_ATTRIBUTE, RECOVERY_PASSWORD_ATTRIBUTE, RECOVERY_AUTHENTICATION_CONTEXT, RECOVERY_CREDENTIAL_REFERENCE);
+        attributeBuilder.addRejectCheck(RejectAttributeChecker.DEFINED, RECOVERY_USERNAME_ATTRIBUTE, RECOVERY_PASSWORD_ATTRIBUTE, RECOVERY_AUTHENTICATION_CONTEXT, RECOVERY_CREDENTIAL_REFERENCE);
+        attributeBuilder.addRejectCheck(new RejectAttributeChecker.SimpleAcceptAttributeChecker(ModelNode.FALSE), RECOVERY);
+    }
+
+}

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceDefinition.java
@@ -87,7 +87,11 @@ class XADataSourceDefinition extends AbstractDataSourceDefinition {
                                                                                                   .addAlternatives(RECOVERY_PASSWORD_ATTRIBUTE.getName())
                                                                                                   .build();
 
-    static final Collection<AttributeDefinition> ATTRIBUTES = unmodifiableList(asList(JNDI_NAME_ATTRIBUTE, STATISTICS_ENABLED_ATTRIBUTE, CONNECTION_FACTORY_ATTRIBUTE, CONNECTION_POOL_ATTRIBUTE, RECOVERY, RECOVERY_USERNAME_ATTRIBUTE, RECOVERY_PASSWORD_ATTRIBUTE, RECOVERY_AUTHENTICATION_CONTEXT, RECOVERY_CREDENTIAL_REFERENCE));
+    static final Collection<AttributeDefinition> ATTRIBUTES_1_0 = unmodifiableList(asList(JNDI_NAME_ATTRIBUTE, STATISTICS_ENABLED_ATTRIBUTE, CONNECTION_FACTORY_ATTRIBUTE, CONNECTION_POOL_ATTRIBUTE));
+
+    static final Collection<AttributeDefinition> ATTRIBUTES_2_0 = unmodifiableList(asList(JNDI_NAME_ATTRIBUTE, STATISTICS_ENABLED_ATTRIBUTE, CONNECTION_FACTORY_ATTRIBUTE, CONNECTION_POOL_ATTRIBUTE, RECOVERY, RECOVERY_USERNAME_ATTRIBUTE, RECOVERY_PASSWORD_ATTRIBUTE, RECOVERY_AUTHENTICATION_CONTEXT, RECOVERY_CREDENTIAL_REFERENCE));
+
+    static final Collection<AttributeDefinition> ATTRIBUTES = ATTRIBUTES_2_0;
 
     static final XADataSourceDefinition INSTANCE = new XADataSourceDefinition();
 

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/logging/AgroalLogger.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/logging/AgroalLogger.java
@@ -95,6 +95,14 @@ public interface AgroalLogger extends BasicLogger {
     @Message(id = 111, value = "CredentialSourceSupplier for datasource '%s' is invalid")
     StartException invalidCredentialSourceSupplier(@Cause Throwable cause, String dataSourceName);
 
+    @LogMessage(level = INFO)
+    @Message(id = 112, value = "Started NON-TRANSACTIONAL datasource '%s' bound to [%s]")
+    void startedNonTransactionalDataSource(String datasource, String jndiName);
+
+    @LogMessage(level = INFO)
+    @Message(id = 113, value = "Started NON-RECOVERABLE xa-datasource '%s' bound to [%s]")
+    void startedNonRecoverableXADataSource(String datasource, String jndiName);
+
     // --- Driver service //
 
     @LogMessage(level = INFO)

--- a/datasources-agroal/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/datasources-agroal/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,23 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2017, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+org.wildfly.extension.datasources.agroal.AgroalTransformers

--- a/datasources-agroal/src/main/resources/org/wildfly/extension/datasources/agroal/LocalDescriptions.properties
+++ b/datasources-agroal/src/main/resources/org/wildfly/extension/datasources/agroal/LocalDescriptions.properties
@@ -143,6 +143,16 @@ datasources-agroal.xa-datasource.connection-pool.background-validation=Time in m
 datasources-agroal.xa-datasource.connection-pool.leak-detection=Time in milliseconds a connection has to be held before a leak warning
 datasources-agroal.xa-datasource.connection-pool.idle-removal=Time in minutes a connection has to be idle before it can be removed
 #
+datasources-agroal.xa-datasource.recovery=Specifies that this XADataSource should be included in transaction recovery procedures
+datasources-agroal.xa-datasource.recovery-username=Username to use for basic authentication with the database during transaction recovery
+datasources-agroal.xa-datasource.recovery-password=Password to use for basic authentication with the database during transaction recovery
+datasources-agroal.xa-datasource.recovery-authentication-context=Reference to a authentication context in Elytron to use during transaction recovery
+datasources-agroal.xa-datasource.recovery-credential-reference=Access to credentials defined through CredentialStorage to use during transaction recovery
+datasources-agroal.xa-datasource.recovery-credential-reference.alias=The alias which denotes stored secret or credential in the store
+datasources-agroal.xa-datasource.recovery-credential-reference.clear-text=Secret specified using clear text (check credential store way of supplying credential/secrets to services)
+datasources-agroal.xa-datasource.recovery-credential-reference.store=The name of the credential store holding the alias to credential
+datasources-agroal.xa-datasource.recovery-credential-reference.type=The type of credential this reference is denoting
+#
 #
 # Driver
 datasources-agroal.driver=List of available JDBC drivers

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
@@ -112,7 +112,32 @@
                     <xs:documentation><![CDATA[ Configuration for the connection pool ]]></xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="recovery-credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Access to credentials defined through CredentialStorage. Alternative to username / password. Exclusively for transaction recovery. ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
+        <xs:attribute name="recovery" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Specifies that this XADataSource should be included in transaction recovery procedures ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-username" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Username to use for basic authentication with the database during transaction recovery ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-password" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Password to use for basic authentication with the database during transaction recovery ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-authentication-context" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Reference to a authentication context in Elytron. Alternative to username / password. Exclusively for transaction recovery. ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attributeGroup ref="common-datasourceAttributes"/>
     </xs:complexType>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
@@ -20,8 +20,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:1.0"
-           xmlns="urn:jboss:domain:datasources-agroal:1.0" elementFormDefault="qualified" version="1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:2.0"
+           xmlns="urn:jboss:domain:datasources-agroal:2.0" elementFormDefault="qualified" version="1.0">
 
     <xs:element name="subsystem" type="subsystemType"/>
 
@@ -112,7 +112,32 @@
                     <xs:documentation><![CDATA[ Configuration for the connection pool ]]></xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="recovery-credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Access to credentials defined through CredentialStorage. Alternative to username / password. Exclusively for transaction recovery. ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
+        <xs:attribute name="recovery" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Specifies that this XADataSource should be included in transaction recovery procedures ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-username" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Username to use for basic authentication with the database during transaction recovery ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-password" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Password to use for basic authentication with the database during transaction recovery ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="recovery-authentication-context" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Reference to a authentication context in Elytron. Alternative to username / password. Exclusively for transaction recovery. ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attributeGroup ref="common-datasourceAttributes"/>
     </xs:complexType>
 

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
@@ -101,22 +101,33 @@ public class AgroalTransformersTestCase extends AbstractSubsystemBaseTest {
         PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM, AgroalExtension.SUBSYSTEM_NAME);
 
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, agroalVersion, ops, new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress, new FailedOperationTransformationConfig.NewAttributesConfig(
+                .addFailedAttribute(subsystemAddress.append("xa-datasource"), new DiscardedAttribute(
                         XADataSourceDefinition.RECOVERY_USERNAME_ATTRIBUTE,
                         XADataSourceDefinition.RECOVERY_PASSWORD_ATTRIBUTE,
                         XADataSourceDefinition.RECOVERY_AUTHENTICATION_CONTEXT,
                         XADataSourceDefinition.RECOVERY_CREDENTIAL_REFERENCE))
-                .addFailedAttribute(subsystemAddress, new CorrectToFalse(
+                .addFailedAttribute(subsystemAddress.append("xa-datasource"), new CorrectToFalse(
                         XADataSourceDefinition.RECOVERY))
         );
     }
 
     // --- //
 
+    private static class DiscardedAttribute extends FailedOperationTransformationConfig.NewAttributesConfig {
+
+        private DiscardedAttribute(AttributeDefinition... attributeDefinitions) {
+            super(convert(attributeDefinitions));
+        }
+
+        @Override public boolean expectDiscarded(ModelNode operation) {
+            return true;
+        }
+    }
+
     private static class CorrectToFalse extends FailedOperationTransformationConfig.NewAttributesConfig {
 
-        public CorrectToFalse(AttributeDefinition... defs) {
-            super(convert(defs));
+        private CorrectToFalse(AttributeDefinition... attributeDefinitions) {
+            super(convert(attributeDefinitions));
         }
 
         @Override

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.datasources.agroal;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test transformation between model versions
+ *
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+public class AgroalTransformersTestCase extends AbstractSubsystemBaseTest {
+
+    public AgroalTransformersTestCase() {
+        super(AgroalExtension.SUBSYSTEM_NAME, new AgroalExtension());
+    }
+
+    private static String getExtensionMavenGAV(ModelTestControllerVersion version) {
+        if (version.isEap()) {
+            return "org.jboss.eap:wildfly-datasources-agroal:" + version.getMavenGavVersion();
+        }
+        return "org.wildfly:wildfly-datasources-agroal:" + version.getMavenGavVersion();
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Create a AdditionalInitialization.MANAGEMENT variant that has all the external capabilities used by the various configs used in this test class
+        return AdditionalInitialization.withCapabilities(
+                AbstractDataSourceDefinition.AUTHENTICATION_CONTEXT_CAPABILITY + ".secure-context",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".test-store"
+        );
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("agroal_2_0-full.xml");
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws IOException {
+        return "schema/wildfly-agroal_2_0.xsd";
+    }
+
+    @Test
+    public void testTransformers_2_0_0() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_2_0, AgroalExtension.VERSION_1_0_0, "agroal_2_0-transform.xml");
+    }
+
+    private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion agroalVersion, String xmlResource) throws Exception {
+        //Boot up empty controllers with the resources needed for the ops coming from the xml to work
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
+
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, agroalVersion)
+               .addMavenResourceURL(getExtensionMavenGAV(controllerVersion))
+               .skipReverseControllerCheck()
+               .dontPersistXml();
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        assertTrue(mainServices.getLegacyServices(agroalVersion).isSuccessfulBoot());
+
+        List<ModelNode> ops = builder.parseXmlResource(xmlResource);
+        System.out.println("ops = " + ops);
+        PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM, AgroalExtension.SUBSYSTEM_NAME);
+
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, agroalVersion, ops, new FailedOperationTransformationConfig()
+                .addFailedAttribute(subsystemAddress, new FailedOperationTransformationConfig.NewAttributesConfig(
+                        XADataSourceDefinition.RECOVERY_USERNAME_ATTRIBUTE,
+                        XADataSourceDefinition.RECOVERY_PASSWORD_ATTRIBUTE,
+                        XADataSourceDefinition.RECOVERY_AUTHENTICATION_CONTEXT,
+                        XADataSourceDefinition.RECOVERY_CREDENTIAL_REFERENCE))
+                .addFailedAttribute(subsystemAddress, new CorrectToFalse(
+                        XADataSourceDefinition.RECOVERY))
+        );
+    }
+
+    // --- //
+
+    private static class CorrectToFalse extends FailedOperationTransformationConfig.NewAttributesConfig {
+
+        public CorrectToFalse(AttributeDefinition... defs) {
+            super(convert(defs));
+        }
+
+        @Override
+        protected boolean isAttributeWritable(String attributeName) {
+            return true;
+        }
+
+        @Override
+        protected boolean checkValue(String attrName, ModelNode attribute, boolean isWriteAttribute) {
+            return !ModelNode.FALSE.equals(attribute);
+        }
+
+        @Override
+        protected ModelNode correctValue(ModelNode toResolve, boolean isWriteAttribute) {
+            return ModelNode.FALSE;
+        }
+
+    }
+
+}

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemBaseParsingTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemBaseParsingTestCase.java
@@ -45,6 +45,6 @@ public class SubsystemBaseParsingTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-agroal_1_0.xsd";
+        return "schema/wildfly-agroal_2_0.xsd";
     }
 }

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemFullParsingTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemFullParsingTestCase.java
@@ -60,7 +60,14 @@ public class SubsystemFullParsingTestCase extends AbstractSubsystemTest {
         parseXmlResource("agroal_1_0-full.xml");
     }
 
-    @SuppressWarnings("SameParameterValue")
+    /**
+     * Tests that the xml is parsed into the correct operations
+     */
+    @Test
+    public void testParse_2_0_Subsystem() throws Exception {
+        parseXmlResource("agroal_2_0-full.xml");
+    }
+
     private void parseXmlResource(String xmlResource) throws Exception {
         KernelServicesBuilder kernelBuilder = createKernelServicesBuilder(createAdditionalInitialization());
         KernelServices services = kernelBuilder.build();

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_1_0-full.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_1_0-full.xml
@@ -14,7 +14,7 @@
     </datasource>
     <datasource name="elytron" jndi-name="java:jboss/datasources/ElytronDS">
         <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" authentication-context="secure-context">
-            <credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential" />
+            <credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential"/>
         </connection-factory>
         <connection-pool max-size="30"/>
     </datasource>
@@ -25,6 +25,15 @@
             </connection-properties>
         </connection-factory>
         <connection-pool initial-size="5" min-size="1" max-size="10" blocking-timeout="2000" background-validation="8000" leak-detection="7000" idle-removal="7"/>
+    </xa-datasource>
+    <xa-datasource name="xa-no-recovery" jndi-name="java:jboss/datasources/ExampleXADS" recovery="false" recovery-username="sar" recovery-password="sar">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" username="sa" password="sa"/>
+        <connection-pool initial-size="5" min-size="1" max-size="10"/>
+    </xa-datasource>
+    <xa-datasource name="xa-no-recovery-elytron" jndi-name="java:jboss/datasources/ExampleXADS" recovery="false" recovery-authentication-context="recovery-context">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" username="sa" password="sa"/>
+        <connection-pool initial-size="5" min-size="1" max-size="10"/>
+        <recovery-credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential"/>
     </xa-datasource>
     <drivers>
         <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-full.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-full.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
     <datasource name="sample" jndi-name="java:jboss/datasources/ExampleDS" jta="false" connectable="true" statistics-enabled="true">
         <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" transaction-isolation="SERIALIZABLE" new-connection-sql="SELECT 1" username="sa" password="sa">
             <connection-properties>
@@ -25,6 +25,15 @@
             </connection-properties>
         </connection-factory>
         <connection-pool initial-size="5" min-size="1" max-size="10" blocking-timeout="2000" background-validation="8000" leak-detection="7000" idle-removal="7"/>
+    </xa-datasource>
+    <xa-datasource name="xa-no-recovery" jndi-name="java:jboss/datasources/ExampleXADS" recovery="false" recovery-username="sar" recovery-password="sar">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" username="sa" password="sa"/>
+        <connection-pool initial-size="5" min-size="1" max-size="10"/>
+    </xa-datasource>
+    <xa-datasource name="xa-no-recovery-elytron" jndi-name="java:jboss/datasources/ExampleXADS" recovery="false" recovery-authentication-context="recovery-context">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" username="sa" password="sa"/>
+        <connection-pool initial-size="5" min-size="1" max-size="10"/>
+        <recovery-credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential"/>
     </xa-datasource>
     <drivers>
         <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-transform.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-transform.xml
@@ -1,0 +1,9 @@
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
+    <xa-datasource name="xa" jndi-name="java:jboss/datasources/ExampleXADS" recovery="${recovery:false}" recovery-username="${recovery-username:abc}" recovery-password="${recovery-password:def}">
+        <connection-factory driver="xa" username="sa" password="sa"/>
+        <connection-pool max-size="10"/>
+    </xa-datasource>
+    <drivers>
+        <driver name="xa" module="com.h2database.h2" class="org.h2.jdbcx.JdbcDataSource"/>
+    </drivers>
+</subsystem>

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
@@ -16,7 +16,7 @@ If the WildFly configuration does not have Agroal subsystem enabled by default, 
     <extension module="org.wildfly.extension.datasources-agroal"/>
     [...]
 </extensions>
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
     [...]
 </subsystem>
 ----
@@ -48,7 +48,7 @@ Any installed _driver_ provides an operation called _class-info_ that lists all 
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
     [...]
     <drivers>
         <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>
@@ -85,7 +85,7 @@ Other features provided by the _connection-factory_ definition include the possi
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
      <datasource [...]>
         [...]
         <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" transaction-isolation="SERIALIZABLE" new-connection-sql="SELECT 1" username="sa" password="sa">
@@ -136,7 +136,7 @@ There is a set of flush operations that perform many of these features on-demand
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
      <datasource [...]>
         [...]
         <connection-pool max-size="30" min-size="10" initial-size="20" blocking-timeout="1000" background-validation="6000" leak-detection="5000" idle-removal="5"/>
@@ -177,7 +177,7 @@ There is also a _reset-statistics_ operation provided.
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
     <xa-datasource name="sample-xa" jndi-name="java:jboss/datasources/ExampleXADS" statistics-enabled="true">
         [...]
     </xa-datasource>
@@ -242,7 +242,7 @@ The _connectable_ attribute allows a non-XA datasource to take part in an XA tra
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
     <datasource name="sample" jndi-name="java:jboss/datasources/ExampleDS" jta="false" connectable="false" statistics-enabled="true">
         [...]
     </datasource>

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Datasources_Agroal.adoc
@@ -16,7 +16,7 @@ If the WildFly configuration does not have Agroal subsystem enabled by default, 
     <extension module="org.wildfly.extension.datasources-agroal"/>
     [...]
 </extensions>
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
     [...]
 </subsystem>
 ----
@@ -48,7 +48,7 @@ Any installed _driver_ provides an operation called _class-info_ that lists all 
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
     [...]
     <drivers>
         <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>
@@ -85,7 +85,7 @@ Other features provided by the _connection-factory_ definition include the possi
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
      <datasource [...]>
         [...]
         <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" transaction-isolation="SERIALIZABLE" new-connection-sql="SELECT 1" username="sa" password="sa">
@@ -136,7 +136,7 @@ There is a set of flush operations that perform many of these features on-demand
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
      <datasource [...]>
         [...]
         <connection-pool max-size="30" min-size="10" initial-size="20" blocking-timeout="1000" background-validation="6000" leak-detection="5000" idle-removal="5"/>
@@ -177,7 +177,7 @@ There is also a _reset-statistics_ operation provided.
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
     <xa-datasource name="sample-xa" jndi-name="java:jboss/datasources/ExampleXADS" statistics-enabled="true">
         [...]
     </xa-datasource>
@@ -242,7 +242,7 @@ The _connectable_ attribute allows a non-XA datasource to take part in an XA tra
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:agroal:1.0">
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:1.0">
     <datasource name="sample" jndi-name="java:jboss/datasources/ExampleDS" jta="false" connectable="false" statistics-enabled="true">
         [...]
     </datasource>
@@ -266,5 +266,4 @@ The _connectable_ attribute allows a non-XA datasource to take part in an XA tra
 [[agroal-xa-datasource-attributes]]
 === XADataSource specific attributes
 
-At the moment there are no attributes specific to a XADataSource definition.
-
+A XADataSource definition has specific attributes related with transaction recovery. This feature is enabled by default but the _recovery_ attribute may disable it. There are also optional attributes to specify credentials for recovery connections in the cases where these need to be different than the ones defined in the connection factory.

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/datasources-agroal/main/module.xml
@@ -41,8 +41,11 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.jandex"/>
+        <module name="org.jboss.jboss-transaction-spi"/>
+        <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11214

Adds an attribute to XA-DataSource to allow disabling the feature, as well as optional attributes for credentials specific to recovery connections. The values of these attributes are then passed to agroal (in connection factory and transaction integration). 

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.