### PR TITLE
[WFLY-11306] Validate requirement for modules previously exported by javax.ejb.api on org.jberet.jberet-core

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -41,12 +41,5 @@
         <module name="org.wildfly.security.elytron-private"/>
         <module name="com.google.guava"/>
         <module name="com.h2database.h2" optional="true"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api and
-             reexported by javaee.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-
     </dependencies>
 </module>


### PR DESCRIPTION
We can safely remove `javax.xml.rpc.api` and `javax.rmi.api`: 

- There are not first level dependencies of jberet-core.jar to those modules 
- jberet-core loads services implementing `org.jberet.spi.BatchEnvironment` and `org.jberet.spi.PartitionHandlerFactory`, but none of the removed modules uses/export services implementing any of those interfaces 
- I have not found external configurations that could make a reference to the removed modules

Jira issue: https://issues.jboss.org/browse/WFLY-11306 

Just for the record:
- it looks like we can remove `org.jboss.jts` module
- It seems jberet only uses `javax.enterprise.api`, `javax.inject.api`, `javax.annotation.api` and  `javax.batch.api` from `javaee.api`, maybe we could reduce the final size removing `javaee.api` and add only the required modules.