### PR TITLE
[WFLY-11330] Upgrade to Galleon and WildFly Galleon Plugins 3.0.0.CR1

### DIFF
--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -115,17 +115,6 @@
                 <artifactId>wildfly-galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>feature-spec-build</id>
-                        <goals>
-                            <goal>generate-feature-specs</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <output-dir>${basedir}/target/resources/features</output-dir>
-                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>feature-pack-build</id>
                         <goals>
                             <goal>build-feature-pack</goal>
@@ -133,6 +122,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <release-name>${full.dist.product.release.name}</release-name>
+                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <task-properties>
                                 <product.release.version>${product.release.version}</product.release.version>
                             </task-properties>
@@ -3384,11 +3374,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.galleon-plugins</groupId>
-            <artifactId>wildfly-config-gen</artifactId>
         </dependency>
     </dependencies>
 

--- a/galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="domain.xml" model="domain">
+    <!-- domain.server-group features are excluded from every domain group below
+         simply to preserve the order of the profiles specified here.
+         Not excluding the server groups will work but profiles full and full-ha
+         will appear in the resulting config before ha because the server groups that are
+         introduced into the config by the first domain group and overriden to reference
+         full and full-ha below will make those profiles installed before ha.
+    -->
+    <feature-group name="domain">
+        <exclude spec="domain.server-group"/>
+    </feature-group>
+    <feature-group name="domain-ha">
+        <exclude spec="domain.server-group"/>
+    </feature-group>
+    <feature-group name="domain-full">
+        <exclude spec="domain.server-group"/>
+    </feature-group>
+    <feature-group name="domain-full-ha">
+        <exclude spec="domain.server-group"/>
+    </feature-group>
+    <feature-group name="domain-load-balancer">
+        <exclude spec="domain.server-group"/>
+    </feature-group>
+
+    <feature spec="domain.server-group">
+        <param name="server-group" value="main-server-group"/>
+        <param name="profile" value="full" />
+        <param name="socket-binding-group" value="full-sockets" />
+        <feature spec="domain.server-group.jvm">
+            <param name="jvm" value="default"/>
+            <param name="heap-size" value="64m"/>
+            <param name="max-heap-size" value="512m"/>
+        </feature>
+    </feature>
+    <feature spec="domain.server-group">
+        <param name="server-group" value="other-server-group"/>
+        <param name="profile" value="full-ha" />
+        <param name="socket-binding-group" value="full-ha-sockets" />
+        <feature spec="domain.server-group.jvm">
+            <param name="jvm" value="default"/>
+            <param name="heap-size" value="64m"/>
+            <param name="max-heap-size" value="512m"/>
+        </feature>
+    </feature>
+</config>

--- a/galleon-pack/src/main/resources/configs/domain/model.xml
+++ b/galleon-pack/src/main/resources/configs/domain/model.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="domain">
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.domain"/>
+    </packages>
+</config>

--- a/galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-master.xml" model="host">
+    <feature-group name="host-master"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-slave.xml" model="host">
+    <feature-group name="host-slave"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/host/host.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/host/host.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host.xml" model="host">
+    <feature-group name="host"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/standalone/model.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/model.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="standalone">
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.standalone"/>
+    </packages>
+</config>

--- a/galleon-pack/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/standalone-full-ha.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full-ha.xml" model="standalone">
+    <feature-group name="standalone-full-ha"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/standalone/standalone-full.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/standalone-full.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-full.xml" model="standalone">
+    <feature-group name="standalone-full"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/standalone-ha.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-ha.xml" model="standalone">
+    <feature-group name="standalone-ha"/>
+</config>

--- a/galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
+    <feature-group name="standalone"/>
+</config>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -51,94 +51,14 @@
         <group name="org.wildfly.security"/>
     </package-schemas>
 
