### PR TITLE
[WFLY-11318] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.ws.common

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -36,7 +36,6 @@
         <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.xml.stream.api"/>
-        <module name="javax.ejb.api"/>
         <module name="javax.jws.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.wsdl4j.api" />
@@ -46,11 +45,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.jboss.jaxbintros"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Removes from `org.jboss.ws.common` modules that were previously exported by `javax.ejb.api`.

- `javax.xml.rpc.api` is still required by classes in jbossws-common.jar, but the other modules can be removed
- None of the removed modules exports services, so looks fine for any service loader executed in  jbossws-common.jar
- I cannot find an external configuration that could require a class exported by the removed modules.  @asoldano , could you also take a look to this point when you have a chance?

Jira issue: https://issues.jboss.org/browse/WFLY-11318

Additional notes: 
From my analisys, it looks like these dependencies are also unused `org.apache.xerces` and `javax.xml.stream.api`, but I'm not sure yet if they can be removed. 