### PR TITLE
[WFLY-11165][WFLY-11271] stripping redundant dependencies in transactions

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -44,13 +44,11 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.as.deployment-repository"/>
         <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.as.network"/>
         <!-- need this for the endpoint service -->
         <module name="org.jboss.as.webservices.server.integration"/>
         <!-- need this for the endpoint security context -->
-        <module name="org.jboss.as.security"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.xts"/>
@@ -60,16 +58,11 @@
         <!-- need this to get the actual SPIProvider  -->
         <module name="org.jboss.ws.common"/>
         <module name="org.jboss.jandex"/>
-        <module name="org.jboss.weld.spi" />
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.core" />
-        <module name="org.jboss.as.weld"/>
         <module name="org.jboss.modules"/>
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.as.ejb3"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.narayana.compensations" />
         <module name="org.wildfly.transaction.client" />
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
@@ -35,7 +35,6 @@
         <module name="org.omg.api" />
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.jts"/>
-        <module name="org.apache.commons.logging"/>
         <module name="org.jboss.logging"/>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
@@ -34,7 +34,6 @@
     <dependencies>
         <module name="sun.jdk"/>
         <module name="org.omg.api" />
-        <module name="org.apache.commons.logging"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.jts.integration"/>
         <module name="org.jboss.jboss-transaction-spi"/>
@@ -44,7 +43,6 @@
         <module name="org.apache.activemq.artemis.journal"/>
         <module name="javax.orb.api"/>
         <module name="javax.enterprise.api"/>
-        <module name="org.jboss.weld.core"/>
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api" export="true" />
         <module name="org.wildfly.transaction.client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
@@ -29,27 +29,16 @@
     </resources>
 
     <dependencies>
-        <module name="javax.ejb.api" />
         <module name="org.jboss.jts" />
-        <module name="javax.xml.ws.api" />
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.spi" />
+        <!-- narayana compensations works directly with weld core -->
         <module name="org.jboss.weld.core" />
+        <module name="javax.xml.ws.api" />
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.xts" />
         <module name="javax.transaction.api" />
         <module name="org.jboss.logging" />
-        <module name="org.jboss.resteasy.resteasy-jaxrs" />
-        <module name="javax.ws.rs.api" />
         <module name="javax.servlet.api" />
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api"  export="true" />
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.jboss.narayana.txframework">
+    <!-- This module is deprecated and subject to being removed in a subsequent release. -->
+    <properties>
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
 
     <resources>
         <artifact name="${org.jboss.narayana.txframework:txframework}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -30,16 +30,19 @@
     </resources>
 
     <dependencies>
+        <module name="org.jboss.jts"/>
+
         <module name="javax.transaction.api"/>
         <module name="javax.resource.api"/>
-        <module name="org.jboss.jts"/>
+        <module name="javax.enterprise.api"/>
+
         <module name="org.jboss.ws.api" services="export"/>
         <module name="org.jboss.ws.jaxws-client" services="export"/>
         <module name="org.jboss.ws.cxf.jbossws-cxf-client" services="export"/>
-        <module name="org.jboss.logging"/>
         <module name="javax.xml.soap.api"/>
         <module name="javax.xml.ws.api"/>
         <module name="javax.xml.stream.api"/>
+
         <!-- this is needed to get javax.xml.namespace.QName but it would be better if it were exposed on its own -->
         <module name="javax.api"/>
         <!-- this is needed because our endpoints are not in a normal deployment and we need to be able
@@ -52,19 +55,12 @@
         <module name="javax.annotation.api"/>
         <!-- this is needed to ensure the JaxWS endpoint classes canb refer to HttpServletRequest etc -->
         <module name="javax.servlet.api"/>
-        <module name="javax.ejb.api" />
-        <module name="org.jboss.jts" />
-        <module name="javax.xml.ws.api" />
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.core" />
-        <module name="javax.enterprise.api"/>
-        <module name="javax.transaction.api" />
+
         <module name="org.jboss.logging" />
         <module name="org.jboss.narayana.compensations" export="true" />
         <module name="org.jboss.narayana.txframework" export="true" />
         <module name="javax.annotation.api"  export="true" />
         <module name="javax.interceptor.api"  export="true" />
-        <module name="org.jboss.weld.spi" />
 
         <!-- This dependency is required only if the
              xts subsystem is present. If it is the
@@ -77,10 +73,5 @@
           </imports>
         </module>
 
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/xts/pom.xml
+++ b/xts/pom.xml
@@ -121,10 +121,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-weld</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.jws</groupId>
             <artifactId>jsr181-api</artifactId>
         </dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11165
https://issues.jboss.org/browse/WFLY-11271

Removing depenencies of transaction module that are redundant - not used so they could be omitted.

/cc @bstansberry @yersan 