### PR TITLE
[WFLY-10493]: Support JMS Java EE resources definition for remote Artemis-based broker.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ConnectionFactoryReferenceFactoryService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ConnectionFactoryReferenceFactoryService.java
@@ -44,6 +44,15 @@ public class ConnectionFactoryReferenceFactoryService implements Service<Managed
 
     private final InjectedValue<Object> connectionFactoryValue = new InjectedValue<Object>();
     private ManagedReference reference;
+    private final String name;
+
+    public ConnectionFactoryReferenceFactoryService(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 
     public synchronized void start(StartContext startContext) throws StartException {
         reference = new ValueManagedReference(new ImmediateValue<Object>(connectionFactoryValue.getValue()));

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
@@ -426,7 +426,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
             // to distinguish CFs with same name in different application (or module).
             final ContextNames.BindInfo bindInfo = getBindInfo(jndi);
 
-            final ConnectionFactoryReferenceFactoryService referenceFactoryService = new ConnectionFactoryReferenceFactoryService();
+            final ConnectionFactoryReferenceFactoryService referenceFactoryService = new ConnectionFactoryReferenceFactoryService(deployment);
             final ServiceName referenceFactoryServiceName = ConnectionFactoryReferenceFactoryService.SERVICE_NAME_BASE
                     .append(bindInfo.getBinderServiceName());
             serviceTarget.addService(referenceFactoryServiceName, referenceFactoryService)

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
@@ -114,7 +114,29 @@ process the consumed messages and it can use the JMSReplyTo destination
 if it is defined on the message. +
 If the MDB needs any other JMS destinations defined on the remote
 server, it must use client-side JNDI by following the
-http://activemq.apache.org/artemis/docs/1.1.0/using-jms.html#jndi-configuration[Artemis
+http://http://activemq.apache.org/artemis/docs/2.6.0/using-jms.html#jndi-configuration[Artemis
 documentation] or configure external configuration context in the naming
 subsystem (which allows to inject the JMS resources using the
 `@Resource` annotation).
+
+[[configuration of a remote destination using annotations]]
+==== Configuration of a remote destination using annotations
+
+The annotation `@JMSDestinationDefinition` can be used to create a destination on a remote Artemis Server. This will work in the same way as for a local server.+
+For this it needs to be able to access Artemis management queue. If your remote Artemis Server management queue is not the default one you can pass the management queue address as a property to the `@JMSDestinationDefinition`.
+Please note that the destination is created remotely but won't be removed once the deployement is undeployed/removed.
+
+[source, java]
+----
+@JMSDestinationDefinition(
+    // explicitly mention a resourceAdapter corresponding to a pooled-connection-factory resource to the remote server
+    resourceAdapter = "activemq-ra",
+    name="java:global/env/myQueue2",
+    interfaceName="javax.jms.Queue",
+    destinationName="myQueue2",
+        properties = {
+            "management-address=my.management.queue",
+            "selector=color = 'red'"
+       }
+)
+----

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging_Connect_a_pooled-connection-factory_to_a_Remote_Artemis_Server.adoc
@@ -22,7 +22,7 @@ created at step (1).
 
 [source, ruby]
 ----
-  /subsystem=messaging-activemq/server=default/remote-connector=remote-artemis:add(socket-binding=remote-artemis)
+  /subsystem=messaging-activemq/remote-connector=remote-artemis:add(socket-binding=remote-artemis)
 
 ----
 
@@ -31,9 +31,36 @@ created at step (2).
 
 [source,ruby]
 ----
-  /subsystem=messaging-activemq/server=default/pooled-connection-factory=remote-artemis:add(connectors=[remote-artemis], entries=[java:/jms/remoteCF])
+  /subsystem=messaging-activemq/pooled-connection-factory=remote-artemis:add(connectors=[remote-artemis], entries=[java:/jms/remoteCF])
    
 ----
+[[configuration-of-a-mdb-using-a-pooled-connection-factory]]
+== JMS Queues and Topics on a remote Artemis Server
+
+You can also add queues and topics defined on a remote Artemis server to be used as if they were local to the server. This mean,s that you can make those remote destinations available viza JNDI just like local destinations. Those destinations are defined out-of the server element:
+
+[source,xml]
+----
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:1.0">
+    <external-jms-queue name="testQueue"
+               entries="jms/queue/test java:jboss/exported/jms/queue/test" />
+    <external-jms-topic name="testTopic"
+               entries="jms/topic/test java:jboss/exported/jms/topic/test" />
+</subsystem>
+----
+
+JMS endpoints can easily be created through the CLI:
+[source,ruby]
+----
+[standalone@localhost:9990 /] /subsystem=messaging-activemq/external-jms-queue=myQueue:read-resource
+{
+    "outcome" => "success",
+    "result" => {
+        "entries" => ["queues/myQueue"]
+    }
+}
+----
+You don't have operations to see or manage attributes of those destinations.
 
 [[configuration-of-a-mdb-using-a-pooled-connection-factory]]
 == Configuration of a MDB using a pooled-connection-factory
@@ -78,8 +105,7 @@ A MDB must also specify which destination it will consume messages from.
 
 The standard way is to define a `destinationLookup` activation config
 property that corresponds to a JNDI lookup on the local server. +
-When the MDB is consuming from a remote Artemis server, there may not
-have such a JNDI binding in the local WildFly. +
+When the MDB is consuming from a remote Artemis server it will now create those bindings locally. +
 It is possible to use the naming subsystem to configure
 <<Naming,external context federation>> to have local JNDI
 bindings delegating to external bindings.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -51,7 +51,6 @@ import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
 import org.apache.activemq.artemis.jdbc.store.sql.PropertySQLProvider;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQSecurityManager;
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.services.path.AbsolutePathService;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.network.ManagedBinding;
@@ -59,8 +58,6 @@ import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -155,6 +152,7 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
         }
     }
 
+    @Override
     public synchronized void start(final StartContext context) throws StartException {
         ClassLoader origTCCL = org.wildfly.security.manager.WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         // Validate whether the AIO native layer can be used
@@ -330,23 +328,6 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
         return server;
     }
 
-    /**
-     * Returns true if a {@link ServiceController} for this service has been {@link org.jboss.msc.service.ServiceBuilder#install() installed}
-     * in MSC under the
-     * {@link MessagingServices#getActiveMQServiceName(org.jboss.as.controller.PathAddress) service name appropriate to the given operation}.
-     *
-     * @param context the operation context
-     * @return {@code true} if a {@link ServiceController} is installed
-     */
-    static boolean isServiceInstalled(final OperationContext context) {
-        if (context.isNormalServer()) {
-            final ServiceName serviceName = MessagingServices.getActiveMQServiceName(context.getCurrentAddress());
-            if (serviceName != null) {
-                return context.getServiceRegistry(false).getService(serviceName) != null;
-            }
-        }
-        return false;
-    }
 
     CommandDispatcherFactory getCommandDispatcherFactory(String key) {
         return commandDispatcherFactories.get(key).get();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -34,9 +34,6 @@ import static org.wildfly.extension.messaging.activemq.MessagingExtension.VERSIO
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
-import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
-import org.apache.activemq.artemis.core.settings.impl.SlowConsumerPolicy;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -96,107 +93,107 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition ADDRESS_FULL_MESSAGE_POLICY = create("address-full-policy", ModelType.STRING)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY.toString()))
+            .setDefaultValue(new ModelNode(AddressFullMessagePolicy.PAGE.toString()))
             .setValidator(new EnumValidator<>(AddressFullMessagePolicy.class, true, false))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition EXPIRY_DELAY = create("expiry-delay", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_EXPIRY_DELAY))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition LAST_VALUE_QUEUE = create("last-value-queue", ModelType.BOOLEAN)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_LAST_VALUE_QUEUE))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition MAX_DELIVERY_ATTEMPTS = create("max-delivery-attempts", ModelType.INT)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS))
+            .setDefaultValue(new ModelNode(10))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition MAX_REDELIVERY_DELAY = create("max-redelivery-delay", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_REDELIVER_DELAY * 10))
+            .setDefaultValue(new ModelNode(0L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition MAX_SIZE_BYTES = create("max-size-bytes", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_MAX_SIZE_BYTES))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition MESSAGE_COUNTER_HISTORY_DAY_LIMIT = create("message-counter-history-day-limit", ModelType.INT)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT))
+            .setDefaultValue(new ModelNode(0))
             .setMeasurementUnit(DAYS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition PAGE_MAX_CACHE_SIZE = create("page-max-cache-size", ModelType.INT)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_PAGE_MAX_CACHE))
+            .setDefaultValue(new ModelNode(5))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition PAGE_SIZE_BYTES = create("page-size-bytes", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_PAGE_SIZE))
+            .setDefaultValue(new ModelNode(10 * 1024 * 1024))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition REDELIVERY_DELAY = create("redelivery-delay", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_REDELIVER_DELAY))
+            .setDefaultValue(new ModelNode(0L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition REDELIVERY_MULTIPLIER = create("redelivery-multiplier", ModelType.DOUBLE)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_REDELIVER_MULTIPLIER))
+            .setDefaultValue(new ModelNode(1.0d))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition REDISTRIBUTION_DELAY = create("redistribution-delay", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_REDISTRIBUTION_DELAY))
+            .setDefaultValue(new ModelNode(-1L))
             .setMeasurementUnit(MILLISECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition SEND_TO_DLA_ON_NO_ROUTE = create("send-to-dla-on-no-route", ModelType.BOOLEAN)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE))
+            .setDefaultValue(new ModelNode(false))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_CHECK_PERIOD = create("slow-consumer-check-period", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD))
+            .setDefaultValue(new ModelNode(5L))
             .setMeasurementUnit(SECONDS)
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_POLICY = create("slow-consumer-policy", ModelType.STRING)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY.toString()))
+            .setDefaultValue(new ModelNode(SlowConsumerPolicy.NOTIFY.toString()))
             .setValidator(new EnumValidator<>(SlowConsumerPolicy.class, true, true))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition SLOW_CONSUMER_THRESHOLD = create("slow-consumer-threshold", ModelType.LONG)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD))
+            .setDefaultValue(new ModelNode(-1L))
             .setRequired(false)
             .setAllowExpression(true)
             .build();
@@ -255,4 +252,13 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(ATTRIBUTES);
     }
