### PR TITLE
[WFLY-11351] Add resource address and attribute to the metric tags

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -73,6 +73,25 @@ The HTTP endpoint exposes the following metrics:
 * Vendor metrics - Metrics from WildFly subsystems are exposed in the `vendor` scope
 * Application metrics - Metrics from the application and from the deployment's subsystems are exposed in the `application` scope.
 
+=== WildFly Metrics Description
+
+WildFly metrics can appears in two scopes:
+
+* `vendor` for metrics defined in subsystem resources (e.g. the `bytes-received` attribute of the `/subsystem=undertow/server=default-server/http-listener=default` resource)
+* `applications` for metrics defined in deployment resources (e.g. the `request-count` attribute on the `/deployment=<deployment name>/subsystem=undertow/servlet=<servlet name>` resource).
+
+The name of the MicroProfile metric is composed of the whole resource address appended by the attribute name.
+For example, `subsystem/undertow/server/default-server/http-listener/default/request-count` and `deployment/example.war/subsystem/undertow/servlet/org.example.MyServlet/request-count` for the two attributes above.
+
+==== Tags
+
+WildFly metrics provides tags corresponding to the resource address elements as well as a tag with the attribute name.
+This allows to be able to query all MicroProfile metrics for a subsystem (e.g. `subsystem="undertow"`) or a deployment (e.g. `deployment="example.war`).
+
+For example, the MicroProfile metric registered for the `request-count` attribute on the `/deployment=example.war/subsystem=undertow/servlet=org.example.MyServlet` resource will have the following tags:
+
+* `subsystem="undertow", servlet="org.example.MyServlet", deployment="example.war", attribute="request-count"` (note that the tag order does not preserve order of the resource address)
+
 == Component Reference
 
 The Eclipse MicroProfile Health is implemented by the SmallRye Health project.

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
@@ -57,18 +57,11 @@ public class DeploymentMetricService implements Service {
     @Override
     public void start(StartContext startContext) {
         MetricRegistry applicationRegistry = MetricRegistries.get(APPLICATION);
-        registeredMetrics = registrationService.get().registerMetrics(rootResource, managementResourceRegistration, applicationRegistry,
-                new MetricsRegistrationService.MetricNameCreator() {
-                    @Override
-                    public String createName(PathAddress address, String attributeName) {
-                        return deploymentAddress.append(address).toPathStyleString().substring(1) + "/" + attributeName;
-                    }
-
-                    @Override
-                    public PathAddress getResourceAddress(PathAddress address) {
-                        return deploymentAddress.append(address);
-                    }
-                });
+        registeredMetrics = registrationService.get().registerMetrics(rootResource,
+                managementResourceRegistration,
+                applicationRegistry,
+                // prepend the deployment address to the subsystem resource address
+                address -> deploymentAddress.append(address));
     }
 
     @Override


### PR DESCRIPTION
To improve query and aggregation of the metrics exposed by the
MicroProfile Metrics HTTP endpoints, the resource address' elements and
the attribute name are added to the tags in the metric' metadata.

Add test in MicroProfileMetricsApplicationTestCase to check WildFly
deployment metrics (using Undertow's request-count)

JIRA: https://issues.jboss.org/browse/WFLY-11351