### PR TITLE
[WFLY-11360] Manually revert commit 43018d35a98a4c7b5905a048aa99d435e…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/transactionintegration/TransactionIntegrationService.java
@@ -24,6 +24,8 @@ package org.jboss.as.connector.services.transactionintegration;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
 
+import javax.transaction.TransactionSynchronizationRegistry;
+
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.txn.integration.JBossContextXATerminator;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
@@ -37,7 +39,6 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.tm.XAResourceRecoveryRegistry;
 import org.jboss.tm.usertx.UserTransactionRegistry;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * A WorkManager Service.
@@ -46,6 +47,8 @@ import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 public final class TransactionIntegrationService implements Service<TransactionIntegration> {
 
     private volatile TransactionIntegration value;
+
+    private final InjectedValue<TransactionSynchronizationRegistry> tsr = new InjectedValue<TransactionSynchronizationRegistry>();
 
     private final InjectedValue<UserTransactionRegistry> utr = new InjectedValue<UserTransactionRegistry>();
 
@@ -65,8 +68,7 @@ public final class TransactionIntegrationService implements Service<TransactionI
 
     @Override
     public void start(StartContext context) throws StartException {
-        this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(),
-                ContextTransactionSynchronizationRegistry.getInstance(), utr.getValue(), terminator.getValue(),
+        this.value = new TransactionIntegrationImpl(ContextTransactionManager.getInstance(), tsr.getValue(), utr.getValue(), terminator.getValue(),
                 rr.getValue());
         ROOT_LOGGER.debugf("Starting JCA TransactionIntegrationService");
     }
@@ -74,6 +76,10 @@ public final class TransactionIntegrationService implements Service<TransactionI
     @Override
     public void stop(StopContext context) {
 
+    }
+
+    public Injector<TransactionSynchronizationRegistry> getTsrInjector() {
+        return tsr;
     }
 
     public Injector<UserTransactionRegistry> getUtrInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -27,6 +27,8 @@ import static org.jboss.as.connector.subsystems.jca.JcaSubsystemRootDefinition.T
 import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
 import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 
+import javax.transaction.TransactionSynchronizationRegistry;
+
 import org.jboss.as.connector.deployers.ra.RaDeploymentActivator;
 import org.jboss.as.connector.services.driver.registry.DriverRegistryService;
 import org.jboss.as.connector.services.transactionintegration.TransactionIntegrationService;
@@ -78,6 +80,7 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 // Ensure the local transaction provider is started
                 .addCapabilityRequirement(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, Void.class)
                 .addCapabilityRequirement(TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY, XAResourceRecoveryRegistry.class, tiService.getRrInjector())
+                .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, tiService.getTsrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_USER_TRANSACTION_REGISTRY, org.jboss.tm.usertx.UserTransactionRegistry.class, tiService.getUtrInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CONTEXT_XA_TERMINATOR, JBossContextXATerminator.class, tiService.getTerminatorInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -567,6 +567,8 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                         CapabilityServiceSupport support = context.getDeploymentUnit().getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
                         // add dependency on the local transaction provider
                         serviceBuilder.requires(support.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider"));
+                        // add dependency on TransactionSynchronizationRegistry
+                        serviceBuilder.addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY);
                     }
                 });
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FileDataStoreAdd.java
@@ -24,6 +24,8 @@ package org.jboss.as.ejb3.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import javax.transaction.TransactionSynchronizationRegistry;
+
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -34,6 +36,7 @@ import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.ejb3.timerservice.persistence.TimerPersistence;
 import org.jboss.as.ejb3.timerservice.persistence.filestore.FileTimerPersistence;
 import org.jboss.as.server.Services;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.service.ServiceBuilder;
@@ -67,6 +70,7 @@ public class FileDataStoreAdd extends AbstractAddStepHandler {
         sb.addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ModuleLoader.class, fileTimerPersistence.getModuleLoader());
         sb.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, fileTimerPersistence.getPathManager());
         sb.requires(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null));
+        sb.addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, fileTimerPersistence.getTransactionSynchronizationRegistry());
         sb.install();
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/FileTimerPersistence.java
@@ -40,7 +40,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.jboss.staxmapper.XMLMapper;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 import javax.transaction.Status;
 import javax.transaction.Synchronization;
@@ -88,6 +87,7 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
     private final boolean createIfNotExists;
     private MarshallerFactory factory;
     private MarshallingConfiguration configuration;
+    private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistry = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<ModuleLoader> moduleLoader = new InjectedValue<ModuleLoader>();
     private final InjectedValue<PathManager> pathManager = new InjectedValue<PathManager>();
     private final String path;
