### PR TITLE
[WFLY-11366] Validate requirement for modules previously exported by javax.ejb.api on javax.management.j2ee.api

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
@@ -30,13 +30,6 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.ejb.api"/>
-        <module name="org.jboss.ejb-client"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
Thi PR removes some unused dependencies from `javax.management.j2ee.api` that were being exported previously by `javax.ejb.api`.

* There are not first level dependencies of jboss-j2eemgmt-api_1.1_spec.jar to those modules
* `javax.management.j2ee.api` resource is just a buch of interfaces without any implementation code; there are no service loaders or external configurations.

Additionally to the removal of the reviously exported dependencies from `javax.ejb.api`, it was found that `org.jboss.ejb-client` was unused. So, we remove it as well in this PR.

Jira issue: https://issues.jboss.org/browse/WFLY-11366