### PR TITLE
[WFLY-11256] Fix Undertow metrics

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -276,7 +276,6 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             ListenerService service =  getListenerService(context);
             if (service == null) {
-                context.getResult().set(0L);
                 return;
             }
             String op = operation.get(NAME).asString();
@@ -303,10 +302,7 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
                         context.getResult().set(stats.getRequestCount());
                         break;
                 }
-            } else {
-                context.getResult().set(0L);
             }
-            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
         }
     }
 


### PR DESCRIPTION
Do not return a meaningless 0 value from the metric read handler as the
metrics already specifies "undefined metric value" from their
definition.

This change will be necessary with WFCORE-4190 to distinguish metrics
that must not be exposed (when their result is undefined according to
their respective runtime).

JIRA: https://issues.jboss.org/browse/WFLY-11256