+
+    private enum AddressFullMessagePolicy {
+        DROP, PAGE, BLOCK, FAIL;
+    }
+
+    private enum SlowConsumerPolicy {
+        KILL, NOTIFY;
+    }
+
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -140,19 +139,15 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
         }
     }
 
-    static void addBroadcastGroupConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+    static void addBroadcastGroupConfigs(final OperationContext context, final List<BroadcastGroupConfiguration> configs, final Set<String> connectors, final ModelNode model)  throws OperationFailedException {
         if (model.hasDefined(CommonAttributes.BROADCAST_GROUP)) {
-            final List<BroadcastGroupConfiguration> configs = configuration.getBroadcastGroupConfigurations();
-            final Set<String> connectors = configuration.getConnectorConfigurations().keySet();
             for (Property prop : model.get(CommonAttributes.BROADCAST_GROUP).asPropertyList()) {
                 configs.add(createBroadcastGroupConfiguration(context, connectors, prop.getName(), prop.getValue()));
-
             }
         }
     }
 
     static BroadcastGroupConfiguration createBroadcastGroupConfiguration(final OperationContext context, final Set<String> connectors, final String name, final ModelNode model) throws OperationFailedException {
-
         final long broadcastPeriod = BroadcastGroupDefinition.BROADCAST_PERIOD.resolveModelAttribute(context, model).asLong();
         final List<String> connectorRefs = new ArrayList<String>();
         if (model.hasDefined(CommonAttributes.CONNECTORS)) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionDefinition.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 
-import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
@@ -134,7 +133,7 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
      */
     // FIXME WFLY-4587 forward-when-no-consumers == true ? STRICT : ON_DEMAND
     public static final SimpleAttributeDefinition MESSAGE_LOAD_BALANCING_TYPE = create("message-load-balancing-type", STRING)
-            .setDefaultValue(new ModelNode("ON_DEMAND"))
+            .setDefaultValue(new ModelNode(MessageLoadBalancingType.ON_DEMAND.toString()))
             .setValidator(new EnumValidator<>(MessageLoadBalancingType.class, true, true))
             .setRequired(false)
             .setAllowExpression(true)
@@ -330,4 +329,9 @@ public class ClusterConnectionDefinition extends PersistentResourceDefinition {
             registry.registerOperationHandler(getNodesDef, ClusterConnectionControlHandler.INSTANCE);
         }
     }
+
+    private enum MessageLoadBalancingType {
+        OFF, STRICT, ON_DEMAND;
+    }
+
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import org.apache.activemq.artemis.api.core.BroadcastEndpointFactory;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.UDPBroadcastEndpointFactory;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -134,18 +133,14 @@ public class DiscoveryGroupAdd extends AbstractAddStepHandler {
         }
     }
 
-    static void addDiscoveryGroupConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+    static Map<String, DiscoveryGroupConfiguration> addDiscoveryGroupConfigs(final OperationContext context, final ModelNode model)  throws OperationFailedException {
+         Map<String, DiscoveryGroupConfiguration> configs = new HashMap<>();
         if (model.hasDefined(CommonAttributes.DISCOVERY_GROUP)) {
-            Map<String, DiscoveryGroupConfiguration> configs = configuration.getDiscoveryGroupConfigurations();
-            if (configs == null) {
-                configs = new HashMap<>();
-                configuration.setDiscoveryGroupConfigurations(configs);
-            }
             for (Property prop : model.get(CommonAttributes.DISCOVERY_GROUP).asPropertyList()) {
                 configs.put(prop.getName(), createDiscoveryGroupConfiguration(context, prop.getName(), prop.getValue()));
-
             }
         }
+        return configs;
     }
 
     static DiscoveryGroupConfiguration createDiscoveryGroupConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ExternalBrokerConfigurationService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ExternalBrokerConfigurationService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.messaging.activemq;
