### PR TITLE
[WFLY-11071] Test checks the "Set-Cookie" response header if there is not undefined domain value.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationServerSetupTask.java
@@ -1,0 +1,116 @@
+package org.jboss.as.test.integration.web.headers.authentication;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.other.KeyStoreUtils;
+import org.wildfly.test.security.common.other.KeyUtils;
+
+import java.io.File;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ * Server setup task for test ResponseHeaderAuthenticationTestCase.
+ * Configures key-store and application-security-domain.
+ */
+public class ResponseHeaderAuthenticationServerSetupTask extends SnapshotRestoreSetupTask {
+
+    public static final String PASSWORD = "password1";
+    private static final String ALIAS = "single-sign-on";
+    private static final String KEYSTORE_FILE_NAME = "single-sign-on.jks";
+
+    @Override
+    public void doSetup(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+
+        // /subsystem=elytron/http-authentication-factory=application-http-authentication:add(http-server-mechanism-factory=global, security-domain=ApplicationDomain,mechanism-configurations=[{mechanism-name=BASIC, mechanism-realm-configurations=[{realm-name=Application Realm}]},{mechanism-name=FORM}])
+        ModelNode addHttpAuthenticationFactory = createOpNode("subsystem=elytron/http-authentication-factory=application-http-authentication", ADD);
+        addHttpAuthenticationFactory.get("http-server-mechanism-factory").set("global");
+        addHttpAuthenticationFactory.get("security-domain").set("ApplicationDomain");
+        addHttpAuthenticationFactory.get("mechanism-configurations").get(0).get("mechanism-name").set("BASIC");
+        addHttpAuthenticationFactory.get("mechanism-configurations").get(0).get("mechanism-realm-configurations").get(0).get("realm-name").set("Application Realm");
+        addHttpAuthenticationFactory.get("mechanism-configurations").get(1).get("mechanism-name").set("FORM");
+        operations.add(addHttpAuthenticationFactory);
+
+        // /subsystem=elytron/key-store=single-sign-on:add(path=single-sign-on.jks, type=JKS, relative-to=jboss.server.config.dir, credential-reference={clear-text=password})
+        ModelNode addKeyStore = createOpNode("subsystem=elytron/key-store=single-sign-on", ADD);
+        addKeyStore.get("path").set(KEYSTORE_FILE_NAME);
+        addKeyStore.get("type").set("JKS");
+        addKeyStore.get("relative-to").set("jboss.server.config.dir");
+        ModelNode credentialReference = new ModelNode();
+        credentialReference.get("clear-text").set(ResponseHeaderAuthenticationTestCase.PASSWORD);
+        addKeyStore.get("credential-reference").set(credentialReference);
+        operations.add(addKeyStore);
+
+        // /subsystem=undertow/application-security-domain=ApplicationDomain:add(http-authentication-factory=application-http-authentication)
+        ModelNode addSecurityDomain = createOpNode("subsystem=undertow/application-security-domain=ApplicationDomain", ADD);
+        addSecurityDomain.get("http-authentication-factory").set("application-http-authentication");
+        operations.add(addSecurityDomain);
+
+        // /subsystem=undertow/application-security-domain=ApplicationDomain/setting=single-sign-on:add(key-alias=single-sign-on, credential-reference={clear-text=password},key-store=single-sign-on)
+        ModelNode addSingleSignOn = createOpNode("subsystem=undertow/application-security-domain=ApplicationDomain/setting=single-sign-on", ADD);
+        addSingleSignOn.get("key-alias").set("single-sign-on");
+        addSingleSignOn.get("credential-reference").set(credentialReference);
+        addSingleSignOn.get("key-store").set("single-sign-on");
+        operations.add(addSingleSignOn);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+
+        this.createKeyStore();
+
+        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+    }
+
+    /**
+     * Creates key store with certificate and stores it on the path {$jboss.home}/standalone/configuration/single-sign-on.jks
+     *
+     * @throws Exception
+     */
+    private void createKeyStore() throws Exception {
+        File keyStoreFile = new File(TestSuiteEnvironment.getSystemProperty("jboss.home") + File.separator + "standalone"
+                + File.separator + "configuration" + File.separator + KEYSTORE_FILE_NAME);
+        keyStoreFile.createNewFile();
+
+        String serverName = "server";
+        KeyPair server = KeyUtils.generateKeyPair();
+        X509Certificate serverCert = KeyUtils.generateX509Certificate(serverName, server);
+
+        KeyStore keyStore = loadKeyStore();
+
+        // generate a key pair
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048, new SecureRandom());
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        PrivateKey signingKey = keyPair.getPrivate();
+
+        keyStore.setKeyEntry(ALIAS, signingKey, PASSWORD.toCharArray(), new X509Certificate[]{serverCert});
+
+        KeyStoreUtils.saveKeystore(keyStore, PASSWORD, keyStoreFile);
+    }
+
+    private static KeyStore loadKeyStore() throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, PASSWORD.toCharArray());
+        return ks;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationTestCase.java
@@ -1,0 +1,87 @@
+package org.jboss.as.test.integration.web.headers.authentication;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Test configures elytron with the key-store and security domain for undertow.
+ * Deploys application with the user/password form and fills the form with the predefined application user credentials.
+ * Test checks the "Set-Cookie" response header if there is not undefined domain value.
+ * Test for [ WFLY-11071 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(ResponseHeaderAuthenticationServerSetupTask.class)
+@RunAsClient
+public class ResponseHeaderAuthenticationTestCase {
+
+    public static final String PASSWORD = "password1";
+    private static final String DEPLOYMENT = "test";
+    private static final String DOMAIN_ATTRIBUTE = "domain=";
+
+    @Deployment(name=DEPLOYMENT)
+    public static Archive<?> createDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
+        war.addAsWebInfResource(ResponseHeaderAuthenticationTestCase.class.getPackage(), "web.xml", "/web.xml");
+        war.addAsWebInfResource(ResponseHeaderAuthenticationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebResource(ResponseHeaderAuthenticationTestCase.class.getPackage(), "login.html", "login.html");
+        war.addAsWebResource(ResponseHeaderAuthenticationTestCase.class.getPackage(), "index.jsp", "index.jsp");
+        war.addAsWebResource(ResponseHeaderAuthenticationTestCase.class.getPackage(), "error.jsp", "error.jsp");
+        return war;
+    }
+
+    /**
+     * Tests if the SSO response header has not domain value undefined.
+     *
+     * @param url
+     * @throws Exception
+     */
+    @Test
+    public void testResponseHeaderAuthentication(@ArquillianResource URL url) throws Exception {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            String appUrl = url.toExternalForm() + "j_security_check";
+
+            HttpPost httpPost = new HttpPost(appUrl);
+            httpPost.addHeader("Referer", url.toExternalForm() + "login.html");
+            List<NameValuePair> formParams = new ArrayList<>();
+            formParams.add(new BasicNameValuePair("j_username", "user1"));
+            formParams.add(new BasicNameValuePair("j_password", PASSWORD));
+            httpPost.setEntity(new UrlEncodedFormEntity(formParams, StandardCharsets.UTF_8));
+            HttpResponse response = httpClient.execute(httpPost);
+
+            Header[] setCookieHeaders = response.getHeaders("Set-Cookie");
+            for (Header header: setCookieHeaders) {
+                String headerValue = header.getValue();
+                if (headerValue.startsWith("JSESSIONIDSSO=") && headerValue.contains(DOMAIN_ATTRIBUTE)) {
+                    String domainValue = headerValue.split(DOMAIN_ATTRIBUTE)[1];
+                    assertNotEquals(domainValue, "undefined");
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/error.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/error.jsp
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>error</title>
+</head>
+<body>
+
+  error.jsp
+
+  <% // =exception %>
+
+  <%
+  out.println("message="+request.getAttribute("javax.servlet.error.message"));
+  %>
+
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/index.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/index.jsp
@@ -1,0 +1,12 @@
+<html>
+<body>
+  <h2>Hello <%=request.getUserPrincipal().getName()%>!</h2>
+  <%
+    StackTraceElement[] s = Thread.currentThread().getStackTrace();
+    for (int i = 0; i < s.length; i++) {
+        System.out.println(i + " : " + s[i]);
+    }
+  %>
+
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/jboss-web.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+    <security-domain>ApplicationDomain</security-domain>
+</jboss-web>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/login.html
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/login.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Test</title>
+</head>
+<body>
+<form method="POST" action="j_security_check" name="loginform">
+    <input type="text" name="j_username" size="16">
+    <input type="password" name="j_password" size="16">
+    <input type="submit" value="login">
+</form>
+</body>
+</html>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+        metadata-complete="true"
+        version="3.0">
+    <display-name>test</display-name>
+    <security-constraint>
+        <display-name>guest</display-name>
+        <web-resource-collection>
+            <web-resource-name>/*</web-resource-name>
+            <url-pattern>/secure/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <realm-name>test</realm-name>
+        <form-login-config>
+            <form-login-page>/login.html</form-login-page>
+            <form-error-page>/error.jsp</form-error-page>
+        </form-login-config>
+    </login-config>
+    <security-role>
+        <role-name>guest</role-name>
+    </security-role>
+    <session-config/>
+    <distributable/>
+</web-app>


### PR DESCRIPTION
Test configures elytron with the key-store and security domain for undertow.
Deploys application with the user/password form and fills the form with the predefined application user credentials.
Test checks the "Set-Cookie" response header if there is not undefined domain value.

Upstream JIRA issue: [WFLY-11071](https://issues.jboss.org/browse/WFLY-11071)