### PR TITLE
[WFLY-11290]: Look up of RemoteConnectionFactory with discovery-group is null.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
@@ -128,11 +128,11 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
                 }
             }
             service = new ExternalConnectionFactoryService(transportConfigurations, socketBindings, outboundSocketBindings, jmsFactoryType, ha);
-            builder.setInstance(service);
         }
+        builder.setInstance(service);
         builder.install();
         for (String entry : Common.ENTRIES.unwrap(context, model)) {
-            MessagingLogger.ROOT_LOGGER.infof("Referencing %s with JNDI name %s", serviceName, entry);
+            MessagingLogger.ROOT_LOGGER.debugf("Referencing %s with JNDI name %s", serviceName, entry);
             BinderServiceUtil.installBinderService(context.getServiceTarget(), entry, service, serviceName);
         }
     }


### PR DESCRIPTION
* Setting the service instance to the ServiceBuilder before installing the service.

JIRA: https://issues.jboss.org/browse/WFLY-11290