### PR TITLE
[WFLY-11280] Upgrade jastow from 2.0.6.Final to 2.0.7.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <version.io.smallrye.smallrye-config>1.3.4</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
-        <version.io.undertow.jastow>2.0.6.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0.SP1</version.javax.enterprise>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11280 