### PR TITLE
[WFLY-10712] Observability: MicroProfile Metrics 

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.batch.jberet.deployment;
 
+import static org.jboss.as.server.deployment.Attachments.DEPLOYMENT_COMPLETE_SERVICES;
+
 import javax.enterprise.inject.spi.BeanManager;
 
 import org.jberet.repository.JobRepository;
@@ -158,7 +160,8 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
             serviceBuilder.install();
 
             // Install the JobOperatorService
-            Services.addServerExecutorDependency(serviceTarget.addService(BatchServiceNames.jobOperatorServiceName(deploymentUnit), jobOperatorService)
+            ServiceName jobOperatorServiceName = BatchServiceNames.jobOperatorServiceName(deploymentUnit);
+            Services.addServerExecutorDependency(serviceTarget.addService(jobOperatorServiceName, jobOperatorService)
                             .addDependency(support.getCapabilityServiceName(Capabilities.BATCH_CONFIGURATION_CAPABILITY.getName()), BatchConfiguration.class, jobOperatorService.getBatchConfigurationInjector())
                             .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, jobOperatorService.getSuspendControllerInjector())
                             .addDependency(BatchServiceNames.batchEnvironmentServiceName(deploymentUnit), SecurityAwareBatchEnvironment.class, jobOperatorService.getBatchEnvironmentInjector()),
@@ -167,6 +170,7 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
 
             // Add the JobOperatorService to the deployment unit
             deploymentUnit.putAttachment(BatchAttachments.JOB_OPERATOR, jobOperatorService);
+            deploymentUnit.addToAttachmentList(DEPLOYMENT_COMPLETE_SERVICES, jobOperatorServiceName);
 
             // Add the JobOperator to the context selector
             selector.registerContext(moduleClassLoader, JobOperatorContext.create(jobOperatorService));

--- a/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
@@ -38,6 +38,10 @@ include::subsystem-configuration/Messaging.adoc[]
 
 include::subsystem-configuration/MicroProfile_Config_SmallRye.adoc[]
 
+include::subsystem-configuration/MicroProfile_Health.adoc[]
+
+include::subsystem-configuration/MicroProfile_Metric.adoc[]
+
 include::subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc[]
 
 include::subsystem-configuration/Security.adoc[]

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -1,0 +1,85 @@
+[[MicroProfile_Metrics_SmallRye]]
+= MicroProfile Metrics Subsystem Configuration
+
+Support for https://microprofile.io/project/eclipse/microprofile-metrics[Eclipse MicroProfile Metrics] is provided by
+ the _microprofile-metrics-smallrye_ subsystem.
+
+[[required-extension]]
+== Required Extension
+
+This extension is included in all the standalone configurations included in the
+WildFly distribution.
+
+You can also add the extension to a configuration without it either by adding
+an `<extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>`
+element to the xml or by using the following CLI operation:
+
+[source,ruby]
+----
+[standalone@localhost:9990 /]/extension=org.wildfly.extension.microprofile.metrics-smallrye:add
+----
+
+== Management Model
+
+The `/subsystem=microprofile-metrics-smallrye` resource defines two attributes:
+
+* `security-enabled` - a boolean to indicate whether authentication is required to access the HTTP metrics endpoint (described below). By default, it is `true`. The
+standalone configurations explicitly sets it to `false` to accept unauthenticated access to the HTTP endpoints.
+* `exposed-subsystems` - a list of strings corresponding to the names of subsystems that exposes their metrics in the HTTP metrics endpoints.
+  By default, it is not defined (there will be no metrics exposed by subsystem. The special wildcard `*` can be used to expose metrics from _all_ subsystems. The standalone
+  configuration sets this attribute to `*`.
+
+== HTTP Endpoint
+
+The Metric HTTP endpoint is accessible on WildFly HTTP management interface http://localhost:9990/metrics[http://localhost:9990/metrics].
+
+Secured access to the HTTP endpoint is controlled by the `security-enabled` attribute of the `/subsystem=microprofile-metrics-smallrye` resource.
+If it is set to `true`, the HTTP client must be authenticated.
+
+If the application server is healthy, it will return a `200 OK` response:
+
+----
+$ curl -v http://localhost:9990/metrics
+< HTTP/1.1 200 OK
+...
+# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution
+.
+# TYPE base:classloader_total_loaded_class_count counter
+base:classloader_total_loaded_class_count 10822.0
+...
+----
+
+If security has been enabled, the HTTP client must pass the credentials corresponding to a management user
+created by the `add-user` script. For example:
+
+----
+$ curl -v --digest -u myadminuser:myadminpassword http://localhost:9990/metrics
+< HTTP/1.1 200 OK
+...
+# HELP base:classloader_total_loaded_class_count Displays the total number of classes that have been loaded since the Java virtual machine has started execution
+.
+# TYPE base:classloader_total_loaded_class_count counter
+base:classloader_total_loaded_class_count 10822.0
+...
+----
+
+If the authentication fails, the  server will reply with a `401 NOT AUTHORIZED` response.
+
+== Exposed Metrics
+
+The HTTP endpoint exposes the following metrics:
+
+* Base metrics - Required metrics specified in the MicroProfile 1.1 specification are exposed in the `base`  scope.
+* Vendor metrics - Metrics from WildFly subsystems are exposed in the `vendor` scope
+* Application metrics - Metrics from the application and from the deployment's subsystems are exposed in the `application` scope.
+
+== Component Reference
+
+The Eclipse MicroProfile Health is implemented by the SmallRye Health project.
+
+****
+
+* https://microprofile.io/project/eclipse/microprofile-metrics[Eclipse MicroProfile Metrics]
+* http://github.com/smallrye/smallrye-metrics/[SmallRye Metrics]
+
+****

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2926,6 +2926,39 @@
         </dependency>
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-metrics-smallrye</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
         <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-mod_cluster-extension</artifactId>
             <exclusions>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -28,6 +28,7 @@
         <subsystem>messaging-activemq-colocated.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -26,6 +26,7 @@
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-jts.xml
@@ -25,6 +25,7 @@
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-picketlink.xml
@@ -26,6 +26,7 @@
         <subsystem>messaging-activemq.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>picketlink-federation.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-rts.xml
@@ -27,6 +27,7 @@
         <subsystem>messaging-activemq.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-xts.xml
@@ -26,6 +26,7 @@
         <subsystem>messaging-activemq.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -24,6 +24,7 @@
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="io.smallrye.metrics">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${io.smallrye:smallrye-metrics}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.eclipse.microprofile.config.api" />
+        <module name="org.eclipse.microprofile.metrics.api" />
+        <module name="org.jboss.logging" />
+        <module name="javax.enterprise.api" />
+        <module name="javax.annotation.api" />
+        <module name="javax.json.api" />
+        <module name="org.jboss.weld.core" />
+        <module name="org.jboss.weld.spi" />
+    </dependencies>
+</module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/metrics/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/microprofile/metrics/api/main/module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.eclipse.microprofile.metrics.api">
+    <resources>
+        <artifact name="${org.eclipse.microprofile.metrics:microprofile-metrics-api}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.enterprise.api" />
+        <module name="org.eclipse.microprofile.config.api" />
+        <module name="org.jboss.weld.core" />
+        <module name="org.jboss.weld.spi" />
+    </dependencies>
+</module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/metrics-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/metrics-smallrye/main/module.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.metrics-smallrye">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.wildfly:wildfly-microprofile-metrics-smallrye}"/>
+    </resources>
+
+    <dependencies>
+        <module name="io.smallrye.metrics" export="true"/>
+        <module name="io.undertow.core"/>
+        <module name="javax.api"/>
+        <module name="org.eclipse.microprofile.metrics.api" />
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.core-security"/>
+        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.extension.microprofile.config-smallrye" />
+        <module name="javax.enterprise.api" />
+        <module name="javax.annotation.api" />
+    </dependencies>
+</module>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1344,6 +1344,17 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-opentracing</artifactId>
             <exclusions>
                 <exclusion>
@@ -1635,6 +1646,17 @@
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -3085,6 +3107,17 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-microprofile-health-smallrye</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-metrics-smallrye</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/galleon-pack/src/main/resources/feature_groups/domain-host-excludes.xml
+++ b/galleon-pack/src/main/resources/feature_groups/domain-host-excludes.xml
@@ -7,26 +7,31 @@
 
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly10.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;,&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly10.1"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.core-management&quot;,&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.discovery&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.elytron&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;,&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly11.0"/>
         <param name="host-release" value="WildFly11.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;,&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly12.0"/>
         <param name="host-release" value="WildFly12.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.ee-security&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;,&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly13.0"/>
         <param name="host-release" value="WildFly13.0"/>
-        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;]"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.datasources-agroal&quot;,&quot;org.wildfly.extension.microprofile.config-smallrye&quot;,&quot;org.wildfly.extension.microprofile.health-smallrye&quot;,&quot;org.wildfly.extension.microprofile.opentracing-smallrye&quot;,&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
+    </feature>
+    <feature spec="domain.host-exclude">
+        <param name="host-exclude" value="WildFly14.0"/>
+        <param name="host-release" value="WildFly14.0"/>
+        <param name="excluded-extensions" value="[&quot;org.wildfly.extension.microprofile.metrics-smallrye&quot;]"/>
     </feature>
     <feature spec="domain.host-exclude">
         <param name="host-exclude" value="WildFly14.0"/>

--- a/galleon-pack/src/main/resources/feature_groups/metrics.xml
+++ b/galleon-pack/src/main/resources/feature_groups/metrics.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="metrics" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.microprofile-metrics-smallrye">
+      <param name="security-enabled" value="false"/>
+      <param name="exposed-subsystems" value="[*]" />
+    </feature>
+</feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-ha.xml
@@ -22,6 +22,7 @@
     <feature-group name="management-interfaces"/>
     <feature-group name="access-control"/>
     <feature-group name="health"/>
+    <feature-group name="metrics" />
 
     <origin name="org.wildfly:wildfly-servlet-galleon-pack">
         <feature-group name="standalone-profile"/>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-profile.xml
@@ -7,5 +7,6 @@
 
     <feature-group name="basic-profile"/>
     <feature-group name="health"/>
+    <feature-group name="metrics" />
 
 </feature-group-spec>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -87,6 +87,7 @@
                 <extension>org.wildfly.extension.messaging-activemq</extension>
                 <extension>org.wildfly.extension.microprofile.config-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.health-smallrye</extension>
+                <extension>org.wildfly.extension.microprofile.metrics-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.opentracing-smallrye</extension>
                 <extension>org.wildfly.extension.picketlink</extension>
                 <extension>org.wildfly.extension.rts</extension>
@@ -117,6 +118,7 @@
                 <extension>org.wildfly.extension.messaging-activemq</extension>
                 <extension>org.wildfly.extension.microprofile.config-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.health-smallrye</extension>
+                <extension>org.wildfly.extension.microprofile.metrics-smallrye</extension>
                 <extension>org.wildfly.extension.microprofile.opentracing-smallrye</extension>
                 <extension>org.wildfly.extension.picketlink</extension>
                 <extension>org.wildfly.extension.rts</extension>

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/DeploymentRestResourcesDefintion.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/DeploymentRestResourcesDefintion.java
@@ -135,7 +135,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadOnlyAttribute(RESOURCE_CLASS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerMetric(RESOURCE_CLASS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,
@@ -143,7 +143,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
                 response.set(className);
             }
         });