+
+import java.util.Map;
+import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+public class ExternalBrokerConfigurationService implements Service<ExternalBrokerConfigurationService> {
+    private final Map<String, TransportConfiguration> connectors;
+    private final Map<String, DiscoveryGroupConfiguration> discoveryGroupConfigurations;
+    private final Map<String, ServiceName> socketBindings;
+    private final Map<String, ServiceName> outboundSocketBindings;
+    private final Map<String, ServiceName> groupBindings;
+    // mapping between the {broadcast|discovery}-groups and the cluster names they use
+    private final Map<String, String> clusterNames;
+    // mapping between the {broadcast|discovery}-groups and the command dispatcher factory they use
+    private final Map<String, ServiceName> commandDispatcherFactories;
+
+    public ExternalBrokerConfigurationService(final Map<String, TransportConfiguration> connectors,
+            Map<String, DiscoveryGroupConfiguration> discoveryGroupConfigurations,
+            Map<String, ServiceName> socketBindings,
+            Map<String, ServiceName> outboundSocketBindings,
+            Map<String, ServiceName> groupBindings,
+            Map<String, ServiceName> commandDispatcherFactories,
+            Map<String, String> clusterNames) {
+        this.connectors = connectors;
+        this.discoveryGroupConfigurations = discoveryGroupConfigurations;
+        this.clusterNames = clusterNames;
+        this.commandDispatcherFactories = commandDispatcherFactories;
+        this.groupBindings = groupBindings;
+        this.outboundSocketBindings = outboundSocketBindings;
+        this.socketBindings = socketBindings;
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    public Map<String, TransportConfiguration> getConnectors() {
+        return connectors;
+    }
+
+    public Map<String, ServiceName> getSocketBindings() {
+        return socketBindings;
+    }
+
+    public Map<String, ServiceName> getOutboundSocketBindings() {
+        return outboundSocketBindings;
+    }
+
+    public Map<String, ServiceName> getGroupBindings() {
+        return groupBindings;
+    }
+
+    public Map<String, String> getClusterNames() {
+        return clusterNames;
+    }
+
+    public Map<String, ServiceName> getCommandDispatcherFactories() {
+        return commandDispatcherFactories;
+    }
+
+    public Map<String, DiscoveryGroupConfiguration> getDiscoveryGroupConfigurations() {
+        return discoveryGroupConfigurations;
+    }
+
+    @Override
+    public ExternalBrokerConfigurationService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerDefinition.java
@@ -31,7 +31,7 @@ import static org.jboss.dmr.ModelType.STRING;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -89,7 +89,7 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition TYPE = create("type", STRING)
             .setAllowExpression(true)
-            .setValidator(new EnumValidator<>(GroupingHandlerConfiguration.TYPE.class, false, true))
+            .setValidator(new EnumValidator<>(Type.class, false, true))
             .setRestartAllServices()
             .build();
 
@@ -116,5 +116,9 @@ public class GroupingHandlerDefinition extends PersistentResourceDefinition {
                 registry.registerReadWriteAttribute(attr, null, GroupingHandlerWriteAttributeHandler.INSTANCE);
             }
         }
+    }
+
+    private enum Type {
+        LOCAL, REMOTE;
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
@@ -24,23 +24,46 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.apache.activemq.artemis.api.core.client.ActiveMQClient.SCHEDULED_THREAD_POOL_SIZE_PROPERTY_KEY;
 import static org.apache.activemq.artemis.api.core.client.ActiveMQClient.THREAD_POOL_MAX_SIZE_PROPERTY_KEY;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.BROADCAST_GROUP;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.DISCOVERY_GROUP;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
+import static org.wildfly.extension.messaging.activemq.MessagingSubsystemRootResourceDefinition.CONFIGURATION_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_SCHEDULED_THREAD_POOL_MAX_SIZE;
 import static org.wildfly.extension.messaging.activemq.MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_THREAD_POOL_MAX_SIZE;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
+import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
 
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.wildfly.clustering.spi.ClusteringDefaultRequirement;
+import org.wildfly.clustering.spi.ClusteringRequirement;
 import org.wildfly.extension.messaging.activemq.deployment.DefaultJMSConnectionFactoryBindingProcessor;
 import org.wildfly.extension.messaging.activemq.deployment.DefaultJMSConnectionFactoryResourceReferenceProcessor;
 import org.wildfly.extension.messaging.activemq.deployment.JMSConnectionFactoryDefinitionAnnotationProcessor;
@@ -59,6 +82,8 @@ import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
+
+    private static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
 
     public static final MessagingSubsystemAdd INSTANCE = new MessagingSubsystemAdd();
 
@@ -128,6 +153,95 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
         }
         context.getServiceTarget().addService(MessagingServices.ACTIVEMQ_CLIENT_THREAD_POOL, new ThreadPoolService())
                 .install();
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                final ServiceTarget serviceTarget = context.getServiceTarget();
+                final ServiceBuilder serviceBuilder = serviceTarget.addService(CONFIGURATION_CAPABILITY.getCapabilityServiceName());
+                // Transform the configuration based on the recursive model
+                final ModelNode model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+                // Process connectors
+                final Set<String> connectorsSocketBindings = new HashSet<String>();
+                final Map<String, TransportConfiguration> connectors = TransportConfigOperationHandlers.processConnectors(context, "localhost", model, connectorsSocketBindings);
+
+                Map<String, ServiceName> outboundSocketBindings = new HashMap<>();
+                Map<String, Boolean> outbounds = TransportConfigOperationHandlers.listOutBoundSocketBinding(context, connectorsSocketBindings);
+                Map<String, ServiceName> socketBindings = new HashMap<>();
+                for (final String connectorSocketBinding : connectorsSocketBindings) {
+                    // find whether the connectorSocketBinding references a SocketBinding or an OutboundSocketBinding
+                    if (outbounds.get(connectorSocketBinding)) {
+                        final ServiceName outboundSocketName = OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(connectorSocketBinding);
+                        outboundSocketBindings.put(connectorSocketBinding, outboundSocketName);
+                    } else {
+                        // check if the socket binding has not already been added by the acceptors
+                        if (!socketBindings.containsKey(connectorSocketBinding)) {
+                            socketBindings.put(connectorSocketBinding, SocketBinding.JBOSS_BINDING_NAME.append(connectorSocketBinding));
+                        }
+                    }
+                }
+                final List<BroadcastGroupConfiguration> broadcastGroupConfigurations =new ArrayList<>();
+                //this requires connectors
+                BroadcastGroupAdd.addBroadcastGroupConfigs(context, broadcastGroupConfigurations, connectors.keySet(), model);
+                final Map<String, DiscoveryGroupConfiguration> discoveryGroupConfigurations = DiscoveryGroupAdd.addDiscoveryGroupConfigs(context, model);
+                final Map<String, String> clusterNames = new HashMap<>();
+                final Map<String, ServiceName> commandDispatcherFactories = new HashMap<>();
+                final Set<ServiceName> commandDispatcherFactoryServices = new HashSet<>();
+                final Map<String, ServiceName> groupBindings = new HashMap<>();
+                final Set<ServiceName> groupBindingServices = new HashSet<>();
+                for (final BroadcastGroupConfiguration config : broadcastGroupConfigurations) {
+                    final String name = config.getName();
+                    final String key = "broadcast" + name;
+                    ModelNode broadcastGroupModel = model.get(BROADCAST_GROUP, name);
+
+                    if (broadcastGroupModel.hasDefined(JGROUPS_CLUSTER.getName())) {
+                        ModelNode channel = BroadcastGroupDefinition.JGROUPS_CHANNEL.resolveModelAttribute(context, broadcastGroupModel);
+                        ServiceName commandDispatcherFactoryServiceName = channel.isDefined() ? ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getServiceName(context, channel.asString()) : ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getServiceName(context);
+                        String clusterName = JGROUPS_CLUSTER.resolveModelAttribute(context, broadcastGroupModel).asString();
+                        if (!commandDispatcherFactoryServices.contains(commandDispatcherFactoryServiceName)) {
+                            commandDispatcherFactoryServices.add(commandDispatcherFactoryServiceName);
+                        }
+                        commandDispatcherFactories.put(key, commandDispatcherFactoryServiceName);
+                        clusterNames.put(key, clusterName);
+                    } else {
+                        final ServiceName groupBindingServiceName = GroupBindingService.getBroadcastBaseServiceName(JBOSS_MESSAGING_ACTIVEMQ).append(name);
+                        if (!groupBindingServices.contains(groupBindingServiceName)) {
+                            groupBindingServices.add(groupBindingServiceName);
+                        }
+                        groupBindings.put(key, groupBindingServiceName);
+                    }
+                }
+                for (final DiscoveryGroupConfiguration config : discoveryGroupConfigurations.values()) {
+                    final String name = config.getName();
+                    final String key = "discovery" + name;
+                    ModelNode discoveryGroupModel = model.get(DISCOVERY_GROUP, name);
+                    if (discoveryGroupModel.hasDefined(JGROUPS_CLUSTER.getName())) {
+                        ModelNode channel = DiscoveryGroupDefinition.JGROUPS_CHANNEL.resolveModelAttribute(context, discoveryGroupModel);
+                        ServiceName commandDispatcherFactoryServiceName = channel.isDefined() ? ClusteringRequirement.COMMAND_DISPATCHER_FACTORY.getServiceName(context, channel.asString()) : ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getServiceName(context);
+                        String clusterName = JGROUPS_CLUSTER.resolveModelAttribute(context, discoveryGroupModel).asString();
+                        if (!commandDispatcherFactoryServices.contains(commandDispatcherFactoryServiceName)) {
+                            commandDispatcherFactoryServices.add(commandDispatcherFactoryServiceName);
+                        }
+                        commandDispatcherFactories.put(key, commandDispatcherFactoryServiceName);
+                        clusterNames.put(key, clusterName);
+                    } else {
+                        final ServiceName groupBindingServiceName = GroupBindingService.getDiscoveryBaseServiceName(JBOSS_MESSAGING_ACTIVEMQ).append(name);
+                        if (!groupBindingServices.contains(groupBindingServiceName)) {
+                            groupBindingServices.add(groupBindingServiceName);
+                        }
+                        groupBindings.put(key, groupBindingServiceName);
+                    }
+                }
+                serviceBuilder.setInstance(new ExternalBrokerConfigurationService(
+                        connectors,
+                        discoveryGroupConfigurations,
+                        socketBindings,
+                        outboundSocketBindings,
+                        groupBindings,
+                        commandDispatcherFactories,
+                        clusterNames))
+                        .install();
+            }
+        }, OperationContext.Stage.RUNTIME);
     }
 
     /**

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemRootResourceDefinition.java
@@ -32,6 +32,8 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the messaging subsystem root resource.
@@ -39,6 +41,9 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class MessagingSubsystemRootResourceDefinition extends PersistentResourceDefinition {
+    public static final RuntimeCapability<Void> CONFIGURATION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq.external.configuration", false)
+            .setServiceType(ExternalBrokerConfigurationService.class)
+            .build();
 
     public static final SimpleAttributeDefinition GLOBAL_CLIENT_THREAD_POOL_MAX_SIZE = create("global-client-thread-pool-max-size", INT)
             .setAttributeGroup("global-client")
@@ -64,10 +69,11 @@ public class MessagingSubsystemRootResourceDefinition extends PersistentResource
     public static final MessagingSubsystemRootResourceDefinition INSTANCE = new MessagingSubsystemRootResourceDefinition();
 
     private MessagingSubsystemRootResourceDefinition() {
-        super(MessagingExtension.SUBSYSTEM_PATH,
-                MessagingExtension.getResourceDescriptionResolver(MessagingExtension.SUBSYSTEM_NAME),
-                MessagingSubsystemAdd.INSTANCE,
-                new ReloadRequiredRemoveStepHandler());
+        super(new SimpleResourceDefinition.Parameters(MessagingExtension.SUBSYSTEM_PATH,
+                MessagingExtension.getResourceDescriptionResolver(MessagingExtension.SUBSYSTEM_NAME))
+                .setAddHandler(MessagingSubsystemAdd.INSTANCE)
+                .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
+                .setCapabilities(CONFIGURATION_CAPABILITY));
     }
 
     @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -629,7 +629,7 @@ class ServerAdd extends AbstractAddStepHandler {
             configuration.getWildcardConfiguration().setRoutingEnabled(WILD_CARD_ROUTING_ENABLED.resolveModelAttribute(context, model).asBoolean());
 
             processStorageConfiguration(context, model, configuration);
-            HAPolicyConfigurationBuilder.addHAPolicyConfiguration(context, configuration, model);
+            HAPolicyConfigurationBuilder.getInstance().addHAPolicyConfiguration(context, configuration, model);
 
             processAddressSettings(context, configuration, model);
             processSecuritySettings(context, configuration, model);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -42,9 +42,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
-import org.apache.activemq.artemis.core.server.JournalType;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
@@ -424,11 +421,11 @@ public class ServerDefinition extends PersistentResourceDefinition {
     public static final SimpleAttributeDefinition JOURNAL_TYPE = create("journal-type", ModelType.STRING)
             .setAttributeGroup("journal")
             .setXmlName("type")
-            .setDefaultValue(new ModelNode(ConfigurationImpl.DEFAULT_JOURNAL_TYPE.toString()))
+            .setDefaultValue(new ModelNode(JournalType.ASYNCIO.toString()))
             .setRequired(false)
             .setAllowExpression(true)
             // list allowed values explicitly to exclude MAPPED
-            .setValidator(new EnumValidator<>(JournalType.class, true, true, JournalType.ASYNCIO, JournalType.NIO))
+            .setValidator(new EnumValidator<>(JournalType.class, true, true))
             .setRestartAllServices()
             .build();
     /**
@@ -641,7 +638,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
     public static final SimpleAttributeDefinition MANAGEMENT_ADDRESS = create("management-address", ModelType.STRING)
             .setAttributeGroup("management")
             .setXmlName("address")
-            .setDefaultValue(new ModelNode(new SimpleString("activemq.management").toString()))
+            .setDefaultValue(new ModelNode("activemq.management"))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
@@ -886,5 +883,19 @@ public class ServerDefinition extends PersistentResourceDefinition {
         }
     }
 
+    enum JournalType {
+        NIO, ASYNCIO;
+        public static final String validValues = Arrays.toString(JournalType.values());
 
+        public static JournalType getType(String type) {
+            switch (type) {
+                case "NIO":
+                    return NIO;
+                case "ASYNCIO":
+                    return ASYNCIO;
+                default:
+                    throw new IllegalStateException("Invalid JournalType:" + type + " valid Types: " + validValues);
+            }
+        }
+    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -350,7 +350,7 @@ public class TransportConfigOperationHandlers {
      * @param bindings      the referenced socket bindings
      * @throws OperationFailedException
      */
-    static void processConnectors(final OperationContext context, final Configuration configuration, final ModelNode params, final Set<String> bindings) throws OperationFailedException {
+    static Map<String, TransportConfiguration> processConnectors(final OperationContext context, final String configServerName, final ModelNode params, final Set<String> bindings) throws OperationFailedException {
         final Map<String, TransportConfiguration> connectors = new HashMap<String, TransportConfiguration>();
         if (params.hasDefined(CONNECTOR)) {
             for (final Property property : params.get(CONNECTOR).asPropertyList()) {
@@ -407,13 +407,13 @@ public class TransportConfigOperationHandlers {
                 parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
                 ModelNode serverNameModelNode = HTTPConnectorDefinition.SERVER_NAME.resolveModelAttribute(context, config);
                 // use the name of this server if the server-name attribute is undefined
-                String serverName = serverNameModelNode.isDefined() ? serverNameModelNode.asString() : configuration.getName();
+                String serverName = serverNameModelNode.isDefined() ? serverNameModelNode.asString() : configServerName;
                 parameters.put(ACTIVEMQ_SERVER_NAME, serverName);
 
                 connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName, extraParameters));
             }
         }
-        configuration.setConnectorConfigurations(connectors);
+        return connectors;
     }
 
     public static TransportConfiguration[] processConnectors(final OperationContext context, final Collection<String> names, Set<String> bindings) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicyConfigurationBuilder.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/HAPolicyConfigurationBuilder.java
@@ -23,17 +23,43 @@
 package org.wildfly.extension.messaging.activemq.ha;
 
 
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONFIGURATION;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLICY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.LIVE_ONLY;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_COLOCATED;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.REPLICATION_SLAVE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_STORE_COLOCATED;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_STORE_MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_STORE_SLAVE;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.SLAVE;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.ALLOW_FAILBACK;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_PORT_OFFSET;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRIES;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.CHECK_FOR_LIVE_SERVER;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.CLUSTER_NAME;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.EXCLUDED_CONNECTORS;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.GROUP_NAME;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.MAX_BACKUPS;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.REQUEST_BACKUP;
+import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.RESTART_BACKUP;
+import static org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes.addScaleDownConfiguration;
 
