### PR TITLE
[WFLY-11263] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.as.xts

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -72,10 +72,5 @@
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.narayana.compensations" />
         <module name="org.wildfly.transaction.client" />
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
These depedencies can be removed from org.jboss.as.xts:

```
<module name="javax.xml.rpc.api"/>
<module name="javax.rmi.api"/>
```

Reasons:
- All first level dependencies used by wildfly-xts.jar are accesible by the other depended-on modules
- wildfly-xts does not load a service from any of its dependencies using ServiceLoading
- There are not DUPs enabling any external configuration for resources exported by the removed modules.

Jira issue: https://issues.jboss.org/browse/WFLY-11263
CC @ochaloup 