### PR TITLE
[WFLY-11369] At EJBClientDescriptorMetaDataProcessor, only set LocalT…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -174,7 +174,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                         profileService);
                 if (ejbClientDescriptorMetaData.isLocalReceiverExcluded() != Boolean.TRUE) {
                     final Boolean passByValue = ejbClientDescriptorMetaData.isLocalReceiverPassByValue();
-                    profileServiceBuilder.addDependency(passByValue == Boolean.TRUE ? LocalTransportProvider.BY_VALUE_SERVICE_NAME : LocalTransportProvider.BY_REFERENCE_SERVICE_NAME, EJBTransportProvider.class, profileService.getLocalTransportProviderInjector());
+                    profileServiceBuilder.addDependency(passByValue == Boolean.FALSE ? LocalTransportProvider.BY_REFERENCE_SERVICE_NAME : LocalTransportProvider.BY_VALUE_SERVICE_NAME, EJBTransportProvider.class, profileService.getLocalTransportProviderInjector());
                 }
                 final Collection<EJBClientDescriptorMetaData.RemotingReceiverConfiguration> receiverConfigurations = ejbClientDescriptorMetaData.getRemotingReceiverConfigurations();
                 for (EJBClientDescriptorMetaData.RemotingReceiverConfiguration receiverConfiguration : receiverConfigurations) {


### PR DESCRIPTION
…ransportProvider to be BY_REFERENCE if passByValue is defined as false

Jira: https://issues.jboss.org/browse/WFLY-11369
EAP Jiras: https://issues.jboss.org/browse/JBEAP-15753 and https://issues.jboss.org/browse/JBEAP-15752