+import java.util.List;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ScaleDownConfiguration;
+import org.apache.activemq.artemis.core.config.ha.ColocatedPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
+import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -44,7 +70,16 @@ import org.jboss.dmr.Property;
  */
 public class HAPolicyConfigurationBuilder {
 
-    public static void addHAPolicyConfiguration(OperationContext context, Configuration configuration, ModelNode model) throws OperationFailedException {
+    private static final HAPolicyConfigurationBuilder INSTANCE = new HAPolicyConfigurationBuilder();
+
+    private HAPolicyConfigurationBuilder() {
+    }
+
+    public static HAPolicyConfigurationBuilder getInstance() {
+        return INSTANCE;
+    }
+
+    public void addHAPolicyConfiguration(OperationContext context, Configuration configuration, ModelNode model) throws OperationFailedException {
 
         if (!model.hasDefined(HA_POLICY)) {
             return;
@@ -56,31 +91,31 @@ public class HAPolicyConfigurationBuilder {
         String type = prop.getName();
         switch (type) {
             case LIVE_ONLY: {
-                haPolicyConfiguration = LiveOnlyDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildLiveOnlyConfiguration(context, haPolicy);
                 break;
             }
             case REPLICATION_MASTER: {
-                haPolicyConfiguration = ReplicationMasterDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildReplicationMasterConfiguration(context, haPolicy);
                 break;
             }
             case REPLICATION_SLAVE: {
-                haPolicyConfiguration = ReplicationSlaveDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildReplicationSlaveConfiguration(context, haPolicy);
                 break;
             }
             case REPLICATION_COLOCATED: {
-                haPolicyConfiguration = ReplicationColocatedDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildReplicationColocatedConfiguration(context, haPolicy);
                 break;
             }
             case SHARED_STORE_MASTER: {
-                haPolicyConfiguration = SharedStoreMasterDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildSharedStoreMasterConfiguration(context, haPolicy);
                 break;
             }
             case SHARED_STORE_SLAVE: {
-                haPolicyConfiguration = SharedStoreSlaveDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildSharedStoreSlaveConfiguration(context, haPolicy);
                 break;
             }
             case SHARED_STORE_COLOCATED: {
-                haPolicyConfiguration = SharedStoreColocatedDefinition.buildConfiguration(context, haPolicy);
+                haPolicyConfiguration = buildSharedStoreColocatedConfiguration(context, haPolicy);
                 break;
             }
             default: {
@@ -90,4 +125,93 @@ public class HAPolicyConfigurationBuilder {
         configuration.setHAPolicyConfiguration(haPolicyConfiguration);
     }
 
+    private HAPolicyConfiguration buildLiveOnlyConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        ScaleDownConfiguration scaleDownConfiguration = ScaleDownAttributes.addScaleDownConfiguration(context, model);
+        return new LiveOnlyPolicyConfiguration(scaleDownConfiguration);
+    }
+
+    private HAPolicyConfiguration buildReplicationMasterConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        ReplicatedPolicyConfiguration haPolicyConfiguration = new ReplicatedPolicyConfiguration();
+        haPolicyConfiguration.setCheckForLiveServer(CHECK_FOR_LIVE_SERVER.resolveModelAttribute(context, model).asBoolean())
+                .setInitialReplicationSyncTimeout(INITIAL_REPLICATION_SYNC_TIMEOUT.resolveModelAttribute(context, model).asLong());
+        ModelNode clusterName = CLUSTER_NAME.resolveModelAttribute(context, model);
+        if (clusterName.isDefined()) {
+            haPolicyConfiguration.setClusterName(clusterName.asString());
+        }
+        ModelNode groupName = GROUP_NAME.resolveModelAttribute(context, model);
+        if (groupName.isDefined()) {
+            haPolicyConfiguration.setGroupName(groupName.asString());
+        }
+        return haPolicyConfiguration;
+    }
+
+    private HAPolicyConfiguration buildReplicationSlaveConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        ReplicaPolicyConfiguration haPolicyConfiguration = new ReplicaPolicyConfiguration()
+                .setAllowFailBack(ALLOW_FAILBACK.resolveModelAttribute(context, model).asBoolean())
+                .setInitialReplicationSyncTimeout(INITIAL_REPLICATION_SYNC_TIMEOUT.resolveModelAttribute(context, model).asLong())
+                .setMaxSavedReplicatedJournalsSize(MAX_SAVED_REPLICATED_JOURNAL_SIZE.resolveModelAttribute(context, model).asInt())
+                .setScaleDownConfiguration(addScaleDownConfiguration(context, model))
+                .setRestartBackup(RESTART_BACKUP.resolveModelAttribute(context, model).asBoolean());
+        ModelNode clusterName = CLUSTER_NAME.resolveModelAttribute(context, model);
+        if (clusterName.isDefined()) {
+            haPolicyConfiguration.setClusterName(clusterName.asString());
+        }
+        ModelNode groupName = GROUP_NAME.resolveModelAttribute(context, model);
+        if (groupName.isDefined()) {
+            haPolicyConfiguration.setGroupName(groupName.asString());
+        }
+        return haPolicyConfiguration;
+    }
+
+    private HAPolicyConfiguration buildReplicationColocatedConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        ColocatedPolicyConfiguration haPolicyConfiguration = new ColocatedPolicyConfiguration()
+                .setRequestBackup(REQUEST_BACKUP.resolveModelAttribute(context, model).asBoolean())
+                .setBackupRequestRetries(BACKUP_REQUEST_RETRIES.resolveModelAttribute(context, model).asInt())
+                .setBackupRequestRetryInterval(BACKUP_REQUEST_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong())
+                .setMaxBackups(MAX_BACKUPS.resolveModelAttribute(context, model).asInt())
+                .setBackupPortOffset(BACKUP_PORT_OFFSET.resolveModelAttribute(context, model).asInt());
+        List<String> connectors = EXCLUDED_CONNECTORS.unwrap(context, model);
+        if (!connectors.isEmpty()) {
+            haPolicyConfiguration.setExcludedConnectors(connectors);
+        }
+        ModelNode masterConfigurationModel = model.get(CONFIGURATION, MASTER);
+        HAPolicyConfiguration masterConfiguration = buildReplicationMasterConfiguration(context, masterConfigurationModel);
+        haPolicyConfiguration.setLiveConfig(masterConfiguration);
+        ModelNode slaveConfigurationModel = model.get(CONFIGURATION, SLAVE);
+        HAPolicyConfiguration slaveConfiguration = buildReplicationSlaveConfiguration(context, slaveConfigurationModel);
+        haPolicyConfiguration.setBackupConfig(slaveConfiguration);
+        return haPolicyConfiguration;
+    }
+
+    private HAPolicyConfiguration buildSharedStoreMasterConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        return new SharedStoreMasterPolicyConfiguration()
+                .setFailoverOnServerShutdown(FAILOVER_ON_SERVER_SHUTDOWN.resolveModelAttribute(context, model).asBoolean());
+    }
+
+    private HAPolicyConfiguration buildSharedStoreSlaveConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        return new SharedStoreSlavePolicyConfiguration()
+                .setAllowFailBack(ALLOW_FAILBACK.resolveModelAttribute(context, model).asBoolean())
+                .setFailoverOnServerShutdown(FAILOVER_ON_SERVER_SHUTDOWN.resolveModelAttribute(context, model).asBoolean())
+                .setRestartBackup(RESTART_BACKUP.resolveModelAttribute(context, model).asBoolean())
+                .setScaleDownConfiguration(ScaleDownAttributes.addScaleDownConfiguration(context, model));
+    }
+
+    private HAPolicyConfiguration buildSharedStoreColocatedConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
+        ColocatedPolicyConfiguration haPolicyConfiguration = new ColocatedPolicyConfiguration()
+                .setRequestBackup(REQUEST_BACKUP.resolveModelAttribute(context, model).asBoolean())
+                .setBackupRequestRetries(BACKUP_REQUEST_RETRIES.resolveModelAttribute(context, model).asInt())
+                .setBackupRequestRetryInterval(BACKUP_REQUEST_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong())
+                .setMaxBackups(MAX_BACKUPS.resolveModelAttribute(context, model).asInt())
+                .setBackupPortOffset(BACKUP_PORT_OFFSET.resolveModelAttribute(context, model).asInt());
+
+        ModelNode masterConfigurationModel = model.get(CONFIGURATION, MASTER);
+        HAPolicyConfiguration masterConfiguration = buildSharedStoreMasterConfiguration(context, masterConfigurationModel);
+        haPolicyConfiguration.setLiveConfig(masterConfiguration);
+
+        ModelNode slaveConfigurationModel = model.get(CONFIGURATION, SLAVE);
+        HAPolicyConfiguration slaveConfiguration = buildSharedStoreSlaveConfiguration(context, slaveConfigurationModel);
+        haPolicyConfiguration.setBackupConfig(slaveConfiguration);
+
+        return haPolicyConfiguration;
+    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/LiveOnlyDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/LiveOnlyDefinition.java
@@ -27,9 +27,6 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLIC
 
 import java.util.Collection;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ScaleDownConfiguration;
-import org.apache.activemq.artemis.core.config.ha.LiveOnlyPolicyConfiguration;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -85,8 +82,4 @@ public class LiveOnlyDefinition extends PersistentResourceDefinition {
         return ATTRIBUTES;
     }
 
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        ScaleDownConfiguration scaleDownConfiguration = ScaleDownAttributes.addScaleDownConfiguration(context, model);
-        return new LiveOnlyPolicyConfiguration(scaleDownConfiguration);
-    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationColocatedDefinition.java
@@ -23,10 +23,7 @@
 package org.wildfly.extension.messaging.activemq.ha;
 
 
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONFIGURATION;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLICY;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.MASTER;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.SLAVE;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_PORT_OFFSET;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRIES;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL;
@@ -40,16 +37,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.ColocatedPolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -94,29 +86,5 @@ public class ReplicationColocatedDefinition extends PersistentResourceDefinition
         return Collections.unmodifiableList(Arrays.asList(
                 ReplicationMasterDefinition.CONFIGURATION_INSTANCE,
                 ReplicationSlaveDefinition.CONFIGURATION_INSTANCE));
-    }
-
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        ColocatedPolicyConfiguration haPolicyConfiguration = new ColocatedPolicyConfiguration()
-                .setRequestBackup(REQUEST_BACKUP.resolveModelAttribute(context, model).asBoolean())
-                .setBackupRequestRetries(BACKUP_REQUEST_RETRIES.resolveModelAttribute(context, model).asInt())
-                .setBackupRequestRetryInterval(BACKUP_REQUEST_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong())
-                .setMaxBackups(MAX_BACKUPS.resolveModelAttribute(context, model).asInt())
-                .setBackupPortOffset(BACKUP_PORT_OFFSET.resolveModelAttribute(context, model).asInt());
-
-        List<String> connectors = EXCLUDED_CONNECTORS.unwrap(context, model);
-        if (!connectors.isEmpty()) {
-            haPolicyConfiguration.setExcludedConnectors(connectors);
-        }
-
-        ModelNode masterConfigurationModel = model.get(CONFIGURATION, MASTER);
-        HAPolicyConfiguration masterConfiguration = ReplicationMasterDefinition.buildConfiguration(context, masterConfigurationModel);
-        haPolicyConfiguration.setLiveConfig(masterConfiguration);
-
-        ModelNode slaveConfigurationModel = model.get(CONFIGURATION, SLAVE);
-        HAPolicyConfiguration slaveConfiguration = ReplicationSlaveDefinition.buildConfiguration(context, slaveConfigurationModel);
-        haPolicyConfiguration.setBackupConfig(slaveConfiguration);
-
-        return haPolicyConfiguration;
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationMasterDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationMasterDefinition.java
@@ -34,17 +34,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.ReplicatedPolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -81,22 +76,5 @@ public class ReplicationMasterDefinition extends PersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return ATTRIBUTES;
-    }
-
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        ReplicatedPolicyConfiguration haPolicyConfiguration = new ReplicatedPolicyConfiguration();
-
-        haPolicyConfiguration.setCheckForLiveServer(CHECK_FOR_LIVE_SERVER.resolveModelAttribute(context, model).asBoolean())
-                .setInitialReplicationSyncTimeout(INITIAL_REPLICATION_SYNC_TIMEOUT.resolveModelAttribute(context, model).asLong());
-
-        ModelNode clusterName = CLUSTER_NAME.resolveModelAttribute(context, model);
-        if (clusterName.isDefined()) {
-            haPolicyConfiguration.setClusterName(clusterName.asString());
-        }
-        ModelNode groupName = GROUP_NAME.resolveModelAttribute(context, model);
-        if (groupName.isDefined()) {
-            haPolicyConfiguration.setGroupName(groupName.asString());
-        }
-        return haPolicyConfiguration;
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationSlaveDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/ReplicationSlaveDefinition.java
@@ -30,23 +30,17 @@ import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.INITIAL_R
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.RESTART_BACKUP;
 import static org.wildfly.extension.messaging.activemq.ha.ManagementHelper.createAddOperation;
