### PR TITLE
[WFLY-11325] Deprecate the org.jdom module and mark its use by org.ja…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
@@ -28,7 +28,9 @@
     <dependencies>
         <module name="nu.xom"/>
         <module name="org.dom4j"/>
-        <module name="org.jdom"/>
+        <!-- jaxen's uses of jdom are not actually used in WildFly
+              See WFLY-11325 / WFLY-11326 -->
+        <module name="org.jdom" optional="true"/>
         <module name="javax.api"/>
     </dependencies>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
@@ -21,6 +21,11 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.jdom">
+    <properties>
+        <!-- WFLY-11326. Remove this in WildFly 16.
+             It is not used by WildFly. -->
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
 
     <dependencies>
         <module name="org.jaxen"/>


### PR DESCRIPTION
…xen as optional

https://issues.jboss.org/browse/WFLY-11325

@yersan I think this will cause a conflict in wf-to-cd.  The module should remain 'unsupported' in CD.