### PR TITLE
[WFLY-11373] run SetupActions when completing Weld initialization

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentCleanupProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentCleanupProcessor.java
@@ -105,7 +105,8 @@ public class WeldDeploymentCleanupProcessor implements DeploymentUnitProcessor {
         final Supplier<WeldBootstrapService> bootstrapSupplier = weldStartCompletionServiceBuilder.requires(weldBootstrapServiceName);
         final Supplier<ExecutorService> executorServiceSupplier = weldStartCompletionServiceBuilder.requires(Services.JBOSS_SERVER_EXECUTOR);
         weldStartCompletionServiceBuilder.requires(weldStartServiceName);
-        weldStartCompletionServiceBuilder.setInstance(new WeldStartCompletionService(bootstrapSupplier, executorServiceSupplier, module.getClassLoader(), serviceControllers));
+        weldStartCompletionServiceBuilder.setInstance(new WeldStartCompletionService(bootstrapSupplier, executorServiceSupplier,
+                WeldDeploymentProcessor.getSetupActions(deploymentUnit), module.getClassLoader(), serviceControllers));
         weldStartCompletionServiceBuilder.install();
     }
 

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -260,11 +260,7 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         weldBootstrapServiceBuilder.setInstance(weldBootstrapService);
         weldBootstrapServiceBuilder.install();
 
-        final List<SetupAction> setupActions = new ArrayList<SetupAction>();
-        JavaNamespaceSetup naming = deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION);
-        if (naming != null) {
-            setupActions.add(naming);
-        }
+        final List<SetupAction> setupActions = getSetupActions(deploymentUnit);
 
         ServiceBuilder<?> startService = serviceTarget.addService(weldStartServiceName);
         for (final ServiceName dependency : dependencies) {
@@ -328,4 +324,12 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         }
     }
 
+    static List<SetupAction> getSetupActions(DeploymentUnit deploymentUnit) {
+        final List<SetupAction> setupActions = new ArrayList<SetupAction>();
+        JavaNamespaceSetup naming = deploymentUnit.getAttachment(org.jboss.as.ee.naming.Attachments.JAVA_NAMESPACE_SETUP_ACTION);
+        if (naming != null) {
+            setupActions.add(naming);
+        }
+        return setupActions;
+    }
 }


### PR DESCRIPTION
This makes sure that EE naming context is set up during the last phase of Weld initialization. This is needed because this last phase of Weld initialization is where the `@Initialized(ApplicationScoped.class)` event is fired from. Beans that are being eagerly initialized by listening to this event might need the EE naming context in order to e.g. properly inject `@Resource(lookup = "java:comp/DefaultManagedThreadFactory")`.

JIRA: https://issues.jboss.org/browse/WFLY-11373

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.