### PR TITLE
[WFLY-11284] StandardConfigsXMLValidationUnitTestCase fails on legacy builds

### DIFF
--- a/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/AbstractValidationUnitTest.java
+++ b/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/AbstractValidationUnitTest.java
@@ -137,7 +137,7 @@ public class AbstractValidationUnitTest {
             }
             Map<String, BigDecimal> mostRecentVersions = new HashMap<>();
             Map<String, String> mostRecentNames = new HashMap<>();
-            Pattern pattern = Pattern.compile("(.*?)_(\\d)_(\\d).xsd");
+            Pattern pattern = Pattern.compile("(.*?)_(\\d+)_(\\d+).xsd");
             for(Map.Entry<String, File> entry : JBOSS_SCHEMAS_MAP.entrySet()) {
                 if (FUTURE_SCHEMA_FILES.contains(entry.getKey())) {
                     // not "current"; it's future.


### PR DESCRIPTION
This patch follows up https://github.com/wildfly/wildfly/pull/11700, where the pattern used in the test was adapted after jboss metadata upgrading.

Jira issue: https://issues.jboss.org/browse/WFLY-11284