-import static org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes.addScaleDownConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.ReplicaPolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -94,23 +88,4 @@ public class ReplicationSlaveDefinition extends PersistentResourceDefinition {
         return ATTRIBUTES;
     }
 
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        ReplicaPolicyConfiguration haPolicyConfiguration = new ReplicaPolicyConfiguration()
-                .setAllowFailBack(ALLOW_FAILBACK.resolveModelAttribute(context, model).asBoolean())
-                .setInitialReplicationSyncTimeout(INITIAL_REPLICATION_SYNC_TIMEOUT.resolveModelAttribute(context, model).asLong())
-                .setMaxSavedReplicatedJournalsSize(MAX_SAVED_REPLICATED_JOURNAL_SIZE.resolveModelAttribute(context, model).asInt())
-                .setScaleDownConfiguration(addScaleDownConfiguration(context, model))
-                .setRestartBackup(RESTART_BACKUP.resolveModelAttribute(context, model).asBoolean());
-
-        ModelNode clusterName = CLUSTER_NAME.resolveModelAttribute(context, model);
-        if (clusterName.isDefined()) {
-            haPolicyConfiguration.setClusterName(clusterName.asString());
-        }
-        ModelNode groupName = GROUP_NAME.resolveModelAttribute(context, model);
-        if (groupName.isDefined()) {
-            haPolicyConfiguration.setGroupName(groupName.asString());
-        }
-
-        return haPolicyConfiguration;
-    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreColocatedDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreColocatedDefinition.java
@@ -22,11 +22,8 @@
 
 package org.wildfly.extension.messaging.activemq.ha;
 
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONFIGURATION;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA_POLICY;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.MASTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_STORE_COLOCATED;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.SLAVE;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_PORT_OFFSET;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRIES;
 import static org.wildfly.extension.messaging.activemq.ha.HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL;
@@ -39,17 +36,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.ColocatedPolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -97,22 +89,4 @@ public class SharedStoreColocatedDefinition extends PersistentResourceDefinition
                 SharedStoreSlaveDefinition.CONFIGURATION_INSTANCE));
     }
 
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        ColocatedPolicyConfiguration haPolicyConfiguration = new ColocatedPolicyConfiguration()
-                .setRequestBackup(REQUEST_BACKUP.resolveModelAttribute(context, model).asBoolean())
-                .setBackupRequestRetries(BACKUP_REQUEST_RETRIES.resolveModelAttribute(context, model).asInt())
-                .setBackupRequestRetryInterval(BACKUP_REQUEST_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong())
-                .setMaxBackups(MAX_BACKUPS.resolveModelAttribute(context, model).asInt())
-                .setBackupPortOffset(BACKUP_PORT_OFFSET.resolveModelAttribute(context, model).asInt());
-
-        ModelNode masterConfigurationModel = model.get(CONFIGURATION, MASTER);
-        HAPolicyConfiguration masterConfiguration = SharedStoreMasterDefinition.buildConfiguration(context, masterConfigurationModel);
-        haPolicyConfiguration.setLiveConfig(masterConfiguration);
-
-        ModelNode slaveConfigurationModel = model.get(CONFIGURATION, SLAVE);
-        HAPolicyConfiguration slaveConfiguration = SharedStoreSlaveDefinition.buildConfiguration(context, slaveConfigurationModel);
-        haPolicyConfiguration.setBackupConfig(slaveConfiguration);
-
-        return haPolicyConfiguration;
-    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreMasterDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreMasterDefinition.java
@@ -30,17 +30,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.SharedStoreMasterPolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -77,8 +72,5 @@ public class SharedStoreMasterDefinition extends PersistentResourceDefinition {
         return ATTRIBUTES;
     }
 
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        return new SharedStoreMasterPolicyConfiguration()
-                .setFailoverOnServerShutdown(FAILOVER_ON_SERVER_SHUTDOWN.resolveModelAttribute(context, model).asBoolean());
-    }
+
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreSlaveDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ha/SharedStoreSlaveDefinition.java
@@ -32,17 +32,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.apache.activemq.artemis.core.config.HAPolicyConfiguration;
-import org.apache.activemq.artemis.core.config.ha.SharedStoreSlavePolicyConfiguration;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.ActiveMQReloadRequiredHandlers;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -88,11 +83,4 @@ public class SharedStoreSlaveDefinition extends PersistentResourceDefinition {
         return ATTRIBUTES;
     }
 
