### PR TITLE
[WFLY-11367] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.metadata.ejb

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
@@ -33,22 +33,8 @@
 
     <dependencies>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.annotation.api"/>
         <module name="javax.api"/>
         <module name="javax.ejb.api" optional="true"/>
-        <module name="javax.interceptor.api" optional="true"/>
-        <module name="javax.jws.api" optional="true"/>
-        <module name="javax.persistence.api" optional="true"/>
-        <module name="javax.xml.bind.api" optional="true"/>
-        <module name="javax.xml.ws.api" optional="true"/>
-        <module name="org.jboss.ejb3" optional="true"/>
-        <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api" optional="true"/>
-        <module name="javax.xml.rpc.api" optional="true"/>
-        <module name="javax.rmi.api" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Thi PR removes some unused dependencies from `org.jboss.metadata.ejb` that were being exported previously by `javax.ejb.api` and clean up additional unused dependencies.

* There are not first level dependencies of jboss-j2eemgmt-api_1.1_spec.jar to those modules
* There are no service loaders
* External configurations that force to load specific files were not found

Jira issue: https://issues.jboss.org/browse/WFLY-11367

CC: @ehsavoie 