-        resourceRegistration.registerReadOnlyAttribute(RESOURCE_PATHS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerMetric(RESOURCE_PATHS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,
@@ -154,7 +154,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
             }
         });
 
-        resourceRegistration.registerReadOnlyAttribute(SUB_RESOURCE_LOCATORS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerMetric(SUB_RESOURCE_LOCATORS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/DeploymentRestResourcesDefintion.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/DeploymentRestResourcesDefintion.java
@@ -135,7 +135,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerMetric(RESOURCE_CLASS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerReadOnlyAttribute(RESOURCE_CLASS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,
@@ -143,7 +143,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
                 response.set(className);
             }
         });
-        resourceRegistration.registerMetric(RESOURCE_PATHS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerReadOnlyAttribute(RESOURCE_PATHS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,
@@ -154,7 +154,7 @@ public class DeploymentRestResourcesDefintion extends SimpleResourceDefinition {
             }
         });
 
-        resourceRegistration.registerMetric(SUB_RESOURCE_LOCATORS, new AbstractRestResReadHandler() {
+        resourceRegistration.registerReadOnlyAttribute(SUB_RESOURCE_LOCATORS, new AbstractRestResReadHandler() {
             @Override
             void handleAttribute(String className, List<JaxrsResourceMethodDescription> methodInvokers,
                     List<JaxrsResourceLocatorDescription> locatorIncokers, Collection<String> servletMappings,

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-parent</artifactId>
+        <!--
+        Maintain separation between the artifact id and the version to help prevent
+        merge conflicts between commits changing the GA and those changing the V.
+        -->
+        <version>15.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-microprofile-metrics-smallrye</artifactId>
+
+    <name>WildFly: MicroProfile Metrics Extension With SmallRye</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-config-smallrye</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-ee</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-undertow</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-weld</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-subsystem-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsContextService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsContextService.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.MetricsRequestHandler;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.server.mgmt.domain.ExtensibleHttpManagement;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MetricsContextService implements Service {
+
+    static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("extension", "metrics", "context");
+
+    private static final String CONTEXT_NAME = "metrics";
+
+    private final Supplier<ExtensibleHttpManagement> extensibleHttpManagement;
+    private final boolean securityEnabled;
+    private final MetricsRequestHandler metricsRequestHandler;
+
+    static void install(OperationContext context, boolean securityEnabled) {
+        ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(SERVICE_NAME);
+
+        Supplier<ExtensibleHttpManagement> extensibleHttpManagement = serviceBuilder.requires(context.getCapabilityServiceName(MicroProfileMetricsSubsystemDefinition.HTTP_EXTENSIBILITY_CAPABILITY, ExtensibleHttpManagement.class));
+
+        Service healthContextService = new MetricsContextService(extensibleHttpManagement, securityEnabled, new MetricsRequestHandler());
+
+        serviceBuilder.setInstance(healthContextService)
+                .install();
+    }
+
+    MetricsContextService(Supplier<ExtensibleHttpManagement> extensibleHttpManagement, boolean securityEnabled, MetricsRequestHandler metricsRequestHandler) {
+        this.extensibleHttpManagement = extensibleHttpManagement;
+        this.securityEnabled = securityEnabled;
+        this.metricsRequestHandler = metricsRequestHandler;
+    }
+
+    @Override
+    public void start(StartContext context) {
+        extensibleHttpManagement.get().addManagementHandler(CONTEXT_NAME, securityEnabled,
+                new HttpHandler() {
+                    boolean checkMetrics = true;
+
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+
+                        if (checkMetrics) {
+                          checkMetrics();
+                          checkMetrics = false;
+                        }
+
+                        String requestPath = exchange.getRequestPath();
+                        String method = exchange.getRequestMethod().toString();
+                        HeaderValues acceptHeaders = exchange.getRequestHeaders().get(Headers.ACCEPT);
+                        metricsRequestHandler.handleRequest(requestPath, method, acceptHeaders == null ? null : acceptHeaders.stream(), (status, message, headers) -> {
+                            exchange.setStatusCode(status);
+                            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                                exchange.getResponseHeaders().put(new HttpString(entry.getKey()), entry.getValue());
+                            }
+                            exchange.getResponseSender().send(message);
+                        });
+                    }
+                });
+    }
+
+    /**
+     * Check that the gauge metric registered in the vendor scope are actually returning a value.
+     *
+     * Some metrics from WildFly could return "undefined" values (when the corresponding statistics-enabled flag is false).
+     * We check them when the 1st HTTP request is served so that smallrye-metrics will only have "correct" metric
+     * (with numeric values) in the Vendor registry.
+     */
+    private synchronized void checkMetrics() {
+        MetricRegistry vendorRegistry = MetricRegistries.get(MetricRegistry.Type.VENDOR);
+        Iterator<Map.Entry<String, Metric>> iterator = vendorRegistry.getMetrics().entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, Metric> entry = iterator.next();
+            Metric metric = entry.getValue();
+            if (metric instanceof Gauge) {
+                Gauge gauge = (Gauge) metric;
+                try {
+                    gauge.getValue();
+                } catch (Exception e) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        extensibleHttpManagement.get().removeContext(CONTEXT_NAME);
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
@@ -1,0 +1,315 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNIT;
+import static org.wildfly.extension.microprofile.config.smallrye.ServiceNames.CONFIG_PROVIDER;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.CLIENT_FACTORY_CAPABILITY;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.MANAGEMENT_EXECUTOR;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.WILDFLY_REGISTRATION_SERVICE;
+import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+
+import io.smallrye.metrics.ExtendedMetadata;
+import io.smallrye.metrics.MetricRegistries;
+import io.smallrye.metrics.setup.JmxRegistrar;
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.jboss.as.controller.LocalModelControllerClient;
+import org.jboss.as.controller.ModelControllerClientFactory;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+public class MetricsRegistrationService implements Service<MetricsRegistrationService> {
+
+    private final ImmutableManagementResourceRegistration rootResourceRegistration;
+    private final Resource rootResource;
+    private final Supplier<ModelControllerClientFactory> modelControllerClientFactory;
+    private final Supplier<Executor> managementExecutor;
+    private final List<String> exposedSubsystems;
+    private final boolean exposeAnySubsystem;
+    private JmxRegistrar jmxRegistrar;
+    private LocalModelControllerClient modelControllerClient;
+
+    static void install(OperationContext context, List<String> exposedSubsystems) {
+        ImmutableManagementResourceRegistration rootResourceRegistration = context.getRootResourceRegistration();
+        Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+
+        ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(WILDFLY_REGISTRATION_SERVICE);
+        Supplier<ModelControllerClientFactory> modelControllerClientFactory = serviceBuilder.requires(context.getCapabilityServiceName(CLIENT_FACTORY_CAPABILITY, ModelControllerClientFactory.class));
+        Supplier<Executor> managementExecutor = serviceBuilder.requires(context.getCapabilityServiceName(MANAGEMENT_EXECUTOR, Executor.class));
+        serviceBuilder.requires(CONFIG_PROVIDER);
+        MetricsRegistrationService service = new MetricsRegistrationService(rootResourceRegistration, rootResource, modelControllerClientFactory, managementExecutor, exposedSubsystems);
+        serviceBuilder.setInstance(service)
+                .install();
+    }
+
+    public MetricsRegistrationService(ImmutableManagementResourceRegistration rootResourceRegistration, Resource rootResource, Supplier<ModelControllerClientFactory> modelControllerClientFactory, Supplier<Executor> managementExecutor, List<String> exposedSubsystems) {
+        this.rootResourceRegistration = rootResourceRegistration;
+        this.rootResource = rootResource;
+        this.modelControllerClientFactory = modelControllerClientFactory;
+        this.managementExecutor = managementExecutor;
+        this.exposedSubsystems = exposedSubsystems;
+        this.exposeAnySubsystem = exposedSubsystems.remove("*");
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        jmxRegistrar = new JmxRegistrar();
+        try {
+            jmxRegistrar.init();
+        } catch (IOException e) {
+            throw LOGGER.failedInitializeJMXRegistrar(e);
+        }
+
+        modelControllerClient = modelControllerClientFactory.get().createClient(managementExecutor.get());
+        // register metrics from WildFly subsystems in the VENDOR metric registry
+        registerMetrics(rootResource,
+                rootResourceRegistration,
+                MetricRegistries.get(MetricRegistry.Type.VENDOR),
+                (address, attributeName) -> address.toPathStyleString().substring(1) + "/" + attributeName);
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        for (MetricRegistry registry : new MetricRegistry[]{
+                MetricRegistries.get(MetricRegistry.Type.BASE),
+                MetricRegistries.get(MetricRegistry.Type.VENDOR)}) {
+            for (String name : registry.getNames()) {
+                registry.remove(name);
+            }
+        }
+
+        modelControllerClient.close();
+        jmxRegistrar = null;
+    }
+
+    @Override
+    public MetricsRegistrationService getValue() {
+        return this;
+    }
+
+    public interface MetricNameCreator {
+        String createName(PathAddress address, String attributeName);
+
+        default PathAddress getResourceAddress(PathAddress address) {
+            return address;
+        }
+    }
+
+    public Set<String> registerMetrics(Resource rootResource,
+                                       ImmutableManagementResourceRegistration managementResourceRegistration,
+                                       MetricRegistry metricRegistry,
+                                       MetricNameCreator metricNameCreator) {
+        Map<PathAddress, Map<String, ModelNode>> metrics = findMetrics(rootResource, managementResourceRegistration);
+        Set<String> registeredMetrics = registerMetrics(metrics, metricRegistry, metricNameCreator);
+        return registeredMetrics;
+    }
+
+
+    private Map<PathAddress, Map<String, ModelNode>> findMetrics(Resource rootResource, ImmutableManagementResourceRegistration managementResourceRegistration) {
+        Map<PathAddress, Map<String, ModelNode>> metrics = new HashMap<>();
+        collectMetrics(rootResource, managementResourceRegistration, PathAddress.EMPTY_ADDRESS, metrics);
+        return metrics;
+    }
+
+    private void collectMetrics(final Resource current, ImmutableManagementResourceRegistration managementResourceRegistration, final PathAddress address, Map<PathAddress, Map<String, ModelNode>> collectedMetrics) {
+
+        if (!isExposingMetrics(address)) {
+            return;
+        }
+
+        Map<String, AttributeAccess> attributes = managementResourceRegistration.getAttributes(address);
+        ModelNode description = null;
+        for (Map.Entry<String, AttributeAccess> entry : attributes.entrySet()) {
+            String attributeName = entry.getKey();
+            AttributeAccess attributeAccess = entry.getValue();
+            if (attributeAccess.getAccessType() == AttributeAccess.AccessType.METRIC
+                    && attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME) {
+                if (description == null) {
+                    DescriptionProvider modelDescription = managementResourceRegistration.getModelDescription(address);
+                    description = modelDescription.getModelDescription(Locale.getDefault());
+                }
+
+                Map<String, ModelNode> metricsForResource = collectedMetrics.get(address);
+                if (metricsForResource == null) {
+                    metricsForResource = new HashMap<>();
+                }
+                metricsForResource.put(attributeName, description.get(ATTRIBUTES, attributeName));
+                collectedMetrics.put(address, metricsForResource);
+            }
+        }
+
+        for (String type : current.getChildTypes()) {
+            if (current.hasChildren(type)) {
+                for (Resource.ResourceEntry entry : current.getChildren(type)) {
+                    final PathElement pathElement = entry.getPathElement();
+                    final PathAddress childAddress = address.append(pathElement);
+                    collectMetrics(entry, managementResourceRegistration, childAddress, collectedMetrics);
+                }
+            }
+        }
+    }
+
+    public Set<String> registerMetrics(Map<PathAddress, Map<String, ModelNode>> metrics, MetricRegistry registry, MetricNameCreator metricNameCreator) {
+        Set<String> registeredMetricNames = new HashSet<>();
+
+        for (Map.Entry<PathAddress, Map<String, ModelNode>> entry : metrics.entrySet()) {
+            PathAddress address = entry.getKey();
+            for (Map.Entry<String, ModelNode> wildflyMetric : entry.getValue().entrySet()) {
+                String attributeName = wildflyMetric.getKey();
+                ModelNode attributeDescription = wildflyMetric.getValue();
+
+                String metricName = metricNameCreator.createName(address, attributeName);
+                String unit = attributeDescription.get(UNIT).asString(MetricUnits.NONE).toLowerCase();
+                String description = attributeDescription.get(DESCRIPTION).asStringOrNull();
+
+                Metadata metadata = new ExtendedMetadata(metricName, attributeName + " for " + address.toHttpStyleString(), description, MetricType.GAUGE, unit);
+
+                ModelType type = attributeDescription.get(TYPE).asType();
+
+                switch (type) {
+                    // simple numerical type
+                    case BIG_DECIMAL:
+                    case BIG_INTEGER:
+                    case DOUBLE:
+                    case INT:
+                    case LONG:
+                        break;
+                    case BYTES:
+                    case LIST:
+                    case OBJECT:
+                    case PROPERTY:
+                    case EXPRESSION:
+                    case BOOLEAN:
+                    case STRING:
+                    case TYPE:
+                    case UNDEFINED:
+                    default:
+                        LOGGER.debugf("Type %s is not supported for MicroProfile Metrics, the attribute %s on %s will not be registered.", type, attributeName, address);
+                        continue;
+                }
+                Metric metric = new Gauge() {
+                    @Override
+                    public Number getValue() {
+                        final ModelNode readAttributeOp = new ModelNode();
+                        readAttributeOp.get(OP).set(READ_ATTRIBUTE_OPERATION);
+                        readAttributeOp.get(OP_ADDR).set(metricNameCreator.getResourceAddress(address).toModelNode());
+                        readAttributeOp.get(ModelDescriptionConstants.INCLUDE_UNDEFINED_METRIC_VALUES).set(true);
+                        readAttributeOp.get(NAME).set(attributeName);
+                        ModelNode response = modelControllerClient.execute(readAttributeOp);
+                        String error = getFailureDescription(response);
+                        if (error != null) {
+                            registry.remove(metricName);
+                            throw LOGGER.unableToReadAttribute(attributeName, address, error);
+                        }
+                        ModelNode result = response.get(RESULT);
+                        if (result.isDefined()) {
+                            try {
+                                switch (type) {
+                                    case INT:
+                                        return result.asInt();
+                                    case LONG:
+                                        return result.asLong();
+                                    default:
+                                        // handle other numerical types as Double
+                                        return result.asDouble();
+                                }
+                            } catch (Exception e) {
+                                throw LOGGER.unableToConvertAttribute(attributeName, address, e);
+                            }
+                        } else {
+                            registry.remove(metricName);
+                            throw LOGGER.undefinedMetric(attributeName, address);
+                        }
+                    }
+                };
+                registry.register(metadata, metric);
+                registeredMetricNames.add(metadata.getName());
+            }
+        }
+        return registeredMetricNames;
+    }
+
+    private boolean isExposingMetrics(PathAddress address) {
+        // root resource
+        if (address.size() == 0) {
+            return true;
+        }
+        if (address.getElement(0).getKey().equals(SUBSYSTEM)) {
+            String subsystemName = address.getElement(0).getValue();
+            return exposeAnySubsystem || exposedSubsystems.contains(subsystemName);
+        }
+        // do not expose metrics for resources outside the subsystems.
+        return false;
+    }
+
+    private boolean isMetric(AttributeAccess attributeAccess) {
+        if (attributeAccess.getAccessType() == AttributeAccess.AccessType.METRIC && attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME) {
+            return true;
+        }
+        return false;
+    }
+
+    private String getFailureDescription(ModelNode result) {
+        if (result.hasDefined(FAILURE_DESCRIPTION)) {
+            return result.get(FAILURE_DESCRIPTION).toString();
+        }
+        return null;
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsExtension.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsExtension.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileMetricsExtension implements Extension {
+
+    static final String EXTENSION_NAME = "org.wildfly.extension.microprofile.metrics.smallrye";
+
+    /**
+     * The name of our subsystem within the model.
+     */
+    public static final String SUBSYSTEM_NAME = "microprofile-metrics-smallrye";
+
+    protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+
+    private static final String RESOURCE_NAME = MicroProfileMetricsExtension.class.getPackage().getName() + ".LocalDescriptions";
+
+    protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_1_0_0;
+
+    private static final MicroProfileMetricsParser_1_0 CURRENT_PARSER = new MicroProfileMetricsParser_1_0();
+
+    static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {
+        return getResourceDescriptionResolver(true, keyPrefix);
+
+    }
+
+    static ResourceDescriptionResolver getResourceDescriptionResolver(final boolean useUnprefixedChildTypes, final String... keyPrefix) {
+        StringBuilder prefix = new StringBuilder();
+        for (String kp : keyPrefix) {
+            if (prefix.length() > 0){
+                prefix.append('.');
+            }
+            prefix.append(kp);
+        }
+        return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, MicroProfileMetricsParser_1_0.class.getClassLoader(), true, useUnprefixedChildTypes);
+    }
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
+        subsystem.registerXMLElementWriter(CURRENT_PARSER);
+
+        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new MicroProfileMetricsSubsystemDefinition());
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileMetricsParser_1_0.NAMESPACE, CURRENT_PARSER);
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsParser_1_0.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsParser_1_0.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileMetricsParser_1_0 extends PersistentResourceXMLParser {
+    /**
+     * The name space used for the {@code subsystem} element
+     */
+    public static final String NAMESPACE = "urn:wildfly:microprofile-metrics-smallrye:1.0";
+
+    private static final PersistentResourceXMLDescription xmlDescription;
+
+    static {
+        xmlDescription = builder(MicroProfileMetricsExtension.SUBSYSTEM_PATH, NAMESPACE)
+                .addAttribute(MicroProfileMetricsSubsystemDefinition.SECURITY_ENABLED)
+                .addAttribute(MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS)
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return xmlDescription;
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.OperationContext.Stage.RUNTIME;
+import static org.jboss.as.server.deployment.Phase.DEPENDENCIES;
+import static org.jboss.as.server.deployment.Phase.INSTALL;
+
+import java.util.List;
+
+import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.server.AbstractDeploymentChainStep;
+import org.jboss.as.server.DeploymentProcessorTarget;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger;
+import org.wildfly.extension.microprofile.metrics.deployment.DependencyProcessor;
+import org.wildfly.extension.microprofile.metrics.deployment.DeploymentMetricProcessor;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
+
+
+    MicroProfileMetricsSubsystemAdd() {
+        super(MicroProfileMetricsSubsystemDefinition.ATTRIBUTES);
+    }
+
+    // temporary until https://issues.jboss.org/browse/WFCORE-4204 is integrated
+    private final int DEPENDENCIES_MICROPROFILE_METRICS = 0x1860;
+    private static final int POST_MODULE_MICROPROFILE_METRICS = 0x3760;
+
+    static final MicroProfileMetricsSubsystemAdd INSTANCE = new MicroProfileMetricsSubsystemAdd();
+
+    @Override
+    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        super.performBoottime(context, operation, model);
+
+        context.addStep(new AbstractDeploymentChainStep() {
+            public void execute(DeploymentProcessorTarget processorTarget) {
+                processorTarget.addDeploymentProcessor(MicroProfileMetricsExtension.SUBSYSTEM_NAME, DEPENDENCIES, DEPENDENCIES_MICROPROFILE_METRICS, new DependencyProcessor());
+                processorTarget.addDeploymentProcessor(MicroProfileMetricsExtension.SUBSYSTEM_NAME, INSTALL, POST_MODULE_MICROPROFILE_METRICS, new DeploymentMetricProcessor());
+            }
+        }, RUNTIME);
+
+        final boolean securityEnabled = MicroProfileMetricsSubsystemDefinition.SECURITY_ENABLED.resolveModelAttribute(context, model).asBoolean();
+        List<String> exposedSubsystems = MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS.unwrap(context, model);
+
+        MetricsRegistrationService.install(context, exposedSubsystems);
+        MetricsContextService.install(context, securityEnabled);
+
+        MicroProfileMetricsLogger.LOGGER.activatingSubsystem();
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ServiceRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDefinition {
+
+    static final String METRICS_REGISTRATION_CAPABILITY = "org.wildlfy.extension.microprofile.metrics.wildfly-registrar";
+
+    static final String CLIENT_FACTORY_CAPABILITY ="org.wildfly.management.model-controller-client-factory";
+    static final String MANAGEMENT_EXECUTOR ="org.wildfly.management.executor";
+    static final RuntimeCapability<Void> METRICS_REGISTRATION_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(METRICS_REGISTRATION_CAPABILITY, MetricsRegistrationService.class)
+            .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR)
+            .build();
+
+    public static final ServiceName WILDFLY_REGISTRATION_SERVICE = METRICS_REGISTRATION_RUNTIME_CAPABILITY.getCapabilityServiceName();
+
+    static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
+    static final RuntimeCapability<Void> EXTENSION_CAPABILITY = RuntimeCapability.Builder.of(MicroProfileMetricsExtension.EXTENSION_NAME)
+            .addRequirements(HTTP_EXTENSIBILITY_CAPABILITY)
+            .build();
+
+    static final AttributeDefinition SECURITY_ENABLED = SimpleAttributeDefinitionBuilder.create("security-enabled", ModelType.BOOLEAN)
+            .setDefaultValue(new ModelNode(true))
+            .setRequired(false)
+            .setRestartAllServices()
+            .setAllowExpression(true)
+            .build();
+
+    static final StringListAttributeDefinition EXPOSED_SUBSYSTEMS = new StringListAttributeDefinition.Builder("exposed-subsystems")
+            .setRequired(false)
+            .setRestartAllServices()
+            .build();
+
+    static final AttributeDefinition[] ATTRIBUTES = { SECURITY_ENABLED, EXPOSED_SUBSYSTEMS };
+
+    protected MicroProfileMetricsSubsystemDefinition() {
+        super(new SimpleResourceDefinition.Parameters(MicroProfileMetricsExtension.SUBSYSTEM_PATH,
+                MicroProfileMetricsExtension.getResourceDescriptionResolver(MicroProfileMetricsExtension.SUBSYSTEM_NAME))
+                .setAddHandler(MicroProfileMetricsSubsystemAdd.INSTANCE)
+                .setRemoveHandler(new ServiceRemoveStepHandler(MicroProfileMetricsSubsystemAdd.INSTANCE))
+                .setCapabilities(METRICS_REGISTRATION_RUNTIME_CAPABILITY, EXTENSION_CAPABILITY));
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Arrays.asList(ATTRIBUTES);
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics._private;
+
+import static org.jboss.logging.Logger.Level.INFO;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.msc.service.StartException;
+
+/**
+ * Log messages for WildFly microprofile-metrics-smallrye Extension.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@MessageLogger(projectCode = "WFLYMETRICS", length = 4)
+public interface MicroProfileMetricsLogger extends BasicLogger {
+    /**
+     * A logger with the category {@code org.wildfly.extension.batch}.
+     */
+    MicroProfileMetricsLogger LOGGER = Logger.getMessageLogger(MicroProfileMetricsLogger.class, "org.wildfly.extension.microprofile.metrics.smallrye");
+
+    /**
+     * Logs an informational message indicating the subsystem is being activated.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 1, value = "Activating Eclipse MicroProfile Metrics Subsystem")
+    void activatingSubsystem();
+
+
+    @Message(id = 2, value = "Failed to initialize metrics from JMX MBeans")
+    StartException failedInitializeJMXRegistrar(@Cause IOException e);
+
+    @Message(id = 3, value = "Unable to read attribute %s on %s: %s.")
+    IllegalStateException unableToReadAttribute(String attributeName, PathAddress address, String error);
+
+    @Message(id = 4, value = "Unable to convert attribute %s on %s to Double value.")
+    IllegalStateException unableToConvertAttribute(String attributeName, PathAddress address, @Cause Exception exception);
+
+    @Message(id = 5, value = "Metric attribute %s on %s is undefined and will not be exposed.")
+    IllegalStateException undefinedMetric(String attributeName, PathAddress address);
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DependencyProcessor.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DependencyProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics.deployment;
+
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoader;
+import org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition;
+
+/**
+ * Add dependencies required by deployment unit to access the Metrics API (programmatically or using CDI).
+ */
+public class DependencyProcessor implements DeploymentUnitProcessor {
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+
+        addModuleDependencies(deploymentUnit);
+
+        phaseContext.addDeploymentDependency(MicroProfileMetricsSubsystemDefinition.WILDFLY_REGISTRATION_SERVICE, DeploymentMetricProcessor.METRICS_REGISTRATION);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+    private void addModuleDependencies(DeploymentUnit deploymentUnit) {
+        final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+        final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "org.eclipse.microprofile.metrics.api", false, false, true, false));
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, "io.smallrye.metrics", false, false, true, false));
+    }
+
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricProcessor.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricProcessor.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics.deployment;
+
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentModelUtils;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.wildfly.extension.microprofile.metrics.MetricsRegistrationService;
+
+public class DeploymentMetricProcessor implements DeploymentUnitProcessor {
+
+    static final AttachmentKey<MetricsRegistrationService> METRICS_REGISTRATION = AttachmentKey.create(MetricsRegistrationService.class);
+
+    private Resource rootResource;
+    private ManagementResourceRegistration managementResourceRegistration;
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) {
+        rootResource = phaseContext.getDeploymentUnit().getAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE);
+        managementResourceRegistration = phaseContext.getDeploymentUnit().getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
+
+        DeploymentMetricService.install(phaseContext.getServiceTarget(), phaseContext.getDeploymentUnit(), rootResource, managementResourceRegistration);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
@@ -1,0 +1,93 @@
+package org.wildfly.extension.microprofile.metrics.deployment;
+
+import static org.eclipse.microprofile.metrics.MetricRegistry.Type.APPLICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import io.smallrye.metrics.MetricRegistries;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.deployment.DeploymentCompleteServiceProcessor;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.extension.microprofile.metrics.MetricsRegistrationService;
+import org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition;
+
+public class DeploymentMetricService implements Service {
+
+
+    private final Resource rootResource;
+    private final ManagementResourceRegistration managementResourceRegistration;
+    private PathAddress deploymentAddress;
+    private final Supplier<MetricsRegistrationService> registrationService;
+    private Set<String> registeredMetrics = new HashSet<>();
+
+    public static void install(ServiceTarget serviceTarget, DeploymentUnit deploymentUnit, Resource rootResource, ManagementResourceRegistration managementResourceRegistration) {
+        PathAddress deploymentAddress = createDeploymentAddressPrefix(deploymentUnit);
+
+        ServiceBuilder<?> sb = serviceTarget.addService(deploymentUnit.getServiceName().append("metrics"));
+        Supplier<MetricsRegistrationService> registrationService = sb.requires(MicroProfileMetricsSubsystemDefinition.WILDFLY_REGISTRATION_SERVICE);
+
+        /*
+         * The deployment metric service depends on the deployment complete service name to ensure that the metrics from
+         * the deployment are collected and registered once the deployment services have all be properly installed.
+         */
+        sb.requires(DeploymentCompleteServiceProcessor.serviceName(deploymentUnit.getServiceName()));
+        sb.setInstance(new DeploymentMetricService(rootResource, managementResourceRegistration, deploymentAddress, registrationService))
+                .install();
+    }
+
+    private DeploymentMetricService(Resource rootResource, ManagementResourceRegistration managementResourceRegistration, PathAddress deploymentAddress, Supplier<MetricsRegistrationService> registrationService) {
+        this.rootResource = rootResource;
+        this.managementResourceRegistration = managementResourceRegistration;
+        this.deploymentAddress = deploymentAddress;
+        this.registrationService = registrationService;
+    }
+
+    @Override
+    public void start(StartContext startContext) {
+        MetricRegistry applicationRegistry = MetricRegistries.get(APPLICATION);
+        registeredMetrics = registrationService.get().registerMetrics(rootResource, managementResourceRegistration, applicationRegistry,
+                new MetricsRegistrationService.MetricNameCreator() {
+                    @Override
+                    public String createName(PathAddress address, String attributeName) {
+                        return deploymentAddress.append(address).toPathStyleString().substring(1) + "/" + attributeName;
+                    }
+
+                    @Override
+                    public PathAddress getResourceAddress(PathAddress address) {
+                        return deploymentAddress.append(address);
+                    }
+                });
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+        if (registeredMetrics != null) {
+            MetricRegistry applicationRegistry = MetricRegistries.get(APPLICATION);
+            for (String registeredMetric : registeredMetrics) {
+                applicationRegistry.remove(registeredMetric);
+            }
+            registeredMetrics = null;
+        }
+    }
+
+    private static PathAddress createDeploymentAddressPrefix(DeploymentUnit deploymentUnit) {
+        if (deploymentUnit.getParent() == null) {
+            return PathAddress.pathAddress(DEPLOYMENT, deploymentUnit.getName());
+        } else {
+            return createDeploymentAddressPrefix(deploymentUnit.getParent()).append(SUBDEPLOYMENT, deploymentUnit.getName());
+        }
+    }
+
+}

--- a/microprofile/metrics-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
+++ b/microprofile/metrics-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.wildfly.extension.microprofile.metrics.MicroProfileMetricsExtension

--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -1,0 +1,77 @@
+classloader.currentLoadedClass.count.displayName: Current Loaded Class Count
+classloader.currentLoadedClass.count.type: counter
+classloader.currentLoadedClass.count.unit: none
+classloader.currentLoadedClass.count.description: Displays the number of classes that are currently loaded in the Java virtual machine.
+classloader.currentLoadedClass.count.mbean: java.lang:type=ClassLoading/LoadedClassCount
+classloader.totalLoadedClass.count.displayName: Total Loaded Class Count
+classloader.totalLoadedClass.count.type: counter
+classloader.totalLoadedClass.count.unit: none
+classloader.totalLoadedClass.count.description: Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
+classloader.totalLoadedClass.count.mbean: java.lang:type=ClassLoading/TotalLoadedClassCount
+classloader.totalUnloadedClass.count.displayName: Total Unloaded Class Count
+classloader.totalUnloadedClass.count.type: counter
+classloader.totalUnloadedClass.count.unit: none
+classloader.totalUnloadedClass.count.description: Displays the total number of classes unloaded since the Java virtual machine has started execution.
+classloader.totalUnloadedClass.count.mbean: java.lang:type=ClassLoading/UnloadedClassCount
+cpu.availableProcessors.displayName: Available Processors
+cpu.availableProcessors.type: gauge
+cpu.availableProcessors.unit: none
+cpu.availableProcessors.description: Displays the number of processors available to the Java virtual machine. This value may change during a particular invocation of the virtual machine.
+cpu.availableProcessors.mbean: java.lang:type=OperatingSystem/AvailableProcessors
+cpu.processCpuLoad.displayName: Process CPU Load
+cpu.processCpuLoad.type: gauge
+cpu.processCpuLoad.unit: none
+cpu.processCpuLoad.description: Displays the "recent cpu usage" for the Java Virtual Machine process.
+cpu.processCpuLoad.mbean: java.lang:type=OperatingSystem/ProcessCpuLoad
+cpu.systemLoadAverage.displayName: System Load Average
+cpu.systemLoadAverage.type: gauge
+cpu.systemLoadAverage.unit: none
+cpu.systemLoadAverage.description: Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platform where it is expensive to implement this method.
+cpu.systemLoadAverage.mbean: java.lang:type=OperatingSystem/SystemLoadAverage
+gc.%s.count.displayName: Garbage Collection Count
+gc.%s.count.type: counter
+gc.%s.count.unit: none
+gc.%s.count.multi: true
+gc.%s.count.description:  Displays the total number of collections that have occurred. This attribute lists -1 if the collection count is undefined for this collector.
+gc.%s.count.mbean: java.lang:type=GarbageCollector,name=%s/CollectionCount
+gc.%s.time.displayName: Garbage Collection Time
+gc.%s.time.type: counter
+gc.%s.time.unit: milliseconds
+gc.%s.time.multi: true
+gc.%s.time.description: Displays the approximate accumulated collection elapsed time in milliseconds. This attribute displays -1 if the collection elapsed time is undefined for this collector. The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. This attribute may display the same value even if the collection count has been incremented if the collection elapsed time is very short.
+gc.%s.time.mbean: java.lang:type=GarbageCollector,name=%s/CollectionTime
+jvm.uptime.displayName: JVM Uptime
+jvm.uptime.type: gauge
+jvm.uptime.unit: milliseconds
+jvm.uptime.description: Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.
+jvm.uptime.mbean: java.lang:type=Runtime/Uptime
+memory.committedHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#committed
+memory.committedHeap.type: gauge
+memory.committedHeap.unit: bytes
+memory.maxHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#max
+memory.maxHeap.description: Number of threads started for this server
+memory.maxHeap.unit: bytes
+memory.maxHeap.type: gauge
+#memory.maxHeap.    labels:
+#memory.maxHeap.      - key: domain
+#memory.maxHeap.        value: memory
+#memory.maxHeap.      - key: type
+#memory.maxHeap.        value: heap
+memory.usedHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#used
+memory.usedHeap.type: gauge
+memory.usedHeap.unit: bytes
+thread.count.mbean: java.lang:type=Threading/ThreadCount
+thread.count.description: Number of currently deployed threads
+thread.count.unit: none
+thread.count.type: counter
+thread.count.displayName: Current Thread count
+thread.daemon.count.displayName: Daemon Thread Count
+thread.daemon.count.type: counter
+thread.daemon.count.unit: none
+thread.daemon.count.description: Displays the current number of live daemon threads.
+thread.daemon.count.mbean: java.lang:type=Threading/DaemonThreadCount
+thread.max.count.displayName: Peak Thread Count
+thread.max.count.type: counter
+thread.max.count.unit: none
+thread.max.count.description: Displays the peak live thread count since the Java virtual machine started or peak was reset. This includes daemon and non-daemon threads.
+thread.max.count.mbean: java.lang:type=Threading/PeakThreadCount

--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/vendor-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/vendor-metrics.properties
@@ -1,0 +1,15 @@
+BufferPool_used_memory_%s.mbean: java.nio:type=BufferPool,name=%s/MemoryUsed
+BufferPool_used_memory_%s.description: The memory used by the NIO pool: %s
+BufferPool_used_memory_%s.multi: true
+BufferPool_used_memory_%s.type: gauge
+BufferPool_used_memory_%s.unit: bytes
+memoryPool.%s.usage.mbean: java.lang:type=MemoryPool,name=%s/Usage#used
+memoryPool.%s.usage.unit: bytes
+memoryPool.%s.usage.description: Current usage of the %s memory pool
+memoryPool.%s.usage.multi: true
+memoryPool.%s.usage.type: gauge
+memoryPool.%s.usage.max.mbean: java.lang:type=MemoryPool,name=%s/PeakUsage#used
+memoryPool.%s.usage.max.unit: bytes
+memoryPool.%s.usage.max.description: Peak usage of the %s memory pool
+memoryPool.%s.usage.max.multi: true
+memoryPool.%s.usage.max.type: gauge

--- a/microprofile/metrics-smallrye/src/main/resources/org/wildfly/extension/microprofile/metrics/LocalDescriptions.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/org/wildfly/extension/microprofile/metrics/LocalDescriptions.properties
@@ -1,0 +1,5 @@
+microprofile-metrics-smallrye=WildFly Extension for Eclipse MicroProfile Metrics With SmallRye
+microprofile-metrics-smallrye.add=Add the subsystem
+microprofile-metrics-smallrye.remove=Remove the subsystem
+microprofile-metrics-smallrye.security-enabled=True if authentication is required to access the HTTP endpoint on the HTTP management interface.
+microprofile-metrics-smallrye.exposed-subsystems=The names of the subsystems that exposes their metrics in the vendor scope (or '*' to expose any subystem metrics).

--- a/microprofile/metrics-smallrye/src/main/resources/schema/wildfly-microprofile-metrics-smallrye_1_0.xsd
+++ b/microprofile/metrics-smallrye/src/main/resources/schema/wildfly-microprofile-metrics-smallrye_1_0.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:wildfly:microprofile-metrics-smallrye:1.0"
+           xmlns="urn:wildfly:microprofile-metrics-smallrye:1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:attribute name="security-enabled" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if authentication is required to access the HTTP endpoint on the HTTP management interface.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="exposed-subsystems" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The names of the subsystems (separated by spaces) that exposes their metrics in the vendor scope (or '*' to expose any subystem metrics).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/microprofile/metrics-smallrye/src/main/resources/subsystem-templates/microprofile-metrics-smallrye.xml
+++ b/microprofile/metrics-smallrye/src/main/resources/subsystem-templates/microprofile-metrics-smallrye.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.wildfly.extension.microprofile.metrics-smallrye</extension-module>
+    <subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:1.0"
+               security-enabled="false"
+               exposed-subsystems="*">
+    </subsystem>
+</config>

--- a/microprofile/metrics-smallrye/src/test/java/org/wildfly/extension/microprofile/metrics/Subsystem_1_0_ParsingTestCase.java
+++ b/microprofile/metrics-smallrye/src/test/java/org/wildfly/extension/microprofile/metrics/Subsystem_1_0_ParsingTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
+
+    public Subsystem_1_0_ParsingTestCase() {
+        super(MicroProfileMetricsExtension.SUBSYSTEM_NAME, new MicroProfileMetricsExtension());
+    }
+
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem_1_0.xml");
+    }
+
+    @Override
+    protected String[] getSubsystemTemplatePaths() throws IOException {
+        return new String[] {
+                "/subsystem-templates/microprofile-metrics-smallrye.xml"
+        };
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws IOException {
+        return "schema/wildfly-microprofile-metrics-smallrye_1_0.xsd";
+    }
+
+    protected Properties getResolvedProperties() {
+        return System.getProperties();
+    }
+
+
+
+}

--- a/microprofile/metrics-smallrye/src/test/resources/org/wildfly/extension/microprofile/metrics/subsystem_1_0.xml
+++ b/microprofile/metrics-smallrye/src/test/resources/org/wildfly/extension/microprofile/metrics/subsystem_1_0.xml
@@ -1,0 +1,3 @@
+<subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:1.0"
+           security-enabled="${security-enabled:true}"
+           exposed-subsystems="undertow transactions" />

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>messaging-activemq</module>
         <module>microprofile/config-smallrye</module>
         <module>microprofile/health-smallrye</module>
+        <module>microprofile/metrics-smallrye</module>
         <module>microprofile/opentracing-extension</module>
         <module>microprofile/opentracing-smallrye</module>
         <module>mod_cluster</module>
@@ -245,6 +246,7 @@
         <version.io.reactivex.rxjava>2.2.2</version.io.reactivex.rxjava>
         <version.io.smallrye.smallrye-config>1.3.4</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-metrics>1.1.2</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -289,6 +291,7 @@
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.health.api>1.0</version.org.eclipse.microprofile.health.api>
+        <version.org.eclipse.microprofile.metrics.api>1.1</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.0.1</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.2</version.org.eclipse.yasson>
@@ -890,6 +893,12 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>wildfly-microprofile-health-smallrye</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>wildfly-microprofile-metrics-smallrye</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -1518,6 +1527,12 @@
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-health</artifactId>
                 <version>${version.io.smallrye.smallrye-health}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-metrics</artifactId>
+                <version>${version.io.smallrye.smallrye-metrics}</version>
             </dependency>
 
             <dependency>
@@ -3842,6 +3857,12 @@
                 <artifactId>microprofile-health-tck</artifactId>
                 <version>${version.org.eclipse.microprofile.health.api}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api</artifactId>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -179,6 +179,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
@@ -66,6 +66,7 @@ public class MicroProfileConfigTestCase {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(MicroProfileConfigTestCase.class.getPackage(),
                         "microprofile-config.properties", "microprofile-config.properties");
+
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
@@ -1,0 +1,82 @@
+package org.wildfly.test.integration.microprofile.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.wildfly.test.integration.microprofile.config.smallrye.HttpUtils.getContent;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonNumber;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.junit.Assert;
+
+public class MetricsHelper {
+
+
+    public static String getPrometheusMetrics(ManagementClient managementClient, String scope, boolean metricMustExist) throws IOException {
+        return getMetrics(managementClient, null, scope, metricMustExist);
+    }
+
+    public static String getJSONMetrics(ManagementClient managementClient, String scope, boolean metricMustExist) throws IOException {
+        return getMetrics(managementClient, "application/json", scope, metricMustExist);
+    }
+
+    private static String getMetrics(ManagementClient managementClient, String accept, String scope, boolean metricMustExist) throws IOException {
+        final String url = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/metrics/" + scope;
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+
+            HttpGet getMetrics = new HttpGet(url);
+            if (accept != null) {
+                getMetrics.addHeader("Accept", accept);
+            }
+
+            try (CloseableHttpResponse resp = client.execute(getMetrics)) {
+                if (metricMustExist) {
+                    assertEquals(200, resp.getStatusLine().getStatusCode());
+                    String content = getContent(resp);
+                    assertNotNull(content);
+                    return content;
+                } else {
+                    assertEquals(204, resp.getStatusLine().getStatusCode());
+                    return null;
+                }
+            }
+        }
+    }
+
+    public static double getMetricValueFromPrometheusOutput(String prometheusContent, String scope, String metricName) {
+        assertNotNull(prometheusContent);
+
+        String[] lines = prometheusContent.split("\\R");
+
+        for (String line : lines) {
+            if (line.startsWith(scope + ":" + metricName)) {
+                String longStr = line.substring((scope + ":" + metricName).length()).trim();
+                return Double.parseDouble(longStr);
+            }
+        }
+
+        Assert.fail(scope + ":" + metricName + " metric not found in " + prometheusContent);
+        return -1;
+    }
+
+    public static double getMetricValueFromJSONOutput(String jsonContent, String counterName) {
+        try (
+                JsonReader jsonReader = Json.createReader(new StringReader(jsonContent))
+        ) {
+            JsonObject payload = jsonReader.readObject();
+            JsonNumber count = payload.getJsonNumber(counterName);
+            return count.doubleValue();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.metrics.application;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getJSONMetrics;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getMetricValueFromJSONOutput;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getMetricValueFromPrometheusOutput;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getPrometheusMetrics;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test application metrics that are provided by a deployment.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MicroProfileMetricsApplicationTestCase {
+
+    @Deployment(name = "MicroProfileMetricsApplicationTestCase", managed = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileMetricsApplicationTestCase.war")
+                .addClasses(TestApplication.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Test
+    @InSequence(1)
+    public void testApplicationMetricBeforeDeployment() throws Exception {
+        getPrometheusMetrics(managementClient, "application", false);
+        getJSONMetrics(managementClient, "application", false);
+
+        // deploy the archive
+        deployer.deploy("MicroProfileMetricsApplicationTestCase");
+    }
+
+    @Test
+    @InSequence(2)
+    @OperateOnDeployment("MicroProfileMetricsApplicationTestCase")
+    public void testApplicationMetricWithPrometheusAfterDeployment(@ArquillianResource URL url) throws Exception {
+        // metrics from deployment subsystems are exposed
+        getPrometheusMetrics(managementClient, "application", true);
+
+        String text = performCall(url);
+        assertNotNull(text);
+        assertTrue(text.contains("Hello From WildFly!"));
+
+        String metrics = getPrometheusMetrics(managementClient, "application", true);
+        double counter = getMetricValueFromPrometheusOutput(metrics, "application", "hello");
+        assertEquals(1.0, counter, 0.0);
+
+        performCall(url);
+        assertNotNull(text);
+        assertTrue(text.contains("Hello From WildFly!"));
+
+        metrics = getPrometheusMetrics(managementClient, "application", true);
+        counter = getMetricValueFromPrometheusOutput(metrics, "application", "hello");
+        assertEquals(2.0, counter, 0.0);
+    }
+
+    @Test
+    @InSequence(3)
+    @OperateOnDeployment("MicroProfileMetricsApplicationTestCase")
+    public void testApplicationMetricWithJSONAfterDeployment(@ArquillianResource URL url) throws Exception {
+        // hello counter is at 2.0 from previous testApplicationMetricWithPrometheusAfterDeployment invocations
+        String metrics = getJSONMetrics(managementClient, "application", true);
+        double counter = getMetricValueFromJSONOutput(metrics, "hello");
+        assertEquals(2.0, counter, 0.0);
+
+        String text = performCall(url);
+        assertNotNull(text);
+        assertTrue(text.contains("Hello From WildFly!"));
+
+        metrics = getJSONMetrics(managementClient, "application", true);
+        counter = getMetricValueFromJSONOutput(metrics, "hello");
+        assertEquals(3.0, counter, 0.0);
+
+        performCall(url);
+        assertNotNull(text);
+        assertTrue(text.contains("Hello From WildFly!"));
+
+        metrics = getJSONMetrics(managementClient, "application", true);
+        counter = getMetricValueFromJSONOutput(metrics, "hello");
+        assertEquals(4.0, counter, 0.0);
+    }
+
+
+    @Test
+    @InSequence(4)
+    public void tesApplicationMetricAfterUndeployment() throws Exception {
+        deployer.undeploy("MicroProfileMetricsApplicationTestCase");
+
+        getPrometheusMetrics(managementClient, "application", false);
+        getJSONMetrics(managementClient, "application", false);
+    }
+
+    private String performCall(URL url) throws Exception {
+        URL appURL = new URL(url.toExternalForm() + "microprofile-metrics-app/hello");
+        return HttpRequest.get(appURL.toExternalForm(), 10, TimeUnit.SECONDS);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/TestApplication.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.metrics.application;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
+ */
+@ApplicationPath("/microprofile-metrics-app")
+public class TestApplication extends Application {
+
+    @Path("/hello")
+    public static class ResourceSimple {
+
+        @GET
+        @Produces("text/plain")
+        @Counted(description = "counter of the Hello call", absolute = true, monotonic = true)
+        public Response hello() {
+            return Response.ok("Hello From WildFly!").build();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/base/MicroProfileMetricsBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/base/MicroProfileMetricsBaseTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.metrics.base;
+
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getJSONMetrics;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getMetricValueFromJSONOutput;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test required base metrics that are always present.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MicroProfileMetricsBaseTestCase {
+
+    // Use an empty deployment as the test deals with base metrics only
+    @Deployment(name = "MicroProfileMetricsBaseTestCase", managed = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileMetricsBaseTestCase.war");
+        return war;
+    }
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @Test
+    public void testBaseMetrics() throws Exception {
+        long start = System.currentTimeMillis();
+        long sleep = 50;
+
+        String metrics = getJSONMetrics(managementClient, "base", true);
+        double uptime1 = getMetricValueFromJSONOutput(metrics, "jvm.uptime");
+        assertTrue(uptime1 > 0);
+
+        Thread.sleep(sleep);
+
+        metrics = getJSONMetrics(managementClient, "base", true);
+        double uptime2 = getMetricValueFromJSONOutput(metrics, "jvm.uptime");
+
+        long interval = System.currentTimeMillis() - start;
+
+        assertTrue( uptime2 > uptime1);
+        assertTrue((uptime2 - uptime1) >= sleep);
+        assertTrue((uptime2 - uptime1) <= interval);
+    }
+}


### PR DESCRIPTION
Add microprofile-metrics-smallrye extension to provide support for
MicroProfile Metrics 1.1
* integrate smallrye-metrics:1.1.2 that implements MicroProfile Metrics
  1.1
* provide the /metrics HTTP endpoint on the management interface
* The extension is added to standalone profiles only (not available in
  domain mode)

Dev analysis: wildfly/wildfly-proposals#147
JIRA: https://issues.jboss.org/browse/WFLY-10712