### PR TITLE
[WFLY-11179]:  Messaging http-acceptor should expose a capability and use it to control dependencies.

### DIFF
--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -222,7 +222,7 @@ public class MigrateTestCase extends AbstractSubsystemTest {
                             rootRegistration, ExtensionRegistryType.SERVER));
                 }
             }, null));
-            registerCapabilities(capabilityRegistry, JGroupsDefaultRequirement.CHANNEL_FACTORY.getName());
+            registerCapabilities(capabilityRegistry, JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), "org.wildfly.remoting.http-listener-registry");
         }
 
         @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -65,4 +65,11 @@ public class Capabilities {
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/management/path-manager/capability.adoc">documentation</a>
      */
     static final String PATH_MANAGER_CAPABILITY = "org.wildfly.management.path-manager";
+
+    /**
+     * The capability for the Http Listener Registry
+     *
+     * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/remoting/http-listener-registry/capability.adoc">documentation</a>
+     */
+    static final String HTTP_LISTENER_REGISTRY_CAPABILITY_NAME = "org.wildfly.remoting.http-listener-registry";
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -92,7 +92,8 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
 
         final HTTPUpgradeService service = new HTTPUpgradeService(activeMQServerName, acceptorName, httpListenerName);
 
-        serviceTarget.addService(MessagingServices.getHttpUpgradeServiceName(activeMQServerName, acceptorName), service)
+        serviceTarget.addService(HTTPAcceptorDefinition.CAPABILITY.getCapabilityServiceName(activeMQServerName,"http-upgrade-service", acceptorName), service)
+                .addAliases(MessagingServices.getHttpUpgradeServiceName(activeMQServerName, acceptorName))
                 .addDependency(MessagingServices.HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
                 .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.listenerRegistry)
                 .addDependency(ActiveMQActivationService.getServiceName(MessagingServices.getActiveMQServiceName(activeMQServerName)))

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -25,6 +25,7 @@ package org.wildfly.extension.messaging.activemq;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JMS_BRIDGE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SUBSYSTEM;
 
+import java.util.function.Function;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -92,5 +93,28 @@ public class MessagingServices {
 
     public static boolean isSubsystemResource(final OperationContext context) {
         return context.getCurrentAddress().size() > 0 && SUBSYSTEM.equals(context.getCurrentAddress().getParent().getLastElement().getKey());
+    }
+
+    public static class ServerNameMapper implements Function<PathAddress, String[]> {
+        private final String name;
+        public ServerNameMapper(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String[] apply(PathAddress pathAddress) {
+            PathAddress serverAddress = getActiveMQServerPathAddress(pathAddress);
+            if (serverAddress.size() > 0) {
+                String servername = getActiveMQServerPathAddress(pathAddress).getLastElement().getValue();
+                return new String[]{
+                    servername,
+                    name,
+                    pathAddress.getLastElement().getValue()
+                };
+            }
+            return new String[]{name,
+                pathAddress.getLastElement().getValue()
+            };
+        }
     }
 }


### PR DESCRIPTION
* Adding a capability and a requirement on http-upgrade-registry

JIRA: https://issues.jboss.org/browse/WFLY-11179