### PR TITLE
WFLY-7618: fix code not to use default platform dependant encoding

### DIFF
--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonDeploymentParsingProcessor.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/deployment/SingletonDeploymentParsingProcessor.java
@@ -22,10 +22,12 @@
 
 package org.wildfly.extension.clustering.singleton.deployment;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -78,7 +80,7 @@ public class SingletonDeploymentParsingProcessor implements DeploymentUnitProces
     }
 
     private SingletonDeploymentConfiguration parse(DeploymentUnit unit, File file) throws DeploymentUnitProcessingException {
-        try (FileReader reader = new FileReader(file)) {
+        try (BufferedReader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             XMLStreamReader xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(reader);
             try  {
                 MutableSingletonDeploymentConfiguration config = new MutableSingletonDeploymentConfiguration(unit);

--- a/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -22,12 +22,11 @@
 
 package org.wildfly.dist.subsystem.xml;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -184,18 +183,10 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         final File tmp = File.createTempFile(getClass().getSimpleName(), "xml");
         tmp.deleteOnExit();
         File target = new File(getBaseDir(), xmlName);
-        BufferedReader reader = new BufferedReader(new FileReader(target));
-        BufferedWriter writer = null;
-        try {
-            writer = new BufferedWriter(new FileWriter(tmp));
-            String line;
-            while ((line = reader.readLine()) != null) {
+        try (BufferedWriter writer= Files.newBufferedWriter(tmp.toPath(), StandardCharsets.UTF_8)) {
+            List<String> lines = Files.readAllLines(target.toPath(), StandardCharsets.UTF_8);
+            for (String line : lines) {
                 writer.write(fixExpressions(line));
-            }
-        } finally {
-            reader.close();
-            if (writer != null) {
-                writer.close();
             }
         }
         return tmp;

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -22,12 +22,11 @@
 
 package org.wildfly.dist.subsystem.xml;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -184,18 +183,10 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         final File tmp = File.createTempFile(getClass().getSimpleName(), "xml");
         tmp.deleteOnExit();
         File target = new File(getBaseDir(), xmlName);
-        BufferedReader reader = new BufferedReader(new FileReader(target));
-        BufferedWriter writer = null;
-        try {
-            writer = new BufferedWriter(new FileWriter(tmp));
-            String line;
-            while ((line = reader.readLine()) != null) {
+        try (BufferedWriter writer= Files.newBufferedWriter(tmp.toPath(), StandardCharsets.UTF_8)) {
+            List<String> lines = Files.readAllLines(target.toPath(), StandardCharsets.UTF_8);
+            for (String line : lines) {
                 writer.write(fixExpressions(line));
-            }
-        } finally {
-            reader.close();
-            if (writer != null) {
-                writer.close();
             }
         }
         return tmp;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -355,22 +355,20 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
             if (resources.hasMoreElements()) {
                 do {
                     final URL url = resources.nextElement();
-                    try (InputStream st = url.openStream()) {
-                        try (InputStreamReader isr = new InputStreamReader(st, StandardCharsets.UTF_8)) {
-                            try (BufferedReader r = new BufferedReader(isr)) {
-                                String line;
-                                while ((line = r.readLine()) != null) {
-                                    line = line.trim();
-                                    if (line.isEmpty() || line.charAt(0) == '#') {
-                                        continue;
-                                    }
-                                    try {
-                                        final EJBClientInterceptor interceptor = Class.forName(line, true, classLoader).asSubclass(EJBClientInterceptor.class).getConstructor().newInstance();
-                                        interceptors.add(interceptor);
-                                    } catch (Exception e) {
-                                        throw EjbLogger.ROOT_LOGGER.failedToCreateEJBClientInterceptor(e, line);
-                                    }
-                                }
+                    try (InputStream st = url.openStream();
+                         InputStreamReader isr = new InputStreamReader(st, StandardCharsets.UTF_8);
+                         BufferedReader r = new BufferedReader(isr)) {
+                        String line;
+                        while ((line = r.readLine()) != null) {
+                            line = line.trim();
+                            if (line.isEmpty() || line.charAt(0) == '#') {
+                                continue;
+                            }
+                            try {
+                                final EJBClientInterceptor interceptor = Class.forName(line, true, classLoader).asSubclass(EJBClientInterceptor.class).getConstructor().newInstance();
+                                interceptors.add(interceptor);
+                            } catch (Exception e) {
+                                throw EjbLogger.ROOT_LOGGER.failedToCreateEJBClientInterceptor(e, line);
                             }
                         }
                     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/LegacyFileStore.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/LegacyFileStore.java
@@ -12,8 +12,9 @@ import org.jboss.marshalling.Unmarshaller;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -111,12 +112,7 @@ public class LegacyFileStore {
 
             }
             if (!timers.isEmpty()) {
-                FileOutputStream out = new FileOutputStream(marker);
-                try {
-                    out.write(new Date().toString().getBytes());
-                } finally {
-                    out.close();
-                }
+                Files.write(marker.toPath(), new Date().toString().getBytes(StandardCharsets.UTF_8));
             }
         } catch (Exception e) {
             EJB3_TIMER_LOGGER.failToRestoreTimersForObjectId(timedObjectId, e);

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/csiv2/CSIv2Util.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/csiv2/CSIv2Util.java
@@ -310,7 +310,7 @@ public final class CSIv2Util {
             // finally, encode the "realm" name as a CSI.GSS_NT_ExportedName.
             // clientAuthMech should contain the DER encoded GSSUPMechOID at this point.
             String realm = asMeta.getRealm();
-            targetName = createGSSExportedName(clientAuthMech, realm.getBytes());
+            targetName = createGSSExportedName(clientAuthMech, realm.getBytes(StandardCharsets.UTF_8));
 
             context = new AS_ContextSec((short) support, (short) require, clientAuthMech, targetName);
         }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/naming/CorbaNamingContext.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/naming/CorbaNamingContext.java
@@ -25,6 +25,7 @@ package org.wildfly.iiop.openjdk.naming;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.Map;
@@ -324,11 +325,11 @@ public class CorbaNamingContext extends NamingContextExtPOA implements Serializa
             CorbaNamingContext newContextImpl = new CorbaNamingContext();
             newContextImpl.init(this.poa, this.doPurge, this.noPing);
             // create the oid for the new context and activate it with the naming service POA.
-            String oid = new String(this.poa.servant_to_id(this)) + "/ctx" + (++this.childCount);
-            this.poa.activate_object_with_id(oid.getBytes(), newContextImpl);
+            String oid = new String(this.poa.servant_to_id(this), StandardCharsets.UTF_8) + "/ctx" + (++this.childCount);
+            this.poa.activate_object_with_id(oid.getBytes(StandardCharsets.UTF_8), newContextImpl);
             // add the newly-created context to the cache.
             contextImpls.put(oid, newContextImpl);
-            return NamingContextExtHelper.narrow(this.poa.create_reference_with_id(oid.getBytes(),
+            return NamingContextExtHelper.narrow(this.poa.create_reference_with_id(oid.getBytes(StandardCharsets.UTF_8),
                     "IDL:omg.org/CosNaming/NamingContextExt:1.0"));
         } catch (Exception e) {
             IIOPLogger.ROOT_LOGGER.failedToCreateNamingContext(e);
@@ -566,7 +567,7 @@ public class CorbaNamingContext extends NamingContextExtPOA implements Serializa
         try {
             byte[] oidBytes = this.poa.reference_to_id(object);
             if (oidBytes != null)
-                oid = new String(oidBytes);
+                oid = new String(oidBytes, StandardCharsets.UTF_8);
         } catch (Exception e) {
             IIOPLogger.ROOT_LOGGER.debug("Unable to obtain id from object", e);
         }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaNamingService.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaNamingService.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.iiop.openjdk.service;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.jboss.msc.inject.Injector;
@@ -85,7 +86,7 @@ public class CorbaNamingService implements Service<NamingContextExt> {
             ns.init(namingPOA, false, false);
 
             // create and activate the root context.
-            byte[] rootContextId = "root".getBytes();
+            byte[] rootContextId = "root".getBytes(StandardCharsets.UTF_8);
             namingPOA.activate_object_with_id(rootContextId, ns);
             namingService = NamingContextExtHelper.narrow(namingPOA.create_reference_with_id(rootContextId,
                     "IDL:omg.org/CosNaming/NamingContextExt:1.0"));

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -42,6 +42,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -92,7 +93,7 @@ public class JdrRunner implements JdrReportCollector {
         List<JdrCommand> commands = new ArrayList<JdrCommand>();
 
         ByteArrayOutputStream versionStream = new ByteArrayOutputStream();
-        PrintWriter versionWriter = new PrintWriter(new OutputStreamWriter(versionStream));
+        PrintWriter versionWriter = new PrintWriter(new OutputStreamWriter(versionStream, StandardCharsets.UTF_8));
         versionWriter.println("JDR: " + Namespace.CURRENT.getUriString());
 
         try {

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
@@ -27,6 +27,7 @@ import org.jboss.vfs.VirtualFile;
 import java.io.ByteArrayInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.zip.ZipEntry;
@@ -143,7 +144,7 @@ public class JdrZipFile {
         name.append("/");
         name.append(path);
 
-        this.add(new ByteArrayInputStream(content.getBytes()), name.toString());
+        this.add(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), name.toString());
     }
 
     /**
@@ -178,7 +179,7 @@ public class JdrZipFile {
      */
     public void addLog(String content, String logName) throws Exception {
         String name = "sos_logs/" + logName;
-        this.add(new ByteArrayInputStream(content.getBytes()), name);
+        this.add(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)), name);
     }
 
     public void close() throws Exception {

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/Utils.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/Utils.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,7 @@ public final class Utils {
     }
 
     public static List<String> readLines(InputStream input) throws IOException {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input,StandardCharsets.UTF_8));
         List<String> result = new ArrayList<String>();
         String line = reader.readLine();
 
@@ -52,7 +53,7 @@ public final class Utils {
     }
 
     public static String toString(VirtualFile r) throws IOException {
-        return new String(toBytes(r));
+        return new String(toBytes(r), StandardCharsets.UTF_8);
     }
 
     public static byte[] toBytes(VirtualFile r) throws IOException {

--- a/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrTestCase.java
+++ b/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrTestCase.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.*;
 
@@ -72,23 +73,23 @@ public class JdrTestCase {
     @Test
     public void testXMLSanitizer() throws Exception {
         String xml = "<test><password>foobar</password></test>";
-        InputStream is = new ByteArrayInputStream(xml.getBytes());
+        InputStream is = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
         XMLSanitizer s = new XMLSanitizer("//password", Filters.TRUE);
         InputStream res = s.sanitize(is);
         byte [] buf = new byte [res.available()];
         res.read(buf);
-        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test><password/></test>", new String(buf));
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?><test><password/></test>", new String(buf, StandardCharsets.UTF_8));
     }
 
     @Test
     public void testPatternSanitizer() throws Exception {
         String propf = "password=123456";
-        InputStream is = new ByteArrayInputStream(propf.getBytes());
+        InputStream is = new ByteArrayInputStream(propf.getBytes(StandardCharsets.UTF_8));
         PatternSanitizer s = new PatternSanitizer("password=.*", "password=*", Filters.TRUE);
         InputStream res = s.sanitize(is);
         byte [] buf = new byte [res.available()];
         res.read(buf);
-        assertEquals("password=*", new String(buf));
+        assertEquals("password=*", new String(buf, StandardCharsets.UTF_8));
     }
 
     @Test

--- a/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultSession.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultSession.java
@@ -171,11 +171,11 @@ public final class VaultSession {
         SecretKeyFactory factory = SecretKeyFactory.getInstance(VAULT_ENC_ALGORITHM);
 
         char[] password = "somearbitrarycrazystringthatdoesnotmatter".toCharArray();
-        PBEParameterSpec cipherSpec = new PBEParameterSpec(salt.getBytes(), iterationCount);
+        PBEParameterSpec cipherSpec = new PBEParameterSpec(salt.getBytes(CHARSET), iterationCount);
         PBEKeySpec keySpec = new PBEKeySpec(password);
         SecretKey cipherKey = factory.generateSecret(keySpec);
 
-        String maskedPass = PBEUtils.encode64(keystorePassword.getBytes(), VAULT_ENC_ALGORITHM, cipherKey, cipherSpec);
+        String maskedPass = PBEUtils.encode64(keystorePassword.getBytes(CHARSET), VAULT_ENC_ALGORITHM, cipherKey, cipherSpec);
 
         return PicketBoxSecurityVault.PASS_MASK_PREFIX + maskedPass;
     }

--- a/security/subsystem/src/test/java/org/jboss/as/security/vault/VaultToolTestCase.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/vault/VaultToolTestCase.java
@@ -34,6 +34,7 @@ import javax.crypto.SecretKey;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -87,7 +88,7 @@ public class VaultToolTestCase extends VaultTest {
         Assert.assertEquals("Exit status is equal to 0", 0, e.status);
     }
     SYSTEM_OUT.flush();
-    String ouput = new String(SYSTEM_OUT.toByteArray());
+    String ouput = new String(SYSTEM_OUT.toByteArray(), StandardCharsets.UTF_8);
     String[] outputLines = ouput.split("\n");
 
     String vaultSharedKey = getStoredAttributeSharedKey(outputLines);

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/HttpRequest.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/eclipselink/HttpRequest.java
@@ -29,6 +29,7 @@ import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -128,7 +129,7 @@ public class HttpRequest {
     }
 
     private static void write(OutputStream out, String message) throws IOException {
-        final OutputStreamWriter writer = new OutputStreamWriter(out);
+        final OutputStreamWriter writer = new OutputStreamWriter(out, StandardCharsets.UTF_8);
         writer.write(message);
         writer.flush();
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/autoignore/TestClass.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/autoignore/TestClass.java
@@ -22,12 +22,9 @@
 package org.jboss.as.test.integration.autoignore;
 
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  *
@@ -44,18 +41,8 @@ public class TestClass implements TestClassMBean {
 
     @Override
     public void start() {
-        final File file = new File(path);
         try {
-            final BufferedWriter writer = new BufferedWriter(new FileWriter(file));
-            final OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
-            try {
-                writer.write("Test\n");
-            } finally {
-                try {
-                    writer.close();
-                } catch (Exception ignore) {
-                }
-            }
+            Files.write(Paths.get(path), "Test\n".getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -255,7 +256,7 @@ public class DeploymentOverlayTestCase {
         op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
         op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
         op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.INPUT_STREAM_INDEX).set(0);
-        opBuilder.addInputStream(new ByteArrayInputStream("new file".getBytes()));
+        opBuilder.addInputStream(new ByteArrayInputStream("new file".getBytes(StandardCharsets.UTF_8)));
         steps.add(op);
 
         //add the non-wildcard link to the server group
@@ -343,7 +344,7 @@ public class DeploymentOverlayTestCase {
     }
 
     public static String getContent(HttpResponse response) throws IOException {
-        InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        InputStreamReader reader = new InputStreamReader(response.getEntity().getContent(),StandardCharsets.UTF_8);
         StringBuilder content = new StringBuilder();
         char[] buffer = new char[8];
         int c;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/StepExecutionMarshaller.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/StepExecutionMarshaller.java
@@ -30,6 +30,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -201,7 +202,7 @@ public class StepExecutionMarshaller {
         if (data == null) {
             return null;
         }
-        final ByteArrayInputStream bais = new ByteArrayInputStream(data.getBytes());
+        final ByteArrayInputStream bais = new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         final ObjectInputStream in = new ObjectInputStream(bais);
         return (Serializable) in.readObject();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.bc;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.Security;
 import java.security.SecurityPermission;
@@ -101,7 +102,7 @@ public class BouncyCastleModuleTestCase {
         desCipher.init(Cipher.ENCRYPT_MODE, myDesKey);
 
         // Sensitive information
-        byte[] text = "Nobody can see me".getBytes();
+        byte[] text = "Nobody can see me".getBytes(StandardCharsets.UTF_8);
         logger.debug("Text [Byte Format]: " + Arrays.toString(text));
         logger.debug("Text: " + new String(text));
 
@@ -114,6 +115,6 @@ public class BouncyCastleModuleTestCase {
 
         // Decrypt the text
         byte[] textDecrypted = desCipher.doFinal(textEncrypted);
-        logger.debug("Text Decryted: " + new String(textDecrypted));
+        logger.debug("Text Decryted: " + new String(textDecrypted,StandardCharsets.UTF_8));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPath2TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPath2TestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.ear;
 
+import java.nio.charset.StandardCharsets;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -40,7 +42,7 @@ public class EarClassPath2TestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
         JavaArchive libJar = ShrinkWrap.create(JavaArchive.class);
         libJar.addClasses(TestAA.class, EarClassPath2TestCase.class);
-        libJar.addAsManifestResource(new ByteArrayAsset("Class-Path: ../../../cp.jar\n".getBytes()), "MANIFEST.MF");
+        libJar.addAsManifestResource(new ByteArrayAsset("Class-Path: ../../../cp.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         war.addAsLibraries(libJar);
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPath3TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPath3TestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.ear;
 
+import java.nio.charset.StandardCharsets;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -40,7 +42,7 @@ public class EarClassPath3TestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
         JavaArchive libJar = ShrinkWrap.create(JavaArchive.class);
         libJar.addClasses(TestAA.class, EarClassPath3TestCase.class);
-        libJar.addAsManifestResource(new ByteArrayAsset("Class-Path: ../../../cp.jar\n".getBytes()), "MANIFEST.MF");
+        libJar.addAsManifestResource(new ByteArrayAsset("Class-Path: ../../../cp.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         war.addAsLibraries(libJar);
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPathTransitiveClosureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarClassPathTransitiveClosureTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.ear;
 
+import java.nio.charset.StandardCharsets;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -47,15 +49,15 @@ public class EarClassPathTransitiveClosureTestCase {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);
         ear.addAsModule(war);
         JavaArchive earLib = ShrinkWrap.create(JavaArchive.class, "earLib.jar");
-        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: ../cp1.jar\n".getBytes()), "MANIFEST.MF");
+        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: ../cp1.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         ear.addAsLibraries(earLib);
 
         earLib = ShrinkWrap.create(JavaArchive.class, "cp1.jar");
-        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: cp2.jar\n".getBytes()), "MANIFEST.MF");
+        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: cp2.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         ear.addAsModule(earLib);
 
         earLib = ShrinkWrap.create(JavaArchive.class, "cp2.jar");
-        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: a/b/c\n".getBytes()), "MANIFEST.MF");
+        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: a/b/c\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         earLib.addClass(TestBB.class);
         ear.addAsModule(earLib);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarLibClassPathTransitiveClosureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarLibClassPathTransitiveClosureTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.deployment.classloading.ear;
 
+import java.nio.charset.StandardCharsets;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -45,11 +47,11 @@ public class EarLibClassPathTransitiveClosureTestCase {
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class);
         ear.addAsModule(war);
         JavaArchive earLib = ShrinkWrap.create(JavaArchive.class, "earLib.jar");
-        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: ../cp1.jar\n".getBytes()), "MANIFEST.MF");
+        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: ../cp1.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         ear.addAsLibraries(earLib);
 
         earLib = ShrinkWrap.create(JavaArchive.class, "cp1.jar");
-        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: cp2.jar\n".getBytes()), "MANIFEST.MF");
+        earLib.addAsManifestResource(new ByteArrayAsset("Class-Path: cp2.jar\n".getBytes(StandardCharsets.UTF_8)), "MANIFEST.MF");
         ear.addAsModule(earLib);
 
         earLib = ShrinkWrap.create(JavaArchive.class, "cp2.jar");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/AbstractOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/AbstractOverlayTestBase.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.deployment.deploymentoverlay;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -72,7 +73,7 @@ public abstract class AbstractOverlayTestBase {
             op = new ModelNode();
             op.get(ModelDescriptionConstants.OP_ADDR).set(new ModelNode());
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES);
-            op.get(ModelDescriptionConstants.BYTES).set(overlayItem.getValue().getBytes());
+            op.get(ModelDescriptionConstants.BYTES).set(overlayItem.getValue().getBytes(StandardCharsets.UTF_8));
             ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             // link content to specific file

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/AffectedDeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/AffectedDeploymentOverlayTestCase.java
@@ -20,6 +20,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEP
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import org.hamcrest.CoreMatchers;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -77,7 +78,8 @@ public class AffectedDeploymentOverlayTestCase extends ContainerResourceMgmtTest
         getModelControllerClient().execute(Operations.createAddOperation(TEST_WILDCARD_ADDRESS.toModelNode()));
 
         op = Operations.createAddOperation(TEST_WILDCARD_ADDRESS.append(ModelDescriptionConstants.CONTENT, "WEB-INF/web.xml").toModelNode());
-        op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(AffectedDeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes());
+        op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(
+                FileUtils.readFile(AffectedDeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes(StandardCharsets.UTF_8));
         getModelControllerClient().execute(op);
 
         op = Operations.createAddOperation(TEST_WILDCARD_ADDRESS.append(ModelDescriptionConstants.CONTENT, "WEB-INF/classes/wildcard-new-file").toModelNode());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
@@ -1,6 +1,7 @@
 package org.jboss.as.test.integration.deployment.deploymentoverlay;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -50,7 +51,7 @@ public class DeploymentOverlayTestCase {
             op = new ModelNode();
             op.get(ModelDescriptionConstants.OP_ADDR).set(new ModelNode());
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES);
-            op.get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "override.xml").getBytes());
+            op.get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "override.xml").getBytes(StandardCharsets.UTF_8));
             ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             //add the content
@@ -84,7 +85,7 @@ public class DeploymentOverlayTestCase {
             addr.add(ModelDescriptionConstants.CONTENT, "WEB-INF/web.xml");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes());
+            op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes(StandardCharsets.UTF_8));
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             op = new ModelNode();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ExplodedDeploymentOverlayTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ExplodedDeploymentOverlayTestCase.java
@@ -22,6 +22,8 @@ package org.jboss.as.test.integration.deployment.deploymentoverlay;
 
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -105,7 +107,7 @@ public class ExplodedDeploymentOverlayTestCase {
         op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
         op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
         op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(
-                FileUtils.readFile(ExplodedDeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes());
+                FileUtils.readFile(ExplodedDeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes(StandardCharsets.UTF_8));
         ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
         op = new ModelNode();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -90,7 +91,7 @@ public class EarOverlayTestBase extends WarOverlayTestBase {
         @Override
         protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
             try (InputStream input = getClass().getClassLoader().getResourceAsStream(META_RESOURCE_IN_JAR_STATIC);
-                 InputStreamReader inputReader = new InputStreamReader(input);
+                 InputStreamReader inputReader = new InputStreamReader(input, StandardCharsets.UTF_8);
                  BufferedReader reader = new BufferedReader(inputReader)) {
                 resp.getWriter().write(reader.readLine());
                 resp.flushBuffer();
@@ -109,7 +110,7 @@ public class EarOverlayTestBase extends WarOverlayTestBase {
                     resp.sendError(404);
                     return;
                 }
-                try (InputStreamReader inputReader = new InputStreamReader(input);
+                try (InputStreamReader inputReader = new InputStreamReader(input, StandardCharsets.UTF_8);
                      BufferedReader reader = new BufferedReader(inputReader)) {
                     resp.getWriter().write(reader.readLine());
                     resp.flushBuffer();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import javax.ejb.Singleton;
 
@@ -50,7 +51,7 @@ public class OverlayEJB implements OverlayableInterface {
             if (is == null) {
                 return null;
             }
-            try (InputStreamReader isr = new InputStreamReader(is);
+            try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
                  BufferedReader br = new BufferedReader(isr);) {
                 return br.readLine();
             }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
@@ -65,7 +66,7 @@ public class WarOverlayTestBase extends JarOverlayTestBase{
             int httpCode = conn.getResponseCode();
             if (httpCode == 200) {
                 try (InputStream input = conn.getInputStream();
-                     InputStreamReader inputReader = new InputStreamReader(input);
+                     InputStreamReader inputReader = new InputStreamReader(input, StandardCharsets.UTF_8);
                      BufferedReader reader = new BufferedReader(inputReader)) {
                     return reader.readLine();
                 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/JarSignerUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/JarSignerUtil.java
@@ -22,11 +22,8 @@
 package org.jboss.as.test.integration.deployment.jcedeployment;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-
-import org.xnio.IoUtils;
+import java.nio.file.Files;
 
 /**
  * Utility for signing jars.
@@ -91,20 +88,7 @@ class JarSignerUtil {
     }
 
     private static void copyFile(final File src, final File dst) throws IOException {
-        FileInputStream in = null;
-        FileOutputStream out = null;
-        try {
-            in = new FileInputStream(src);
-            out = new FileOutputStream(dst);
-            byte[] buffer = new byte[4096];
-            int read;
-            while ((read = in.read(buffer)) != -1) {
-                out.write(buffer, 0, read);
-            }
-        } finally {
-            IoUtils.safeClose(in);
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src.toPath(), dst.toPath());
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/provider/DummyCipher.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/jcedeployment/provider/DummyCipher.java
@@ -25,6 +25,8 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+
+import java.nio.charset.StandardCharsets;
 import java.security.AlgorithmParameters;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -120,7 +122,7 @@ public class DummyCipher implements DPCipher {
                 cipher = "decrypted";
                 break;
         }
-        return cipher.getBytes().clone();
+        return cipher.getBytes(StandardCharsets.UTF_8).clone();
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import javax.ejb.EJB;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
@@ -116,7 +117,7 @@ public class WarJBossDeploymentStructureTestCase {
             int res;
             StringBuilder sb = new StringBuilder();
             while ((res = clazz.read(data)) > 0) {
-                sb.append(new String(data, 0, res));
+                sb.append(new String(data, 0, res, StandardCharsets.UTF_8));
             }
             Assert.assertEquals("Root file", sb.toString());
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/util/AppClientWrapper.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/appclient/util/AppClientWrapper.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -49,7 +50,6 @@ public class AppClientWrapper implements Runnable {
     private static final String errThreadHame = "APPCLIENT-err";
 
     private Process appClientProcess;
-    private PrintWriter writer;
     private BufferedReader outputReader;
     private BufferedReader errorReader;
     private BlockingQueue<String> outputQueue = new LinkedBlockingQueue<String>();
@@ -150,9 +150,9 @@ public class AppClientWrapper implements Runnable {
         });
         Runtime.getRuntime().addShutdownHook(shutdownThread);
         appClientProcess = Runtime.getRuntime().exec(getAppClientCommand());
-        writer = new PrintWriter(appClientProcess.getOutputStream());
-        outputReader = new BufferedReader(new InputStreamReader(appClientProcess.getInputStream()));
-        errorReader = new BufferedReader(new InputStreamReader(appClientProcess.getErrorStream()));
+        new PrintWriter(appClientProcess.getOutputStream());
+        outputReader = new BufferedReader(new InputStreamReader(appClientProcess.getInputStream(), StandardCharsets.UTF_8));
+        errorReader = new BufferedReader(new InputStreamReader(appClientProcess.getErrorStream(), StandardCharsets.UTF_8));
 
         final Thread readOutputThread = new Thread(this, outThreadHame);
         readOutputThread.start();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/globalmodules/GlobalModulesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/globalmodules/GlobalModulesTestCase.java
@@ -29,13 +29,13 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UND
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.sql.SQLException;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -58,7 +58,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.xnio.IoUtils;
 
 /**
  * @author Stuart Douglas
@@ -162,16 +161,7 @@ public class GlobalModulesTestCase {
 
 
     private static void copyFile(File target, InputStream src) throws IOException {
-        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-        try {
-            int i = src.read();
-            while (i != -1) {
-                out.write(i);
-                i = src.read();
-            }
-        } finally {
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src,  target.toPath());
     }
 
     private static File getModulePath() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/HttpUpgradeHandlerInjectionSupportTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/HttpUpgradeHandlerInjectionSupportTestCase.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -83,7 +84,7 @@ public class HttpUpgradeHandlerInjectionSupportTestCase extends InjectionSupport
         try {
 
             socket = new Socket(host, port);
-            out = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+            out = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8));
 
             // Initial HTTP upgrade request
             out.write("GET /" + contextRoot + "TestUpgradeServlet HTTP/1.1" + CRLF);
@@ -94,7 +95,7 @@ public class HttpUpgradeHandlerInjectionSupportTestCase extends InjectionSupport
             out.flush();
 
             // Receive the protocol upgrade response
-            in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            in = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8));
             String line = null;
             while ((line = in.readLine()) != null) {
                 if ("".equals(line)) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/TestReadListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/support/servlet/TestReadListener.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.ee.injection.support.servlet;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.servlet.ReadListener;
@@ -55,9 +56,9 @@ public class TestReadListener implements ReadListener {
             // Expected data is "dummy request#"
             len = input.read(b);
             if (len > 0) {
-                String data = new String(b, 0, len);
+                String data = new String(b, 0, len, StandardCharsets.UTF_8);
                 if (data.endsWith("#")) {
-                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(handler.getWebConnection().getOutputStream()));
+                    BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(handler.getWebConnection().getOutputStream(), StandardCharsets.UTF_8));
                     writeLine(writer, "isPostConstructCallbackInvoked: " + handler.isPostConstructCallbackInvoked());
                     writeLine(writer, "isInjectionOk: " + handler.isInjectionOk());
                     writeLine(writer, "isInterceptorInvoked: " + isInterceptorInvoked());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/log/InvalidTransactionAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/log/InvalidTransactionAttributeTestCase.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -67,7 +68,7 @@ public class InvalidTransactionAttributeTestCase {
             deployer.deploy("invalidtransactionattribute");
             try {
                 System.setOut(oldOut);
-                String output = new String(baos.toByteArray());
+                String output = new String(baos.toByteArray(), StandardCharsets.UTF_8);
                 Assert.assertFalse(output, output.contains("WFLYEJB0463"));
                 Assert.assertFalse(output, output.contains("ERROR"));
             } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -37,6 +37,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -349,7 +350,7 @@ public class AuthenticationTestCase {
                 final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 if (username != null) {
                     final String userpassword = username + ":" + password;
-                    final String basicAuthorization = java.util.Base64.getEncoder().encodeToString(userpassword.getBytes());
+                    final String basicAuthorization = java.util.Base64.getEncoder().encodeToString(userpassword.getBytes(StandardCharsets.UTF_8));
                     conn.setRequestProperty("Authorization", "Basic " + basicAuthorization);
                 }
                 conn.setDoInput(true);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/PollingUtils.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/PollingUtils.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -129,7 +130,7 @@ public class PollingUtils {
                 conn.setDoInput(true);
                 if (request != null) {
                     conn.setDoOutput(true);
-                    osw = new OutputStreamWriter(conn.getOutputStream());
+                    osw = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
                     osw.write(request);
                     osw.flush();
                 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/multipart/JaxrsMultipartProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/multipart/JaxrsMultipartProviderTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.jaxrs.multipart;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 import javax.activation.DataSource;
@@ -73,7 +74,7 @@ public class JaxrsMultipartProviderTestCase {
     @Test
     public void testJaxRsWithNoApplication() throws Exception {
         String result = performCall("myjaxrs/form");
-        DataSource mimeData = new ByteArrayDataSource(result.getBytes(),"multipart/related");
+        DataSource mimeData = new ByteArrayDataSource(result.getBytes(StandardCharsets.UTF_8),"multipart/related");
         MimeMultipart mime = new MimeMultipart(mimeData);
         String string  = (String)mime.getBodyPart(0).getContent();
         Assert.assertEquals("Hello", string);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/provider/preference/CustomMessageBodyWriter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/provider/preference/CustomMessageBodyWriter.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -49,7 +50,7 @@ public class CustomMessageBodyWriter implements MessageBodyWriter<Object> {
 
     public void writeTo(Object arg0, Class<?> arg1, Type arg2, Annotation[] arg3, MediaType arg4,
             MultivaluedMap<String, Object> arg5, OutputStream arg6) throws IOException, WebApplicationException {
-        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(arg6));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(arg6,StandardCharsets.UTF_8));
         bw.write(arg0.toString());
         bw.flush();
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/beanvalidation/cdi/BeanValidationCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/beanvalidation/cdi/BeanValidationCdiIntegrationTestCase.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -118,7 +119,7 @@ public class BeanValidationCdiIntegrationTestCase {
             HttpGet getRequest = new HttpGet(requestUrl);
             HttpResponse response = client.execute(getRequest);
             try {
-                String responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                String responseString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
 
                 // Get the JSF view state
                 Matcher jsfViewMatcher = viewStatePattern.matcher(responseString);
@@ -140,11 +141,11 @@ public class BeanValidationCdiIntegrationTestCase {
             list.add(new BasicNameValuePair("register:inputNumber", Integer.toString(numberOfPeople)));
             list.add(new BasicNameValuePair("register:registerButton", "Register"));
 
-            post.setEntity(new StringEntity(URLEncodedUtils.format(list, "UTF-8"), ContentType.APPLICATION_FORM_URLENCODED));
+            post.setEntity(new StringEntity(URLEncodedUtils.format(list, StandardCharsets.UTF_8), ContentType.APPLICATION_FORM_URLENCODED));
             response = client.execute(post);
 
             try {
-                return IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                return IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/doctype/DoctypeDeclTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/doctype/DoctypeDeclTestCase.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -112,7 +113,7 @@ public class DoctypeDeclTestCase {
             HttpResponse response = client.execute(getRequest);
             try {
                 // Get the JSF view state
-                String responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                String responseString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
                 Matcher jsfViewMatcher = viewStatePattern.matcher(responseString);
                 if (jsfViewMatcher.find()) {
                     jsfViewState = jsfViewMatcher.group(1);
@@ -128,12 +129,12 @@ public class DoctypeDeclTestCase {
             list.add(new BasicNameValuePair("register", "register"));
             list.add(new BasicNameValuePair("register:inputName", name));
             list.add(new BasicNameValuePair("register:registerButton", "Register"));
-            post.setEntity(new StringEntity(URLEncodedUtils.format(list, "UTF-8"), ContentType.APPLICATION_FORM_URLENCODED));
+            post.setEntity(new StringEntity(URLEncodedUtils.format(list, StandardCharsets.UTF_8), ContentType.APPLICATION_FORM_URLENCODED));
             response = client.execute(post);
 
             try {
                 assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
-                return IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                return IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/duplicateid/DuplicateIDIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/duplicateid/DuplicateIDIntegrationTestCase.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -131,7 +132,7 @@ public class DuplicateIDIntegrationTestCase {
                 params.add(new BasicNameValuePair(input.getName(), input.getValue()));
             }
         }
-        request.setEntity(new UrlEncodedFormEntity(params, "UTF-8"));
+        request.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
         log.debug("Clicking on submit button '{}'.", buttonValue);
         return client.execute(request);
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/jsf23/JSF23SanityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/jsf23/JSF23SanityTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.jsf.jsf23;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -91,7 +92,7 @@ public class JSF23SanityTestCase {
             HttpGet getRequest = new HttpGet(requestUrl);
             HttpResponse response = client.execute(getRequest);
             try {
-                responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                responseString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
 
                 // Get the JSF view state
                 Matcher jsfViewMatcher = viewStatePattern.matcher(responseString);
@@ -110,11 +111,11 @@ public class JSF23SanityTestCase {
             list.add(new BasicNameValuePair("register", "register"));
             list.add(new BasicNameValuePair("register:registerButton", "Register"));
 
-            post.setEntity(new StringEntity(URLEncodedUtils.format(list, "UTF-8"), ContentType.APPLICATION_FORM_URLENCODED));
+            post.setEntity(new StringEntity(URLEncodedUtils.format(list, StandardCharsets.UTF_8), ContentType.APPLICATION_FORM_URLENCODED));
             response = client.execute(post);
 
             try {
-                responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+                responseString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
             } finally {
                 HttpClientUtils.closeQuietly(response);
             }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/servlet/Servlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/deploy/runtime/servlet/Servlet.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.management.deploy.runtime.servlet;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -42,6 +43,6 @@ public class Servlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.getOutputStream().write(SUCCESS.getBytes());
+        resp.getOutputStream().write(SUCCESS.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ObjectFactoryWithEnvironmentBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ObjectFactoryWithEnvironmentBindingTestCase.java
@@ -37,12 +37,11 @@ import static org.jboss.as.naming.subsystem.NamingSubsystemModel.ENVIRONMENT;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.MODULE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.OBJECT_FACTORY;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -222,16 +221,7 @@ public class ObjectFactoryWithEnvironmentBindingTestCase {
     }
 
     private static void copyFile(File target, InputStream src) throws IOException {
-        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-        try {
-            int i = src.read();
-            while (i != -1) {
-                out.write(i);
-                i = src.read();
-            }
-        } finally {
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src, target.toPath());
     }
 
     private static void deleteRecursively(File file) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/aselytron/SecurityDomainAsElytronSecurityRealmTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/aselytron/SecurityDomainAsElytronSecurityRealmTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.security.aselytron;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
@@ -261,10 +262,10 @@ public class SecurityDomainAsElytronSecurityRealmTestCase {
          */
         @Override
         public void setup(ManagementClient managementClient, String containerId) throws Exception {
-            FileUtils.writeStringToFile(FILE_USERS1, USERS1_CONTENT, "UTF-8");
-            FileUtils.writeStringToFile(FILE_ROLES1, ROLES1_CONTENT, "UTF-8");
-            FileUtils.writeStringToFile(FILE_USERS2, USERS2_CONTENT, "UTF-8");
-            FileUtils.writeStringToFile(FILE_ROLES2, ROLES2_CONTENT, "UTF-8");
+            FileUtils.writeStringToFile(FILE_USERS1, USERS1_CONTENT, StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(FILE_ROLES1, ROLES1_CONTENT, StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(FILE_USERS2, USERS2_CONTENT, StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(FILE_ROLES2, ROLES2_CONTENT, StandardCharsets.UTF_8);
         }
 
         /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModuleTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/CustomAuditProviderModuleTest.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.security.auditing;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -39,7 +40,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -200,7 +200,6 @@ public class CustomAuditProviderModuleTest {
 
     }
 
-    private static final Charset UTF_8 = Charset.forName("utf-8");
     private static String RANDOM_EXECUTION_ID = String.valueOf(UUID.randomUUID().toString().replace("-", ""));
     private static final String AUDIT_HANDLER_NAME;
     private static final String AUDIT_LOG_FILE_NAME;
@@ -268,7 +267,7 @@ public class CustomAuditProviderModuleTest {
 
             if (password != null) {
                 request.addHeader(HttpHeaders.AUTHORIZATION,
-                        "Basic " + FlexBase64.encodeString((user + ":" + password).getBytes("utf-8"), false));
+                        "Basic " + FlexBase64.encodeString((user + ":" + password).getBytes(UTF_8), false));
             }
 
             HttpResponse response = httpclient.execute(request);
@@ -276,7 +275,7 @@ public class CustomAuditProviderModuleTest {
             StatusLine statusLine = response.getStatusLine();
             assertEquals(expectedStatusCode, statusLine.getStatusCode());
             if (statusLine.getStatusCode() == 200) {
-                String body = EntityUtils.toString(entity, "utf-8");
+                String body = EntityUtils.toString(entity, UTF_8);
                 assertEquals("GOOD", body);
             } else {
                 EntityUtils.consume(entity);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
@@ -31,8 +31,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -177,7 +178,7 @@ public class SecurityAuditingTestCase extends AnnSBTest {
         assertTrue("Audit log file has not been created (" + auditLog.getAbsolutePath() + ")", auditLog.exists());
         assertTrue("Audit log file is closed for reading (" + auditLog.getAbsolutePath() + ")", auditLog.canRead());
 
-        BufferedReader reader = new BufferedReader(new FileReader(auditLog));
+        BufferedReader reader = Files.newBufferedReader(auditLog.toPath(), StandardCharsets.UTF_8);
 
         while (reader.readLine() != null) {
             // we need to get trough all old records (if any)
@@ -201,7 +202,7 @@ public class SecurityAuditingTestCase extends AnnSBTest {
         assertTrue("Audit log file has not been created (" + auditLog.getAbsolutePath() + ")", auditLog.exists());
         assertTrue("Audit log file is closed for reading (" + auditLog.getAbsolutePath() + ")", auditLog.canRead());
 
-        BufferedReader reader = new BufferedReader(new FileReader(auditLog));
+        BufferedReader reader = Files.newBufferedReader(auditLog.toPath(), StandardCharsets.UTF_8);
 
         while (reader.readLine() != null) {
             // we need to get trough all old records (if any)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/EESecurityAuthMechanismTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/EESecurityAuthMechanismTestCase.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -75,7 +76,7 @@ public class EESecurityAuthMechanismTestCase {
 
         httpResponse.getEntity().writeTo(bos);
 
-        assertTrue(new String(bos.toByteArray()).contains("Unsecured"));
+        assertTrue(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("Unsecured"));
     }
 
     @Test
@@ -90,7 +91,7 @@ public class EESecurityAuthMechanismTestCase {
 
         httpResponse.getEntity().writeTo(bos);
 
-        assertTrue(new String(bos.toByteArray()).contains("Welcome"));
+        assertTrue(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("Welcome"));
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JASPIHttpSchemeServerAuthModelTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/JASPIHttpSchemeServerAuthModelTestCase.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -78,7 +79,7 @@ public class JASPIHttpSchemeServerAuthModelTestCase {
 
         httpResponse.getEntity().writeTo(bos);
 
-        assertTrue(new String(bos.toByteArray()).contains("Unsecured"));
+        assertTrue(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("Unsecured"));
     }
 
     @Test
@@ -93,7 +94,7 @@ public class JASPIHttpSchemeServerAuthModelTestCase {
 
         httpResponse.getEntity().writeTo(bos);
 
-        assertTrue(new String(bos.toByteArray()).contains("Welcome"));
+        assertTrue(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("Welcome"));
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/CustomLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/CustomLoginModuleTestCase.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -51,7 +52,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.HTTP;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -190,7 +190,7 @@ public class CustomLoginModuleTestCase {
             nvps.add(new BasicNameValuePair("j_username", user));
             nvps.add(new BasicNameValuePair("j_password", pass));
 
-            httpost.setEntity(new UrlEncodedFormEntity(nvps, HTTP.UTF_8));
+            httpost.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
 
             response = httpclient.execute(httpost);
             entity = response.getEntity();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLDAPServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLDAPServerSetupTask.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.security.loginmodules;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,7 +91,7 @@ public class LdapExtLDAPServerSetupTask implements ServerSetupTask {
         for (final String role : ROLE_NAMES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        QUERY_ROLES = URLEncodedUtils.format(qparams, "UTF-8");
+        QUERY_ROLES = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     private DirectoryService directoryService1;
@@ -163,12 +164,12 @@ public class LdapExtLDAPServerSetupTask implements ServerSetupTask {
         final String ldifContent = StrSubstitutor.replace(
                 IOUtils.toString(
                         LdapExtLoginModuleTestCase.class.getResourceAsStream(LdapExtLoginModuleTestCase.class.getSimpleName()
-                                + ".ldif"), "UTF-8"), map);
+                                + ".ldif"), StandardCharsets.UTF_8), map);
         LOGGER.debug(ldifContent);
 
         final SchemaManager schemaManager = directoryService1.getSchemaManager();
         try {
-            for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent))) {
+            for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
                 directoryService1.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
             }
         } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/MultipleCustomLoginModulesTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/MultipleCustomLoginModulesTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.http.HttpEntity;
@@ -187,7 +188,7 @@ public class MultipleCustomLoginModulesTest {
 
             if (password != null) {
                 request.addHeader(HttpHeaders.AUTHORIZATION,
-                        "Basic " + FlexBase64.encodeString((user + ":" + password).getBytes("utf-8"), false));
+                        "Basic " + FlexBase64.encodeString((user + ":" + password).getBytes(StandardCharsets.UTF_8), false));
             }
 
             HttpResponse response = httpclient.execute(request);
@@ -195,7 +196,7 @@ public class MultipleCustomLoginModulesTest {
             StatusLine statusLine = response.getStatusLine();
             assertEquals(expectedStatusCode, statusLine.getStatusCode());
             if (statusLine.getStatusCode() == 200) {
-                String body = EntityUtils.toString(entity, "utf-8");
+                String body = EntityUtils.toString(entity, StandardCharsets.UTF_8);
                 assertEquals("GOOD", body);
             } else {
                 EntityUtils.consume(entity);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RunAsLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RunAsLoginModuleTestCase.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import javax.security.auth.AuthPermission;
@@ -153,7 +154,7 @@ public class RunAsLoginModuleTestCase {
         HttpResponse response;
 
         HttpGet httpget = new HttpGet(url.toString());
-        String headerValue = Base64.getEncoder().encodeToString("anil:anil".getBytes());
+        String headerValue = Base64.getEncoder().encodeToString("anil:anil".getBytes(StandardCharsets.UTF_8));
         Assert.assertNotNull(headerValue);
         httpget.addHeader("Authorization", "Basic " + headerValue);
         String text;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/AdvancedLdapLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/AdvancedLdapLoginModuleTestCase.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedActionException;
 import java.security.Security;
 import java.util.ArrayList;
@@ -145,7 +146,7 @@ public class AdvancedLdapLoginModuleTestCase {
         for (final String role : ROLE_NAMES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        QUERY_ROLES = URLEncodedUtils.format(qparams, "UTF-8");
+        QUERY_ROLES = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     @ArquillianResource
@@ -411,11 +412,11 @@ public class AdvancedLdapLoginModuleTestCase {
             final String ldifContent = StrSubstitutor.replace(
                     IOUtils.toString(
                             AdvancedLdapLoginModuleTestCase.class.getResourceAsStream(AdvancedLdapLoginModuleTestCase.class
-                                    .getSimpleName() + ".ldif"), "UTF-8"), map);
+                                    .getSimpleName() + ".ldif"), StandardCharsets.UTF_8), map);
             LOGGER.trace(ldifContent);
             final SchemaManager schemaManager = directoryService.getSchemaManager();
             try {
-                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent))) {
+                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
                     directoryService.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
                 }
             } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/SPNEGOLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/SPNEGOLoginModuleTestCase.java
@@ -595,12 +595,12 @@ public class SPNEGOLoginModuleTestCase {
             final String ldifContent = StrSubstitutor.replace(
                     IOUtils.toString(
                             SPNEGOLoginModuleTestCase.class.getResourceAsStream(SPNEGOLoginModuleTestCase.class.getSimpleName()
-                                    + ".ldif"), "UTF-8"), map);
+                                    + ".ldif"), StandardCharsets.UTF_8), map);
             LOGGER.trace(ldifContent);
             final SchemaManager schemaManager = directoryService.getSchemaManager();
             try {
 
-                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent))) {
+                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
                     directoryService.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
                 }
             } catch (Exception e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/vault/ExternalPasswordCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/vault/ExternalPasswordCommandsTestCase.java
@@ -29,10 +29,10 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Set;
@@ -187,9 +187,7 @@ public class ExternalPasswordCommandsTestCase {
     public void testPicketboxClassPassword() throws Exception {
 
         File tmpPassword = new File(System.getProperty("java.io.tmpdir"), "tmp.password");
-        FileWriter writer = new FileWriter(tmpPassword);
-        writer.write(VAULT_PASSWORD);
-        writer.close();
+        Files.write(tmpPassword.toPath(), VAULT_PASSWORD.getBytes(StandardCharsets.UTF_8));
 
         String passwordCmd = "{CLASS@org.picketbox}org.jboss.security.plugins.TmpFilePassword:${java.io.tmpdir}/tmp.password";
         passwordCmd = StringPropertyReplacer.replaceProperties(passwordCmd);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPInteroperabilityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPInteroperabilityTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -166,7 +167,7 @@ public class JBossPDPInteroperabilityTestCase {
         try {
             policyDir.mkdirs();
             final JBossPDP pdp = createPDPForMed(policyDir);
-            final String requestTemplate = IOUtils.toString(requestIS, "UTF-8");
+            final String requestTemplate = IOUtils.toString(requestIS, StandardCharsets.UTF_8);
             LOGGER.trace("REQUEST template: " + requestTemplate);
             final Map<String, Object> substitutionMap = new HashMap<String, Object>();
 
@@ -249,7 +250,7 @@ public class JBossPDPInteroperabilityTestCase {
      */
     private int getDecisionForStr(PolicyDecisionPoint pdp, String requestStr) throws Exception {
         final RequestContext request = RequestResponseContextFactory.createRequestCtx();
-        request.readRequest(IOUtils.toInputStream(requestStr));
+        request.readRequest(IOUtils.toInputStream(requestStr, StandardCharsets.UTF_8));
         return getDecision(pdp, request);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/filter/AnnotatedFilter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/filter/AnnotatedFilter.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.web.filter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -46,7 +47,7 @@ public class AnnotatedFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        servletResponse.getOutputStream().write(OUTPUT.getBytes());
+        servletResponse.getOutputStream().write(OUTPUT.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/RSCodeResponder.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/RSCodeResponder.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.web.headers;
 
+import java.nio.charset.StandardCharsets;
+
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
@@ -47,7 +49,7 @@ public class RSCodeResponder {
     @Produces(MediaType.APPLICATION_JSON)
     public Response return204(@PathParam("code") final String code,@Context HttpServletResponse resp) throws Exception{
         resp.setContentType("application/json");
-        resp.getOutputStream().write((CONTENT).getBytes());
+        resp.getOutputStream().write((CONTENT).getBytes(StandardCharsets.UTF_8));
         return Response.status(Integer.parseInt(code)).build();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
@@ -33,9 +33,10 @@ import static org.junit.Assert.assertTrue;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FilePermission;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -279,7 +280,7 @@ public class ServletRunAsTestCase {
     }
 
     private String readFirstLineOfFile(File file) throws IOException {
-        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+        try (BufferedReader br = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
             return br.readLine();
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/ejb/SessionObjectReferenceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/ejb/SessionObjectReferenceTestCase.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -92,7 +93,7 @@ public class SessionObjectReferenceTestCase {
     @Test
     public void testEcho() throws Exception {
         String result = performCall("simple", "Hello+world");
-        XMLDecoder decoder = new XMLDecoder(new ByteArrayInputStream(result.getBytes()));
+        XMLDecoder decoder = new XMLDecoder(new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8)));
         List<String> results = (List<String>) decoder.readObject();
         List<Exception> exceptions = (List<Exception>) decoder.readObject();
         String sharedContext = (String) decoder.readObject();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/multideployment/WeldModuleDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/multideployment/WeldModuleDeploymentTestCase.java
@@ -22,13 +22,13 @@
 
 package org.jboss.as.test.integration.weld.multideployment;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 
 import javax.inject.Inject;
 
@@ -48,7 +48,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.xnio.IoUtils;
 
 /**
  * Tests that beans definied in a static can be used by a deployment
@@ -127,16 +126,7 @@ public class WeldModuleDeploymentTestCase {
     }
 
     private static void copyFile(File target, InputStream src) throws IOException {
-        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-        try {
-            int i = src.read();
-            while (i != -1) {
-                out.write(i);
-                i = src.read();
-            }
-        } finally {
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src, target.toPath());
     }
 
     private static File getModulePath() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusterHttpClientUtil.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -121,7 +122,7 @@ public final class ClusterHttpClientUtil {
 
         // Consume it
         StringBuilder sb = new StringBuilder();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(response.getEntity().getContent()), 4096)) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8), 4096)) {
             String line;
             while ((line = br.readLine()) != null) {
                 sb.append(line);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering.cluster.jsf;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
         Matcher matcher;
 
         NumberGuessState state = new NumberGuessState();
-        String responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+        String responseString = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
 
         Map.Entry<String, String> sessionRouteEntry = parseSessionRoute(response);
         state.sessionId = (sessionRouteEntry != null) ? sessionRouteEntry.getKey() : sessionId;
@@ -144,7 +145,7 @@ public class JSFFailoverTestCase extends AbstractClusteringTestCase {
         list.add(new BasicNameValuePair("numberGuess:guessButton", "Guess"));
         list.add(new BasicNameValuePair("numberGuess:inputGuess", guess));
 
-        post.setEntity(new StringEntity(URLEncodedUtils.format(list, "UTF-8"), ContentType.APPLICATION_FORM_URLENCODED));
+        post.setEntity(new StringEntity(URLEncodedUtils.format(list, StandardCharsets.UTF_8), ContentType.APPLICATION_FORM_URLENCODED));
         if (sessionId != null) {
             post.setHeader("Cookie", "JSESSIONID=" + sessionId);
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -109,7 +110,7 @@ public class FormAuthenticationWebFailoverTestCase extends AbstractClusteringTes
             pairs.add(new BasicNameValuePair("j_username", "allowed"));
             pairs.add(new BasicNameValuePair("j_password", "password"));
 
-            login.setEntity(new UrlEncodedFormEntity(pairs, "UTF-8"));
+            login.setEntity(new UrlEncodedFormEntity(pairs, StandardCharsets.UTF_8));
             response = client.execute(login);
             try {
                 Assert.assertEquals(HttpServletResponse.SC_FOUND, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/FileAuditLogTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/audit/FileAuditLogTestCase.java
@@ -21,11 +21,18 @@
  */
 package org.wildfly.test.integration.elytron.audit;
 
-import java.io.BufferedReader;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.jboss.as.test.shared.CliUtils.asAbsolutePath;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
-import java.io.FileReader;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
 import org.codehaus.plexus.util.FileUtils;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -40,13 +47,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.security.common.elytron.FileAuditLog;
-
-import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-import static org.jboss.as.test.shared.CliUtils.asAbsolutePath;
-import static org.junit.Assert.assertTrue;
-import static org.wildfly.test.integration.elytron.audit.AbstractAuditLogTestCase.SD_WITHOUT_LOGIN_PERMISSION;
-import static org.wildfly.test.integration.elytron.audit.AbstractAuditLogTestCase.setEventListenerOfApplicationDomain;
 
 /**
  * Test case for 'file-audit-log' Elytron subsystem resource.
@@ -198,10 +198,8 @@ public class FileAuditLogTestCase extends AbstractAuditLogTestCase {
     }
 
     private static boolean loggedAuthResult(File file, String user, String expectedEvent) throws Exception {
-        BufferedReader reader = new BufferedReader(new FileReader(file));
-
-        String line;
-        while ((line = reader.readLine()) != null) {
+        List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+        for (String line : lines) {
             if (line.contains(expectedEvent) && line.contains(user)) {
                 return true;
             }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/AggregateRealmTestCase.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -78,8 +79,6 @@ import org.junit.runner.RunWith;
 @ServerSetup({AggregateRealmTestCase.SetupTask.class})
 public class AggregateRealmTestCase {
 
-    private static final String CHARSET_UTF_8 = "UTF-8";
-
     private static final String AGGREGATE_REALM_SAME_TYPE_NAME = "elytron-aggregate-realm-same-type";
     private static final String AGGREGATE_REALM_DIFFERENT_TYPE_NAME = "elytron-aggregate-realm-different-type";
 
@@ -107,7 +106,7 @@ public class AggregateRealmTestCase {
         for (final String role : ALL_TESTED_ROLES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        QUERY_ROLES = URLEncodedUtils.format(qparams, "UTF-8");
+        QUERY_ROLES = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     @Deployment(name = AGGREGATE_REALM_SAME_TYPE_NAME)
@@ -592,13 +591,13 @@ public class AggregateRealmTestCase {
             sb.append(createPropertiesUserWithHashedPassword(USER_WITH_TWO_ROLES, CORRECT_PASSWORD, PROPERTIES_REALM_AUTHN_NAME));
             sb.append(createPropertiesUserWithHashedPassword(USER_WITH_DIFFERENT_ROLE_IN_DIFFERENT_REALM, CORRECT_PASSWORD, PROPERTIES_REALM_AUTHN_NAME));
             sb.append(createPropertiesUserWithHashedPassword(USER_ONLY_IN_AUTHORIZATION, CORRECT_PASSWORD, PROPERTIES_REALM_AUTHN_NAME));
-            FileUtils.writeStringToFile(usersAuthnRealmFile, sb.toString(), CHARSET_UTF_8);
+            FileUtils.writeStringToFile(usersAuthnRealmFile, sb.toString(), StandardCharsets.UTF_8);
         }
 
         private void createRolesProperties_authnRealm() throws IOException {
             StringBuilder sb = new StringBuilder();
             sb.append(USER_WITH_DIFFERENT_ROLE_IN_DIFFERENT_REALM + "=" + ROLE_USER + "\n");
-            FileUtils.writeStringToFile(rolesAuthnRealmFile, sb.toString(), CHARSET_UTF_8);
+            FileUtils.writeStringToFile(rolesAuthnRealmFile, sb.toString(), StandardCharsets.UTF_8);
         }
 
         private void createUsersProperties_authzRealm() throws IOException {
@@ -608,7 +607,7 @@ public class AggregateRealmTestCase {
             sb.append(createPropertiesUserWithHashedPassword(USER_WITH_ONE_ROLE, AUTHORIZATION_REALM_PASSWORD, PROPERTIES_REALM_AUTHZ_NAME));
             sb.append(createPropertiesUserWithHashedPassword(USER_WITH_TWO_ROLES, AUTHORIZATION_REALM_PASSWORD, PROPERTIES_REALM_AUTHZ_NAME));
             sb.append(createPropertiesUserWithHashedPassword(USER_WITH_DIFFERENT_ROLE_IN_DIFFERENT_REALM, AUTHORIZATION_REALM_PASSWORD, PROPERTIES_REALM_AUTHZ_NAME));
-            FileUtils.writeStringToFile(usersAuthzRealmFile, sb.toString(), CHARSET_UTF_8);
+            FileUtils.writeStringToFile(usersAuthzRealmFile, sb.toString(), StandardCharsets.UTF_8);
         }
 
         private void createRolesProperties_authzRealm() throws IOException {
@@ -617,7 +616,7 @@ public class AggregateRealmTestCase {
             sb.append(USER_WITH_TWO_ROLES + "=" + ROLE_USER + "," + ROLE_ADMIN + "\n");
             sb.append(USER_WITH_DIFFERENT_ROLE_IN_DIFFERENT_REALM + "=" + ROLE_ADMIN + "\n");
             sb.append(USER_ONLY_IN_AUTHORIZATION + "=" + ROLE_USER + "\n");
-            FileUtils.writeStringToFile(rolesAuthzRealmFile, sb.toString(), CHARSET_UTF_8);
+            FileUtils.writeStringToFile(rolesAuthzRealmFile, sb.toString(), StandardCharsets.UTF_8);
         }
 
         private String createPropertiesUserWithHashedPassword(String username, String password, String realmName) {

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
@@ -23,6 +23,7 @@ package org.wildfly.test.integration.elytron.realm;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -106,7 +107,7 @@ public class LdapRealmTestCase {
         for (final String role : ALL_TESTED_ROLES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        QUERY_ROLES = URLEncodedUtils.format(qparams, "UTF-8");
+        QUERY_ROLES = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     @Deployment(name = DEPLOYMENT)

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/roledecoders/SimpleRoleDecoderTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/roledecoders/SimpleRoleDecoderTestCase.java
@@ -23,6 +23,7 @@ package org.wildfly.test.integration.elytron.roledecoders;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -83,7 +84,7 @@ public class SimpleRoleDecoderTestCase {
         for (final String role : ALL_TESTED_ROLES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        QUERY_ROLES = URLEncodedUtils.format(qparams, "UTF-8");
+        QUERY_ROLES = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     @Deployment(name = DECODE_FROM_ROLE_ATTRIBUTE_A)

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/rolemappers/AbstractRoleMapperTest.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/rolemappers/AbstractRoleMapperTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -88,7 +89,7 @@ public abstract class AbstractRoleMapperTest {
         for (final String role : allTestedRoles()) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        String queryRoles = URLEncodedUtils.format(qparams, "UTF-8");
+        String queryRoles = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
         return new URL(webAppURL.toExternalForm() + RolePrintingServlet.SERVLET_PATH.substring(1) + "?"
                 + queryRoles);
     }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securitydomain/SecurityDomainTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/securitydomain/SecurityDomainTestCase.java
@@ -23,6 +23,7 @@ package org.wildfly.test.integration.elytron.securitydomain;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -100,7 +101,7 @@ public class SecurityDomainTestCase {
         for (final String role : ALL_TESTED_ROLES) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        queryRoles = URLEncodedUtils.format(qparams, "UTF-8");
+        queryRoles = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
     }
 
     @Deployment(name = DEFAULT_REALM)

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/util/HttpUtil.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/util/HttpUtil.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class HttpUtil {
         final Map<String, String> headers;
         if (username != null) {
             final String userpassword = username + ":" + password;
-            final String basicAuthorization = java.util.Base64.getEncoder().encodeToString(userpassword.getBytes());
+            final String basicAuthorization = java.util.Base64.getEncoder().encodeToString(userpassword.getBytes(StandardCharsets.UTF_8));
             headers = Collections.singletonMap("Authorization", "Basic " + basicAuthorization);
         } else {
             headers = Collections.emptyMap();

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/AbstractTestsuite.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/AbstractTestsuite.java
@@ -5,11 +5,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
-import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.xnio.IoUtils;
 
 /**
  * @author <a href="mailto:hsvabek@redhat.com">Hynek Svabek</a>
@@ -222,17 +221,7 @@ public abstract class AbstractTestsuite {
     }
 
     protected static void copyModuleFile(File target, InputStream src) throws IOException {
-        final BufferedOutputStream out = new BufferedOutputStream(
-                new FileOutputStream(target));
-        try {
-            int i = src.read();
-            while (i != -1) {
-                out.write(i);
-                i = src.read();
-            }
-        } finally {
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
 
     protected <T> T lookup(final Class<T> remoteClass, final Class<?> beanClass, final String archiveName) throws NamingException {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -234,7 +235,7 @@ public class ReloadRequiringChangesTestCase {
             Assert.assertEquals(200, connection.getResponseCode());
             connection.getInputStream();
 
-            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
             String line;
             while ((line = in.readLine()) != null) {
                 if (line.contains("address location")) {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -435,7 +436,7 @@ public class WSAttributesChangesTestCase {
             Assert.assertEquals(200, connection.getResponseCode());
             connection.getInputStream();
 
-            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+            BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
             String line;
             while ((line = in.readLine()) != null) {
                 if (line.contains("address location")) {
@@ -470,7 +471,7 @@ public class WSAttributesChangesTestCase {
             try {
                 connection.connect();
                 Assert.assertEquals(200, connection.getResponseCode());
-                BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
                 String line;
                 while ((line = in.readLine()) != null) {
                     if (line.contains("address location")) {

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
@@ -42,7 +42,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -54,6 +53,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -330,7 +330,7 @@ public abstract class AbstractSecurityContextPropagationTestBase {
             nvps.add(new BasicNameValuePair("j_username", username));
             nvps.add(new BasicNameValuePair("j_password", password));
 
-            httpPost.setEntity(new UrlEncodedFormEntity(nvps, "UTF-8"));
+            httpPost.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
 
             response = httpClient.execute(httpPost);
             entity = response.getEntity();
@@ -723,7 +723,7 @@ public abstract class AbstractSecurityContextPropagationTestBase {
                 LOGGER.error("Command line error occured during JGroups reconfiguration", e);
             } finally {
                 LOGGER.debugf("Output of JGroups reconfiguration (switch to TCPPING): %s",
-                        new String(consoleOut.toByteArray()));
+                        new String(consoleOut.toByteArray(), StandardCharsets.UTF_8));
             }
         }
 
@@ -790,12 +790,11 @@ public abstract class AbstractSecurityContextPropagationTestBase {
         }
 
         private void addCliCommands(File file, List<String> commands) throws IOException {
-            try (BufferedWriter bw = new BufferedWriter(new FileWriter(file, true))) {
+            try (BufferedWriter bw = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
                 for (String command : commands) {
                     bw.append(command);
                 }
             }
-
         }
     }
 

--- a/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/util/LdapServerSetupTask.java
+++ b/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/util/LdapServerSetupTask.java
@@ -52,6 +52,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,11 +115,11 @@ public class LdapServerSetupTask implements ServerSetupTask {
         final Map<String, String> map = new HashMap<String, String>();
         map.put("hostname", NetworkUtils.formatPossibleIpv6Address(hostname));
         directoryService = DSAnnotationProcessor.getDirectoryService();
-        final String ldifContent = StrSubstitutor.replace(IOUtils.toString(LdapServerSetupTask.class.getResourceAsStream("picketlink-idm-tests.ldif"), "UTF-8"), map);
+        final String ldifContent = StrSubstitutor.replace(IOUtils.toString(LdapServerSetupTask.class.getResourceAsStream("picketlink-idm-tests.ldif"), StandardCharsets.UTF_8), map);
 
         final SchemaManager schemaManager = directoryService.getSchemaManager();
         try {
-            for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent))) {
+            for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
                 directoryService.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
             }
         } catch (Exception e) {

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/EarDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/EarDeploymentTestCase.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotNull;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -100,7 +101,7 @@ public class EarDeploymentTestCase extends ContainerResourceMgmtTestBase {
     @Test
     public void testWebConfiguration() throws Throwable {
         URL servletURL = new URL("http://" + url.getHost() + ":8080/servlet" + RaServlet.URL_PATTERN);
-        BufferedReader br = new BufferedReader(new InputStreamReader(servletURL.openStream()));
+        BufferedReader br = new BufferedReader(new InputStreamReader(servletURL.openStream(), StandardCharsets.UTF_8));
         String message = br.readLine();
         assertEquals(RaServlet.SUCCESS, message);
     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/DeploymentOverlayTestCase.java
@@ -1,6 +1,7 @@
 package org.jboss.as.test.integration.deployment.deploymentoverlay;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -49,7 +50,7 @@ public class DeploymentOverlayTestCase {
             op = new ModelNode();
             op.get(ModelDescriptionConstants.OP_ADDR).set(new ModelNode());
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES);
-            op.get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "override.xml").getBytes());
+            op.get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "override.xml").getBytes(StandardCharsets.UTF_8));
             ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             //add the content
@@ -83,7 +84,8 @@ public class DeploymentOverlayTestCase {
             addr.add(ModelDescriptionConstants.CONTENT, "WEB-INF/web.xml");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES).set(FileUtils.readFile(DeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes());
+            op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.BYTES)
+                .set(FileUtils.readFile(DeploymentOverlayTestCase.class, "wildcard-override.xml").getBytes(StandardCharsets.UTF_8));
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             op = new ModelNode();

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/annotationsmodule/WebModuleDeploymentTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/annotationsmodule/WebModuleDeploymentTestCase.java
@@ -47,15 +47,14 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.xnio.IoUtils;
 
-import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 
 import static org.junit.Assert.assertEquals;
 
@@ -136,16 +135,7 @@ public class WebModuleDeploymentTestCase {
     }
 
     private static void copyFile(File target, InputStream src) throws IOException {
-        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
-        try {
-            int i = src.read();
-            while (i != -1) {
-                out.write(i);
-                i = src.read();
-            }
-        } finally {
-            IoUtils.safeClose(out);
-        }
+        Files.copy(src, target.toPath());
     }
 
     private static File getModulePath() {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/formauth/FormAuthUnitTestCase.java
@@ -50,6 +50,7 @@ import org.junit.runner.RunWith;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -166,7 +167,7 @@ public class FormAuthUnitTestCase {
         List<NameValuePair> formparams = new ArrayList<NameValuePair>();
         formparams.add(new BasicNameValuePair("j_username", "baduser"));
         formparams.add(new BasicNameValuePair("j_password", "badpass"));
-        formPost.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
+        formPost.setEntity(new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8));
 
         log.trace("Executing request " + formPost.getRequestLine());
         HttpResponse postResponse = httpclient.execute(formPost);
@@ -215,7 +216,7 @@ public class FormAuthUnitTestCase {
 
         List<NameValuePair> restrictedParams = new ArrayList<NameValuePair>();
         restrictedParams.add(new BasicNameValuePair("checkParam", "123456"));
-        restrictedPost.setEntity(new UrlEncodedFormEntity(restrictedParams, "UTF-8"));
+        restrictedPost.setEntity(new UrlEncodedFormEntity(restrictedParams, StandardCharsets.UTF_8));
 
         log.trace("Executing request " + restrictedPost.getRequestLine());
         HttpResponse restrictedResponse = httpclient.execute(restrictedPost);
@@ -247,7 +248,7 @@ public class FormAuthUnitTestCase {
         List<NameValuePair> formparams = new ArrayList<NameValuePair>();
         formparams.add(new BasicNameValuePair("j_username", "user1"));
         formparams.add(new BasicNameValuePair("j_password", "password1"));
-        formPost.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
+        formPost.setEntity(new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8));
 
         log.trace("Executing request " + formPost.getRequestLine());
         HttpResponse postResponse = httpclient.execute(formPost);
@@ -367,7 +368,7 @@ public class FormAuthUnitTestCase {
         List<NameValuePair> formparams = new ArrayList<NameValuePair>();
         formparams.add(new BasicNameValuePair("j_username", username));
         formparams.add(new BasicNameValuePair("j_password", password));
-        formPost.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
+        formPost.setEntity(new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8));
 
         log.trace("Executing request " + formPost.getRequestLine());
         HttpResponse postResponse = httpclient.execute(formPost);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
@@ -2,11 +2,12 @@ package org.jboss.as.test.integration.web.handlers;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -132,7 +133,7 @@ public abstract class RequestDumpingHandlerTestImpl {
         Assert.assertTrue("The '" + logFilePath + "' is not a file", logFilePath.toFile().isFile());
 
         // logfile exists -> read its content...
-        LineNumberReader lnr = new LineNumberReader(new FileReader(logFilePath.toFile()));
+        LineNumberReader lnr = new LineNumberReader(Files.newBufferedReader(logFilePath, StandardCharsets.UTF_8));
         StringBuilder sb = new StringBuilder();
 
         log.trace("I am skipping '" + skipBytes + "' bytes from the beggining of the file.");
@@ -357,7 +358,7 @@ public abstract class RequestDumpingHandlerTestImpl {
                 }
             });
 
-            BufferedReader br = new BufferedReader(new InputStreamReader(httpsConn.getInputStream()));
+            BufferedReader br = new BufferedReader(new InputStreamReader(httpsConn.getInputStream(), StandardCharsets.UTF_8));
 
             StringBuilder sb = new StringBuilder();
             String input;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/JspMappingTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/JspMappingTestCase.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -133,7 +134,7 @@ public class JspMappingTestCase {
     }
 
     private String getContent(InputStream content) throws Exception {
-        BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(content, StandardCharsets.UTF_8));
         StringBuilder out = new StringBuilder();
         String line;
         while ((line = reader.readLine()) != null) {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebSecuritySimpleRoleMappingSecurityManagerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebSecuritySimpleRoleMappingSecurityManagerTestCase.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -126,7 +127,7 @@ public class WebSecuritySimpleRoleMappingSecurityManagerTestCase {
             StatusLine statusLine = response.getStatusLine();
             assertEquals(expectedCode, statusLine.getStatusCode());
             InputStream input = entity.getContent();
-            assertEquals(expectedOut, new String(IOUtil.asByteArray(input)));
+            assertEquals(expectedOut, new String(IOUtil.asByteArray(input), StandardCharsets.UTF_8));
             input.close();
         }
     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/websocket/AnnotatedClient.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/websocket/AnnotatedClient.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.web.security.websocket;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +72,7 @@ public class AnnotatedClient {
         public void beforeRequest(Map<String, List<String>> headers) {
             String credentials = user + ":" + password;
             headers.put("AUTHORIZATION", Collections.singletonList("Basic " + FlexBase64.encodeString(credentials
-                    .getBytes(), false)));
+                    .getBytes(StandardCharsets.UTF_8), false)));
         }
     }
 }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -73,6 +73,7 @@ import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecurityPermission;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -161,7 +162,7 @@ public class AuthenticationPolicyContextTestCase {
     private static String replaceNodeAddress(String resourceName) {
         String content = null;
         try {
-            content = IOUtils.toString(AuthenticationPolicyContextTestCase.class.getResourceAsStream(resourceName), "UTF-8");
+            content = IOUtils.toString(AuthenticationPolicyContextTestCase.class.getResourceAsStream(resourceName), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Exception during replacing node address in resource", e);
         }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/schemalocations/SchemaLocationsRewriteTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/schemalocations/SchemaLocationsRewriteTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ws.schemalocations;
 
 import java.io.ByteArrayInputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import org.jboss.logging.Logger;
@@ -134,7 +135,7 @@ public class SchemaLocationsRewriteTestCase {
 
         List<String> values = new ArrayList<>();
         XMLInputFactory xmlif = XMLInputFactory.newInstance();
-        XMLEventReader eventReader = xmlif.createXMLEventReader(new ByteArrayInputStream(document.getBytes()));
+        XMLEventReader eventReader = xmlif.createXMLEventReader(new ByteArrayInputStream(document.getBytes(StandardCharsets.UTF_8)));
 
         while (eventReader.hasNext()) {
             XMLEvent xmlEvent = eventReader.nextEvent();

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
@@ -27,6 +27,7 @@ import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.PropertyPermission;
 
@@ -133,11 +134,8 @@ public class ServiceRefEarTestCase {
     }
 
     private String receiveFirstLineFromUrl(URL url) throws Exception {
-        BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()));
-        try {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
             return br.readLine();
-        } finally {
-            br.close();
         }
     }
 }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
@@ -27,6 +27,7 @@ import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.net.SocketPermission;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 import java.util.PropertyPermission;
 
@@ -126,11 +127,8 @@ public class ServiceRefSevletTestCase {
     }
 
     private String receiveFirstLineFromUrl(URL url) throws Exception {
-        BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream()));
-        try {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
             return br.readLine();
-        } finally {
-            br.close();
         }
     }
 }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsa/TestNoAddressingTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsa/TestNoAddressingTestCase.java
@@ -21,14 +21,12 @@
  */
 package org.jboss.as.test.integration.ws.wsa;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+
 import javax.xml.namespace.QName;
 import javax.xml.ws.BindingProvider;
 import javax.xml.ws.Service;
@@ -125,15 +123,6 @@ public class TestNoAddressingTestCase {
     }
 
     protected static void downloadWSDLToFile(URL wsdlURL, File wsdlFile) throws IOException {
-        BufferedReader in = new BufferedReader(new InputStreamReader(wsdlURL.openStream()));
-        BufferedWriter out = new BufferedWriter(new FileWriter(wsdlFile));
-        String inputLine;
-        while ((inputLine = in.readLine()) != null) {
-            out.write(inputLine);
-            out.newLine();
-        }
-        in.close();
-        out.flush();
-        out.close();
+        Files.copy(wsdlURL.openStream(), wsdlFile.toPath());
     }
 }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsrm/ReliableCheckHandler.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsrm/ReliableCheckHandler.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.ws.wsrm;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Set;
 import javax.xml.namespace.QName;
@@ -234,7 +235,7 @@ public class ReliableCheckHandler implements SOAPHandler<SOAPMessageContext> {
             }
             final byte[] theBytes = new byte[count];
             System.arraycopy(buf, 0, theBytes, 0, count);
-            logger.log(level, new String(theBytes));
+            logger.log(level, new String(theBytes, StandardCharsets.UTF_8));
             reset();
         }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/crypto/XMLSignatureFactoryTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/crypto/XMLSignatureFactoryTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.ws.wsse.crypto;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 
@@ -64,7 +65,7 @@ public class XMLSignatureFactoryTestCase {
         XMLSignatureFactory fac = XMLSignatureFactory.getInstance("DOM");
         Assert.assertNotNull(fac);
 
-        BufferedReader br = new BufferedReader(new InputStreamReader(baseUrl.openStream()));
+        BufferedReader br = new BufferedReader(new InputStreamReader(baseUrl.openStream(), StandardCharsets.UTF_8));
         try {
             Assert.assertEquals("OK", br.readLine());
         } finally {

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
@@ -61,6 +61,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import static org.junit.Assert.assertEquals;
@@ -565,7 +566,7 @@ public class WSTrustTestCase {
     private static String replaceNodeAddress(String resourceName) {
         String content = null;
         try {
-            content = IOUtils.toString(WSTrustTestCase.class.getResourceAsStream(resourceName), "UTF-8");
+            content = IOUtils.toString(WSTrustTestCase.class.getResourceAsStream(resourceName), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Exception during replacing node address in resource", e);
         }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacySubsystemConfigurationUtil.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacySubsystemConfigurationUtil.java
@@ -24,13 +24,12 @@ package org.jboss.as.test.integration.domain.mixed;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -97,10 +96,9 @@ public class LegacySubsystemConfigurationUtil {
 
     private String extractSubsystemXml(File file) throws IOException {
         StringBuilder sb = new StringBuilder();
-        BufferedReader reader = new BufferedReader(new FileReader(file));
-        String line = reader.readLine();
+        List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
         boolean inSusbsystem = false;
-        while (line != null) {
+        for (String line : lines) {
             if (!inSusbsystem) {
                 if (line.contains(SUBSYSTEM_OPEN)) {
                     inSusbsystem = true;
@@ -116,7 +114,6 @@ public class LegacySubsystemConfigurationUtil {
                     break;
                 }
             }
-            line = reader.readLine();
         }
         return sb.toString();
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractKrb5ConfServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractKrb5ConfServerSetupTask.java
@@ -26,6 +26,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -93,8 +94,8 @@ public abstract class AbstractKrb5ConfServerSetupTask implements ServerSetupTask
         FileUtils.write(
                 KRB5_CONF_FILE,
                 StrSubstitutor.replace(
-                        IOUtils.toString(AbstractKrb5ConfServerSetupTask.class.getResourceAsStream(KRB5_CONF), "UTF-8"), map),
-                "UTF-8");
+                        IOUtils.toString(AbstractKrb5ConfServerSetupTask.class.getResourceAsStream(KRB5_CONF), StandardCharsets.UTF_8), map),
+                StandardCharsets.UTF_8);
         createServerKeytab(cannonicalHost);
         final List<UserForKeyTab> kerberosUsers = kerberosUsers();
         if (kerberosUsers != null) {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/RolesPrintingServletUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/RolesPrintingServletUtils.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.security.common;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -53,7 +54,7 @@ public class RolesPrintingServletUtils {
         for (final String role : allPossibleRoles) {
             qparams.add(new BasicNameValuePair(RolePrintingServlet.PARAM_ROLE_NAME, role));
         }
-        String queryRoles = URLEncodedUtils.format(qparams, "UTF-8");
+        String queryRoles = URLEncodedUtils.format(qparams, StandardCharsets.UTF_8);
         try {
             return new URL(webAppURL.toExternalForm() + RolePrintingServlet.SERVLET_PATH.substring(1) + "?" + queryRoles);
         } catch (MalformedURLException ex) {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -39,6 +39,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.MessageDigest;
 import java.security.PrivilegedActionException;
@@ -65,7 +66,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.directory.server.annotations.CreateTransport;
-import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
@@ -237,7 +237,7 @@ public class Utils extends CoreUtils {
         } catch (Exception e) {
             e.printStackTrace();
         }
-        byte[] bytes = target.getBytes();
+        byte[] bytes = target.getBytes(StandardCharsets.UTF_8);
         byte[] byteHash = md.digest(bytes);
 
         String encodedHash = null;
@@ -373,7 +373,7 @@ public class Utils extends CoreUtils {
             nvps.add(new BasicNameValuePair("j_username", user));
             nvps.add(new BasicNameValuePair("j_password", pass));
 
-            httpost.setEntity(new UrlEncodedFormEntity(nvps, "UTF-8"));
+            httpost.setEntity(new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8));
 
             response = httpClient.execute(httpost);
             entity = response.getEntity();
@@ -522,8 +522,8 @@ public class Utils extends CoreUtils {
 
         // use UTF-8 charset for credentials
         Registry<AuthSchemeProvider> authSchemeRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-                .register(AuthSchemes.BASIC, new BasicSchemeFactory(Consts.UTF_8))
-                .register(AuthSchemes.DIGEST, new DigestSchemeFactory(Consts.UTF_8))
+                .register(AuthSchemes.BASIC, new BasicSchemeFactory(StandardCharsets.UTF_8))
+                .register(AuthSchemes.DIGEST, new DigestSchemeFactory(StandardCharsets.UTF_8))
                 .build();
         try (CloseableHttpClient httpClient = HttpClientBuilder.create()
                 .setDefaultAuthSchemeRegistry(authSchemeRegistry)
@@ -995,7 +995,7 @@ public class Utils extends CoreUtils {
         map.put("password", keystorePassword);
 
         try {
-            content = StrSubstitutor.replace(IOUtils.toString(CoreUtils.class.getResourceAsStream(originalFile), "UTF-8"), map);
+            content = StrSubstitutor.replace(IOUtils.toString(CoreUtils.class.getResourceAsStream(originalFile), StandardCharsets.UTF_8), map);
         } catch (IOException ex) {
             String message = "Cannot find or modify configuration file " + originalFile + " , error : " + ex.getMessage();
             LOGGER.error(message);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/JBossNegotiateScheme.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/JBossNegotiateScheme.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.test.integration.security.common.negotiation;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
@@ -170,7 +172,7 @@ public class JBossNegotiateScheme extends AuthSchemeBase {
             }
 
             state = State.TOKEN_GENERATED;
-            String tokenstr = new String(base64codec.encode(token));
+            String tokenstr = new String(base64codec.encode(token), StandardCharsets.UTF_8);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Sending response '" + tokenstr + "' back to the auth server");
             }
@@ -244,7 +246,7 @@ public class JBossNegotiateScheme extends AuthSchemeBase {
             LOGGER.debug("Received challenge '" + challenge + "' from the auth server");
         }
         if (state == State.UNINITIATED) {
-            token = new Base64().decode(challenge.getBytes());
+            token = new Base64().decode(challenge.getBytes(StandardCharsets.UTF_8));
             state = State.CHALLENGE_RECEIVED;
         } else {
             LOGGER.debug("Authentication already attempted");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -248,7 +249,7 @@ public abstract class SSOTestBase {
         List<NameValuePair> formparams = new ArrayList<>();
         formparams.add(new BasicNameValuePair("j_username", "user1"));
         formparams.add(new BasicNameValuePair("j_password", "password1"));
-        formPost.setEntity(new UrlEncodedFormEntity(formparams, "UTF-8"));
+        formPost.setEntity(new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8));
 
         HttpResponse postResponse = httpConn.execute(formPost);
         try {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletContainerInitializerDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/ServletContainerInitializerDeploymentProcessor.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -204,7 +205,7 @@ public class ServletContainerInitializerDeploymentProcessor implements Deploymen
         try {
             // Get the ServletContainerInitializer class name
             is = sci.openStream();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
             String servletContainerInitializerClassName = reader.readLine();
             while (servletContainerInitializerClassName != null) {
                 try {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-7618

This is just #11451 with the unused testsuite/domain import removed....

and a flaw in the BuildConfigurationTestBase changed corrected.