### PR TITLE
[WFLY-11235] Server with HA profile bound to 0.0.0.0 sends cluster topology containing this address to client

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3175,4 +3175,7 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 508, value = "Failed to persist timer's state %s due to %s")
     void exceptionPersistTimerState(Timer timer, Exception e);
+
+    @Message(id = 509, value = "Client mapping is bound to '%s' in cluster mode, please specify client mappings in socket-binding: %s")
+    RuntimeException badBindingInClusterMode(String destHostAddress, String socketBindingName);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 
 import org.jboss.as.clustering.controller.CapabilityServiceConfigurator;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.network.ClientMapping;
 import org.jboss.as.remoting.RemotingConnectorBindingInfoService;
 import org.jboss.msc.Service;
@@ -101,7 +102,11 @@ public class EJBRemotingConnectorClientMappingsEntryProviderService implements C
             // This needs to be configurable (i.e. send either host name or the IP address). But
             // since this is a corner case (i.e. absence of any client-mappings for a socket binding),
             // this should be OK for now
-            final String destinationAddress = info.getSocketBinding().getAddress().getHostAddress();
+            InetAddress addr = info.getSocketBinding().getAddress();
+            String destinationAddress = addr.getHostAddress();
+            if (addr.isAnyLocalAddress() && !this.group.get().isSingleton()) {
+                throw EjbLogger.REMOTE_LOGGER.badBindingInClusterMode(destinationAddress, info.getSocketBinding().getName());
+            }
             final InetAddress clientNetworkAddress;
             try {
                 clientNetworkAddress = InetAddress.getByName("::");


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-11235

When binding `0.0.0.0` in the target EJB server, it will broadcast such `any-address` to the whole cluster, which leads to the problem that the client will try to locate such EJB service using `0.0.0.0`, and it will fail.

~~Proposed fix is trying to use `InetAddress.getLocalHost().getHostAddress()` as the destination address in case such `any-address` is specified. There will still be problem if multiple network interfaces available and it may return an IP address which is not a desired one, but in that case, there should be more requirements on how to specify it IMO, and binding to `0.0.0.0` is not a recommended way for production.~~

Updated:

Proposed fix is trying to throw a RuntimeException if binding to `0.0.0.0` in cluster mode when an EJB is deployed.

There is no tests attached, because it needs 2 physical separated machines(like VMs) to reproduce. I attached the reproducer in the linked Jira for verification. (WFLY-11235-reproducer.zip)


Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted