### PR TITLE
[WFLY-11276] Validate requirement for modules previously exported by javax.ejb.api on org.wildfly.extension.rts

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -61,9 +61,5 @@
         <module name="org.hibernate.validator" services="export"/>
         <module name="org.jboss.narayana.rts"/>
         <module name="org.wildfly.transaction.client"/>
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
These depedencies can be removed from org.wildfly.extension.rts:

```
<module name="javax.xml.rpc.api"/>
<module name="javax.rmi.api"/>
```

Reasons:
- All first level dependencies used by wildfly-rts.jar are accesible by the other depended-on modules
- wildfly-rts does not load a service from any of its dependencies using ServiceLoading
- There are not DUPs enabling any external configuration for resources exported by the removed modules.

Jira issue: https://issues.jboss.org/browse/WFLY-11276
CC @ochaloup 