### PR TITLE
[WFLY-11323] Fixing flaky test WritableServiceBasedNamingStoreTestCase.testPermissions

### DIFF
--- a/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
@@ -253,7 +253,9 @@ public class WritableServiceBasedNamingStoreTestCase {
         WritableServiceBasedNamingStore.pushOwner(OWNER_FOO);
         try {
             permissions.add(new JndiPermission(store.getBaseName()+"/"+name,"bind,list,listBindings"));
-            store.bind(new CompositeName(name), value);
+            Name nameObj = new CompositeName(name);
+            store.bind(nameObj, value);
+            store.lookup(nameObj);
         } finally {
             WritableServiceBasedNamingStore.popOwner();
         }


### PR DESCRIPTION
Issue link: https://issues.jboss.org/browse/WFLY-11323

testPermissions fails when run by itself even when there’s no bug in the code.

This test can be fixed by looking up the name before testActionWithPermission is called. Let me know if you want to discuss more.
