### PR TITLE
[WFLY-11339] FilePermission, read only, granted to ALL FILES because …

### DIFF
--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.integration.ws.serviceref;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.net.SocketPermission;
@@ -89,7 +88,7 @@ public class ServiceRefEarTestCase {
         // and CXF guys are not willing to add more privileged blocks into their code, thus deployments need to have
         // the following permissions (note that the wsdl.properties permission is needed by wsdl4j)
         ear.addAsManifestResource(createPermissionsXmlAsset(
-                new FilePermission(System.getProperty("java.home") + File.separator + "lib" + File.separator + "wsdl.properties", "read"),
+                new FilePermission("<<ALL FILES>>", "read"),
                 new PropertyPermission("user.dir", "read"),
                 new RuntimePermission("getClassLoader"),
                 new RuntimePermission("org.apache.cxf.permission", "resolveUri"),

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.integration.ws.serviceref;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FilePermission;
 import java.io.InputStreamReader;
 import java.net.SocketPermission;
@@ -82,7 +81,7 @@ public class ServiceRefSevletTestCase {
         // and CXF guys are not willing to add more privileged blocks into their code, thus deployments need to have
         // the following permissions (note that the wsdl.properties permission is needed by wsdl4j)
         war.addAsManifestResource(createPermissionsXmlAsset(
-                new FilePermission(System.getProperty("java.home") + File.separator + "lib" + File.separator + "wsdl.properties", "read"),
+                new FilePermission("<<ALL FILES>>", "read"),
                 new PropertyPermission("user.dir", "read"),
                 new RuntimePermission("getClassLoader"),
                 new RuntimePermission("org.apache.cxf.permission", "resolveUri"),

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefTestCase.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.test.integration.ws.serviceref;
 
-import java.io.File;
 import java.io.FilePermission;
 import java.net.SocketPermission;
 import java.util.Hashtable;
@@ -92,7 +91,7 @@ public class ServiceRefTestCase {
                 // and CXF guys are not willing to add more privileged blocks into their code, thus deployments need to have
                 // the following permissions (note that the wsdl.properties permission is needed by wsdl4j)
                 .addAsManifestResource(createPermissionsXmlAsset(
-                        new FilePermission(System.getProperty("java.home") + File.separator + "lib" + File.separator + "wsdl.properties", "read"),
+                    new FilePermission("<<ALL FILES>>", "read"),
                         new PropertyPermission("user.dir", "read"),
                         new RuntimePermission("getClassLoader"),
                         new RuntimePermission("org.apache.cxf.permission", "resolveUri"),


### PR DESCRIPTION
…the failing jar reference is dependent on user's mvn repo dir and the jar version.
https://issues.jboss.org/browse/WFLY-11339