### PR TITLE
[WFLY-11386] Dependencies: Manifest Entries should be a heading

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Class_Loading_in_WildFly.adoc
@@ -140,7 +140,8 @@ It is also possible to override the ear-subdeployments-isolated element
 value at a per deployment level. See the section on
 jboss-deployment-structure.xml below.
 
-`Dependencies:` *Manifest Entries*
+[[dependencies-manifest-entries]]
+=== `Dependencies:` Manifest Entries
 
 Deployments (or more correctly modules within a deployment) may set up
 dependencies on other modules by adding a `Dependencies:` manifest


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11386

Dependencies: Manifest Entries is formatted (bold) as a heading, but it is not a heading, has no anchor, and hence cannot be linked directly e.g. from stackoverflow.