### PR TITLE
[WFLY-11341] Upgrade WildFly Core 7.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>7.0.0.Alpha5</version.org.wildfly.core>
+        <version.org.wildfly.core>7.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.12.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11341

---


# Release Notes - WildFly Core - Version 7.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4208'>WFCORE-4208</a>] -         Upgrade WildFly Elytron to 1.7.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4209'>WFCORE-4209</a>] -         Upgrade Elytron Web to 1.3.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4210'>WFCORE-4210</a>] -         Upgrade WildFly Elytron Tool to 1.5.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4212'>WFCORE-4212</a>] -         Upgrade to Galleon and WildFly Galleon Plugins 3.0.0.CR1
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4148'>WFCORE-4148</a>] -         Check and consider to put escaped quotes (\&quot;) back to the -Xloggc in standalone.sh
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4192'>WFCORE-4192</a>] -         Server-server EJB invocation fails if no security is defined on target bean due to faulty permission check 
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4200'>WFCORE-4200</a>] -         Deprecate legacy CapabilityServiceBuilder methods and provide alternatives
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4202'>WFCORE-4202</a>] -         org.jboss.msc module optional dependencies issues
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4204'>WFCORE-4204</a>] -         Add Phase priorities for MicroProfile DUPs
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4211'>WFCORE-4211</a>] -         Missing docs: Embedded container does not work without the JVM being launched with java.se module on Java 11
</li>
</ul>
                            
<h2>        Sub-task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4201'>WFCORE-4201</a>] -         Eliminate ServiceBuilder.addDependency(ServiceName) method usages
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4203'>WFCORE-4203</a>] -         Eliminate ServiceBuilder.addDependency(ServiceName,Injector) method usages
</li>
</ul>
        