-    static HAPolicyConfiguration buildConfiguration(OperationContext context, ModelNode model) throws OperationFailedException {
-        return new SharedStoreSlavePolicyConfiguration()
-                .setAllowFailBack(ALLOW_FAILBACK.resolveModelAttribute(context, model).asBoolean())
-                .setFailoverOnServerShutdown(FAILOVER_ON_SERVER_SHUTDOWN.resolveModelAttribute(context, model).asBoolean())
-                .setRestartBackup(RESTART_BACKUP.resolveModelAttribute(context, model).asBoolean())
-                .setScaleDownConfiguration(ScaleDownAttributes.addScaleDownConfiguration(context, model));
-    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
@@ -15,12 +15,21 @@
  */
 package org.wildfly.extension.messaging.activemq.jms;
 
+import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartException;
 
 /**
  *
@@ -73,13 +82,90 @@ public class DestinationConfiguration {
         return ActiveMQJMSClient.createQueue(this.managementQueueAddress);
     }
 
-    public QueueConnection createQueueConnection(QueueConnectionFactory cf) throws JMSException {
+    private Connection createQueueConnection(ConnectionFactory cf) throws JMSException {
         if(this.managementUsername != null && !this.managementUsername.isEmpty()) {
-            return cf.createQueueConnection(managementUsername, managementPassword);
+            return cf.createConnection(managementUsername, managementPassword);
         }
-        return cf.createQueueConnection();
+        return cf.createConnection();
     }
 
+    public void createQueue(ConnectionFactory cf, Queue managementQueue, String queueName) throws JMSException, StartException {
+        try (Connection connection = createQueueConnection(cf)) {
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            connection.start();
+            QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
+            Message m = session.createMessage();
+            if (getSelector() != null && !getSelector().isEmpty()) {
+                org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", queueName, queueName, getSelector(), isDurable(), RoutingType.ANYCAST.name());
+            } else {
+                org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", queueName, queueName, isDurable(), RoutingType.ANYCAST.name());
+            }
+            Message reply = requestor.request(m);
+            ROOT_LOGGER.infof("Creating queue %s returned %s", queueName, reply);
+            if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                String body = reply.getBody(String.class);
+                if (!destinationAlreadyExist(body)) {
+                    throw ROOT_LOGGER.remoteDestinationCreationFailed(queueName, body);
+                }
+            }
+            ROOT_LOGGER.infof("Queue %s has been created", queueName);
+        }
+    }
+
+    private boolean destinationAlreadyExist(String body) {
+        return body.contains("AMQ119019") || body.contains("AMQ119018") || body.contains("AMQ229019") || body.contains("AMQ229018");
+    }
+
+    public void destroyQueue(ConnectionFactory cf, Queue managementQueue, String queueName) throws JMSException {
+        try (Connection connection = createQueueConnection(cf)) {
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            connection.start();
+            QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
+            Message m = session.createMessage();
+            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", queueName, true, true);
+            Message reply = requestor.request(m);
+            ROOT_LOGGER.debugf("Deleting queue %s returned %s", queueName, reply);
+            if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                throw ROOT_LOGGER.remoteDestinationDeletionFailed(queueName, reply.getBody(String.class));
+            }
+            ROOT_LOGGER.debugf("Queue %s has been deleted", queueName);
+        }
+    }
+
+    public void createTopic(ConnectionFactory cf, Queue managementQueue, String topicName) throws JMSException, StartException {
+        try (Connection connection = createQueueConnection(cf)) {
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            connection.start();
+            QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
+            Message m = session.createMessage();
+            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", topicName, topicName, isDurable(), RoutingType.MULTICAST.name());
+            Message reply = requestor.request(m);
+            ROOT_LOGGER.infof("Creating topic %s returned %s", topicName, reply);
+            if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                String body = reply.getBody(String.class);
+                if (!destinationAlreadyExist(body)) {
+                    throw ROOT_LOGGER.remoteDestinationCreationFailed(topicName, body);
+                }
+            }
+            ROOT_LOGGER.infof("Topic %s has been created", topicName);
+        }
+    }
+
+    public void destroyTopic(ConnectionFactory cf, Queue managementQueue, String topicName) throws JMSException {
+        try (Connection connection = createQueueConnection(cf)) {
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            connection.start();
+            QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
+            Message m = session.createMessage();
+            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", topicName, true, true);
+            Message reply = requestor.request(m);
+            ROOT_LOGGER.debugf("Deleting topic " + topicName + " returned " + reply);
+            if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                throw ROOT_LOGGER.remoteDestinationDeletionFailed(topicName, reply.getBody(String.class));
+            }
+            ROOT_LOGGER.debugf("Topic %s has been deleted", topicName);
+        }
+    }
     public static class Builder {
 
         private boolean durable = false;

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.messaging.activemq.jms;
+
+import javax.jms.JMSException;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+public class DestinationConfiguration {
+
+    private final boolean durable;
+    private final String selector;
+    private final String name;
+    private final String managementQueueAddress;
+    private final String managementUsername;
+    private final String managementPassword;
+    private final String resourceAdapter;
+    private final ServiceName destinationServiceName;
+
+    public DestinationConfiguration(boolean durable, String selector, String name, String managementQueueAddress,
+            String managementUsername, String managementPassword, String resourceAdapter, ServiceName destinationServiceName) {
+        this.durable = durable;
+        this.selector = selector;
+        this.name = name;
+        this.managementQueueAddress = managementQueueAddress;
+        this.managementUsername = managementUsername;
+        this.managementPassword = managementPassword;
+        this.resourceAdapter = resourceAdapter;
+        this.destinationServiceName = destinationServiceName;
+    }
+
+    public boolean isDurable() {
+        return durable;
+    }
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ServiceName getDestinationServiceName() {
+        return destinationServiceName;
+    }
+
+    public String getResourceAdapter() {
+        return resourceAdapter;
+    }
+
+    public Queue getManagementQueue() {
+        return ActiveMQJMSClient.createQueue(this.managementQueueAddress);
+    }
+
+    public QueueConnection createQueueConnection(QueueConnectionFactory cf) throws JMSException {
+        if(this.managementUsername != null && !this.managementUsername.isEmpty()) {
+            return cf.createQueueConnection(managementUsername, managementPassword);
+        }
+        return cf.createQueueConnection();
+    }
+
+    public static class Builder {
+
+        private boolean durable = false;
+        private String selector = null;
+        private String name;
+        private String managementQueueAddress = "activemq.management";
+        private String managementUsername = null;
+        private String managementPassword = null;
+        private String resourceAdapter;
+        private ServiceName destinationServiceName;
+
+        private Builder() {
+        }
+
+        public static Builder getInstance() {
+            return new Builder();
+        }
+
+        public Builder setDurable(boolean durable) {
+            this.durable = durable;
+            return this;
+        }
+
+        public Builder setSelector(String selector) {
+            this.selector = selector;
+            return this;
+        }
+
+        public Builder setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder setDestinationServiceName(ServiceName destinationServiceName) {
+            this.destinationServiceName = destinationServiceName;
+            return this;
+        }
+
+        public Builder setResourceAdapter(String resourceAdapter) {
+            this.resourceAdapter = resourceAdapter;
+            return this;
+        }
+
+        public Builder setManagementQueueAddress(String managementQueueAddress) {
+            this.managementQueueAddress = managementQueueAddress;
+            return this;
+        }
+
+        public Builder setManagementUsername(String managementUsername) {
+            this.managementUsername = managementUsername;
+            return this;
+        }
+
+        public Builder setManagementPassword(String managementPassword) {
+            this.managementPassword = managementPassword;
+            return this;
+        }
+
+        public DestinationConfiguration build() {
+            return new DestinationConfiguration(durable, selector, name, managementQueueAddress, managementUsername,
+                    managementPassword,resourceAdapter, destinationServiceName);
+        }
+
+    }
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueDefinition.java
@@ -34,10 +34,9 @@ import org.wildfly.extension.messaging.activemq.MessagingExtension;
 public class ExternalJMSQueueDefinition extends PersistentResourceDefinition {
 
     public static final AttributeDefinition[] ATTRIBUTES = {CommonAttributes.DESTINATION_ENTRIES};
-
     private final boolean registerRuntimeOnly;
 
-    public ExternalJMSQueueDefinition(final boolean registerRuntimeOnly) {
+    public ExternalJMSQueueDefinition(boolean registerRuntimeOnly) {
         super(MessagingExtension.EXTERNAL_JMS_QUEUE_PATH,
                 MessagingExtension.getResourceDescriptionResolver(CommonAttributes.EXTERNAL_JMS_QUEUE),
                 ExternalJMSQueueAdd.INSTANCE,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
@@ -16,20 +16,19 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
-
+import java.util.Collection;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
-import javax.jms.Message;
 import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueRequestor;
-import javax.jms.QueueSession;
-import javax.jms.Session;
 import javax.naming.NamingException;
-import org.apache.activemq.artemis.api.core.RoutingType;
-import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.ra.ActiveMQRAConnectionFactory;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.naming.NamingContext;
 import org.jboss.as.naming.NamingStore;
@@ -43,6 +42,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
  * Service responsible for creating and destroying a client {@code javax.jms.Queue}.
@@ -57,14 +57,15 @@ public class ExternalJMSQueueService implements Service<Queue> {
     private final InjectedValue<NamingStore> namingStoreInjector = new InjectedValue<NamingStore>();
     private final InjectedValue<ExternalPooledConnectionFactoryService> pcfInjector = new InjectedValue<ExternalPooledConnectionFactoryService>();
     private Queue queue;
+    private ClientSessionFactory sessionFactory;
 
-    public ExternalJMSQueueService(final String queueName) {
-        this.queueName = queueName;
+    private ExternalJMSQueueService(final String queueName) {
+        this.queueName = JMS_QUEUE_PREFIX + queueName;
         this.config = null;
     }
 
     private ExternalJMSQueueService(final DestinationConfiguration config) {
-        this.queueName = config.getName();
+        this.queueName = JMS_QUEUE_PREFIX + config.getName();
         this.config = config;
     }
 
@@ -72,29 +73,48 @@ public class ExternalJMSQueueService implements Service<Queue> {
     public synchronized void start(final StartContext context) throws StartException {
         NamingStore namingStore = namingStoreInjector.getOptionalValue();
         if(namingStore!= null) {
-            Queue managementQueue = config.getManagementQueue();
+            final Queue managementQueue = config.getManagementQueue();
             final NamingContext storeBaseContext = new NamingContext(namingStore, null);
             try {
-                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
-                try (QueueConnection connection = config.createQueueConnection(cf)) {
-                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-                    connection.start();
-                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
-                    Message m = session.createMessage();
-                    if (config.getSelector() != null && !config.getSelector().isEmpty()) {
-                        org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_QUEUE_PREFIX + queueName, JMS_QUEUE_PREFIX + queueName, config.getSelector(), config.isDurable(), RoutingType.ANYCAST.name());
-                    } else {
-                        org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_QUEUE_PREFIX + queueName, JMS_QUEUE_PREFIX + queueName, config.isDurable(), RoutingType.ANYCAST.name());
+                ConnectionFactory cf = (ConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                if (cf instanceof ActiveMQRAConnectionFactory) {
+                    ActiveMQRAConnectionFactory raCf = (ActiveMQRAConnectionFactory) cf;
+                    ServerLocator locator = raCf.getDefaultFactory().getServerLocator();
+                    sessionFactory = locator.createSessionFactory();
+                    ClusterTopologyListener listener = new ClusterTopologyListener() {
+                        @Override
+                        public void nodeUP(TopologyMember member, boolean last) {
+                            try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(false, member.getLive())) {
+                                MessagingLogger.ROOT_LOGGER.infof("Creating queue %s on node UP %s - %s", queueName, member.getNodeId(), member.getLive().toJson());
+                                config.createQueue(factory, managementQueue, queueName);
+                            } catch (JMSException | StartException ex) {
+                                MessagingLogger.ROOT_LOGGER.errorf(ex, "Creating queue %s on node UP %s failed", queueName, member.getLive().toJson());
+                                throw new RuntimeException(ex);
+                            }
+                            if (member.getBackup() != null) {
+                                try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(false, member.getBackup())) {
+                                    MessagingLogger.ROOT_LOGGER.infof("Creating queue %s on backup node UP %s - %s", queueName, member.getNodeId(), member.getBackup().toJson());
+                                    config.createQueue(factory, managementQueue, queueName);
+                                } catch (JMSException | StartException ex) {
+                                    throw new RuntimeException(ex);
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void nodeDown(long eventUID, String nodeID) {}
+                    };
+                    locator.addClusterTopologyListener(listener);
+                    Collection<TopologyMemberImpl> members = locator.getTopology().getMembers();
+                    if (members == null || members.isEmpty()) {
+                        config.createQueue(cf, managementQueue, queueName);
                     }
-                    Message reply = requestor.request(m);
-                    ROOT_LOGGER.debugf("Creating queue %s returned %s", JMS_QUEUE_PREFIX + queueName, reply);
-                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
-                        throw ROOT_LOGGER.remoteDestinationCreationFailed(JMS_QUEUE_PREFIX + queueName, reply.getBody(String.class));
-                    }
-                    ROOT_LOGGER.debugf("Queue %s has been created", JMS_QUEUE_PREFIX + queueName);
+                } else {
+                    config.createQueue(cf, managementQueue, queueName);
                 }
-            } catch (NamingException | JMSException ex) {
-                    throw new StartException(ex);
+            } catch (Exception ex) {
+                MessagingLogger.ROOT_LOGGER.errorf(ex, "Error starting the external queue service %s", ex.getMessage());
+                throw new StartException(ex);
             } finally {
                 try {
                     storeBaseContext.close();
@@ -103,41 +123,15 @@ public class ExternalJMSQueueService implements Service<Queue> {
                 }
             }
         }
-        queue = ActiveMQJMSClient.createQueue(JMS_QUEUE_PREFIX + queueName);
+        queue = ActiveMQJMSClient.createQueue(queueName);
     }
+
 
     @Override
     public synchronized void stop(final StopContext context) {
-        NamingStore namingStore = namingStoreInjector.getOptionalValue();
-        if(namingStore!= null) {
-            Queue managementQueue = config.getManagementQueue();
-            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
-            try {
-                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
-                try (QueueConnection connection = config.createQueueConnection(cf)) {
-                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-                    connection.start();
-                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
-                    Message m = session.createMessage();
-                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", JMS_QUEUE_PREFIX + queueName, true, true);
-                    Message reply = requestor.request(m);
-                    ROOT_LOGGER.debugf("Deleting queue %s returned %s", JMS_QUEUE_PREFIX + queueName, reply);
-                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
-                        throw ROOT_LOGGER.remoteDestinationDeletionFailed(JMS_QUEUE_PREFIX + queueName, reply.getBody(String.class));
-                    }
-                    ROOT_LOGGER.debugf("Queue %s has been deleted", JMS_QUEUE_PREFIX + queueName);
-                }
-            } catch (NamingException | JMSException ex) {
-                    throw new RuntimeException(ex);
-            } finally {
-                try {
-                    storeBaseContext.close();
-                } catch (NamingException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
+        if(sessionFactory != null) {
+            sessionFactory.close();
         }
-        queue = null;
     }
 
     @Override
@@ -161,4 +155,5 @@ public class ExternalJMSQueueService implements Service<Queue> {
         serviceBuilder.install();
         return service;
     }
+
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSQueueService.java
@@ -16,8 +16,24 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 
+import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.naming.NamingException;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.naming.NamingContext;
+import org.jboss.as.naming.NamingStore;
+import org.jboss.as.naming.service.NamingService;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -26,6 +42,7 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 
 /**
  * Service responsible for creating and destroying a client {@code javax.jms.Queue}.
@@ -36,19 +53,90 @@ public class ExternalJMSQueueService implements Service<Queue> {
 
     static final String JMS_QUEUE_PREFIX = "jms.queue.";
     private final String queueName;
+    private final DestinationConfiguration config;
+    private final InjectedValue<NamingStore> namingStoreInjector = new InjectedValue<NamingStore>();
+    private final InjectedValue<ExternalPooledConnectionFactoryService> pcfInjector = new InjectedValue<ExternalPooledConnectionFactoryService>();
     private Queue queue;
 
     public ExternalJMSQueueService(final String queueName) {
         this.queueName = queueName;
+        this.config = null;
+    }
+
+    private ExternalJMSQueueService(final DestinationConfiguration config) {
+        this.queueName = config.getName();
+        this.config = config;
     }
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
+        NamingStore namingStore = namingStoreInjector.getOptionalValue();
+        if(namingStore!= null) {
+            Queue managementQueue = config.getManagementQueue();
+            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
+            try {
+                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                try (QueueConnection connection = config.createQueueConnection(cf)) {
+                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+                    connection.start();
+                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
+                    Message m = session.createMessage();
+                    if (config.getSelector() != null && !config.getSelector().isEmpty()) {
+                        org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_QUEUE_PREFIX + queueName, JMS_QUEUE_PREFIX + queueName, config.getSelector(), config.isDurable(), RoutingType.ANYCAST.name());
+                    } else {
+                        org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_QUEUE_PREFIX + queueName, JMS_QUEUE_PREFIX + queueName, config.isDurable(), RoutingType.ANYCAST.name());
+                    }
+                    Message reply = requestor.request(m);
+                    ROOT_LOGGER.debugf("Creating queue %s returned %s", JMS_QUEUE_PREFIX + queueName, reply);
+                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                        throw ROOT_LOGGER.remoteDestinationCreationFailed(JMS_QUEUE_PREFIX + queueName, reply.getBody(String.class));
+                    }
+                    ROOT_LOGGER.debugf("Queue %s has been created", JMS_QUEUE_PREFIX + queueName);
+                }
+            } catch (NamingException | JMSException ex) {
+                    throw new StartException(ex);
+            } finally {
+                try {
+                    storeBaseContext.close();
+                } catch (NamingException ex) {
+                    throw new StartException(ex);
+                }
+            }
+        }
         queue = ActiveMQJMSClient.createQueue(JMS_QUEUE_PREFIX + queueName);
     }
 
     @Override
     public synchronized void stop(final StopContext context) {
+        NamingStore namingStore = namingStoreInjector.getOptionalValue();
+        if(namingStore!= null) {
+            Queue managementQueue = config.getManagementQueue();
+            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
+            try {
+                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                try (QueueConnection connection = config.createQueueConnection(cf)) {
+                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+                    connection.start();
+                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
+                    Message m = session.createMessage();
+                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", JMS_QUEUE_PREFIX + queueName, true, true);
+                    Message reply = requestor.request(m);
+                    ROOT_LOGGER.debugf("Deleting queue %s returned %s", JMS_QUEUE_PREFIX + queueName, reply);
+                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                        throw ROOT_LOGGER.remoteDestinationDeletionFailed(JMS_QUEUE_PREFIX + queueName, reply.getBody(String.class));
+                    }
+                    ROOT_LOGGER.debugf("Queue %s has been deleted", JMS_QUEUE_PREFIX + queueName);
+                }
+            } catch (NamingException | JMSException ex) {
+                    throw new RuntimeException(ex);
+            } finally {
+                try {
+                    storeBaseContext.close();
+                } catch (NamingException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
         queue = null;
     }
 
@@ -60,6 +148,16 @@ public class ExternalJMSQueueService implements Service<Queue> {
     public static Service<Queue> installService(final String name, final ServiceTarget serviceTarget, final ServiceName serviceName) {
         final ExternalJMSQueueService service = new ExternalJMSQueueService(name);
         final ServiceBuilder<Queue> serviceBuilder = serviceTarget.addService(serviceName, service);
+        serviceBuilder.install();
+        return service;
+    }
+
+    public static Service<Queue> installRuntimeQueueService(final DestinationConfiguration config, final ServiceTarget serviceTarget, final ServiceName pcf) {
+        final ExternalJMSQueueService service = new ExternalJMSQueueService(config);
+        final ServiceBuilder<Queue> serviceBuilder = serviceTarget.addService(config.getDestinationServiceName(), service);
+        serviceBuilder.addDependency(NamingService.SERVICE_NAME, NamingStore.class, service.namingStoreInjector);
+        serviceBuilder.addDependency(pcf, ExternalPooledConnectionFactoryService.class, service.pcfInjector);
+        serviceBuilder.addDependencies(ConnectorServices.RESOURCE_ADAPTER_SERVICE_PREFIX.append(config.getResourceAdapter()));
         serviceBuilder.install();
         return service;
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSTopicService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSTopicService.java
@@ -17,22 +17,20 @@ package org.wildfly.extension.messaging.activemq.jms;
 
 
 
-import static org.wildfly.extension.messaging.activemq.jms.ExternalJMSQueueService.JMS_QUEUE_PREFIX;
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
-
+import java.util.Collection;
+import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
-import javax.jms.Message;
 import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueConnectionFactory;
-import javax.jms.QueueRequestor;
-import javax.jms.QueueSession;
-import javax.jms.Session;
 import javax.jms.Topic;
 import javax.naming.NamingException;
-import org.apache.activemq.artemis.api.core.RoutingType;
-import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener;
+import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.client.TopologyMember;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.ra.ActiveMQRAConnectionFactory;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.naming.NamingContext;
 import org.jboss.as.naming.NamingStore;
@@ -46,6 +44,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
  * Service responsible for creating and destroying a client {@code javax.jms.Topic}.
@@ -53,46 +52,71 @@ import org.jboss.msc.value.InjectedValue;
  * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
  */
 public class ExternalJMSTopicService implements Service<Topic> {
-    private final String name;
-    private final DestinationConfiguration config;
     static final String JMS_TOPIC_PREFIX = "jms.topic.";
+
     private final InjectedValue<NamingStore> namingStoreInjector = new InjectedValue<NamingStore>();
     private final InjectedValue<ExternalPooledConnectionFactoryService> pcfInjector = new InjectedValue<ExternalPooledConnectionFactoryService>();
 
     private Topic topic;
+    private final String topicName;
+    private final DestinationConfiguration config;
+    private ClientSessionFactory sessionFactory;
 
-    public ExternalJMSTopicService(String name) {
-        this.name = name;
+    private ExternalJMSTopicService(String name) {
+        this.topicName = JMS_TOPIC_PREFIX + name;
         this.config = null;
     }
 
     private ExternalJMSTopicService(final DestinationConfiguration config) {
-        this.name = config.getName();
+        this.topicName = JMS_TOPIC_PREFIX + config.getName();
         this.config = config;
     }
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
         NamingStore namingStore = namingStoreInjector.getOptionalValue();
-        if (namingStore != null) {
-            Queue managementQueue = config.getManagementQueue();
+        if(namingStore!= null) {
+            final Queue managementQueue = config.getManagementQueue();
             final NamingContext storeBaseContext = new NamingContext(namingStore, null);
             try {
-                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
-                try (QueueConnection connection = config.createQueueConnection(cf)) {
-                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-                    connection.start();
-                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
-                    Message m = session.createMessage();
-                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_TOPIC_PREFIX + name, JMS_TOPIC_PREFIX + name, config.isDurable(), RoutingType.MULTICAST.name());
-                    Message reply = requestor.request(m);
-                    ROOT_LOGGER.debugf("Creating topic " + JMS_TOPIC_PREFIX + name + " returned " + reply);
-                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
-                        throw ROOT_LOGGER.remoteDestinationCreationFailed(JMS_TOPIC_PREFIX + name, reply.getBody(String.class));
+                ConnectionFactory cf = (ConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                if (cf instanceof ActiveMQRAConnectionFactory) {
+                    ActiveMQRAConnectionFactory raCf = (ActiveMQRAConnectionFactory) cf;
+                    ServerLocator locator = raCf.getDefaultFactory().getServerLocator();
+                    sessionFactory = locator.createSessionFactory();
+                    ClusterTopologyListener listener = new ClusterTopologyListener() {
+                        @Override
+                        public void nodeUP(TopologyMember member, boolean last) {
+                            try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(false, member.getLive())) {
+                                MessagingLogger.ROOT_LOGGER.infof("Creating topic %s on node UP %s - %s", topicName, member.getNodeId(), member.getLive().toJson());
+                                config.createTopic(factory, managementQueue, topicName);
+                            } catch (JMSException | StartException ex) {
+                                MessagingLogger.ROOT_LOGGER.errorf(ex, "Creating topic %s on node UP %s failed", topicName, member.getLive().toJson());
+                                throw new RuntimeException(ex);
+                            }
+                            if (member.getBackup() != null) {
+                                try (ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(false, member.getBackup())) {
+                                    MessagingLogger.ROOT_LOGGER.infof("Creating topic %s on backup node UP %s - %s", topicName, member.getNodeId(), member.getBackup().toJson());
+                                    config.createTopic(factory, managementQueue, topicName);
+                                } catch (JMSException | StartException ex) {
+                                    throw new RuntimeException(ex);
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void nodeDown(long eventUID, String nodeID) {}
+                    };
+                    locator.addClusterTopologyListener(listener);
+                    Collection<TopologyMemberImpl> members = locator.getTopology().getMembers();
+                    if (members == null || members.isEmpty()) {
+                        config.createTopic(cf, managementQueue, topicName);
                     }
-                    ROOT_LOGGER.debugf("Topic %s has been created", JMS_TOPIC_PREFIX + name);
+                } else {
+                    config.createTopic(cf, managementQueue, topicName);
                 }
-            } catch (NamingException | JMSException ex) {
+            } catch (Exception ex) {
+                MessagingLogger.ROOT_LOGGER.errorf(ex, "Error starting the external queue service %s", ex.getMessage());
                 throw new StartException(ex);
             } finally {
                 try {
@@ -102,41 +126,15 @@ public class ExternalJMSTopicService implements Service<Topic> {
                 }
             }
         }
-        topic = ActiveMQJMSClient.createTopic(JMS_TOPIC_PREFIX + name);
+        topic = ActiveMQJMSClient.createTopic(topicName);
     }
+
 
     @Override
     public synchronized void stop(final StopContext context) {
-        NamingStore namingStore = namingStoreInjector.getOptionalValue();
-        if (namingStore != null) {
-            Queue managementQueue = config.getManagementQueue();
-            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
-            try {
-                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
-                try (QueueConnection connection = config.createQueueConnection(cf)) {
-                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
-                    connection.start();
-                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
-                    Message m = session.createMessage();
-                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", JMS_TOPIC_PREFIX + name, true, true);
-                    Message reply = requestor.request(m);
-                    ROOT_LOGGER.debugf("Deleting topic " + JMS_TOPIC_PREFIX + name + " returned " + reply);
-                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
-                        throw ROOT_LOGGER.remoteDestinationDeletionFailed(JMS_QUEUE_PREFIX + name, reply.getBody(String.class));
-                    }
-                    ROOT_LOGGER.debugf("Topic %s has been deleted", JMS_TOPIC_PREFIX + name);
-                }
-            } catch (NamingException | JMSException ex) {
-                throw new RuntimeException(ex);
-            } finally {
-                try {
-                    storeBaseContext.close();
-                } catch (NamingException ex) {
-                    throw new RuntimeException(ex);
-                }
-            }
+        if(sessionFactory != null) {
+            sessionFactory.close();
         }
-        topic = null;
     }
 
     @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSTopicService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalJMSTopicService.java
@@ -16,8 +16,27 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 
+
+import static org.wildfly.extension.messaging.activemq.jms.ExternalJMSQueueService.JMS_QUEUE_PREFIX;
+import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+import javax.jms.Session;
 import javax.jms.Topic;
+import javax.naming.NamingException;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.naming.NamingContext;
+import org.jboss.as.naming.NamingStore;
+import org.jboss.as.naming.service.NamingService;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -26,6 +45,7 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 
 /**
  * Service responsible for creating and destroying a client {@code javax.jms.Topic}.
@@ -34,21 +54,88 @@ import org.jboss.msc.service.StopContext;
  */
 public class ExternalJMSTopicService implements Service<Topic> {
     private final String name;
+    private final DestinationConfiguration config;
     static final String JMS_TOPIC_PREFIX = "jms.topic.";
+    private final InjectedValue<NamingStore> namingStoreInjector = new InjectedValue<NamingStore>();
+    private final InjectedValue<ExternalPooledConnectionFactoryService> pcfInjector = new InjectedValue<ExternalPooledConnectionFactoryService>();
 
     private Topic topic;
 
     public ExternalJMSTopicService(String name) {
         this.name = name;
+        this.config = null;
+    }
+
+    private ExternalJMSTopicService(final DestinationConfiguration config) {
+        this.name = config.getName();
+        this.config = config;
     }
 
     @Override
     public synchronized void start(final StartContext context) throws StartException {
+        NamingStore namingStore = namingStoreInjector.getOptionalValue();
+        if (namingStore != null) {
+            Queue managementQueue = config.getManagementQueue();
+            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
+            try {
+                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                try (QueueConnection connection = config.createQueueConnection(cf)) {
+                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+                    connection.start();
+                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
+                    Message m = session.createMessage();
+                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", JMS_TOPIC_PREFIX + name, JMS_TOPIC_PREFIX + name, config.isDurable(), RoutingType.MULTICAST.name());
+                    Message reply = requestor.request(m);
+                    ROOT_LOGGER.debugf("Creating topic " + JMS_TOPIC_PREFIX + name + " returned " + reply);
+                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                        throw ROOT_LOGGER.remoteDestinationCreationFailed(JMS_TOPIC_PREFIX + name, reply.getBody(String.class));
+                    }
+                    ROOT_LOGGER.debugf("Topic %s has been created", JMS_TOPIC_PREFIX + name);
+                }
+            } catch (NamingException | JMSException ex) {
+                throw new StartException(ex);
+            } finally {
+                try {
+                    storeBaseContext.close();
+                } catch (NamingException ex) {
+                    throw new StartException(ex);
+                }
+            }
+        }
         topic = ActiveMQJMSClient.createTopic(JMS_TOPIC_PREFIX + name);
     }
 
     @Override
     public synchronized void stop(final StopContext context) {
+        NamingStore namingStore = namingStoreInjector.getOptionalValue();
+        if (namingStore != null) {
+            Queue managementQueue = config.getManagementQueue();
+            final NamingContext storeBaseContext = new NamingContext(namingStore, null);
+            try {
+                QueueConnectionFactory cf = (QueueConnectionFactory) storeBaseContext.lookup(pcfInjector.getValue().getBindInfo().getAbsoluteJndiName());
+                try (QueueConnection connection = config.createQueueConnection(cf)) {
+                    QueueSession session = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+                    connection.start();
+                    QueueRequestor requestor = new QueueRequestor(session, managementQueue);
+                    Message m = session.createMessage();
+                    org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", JMS_TOPIC_PREFIX + name, true, true);
+                    Message reply = requestor.request(m);
+                    ROOT_LOGGER.debugf("Deleting topic " + JMS_TOPIC_PREFIX + name + " returned " + reply);
+                    if(!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+                        throw ROOT_LOGGER.remoteDestinationDeletionFailed(JMS_QUEUE_PREFIX + name, reply.getBody(String.class));
+                    }
+                    ROOT_LOGGER.debugf("Topic %s has been deleted", JMS_TOPIC_PREFIX + name);
+                }
+            } catch (NamingException | JMSException ex) {
+                throw new RuntimeException(ex);
+            } finally {
+                try {
+                    storeBaseContext.close();
+                } catch (NamingException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
         topic = null;
     }
 
@@ -60,6 +147,16 @@ public class ExternalJMSTopicService implements Service<Topic> {
     public static ExternalJMSTopicService installService(final String name, final ServiceName serviceName, final ServiceTarget serviceTarget) {
         final ExternalJMSTopicService service = new ExternalJMSTopicService(name);
         final ServiceBuilder<Topic> serviceBuilder = serviceTarget.addService(serviceName, service);
+        serviceBuilder.install();
+        return service;
+    }
+
+    public static ExternalJMSTopicService installRuntimeTopicService(final DestinationConfiguration config, final ServiceTarget serviceTarget, final ServiceName pcf) {
+        final ExternalJMSTopicService service = new ExternalJMSTopicService(config);
+        final ServiceBuilder<Topic> serviceBuilder = serviceTarget.addService(config.getDestinationServiceName(), service);
+        serviceBuilder.addDependency(NamingService.SERVICE_NAME, NamingStore.class, service.namingStoreInjector);
+        serviceBuilder.addDependency(pcf, ExternalPooledConnectionFactoryService.class, service.pcfInjector);
+        serviceBuilder.addDependencies(ConnectorServices.RESOURCE_ADAPTER_SERVICE_PREFIX.append(config.getResourceAdapter()));
         serviceBuilder.install();
         return service;
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -38,7 +38,6 @@ import static org.wildfly.extension.messaging.activemq.MessagingExtension.MESSAG
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshallers;
 import org.jboss.as.controller.AttributeParsers;
@@ -265,4 +264,7 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
         }
     }
 
+    private enum QualityOfServiceMode {
+        AT_MOST_ONCE, DUPLICATES_OK, ONCE_AND_ONLY_ONCE;
+    }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -858,4 +858,10 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 98, value = "Unable to load module %s - the module or one of its dependencies is missing [%s]")
     OperationFailedException moduleNotFound(String moduleName, String missingModule, @Cause ModuleNotFoundException e);
+
+    @Message(id = 99, value = "Creating the remote destination %s failed with error %s")
+    StartException remoteDestinationCreationFailed(String destinationName, String error);
+
+    @Message(id = 100, value = "Deleting the remote destination %s failed with error %s")
+    RuntimeException remoteDestinationDeletionFailed(String destinationName, String error);
 }


### PR DESCRIPTION
    * Creating queue / topic on deployments
    * Deleting queue / topic in undeployments
    * Looking for default ee resource adapter if none is specified.
    * Making @JMSConnectionFactoryDefinition work without internal broker.
    * Adding support for description of runtime external destinations.
    * Adding support for management address definition in the @JMSDestinationDefinition

 JIRA: https://issues.jboss.org/browse/WFLY-10493 
https://github.com/wildfly/wildfly-proposals/pull/78
