### PR TITLE
[WFLY-11303] Unnecessary registration of a CDI portable extension in Smallrye micro profile config

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/config-smallrye/main/module.xml
@@ -40,11 +40,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
         <module name="org.eclipse.microprofile.config.api"/>
-        <module name="org.jboss.as.weld" />
-        <module name="org.jboss.as.ee" />
         <module name="javax.enterprise.api" />
-        <module name="javax.annotation.api" />
     </dependencies>
 </module>

--- a/microprofile/config-smallrye/pom.xml
+++ b/microprofile/config-smallrye/pom.xml
@@ -19,7 +19,8 @@
   ~ License along with this software; if not, write to the Free
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -53,18 +54,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-ee</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-undertow</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-weld</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/SubsystemDeploymentProcessor.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/SubsystemDeploymentProcessor.java
@@ -25,19 +25,16 @@ package org.wildfly.extension.microprofile.config.smallrye.deployment;
 import java.util.List;
 
 import io.smallrye.config.SmallRyeConfigBuilder;
-import io.smallrye.config.inject.ConfigExtension;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.spi.ConfigBuilder;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
-import org.jboss.as.ee.weld.WeldDeploymentMarker;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-import org.jboss.as.weld.deployment.WeldPortableExtensions;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -69,12 +66,6 @@ public class SubsystemDeploymentProcessor implements DeploymentUnitProcessor {
         deploymentUnit.putAttachment(CONFIG_PROVIDER_RESOLVER, configProviderResolver);
 
         configProviderResolver.registerConfig(config, module.getClassLoader());
-
-        if (WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
-            WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(deploymentUnit);
-            extensions.registerExtensionInstance(new ConfigExtension(), deploymentUnit);
-        }
-
     }
 
     private void addConfigSourcesFromServices(ConfigBuilder builder, ServiceRegistry serviceRegistry, ClassLoader classloader) {


### PR DESCRIPTION
The ConfigExtension is being already registered automatically by Weld becuase it is found in the classpath, so it is unnecesary resgister it again in wildfly smallrye-config.

This PR also removes some unnecesary jboss modules and maven dependencies.

Jira issue: https://issues.jboss.org/browse/WFLY-11303

cc: @jmesnil 