### PR TITLE
[WFLY-11342] Remove unused dependencies from org.jboss.as.xts

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -52,11 +52,8 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.xts"/>
-        <module name="org.jboss.threads"/>
         <!-- need this to get the SPIProviderResolver  -->
         <module name="org.jboss.ws.spi"/>
-        <!-- need this to get the actual SPIProvider  -->
-        <module name="org.jboss.ws.common"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.modules"/>
         <module name="javax.enterprise.api"/>


### PR DESCRIPTION
Analisys shows that these depdencies are no longer required for `org.jboss.as.xts`
- org.jboss.ws.common
- org.jboss.threads

Jira issue: https://issues.jboss.org/browse/WFLY-11342