### PR TITLE
[WFLY-11295] Upgrade WildFly Core 7.0.0.Alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>7.0.0.Alpha4</version.org.wildfly.core>
+        <version.org.wildfly.core>7.0.0.Alpha5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11295

----


## Release Notes - WildFly Core - Version 7.0.0.Alpha5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3473'>WFCORE-3473</a>] -         Update Http Core to 4.4.5 and Client to 4.5.4
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4174'>WFCORE-4174</a>] -         Update jackson-databind to 2.9.5 and mockserver-netty to 5.4.1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4175'>WFCORE-4175</a>] -         Undertow 2.0.14.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4187'>WFCORE-4187</a>] -         Undertow 2.0.15.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3966'>WFCORE-3966</a>] -         JwtValidator jku and kid header parameters
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4177'>WFCORE-4177</a>] -         LegacyKernelServiceInitializerImpl.reverseCheckConfig should default to AdditionalInitialization.MANAGEMENT
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3873'>WFCORE-3873</a>] -         SNI support for https-listeners
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4127'>WFCORE-4127</a>] -         Disable CLI paging with an option
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4144'>WFCORE-4144</a>] -         Add support for registering a single JVM / Server wide default SSLContext
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4116'>WFCORE-4116</a>] -         JDK 10: illegal reflective access by ClassReflectionIndex
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4120'>WFCORE-4120</a>] -         It is possible add modules as extensions when they are not really an extension
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4165'>WFCORE-4165</a>] -         The SuspendController is not exposed via a capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4166'>WFCORE-4166</a>] -         HttpListenerRegistryService is not exposed via a capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4173'>WFCORE-4173</a>] -         Do not register socket-binding bound attributes as metrics
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4182'>WFCORE-4182</a>] -         Minor typos in shutdown and reload help descriptions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4183'>WFCORE-4183</a>] -         ReadResourceHandler returns runtime values stored in the DMR model even if include-runtime=false
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4184'>WFCORE-4184</a>] -         ModelTestUtils.trimUndefinedChildren loses track of what object is undefined
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4186'>WFCORE-4186</a>] -         RBAC classification resources should not store default-xxx attribute values in the DMR model
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4189'>WFCORE-4189</a>] -         Hard coded failIfNoTests=true fails WF core build if no tests are executed
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4190'>WFCORE-4190</a>] -         Distinguish undefined metric value
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4191'>WFCORE-4191</a>] -         Fix IO Metrics Registration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4195'>WFCORE-4195</a>] -         CLI/Admin Console does not prompt for a reload after adding a new server-group to server-scoped-roles.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4196'>WFCORE-4196</a>] -         SNICombinedWithALPNTestCase fails with IBM JDK
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4198'>WFCORE-4198</a>] -         Remove org.dom4j dependency from the org.jboss.log4j.logmanager module
</li>
</ul>
                            
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4179'>WFCORE-4179</a>] -         Refactor MBeanRegistrationService from WildFly-Core to WildFly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4180'>WFCORE-4180</a>] -         Eliminate ServiceBuilder&#39;s addInjection() &amp; addInjectionValue() usages
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4194'>WFCORE-4194</a>] -         Eliminate ServiceBuilder&#39;s addDependencies() usages
</li>
</ul>
        