### PR TITLE
[WFLY-11321]: Document the "Arbitrary Descriptors" we use in our attribute definitions.

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
@@ -331,6 +331,14 @@ m, h, KB, MB, TB. See the
 `org.jboss.as.controller.client.helpers.MeasurementUnit` in the
 org.jboss.as:jboss-as-controller-client artifact for a listing of legal
 measurement units..
+* `filesystem-path` – boolean – a flag to indicate that the attribute is a 
+path on the filesystem.
+* `attached-streams` – boolean – a flag to indicate that the attribute is a 
+stream id to an attached stream.
+* `relative-to` – boolean – a flag to indicate that the attribute is a 
+relative path.
+* `feature-reference` – boolean – a flag to indicate that the attribute is a
+reference to a provisioning feature via a capability.
 
 Some examples:
 


### PR DESCRIPTION
* Adding the following definitions :
  - `filesystem-path`
  - `attached-streams`
  - `relative-to`
  - `feature-reference`

Jira: https://issues.jboss.org/browse/WFLY-11321