@@ -227,14 +227,13 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
             } else {
 
                 final String key = timerTransactionKey(timer);
-                final TransactionSynchronizationRegistry tsr = ContextTransactionSynchronizationRegistry.getInstance();
-                Object existing = tsr.getResource(key);
+                Object existing = transactionSynchronizationRegistry.getValue().getResource(key);
                 //check is there is already a persist sync for this timer
                 if (existing == null) {
-                    tsr.registerInterposedSynchronization(new PersistTransactionSynchronization(lock, key, newTimer));
+                    transactionSynchronizationRegistry.getValue().registerInterposedSynchronization(new PersistTransactionSynchronization(lock, key, newTimer));
                 }
                 //update the most recent version of the timer to be persisted
-                tsr.putResource(key, timer);
+                transactionSynchronizationRegistry.getValue().putResource(key, timer);
             }
         } catch (SystemException e) {
             throw new RuntimeException(e);
@@ -306,7 +305,7 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
                 return timerImpl;
             }
             final String key = timerTransactionKey(timerImpl);
-            TimerImpl existing = (TimerImpl) ContextTransactionSynchronizationRegistry.getInstance().getResource(key);
+            TimerImpl existing = (TimerImpl) transactionSynchronizationRegistry.getValue().getResource(key);
             return existing != null ? existing : timerImpl;
         } catch (SystemException e) {
             throw new RuntimeException(e);
@@ -445,7 +444,7 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
         @Override
         public void beforeCompletion() {
             //get the latest version of the entity
-            timer = (TimerImpl) ContextTransactionSynchronizationRegistry.getInstance().getResource(transactionKey);
+            timer = (TimerImpl) transactionSynchronizationRegistry.getValue().getResource(transactionKey);
             if (timer == null) {
                 return;
             }
@@ -510,6 +509,10 @@ public class FileTimerPersistence implements TimerPersistence, Service<FileTimer
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public InjectedValue<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistry() {
+        return transactionSynchronizationRegistry;
     }
 
     public InjectedValue<ModuleLoader> getModuleLoader() {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -36,9 +36,10 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.transaction.TransactionUtil;
+import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Represents the Extended persistence context injected into a stateful bean.  At bean invocation time,
@@ -276,13 +277,13 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
                 @Override
                 public Object run() {
                     transactionManager = ContextTransactionManager.getInstance();
-                    transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
+                    transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
                     return null;
                 }
             });
         } else {
             transactionManager = ContextTransactionManager.getInstance();
-            transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
+            transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) CurrentServiceContainer.getServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
         }
     }
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -41,10 +41,10 @@ import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.jpa.transaction.TransactionUtil;
 import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Transaction scoped entity manager will be injected into SLSB or SFSB beans.  At bean invocation time, they
@@ -120,7 +120,7 @@ public class TransactionScopedEntityManager extends AbstractEntityManager implem
         final ServiceController<?> controller = currentServiceContainer().getService(JPAServiceNames.getPUServiceName(puScopedName));
         final PersistenceUnitServiceImpl persistenceUnitService = (PersistenceUnitServiceImpl) controller.getService();
         transactionManager = ContextTransactionManager.getInstance();
-        transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
+        transactionSynchronizationRegistry = (TransactionSynchronizationRegistry) currentServiceContainer().getService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
 
         emf = persistenceUnitService.getEntityManagerFactory();
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -51,6 +51,7 @@ import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -58,7 +59,6 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.value.ImmediateValue;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * Represents the PersistenceContext injected into a component.
@@ -153,7 +153,9 @@ public class PersistenceContextInjectionSource extends InjectionSource {
             EntityManagerFactory emf = service.getEntityManagerFactory();
             EntityManager entityManager;
             boolean standardEntityManager = ENTITY_MANAGER_CLASS.equals(injectionTypeName);
-            TransactionSynchronizationRegistry tsr = ContextTransactionSynchronizationRegistry.getInstance();
+            //TODO: change all this to use injections
+            //this is currntly safe, as there is a DUP dependency on the TSR
+            TransactionSynchronizationRegistry tsr = (TransactionSynchronizationRegistry) serviceRegistry.getRequiredService(TransactionSynchronizationRegistryService.SERVICE_NAME).getValue();
             TransactionManager transactionManager = ContextTransactionManager.getInstance();
             if (type.equals(PersistenceContextType.TRANSACTION)) {
                 entityManager = new TransactionScopedEntityManager(unitName, properties, emf, synchronizationType, tsr, transactionManager);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -41,6 +41,7 @@ import org.jboss.as.server.deployment.DeploymentUtils;
 import org.jboss.as.server.deployment.JPADeploymentMarker;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
 import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.metadata.parser.util.NoopXMLResolver;
 import org.jboss.vfs.VirtualFile;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
@@ -95,6 +96,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
 
         CapabilityServiceSupport capabilitySupport = phaseContext.getDeploymentUnit().getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
         phaseContext.addDeploymentDependency(capabilitySupport.getCapabilityServiceName(JPAServiceNames.LOCAL_TRANSACTION_PROVIDER_CAPABILITY), JpaAttachments.LOCAL_TRANSACTION_PROVIDER);
+        phaseContext.addDeploymentDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY);
     }
 
     @Override

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.naming.ValueManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.txn.service.TxnServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.modules.Module;
@@ -60,6 +61,7 @@ import org.wildfly.extension.picketlink.idm.service.FileIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.JPAIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.PartitionManagerService;
 