-    <config model="standalone">
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.standalone"/>
-        </packages>
-    </config>
-
-    <config model="domain">
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.domain"/>
-        </packages>
-    </config>
-
-    <config name="standalone.xml" model="standalone">
-        <feature-group name="standalone"/>
-    </config>
-
-    <config name="standalone-ha.xml" model="standalone">
-        <feature-group name="standalone-ha"/>
-     </config>
-
-    <config name="standalone-full.xml" model="standalone">
-        <feature-group name="standalone-full"/>
-    </config>
-
-    <config name="standalone-full-ha.xml" model="standalone">
-        <feature-group name="standalone-full-ha"/>
-    </config>
-
-
-    <config name="domain.xml" model="domain">
-        <!-- domain.server-group features are excluded from every domain group below
-             simply to preserve the order of the profiles specified here.
-             Not excluding the server groups will work but profiles full and full-ha
-             will appear in the resulting config before ha because the server groups that are
-             introduced into the config by the first domain group and overriden to reference
-             full and full-ha below will make those profiles installed before ha.
-        -->
-        <feature-group name="domain">
-            <exclude spec="domain.server-group"/>
-        </feature-group>
-        <feature-group name="domain-ha">
-            <exclude spec="domain.server-group"/>
-        </feature-group>
-        <feature-group name="domain-full">
-            <exclude spec="domain.server-group"/>
-        </feature-group>
-        <feature-group name="domain-full-ha">
-            <exclude spec="domain.server-group"/>
-        </feature-group>
-        <feature-group name="domain-load-balancer">
-            <exclude spec="domain.server-group"/>
-        </feature-group>
-
-        <feature spec="domain.server-group">
-            <param name="server-group" value="main-server-group"/>
-            <param name="profile" value="full" />
-            <param name="socket-binding-group" value="full-sockets" />
-            <feature spec="domain.server-group.jvm">
-                <param name="jvm" value="default"/>
-                <param name="heap-size" value="64m"/>
-                <param name="max-heap-size" value="512m"/>
-            </feature>
-        </feature>
-        <feature spec="domain.server-group">
-            <param name="server-group" value="other-server-group"/>
-            <param name="profile" value="full-ha" />
-            <param name="socket-binding-group" value="full-ha-sockets" />
-            <feature spec="domain.server-group.jvm">
-                <param name="jvm" value="default"/>
-                <param name="heap-size" value="64m"/>
-                <param name="max-heap-size" value="512m"/>
-            </feature>
-        </feature>
-    </config>
-
-    <config name="host.xml" model="host">
-        <feature-group name="host"/>
-    </config>
-
-    <config name="host-master.xml" model="host">
-        <feature-group name="host-master"/>
-    </config>
-
-    <config name="host-slave.xml" model="host">
-        <feature-group name="host-slave"/>
-    </config>
+    <config name="standalone.xml" model="standalone"/>
+    <config name="standalone-ha.xml" model="standalone"/>
+    <config name="standalone-full.xml" model="standalone"/>
+    <config name="standalone-full-ha.xml" model="standalone"/>
+    <config name="domain.xml" model="domain"/>
+    <config name="host.xml" model="host"/>
+    <config name="host-master.xml" model="host"/>
+    <config name="host-slave.xml" model="host"/>
 
     <generate-feature-specs>
         <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -180,13 +180,13 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>2.0.1.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>3.0.0.CR1</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>2.0.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>3.0.0.CR1</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -526,17 +526,6 @@
                 <artifactId>wildfly-galleon-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>feature-spec-build</id>
-                        <goals>
-                            <goal>generate-feature-specs</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <output-dir>${basedir}/target/resources/features</output-dir>
-                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>feature-pack-build</id>
                         <goals>
                             <goal>build-feature-pack</goal>
@@ -544,6 +533,7 @@
                         <phase>prepare-package</phase>
                         <configuration>
                             <release-name>${servlet.dist.product.release.name}</release-name>
+                            <fork-embedded>${galleon.fork.embedded}</fork-embedded>
                             <task-properties>
                                 <product.release.version>${product.release.version}</product.release.version>
                             </task-properties>

--- a/servlet-galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/domain/domain.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="domain.xml" model="domain">
+    <feature-group name="domain"/>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/domain/model.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/domain/model.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="domain">
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.domain"/>
+    </packages>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/host/host-master.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-master.xml" model="host">
+    <feature-group name="host-master"/>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/host/host-slave.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host-slave.xml" model="host">
+    <feature-group name="host-slave"/>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/host/host.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/host/host.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="host.xml" model="host">
+    <feature-group name="host"/>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/standalone/model.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/standalone/model.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="standalone">
+    <packages>
+        <package name="product.conf" optional="true"/>
+        <package name="misc.standalone"/>
+    </packages>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-load-balancer.xml" model="standalone">
+    <feature-group name="standalone-load-balancer"/>
+</config>

--- a/servlet-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/servlet-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone.xml" model="standalone">
+    <feature-group name="standalone"/>
+</config>

--- a/servlet-galleon-pack/wildfly-feature-pack-build.xml
+++ b/servlet-galleon-pack/wildfly-feature-pack-build.xml
@@ -44,43 +44,12 @@
 <!--        <group name="org.wildfly.security"/> -->
     </package-schemas>
 
-    <config model="standalone">
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.standalone"/>
-        </packages>
-    </config>
-
-    <config model="domain">
-        <packages>
-            <package name="product.conf" optional="true"/>
-            <package name="misc.domain"/>
-        </packages>
-    </config>
-
-    <config name="standalone.xml" model="standalone">
-        <feature-group name="standalone"/>
-    </config>
-
-    <config name="standalone-load-balancer.xml" model="standalone">
-        <feature-group name="standalone-load-balancer"/>
-    </config>
-
-    <config name="domain.xml" model="domain">
-        <feature-group name="domain"/>
-    </config>
-
-    <config name="host.xml" model="host">
-        <feature-group name="host"/>
-    </config>
-
-    <config name="host-master.xml" model="host">
-        <feature-group name="host-master"/>
-    </config>
-
-    <config name="host-slave.xml" model="host">
-        <feature-group name="host-slave"/>
-    </config>
+    <config name="standalone.xml" model="standalone"/>
+    <config name="standalone-load-balancer.xml" model="standalone"/>
+    <config name="domain.xml" model="domain"/>
+    <config name="host.xml" model="host"/>
+    <config name="host-master.xml" model="host"/>
+    <config name="host-slave.xml" model="host"/>
 
     <generate-feature-specs>
         <extensions>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11330

Key changes here are:

* generate-feature-specs goal merged into build-feature-pack;
* default config definitions moved from wildfly-feature-pack-build.xml to their own files (and from the generated feature-pack.xml to their own files).