### PR TITLE
[WFLY-11257] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.as.jsr77

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -52,11 +52,5 @@
 
         <!-- Only here temporarily -->
         <module name="org.jboss.ejb-client"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
These depedencies can be removed from org.jboss.as.jsr77:
```
<module name="javax.transaction.api"/>
<module name="javax.xml.rpc.api"/>
<module name="javax.rmi.api"/>
```

Reasons:
- All first level dependencies used by wildfly-jsr77.jar are accesible by the other depended-on modules
- org.jboss.as.jsr77 does not load a service from any of its dependencies using ServiceLoading
- There are not DUPs enabling any external configuration for resources exported by the removed modules.

Jira issue: https://issues.jboss.org/browse/WFLY-11257