+import javax.transaction.TransactionSynchronizationRegistry;
 import java.util.List;
 
 import static org.jboss.as.controller.PathAddress.EMPTY_ADDRESS;
@@ -341,6 +343,10 @@ public class PartitionManagerAddHandler extends AbstractAddStepHandler {
                ContextTransactionManager, ContextTransactionSynchronizationRegistry and LocalUserTransaction
                can be made knowing that the global default TM, TSR and UT will be from that provider. */
             storeServiceBuilder.requires(context.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider", null));
+
+            storeServiceBuilder
+                .addDependency(TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY, TransactionSynchronizationRegistry.class, storeService
+                    .getTransactionSynchronizationRegistry());
 
             if (jpaDataSourceNode.isDefined()) {
                 storeConfig.dataSourceJndiUrl(toJndiName(jpaDataSourceNode.asString()));

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/service/JPAIdentityStoreService.java
@@ -29,6 +29,7 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 import org.picketlink.idm.jpa.internal.JPAIdentityStore;
 import org.picketlink.idm.spi.ContextInitializer;
 import org.picketlink.idm.spi.IdentityContext;
@@ -37,7 +38,6 @@ import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfiguratio
 import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfigurationBuilder;
 import org.wildfly.extension.picketlink.idm.jpa.transaction.TransactionalEntityManagerHelper;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -47,6 +47,7 @@ import javax.persistence.Persistence;
 import javax.persistence.metamodel.EntityType;
 import javax.transaction.Status;
 import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
@@ -71,6 +72,7 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     private final JPAStoreSubsystemConfigurationBuilder configurationBuilder;
     private JPAStoreSubsystemConfiguration storeConfig;
     private EntityManagerFactory emf;
+    private InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistry = new InjectedValue<TransactionSynchronizationRegistry>();
     private TransactionalEntityManagerHelper transactionalEntityManagerHelper;
 
     public JPAIdentityStoreService(JPAStoreSubsystemConfigurationBuilder configurationBuilder) {
@@ -81,7 +83,7 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     public void start(StartContext startContext) throws StartException {
         this.storeConfig = this.configurationBuilder.create();
         this.transactionalEntityManagerHelper = new TransactionalEntityManagerHelper(
-            ContextTransactionSynchronizationRegistry.getInstance(),
+            this.transactionSynchronizationRegistry.getValue(),
             ContextTransactionManager.getInstance());
 
         try {
@@ -115,6 +117,10 @@ public class JPAIdentityStoreService implements Service<JPAIdentityStoreService>
     @Override
     public JPAIdentityStoreService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
+    }
+
+    public InjectedValue<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistry() {
+        return this.transactionSynchronizationRegistry;
     }
 
     private void configureEntityManagerFactory() {

--- a/transactions/src/main/java/org/jboss/as/txn/service/TransactionSynchronizationRegistryService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TransactionSynchronizationRegistryService.java
@@ -36,8 +36,7 @@ import org.jboss.msc.value.InjectedValue;
  * @author Stuart Douglas
  */
 public class TransactionSynchronizationRegistryService extends AbstractService<TransactionSynchronizationRegistry> {
-    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
-     *              and org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry to obtain a TransactionSynchronizationRegistry reference. */
+    /** @deprecated Use {@link TxnServices#JBOSS_TXN_SYNCHRONIZATION_REGISTRY}  */
     @Deprecated
     public static final ServiceName SERVICE_NAME = TxnServices.JBOSS_TXN_SYNCHRONIZATION_REGISTRY;
     /** Non-deprecated service name only for use within the subsystem */

--- a/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/TxnServices.java
@@ -61,9 +61,6 @@ public final class TxnServices {
 
     public static final ServiceName JBOSS_TXN_USER_TRANSACTION_REGISTRY = JBOSS_TXN.append("UserTransactionRegistry");
 
-    /** @deprecated Use the "org.wildfly.transactions.global-default-local-provider" capability to confirm existence of a local provider
-     *              and org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry to obtain a TransactionSynchronizationRegistry reference. */
-    @Deprecated
     public static final ServiceName JBOSS_TXN_SYNCHRONIZATION_REGISTRY = JBOSS_TXN.append("TransactionSynchronizationRegistry");
 
     public static final ServiceName JBOSS_TXN_JTA_ENVIRONMENT = JBOSS_TXN.append("JTAEnvironment");


### PR DESCRIPTION
…b38a436 "[WFLY-11166] Use the org.wildfly.transactions.local-provider capability and ContextTransactionSynchronizationRegistry instead of direct use of ServiceName constants"

This is not a simple revert as there have been subsequent changes.

This also removes the deprecation of the TxnServices and TransactionSynchronizationRegistryService service name constants. Use of those should still be replaced with some sort of capability, but the WFLY-11166 approach of using ContextTransactionSynchronizationRegistry is currently not correct.

https://issues.jboss.org/browse/WFLY-11360