### PR TITLE
[WFLY-11398] WARN when a clustered EJB is bound to INADDR_ANY (0.0.0.0).…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3175,4 +3175,9 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 508, value = "Failed to persist timer's state %s due to %s")
     void exceptionPersistTimerState(Timer timer, Exception e);
+
+    @LogMessage(level = WARN)
+    @Message(id = 509, value = "Clustered EJBs in Node: %s are bound to INADDR_ANY(%s). Client cannot reach back the cluster when they are not in the same local network.")
+    void clusteredEJBsBoundToINADDRANY(String nodeName, String ip);
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -70,6 +70,8 @@ import javax.net.ssl.SSLSession;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -465,6 +467,13 @@ final class AssociationImpl implements Association, AutoCloseable {
                 final List<ClientMapping> clientMappingList = entry.getValue();
                 final List<ClusterTopologyListener.MappingInfo> mappingInfoList = new ArrayList<>(clientMappingList.size());
                 for (ClientMapping clientMapping : clientMappingList) {
+                    try {
+                        if (InetAddress.getByName(clientMapping.getDestinationAddress()).isAnyLocalAddress()) {
+                            EjbLogger.REMOTE_LOGGER.clusteredEJBsBoundToINADDRANY(nodeName, clientMapping.getDestinationAddress());
+                        }
+                    } catch (UnknownHostException e) {
+                        // ignore
+                    }
                     mappingInfoList.add(new ClusterTopologyListener.MappingInfo(
                         clientMapping.getDestinationAddress(),
                         clientMapping.getDestinationPort(),


### PR DESCRIPTION
… as it can not reach back the cluster when not in the same local network

Jira: https://issues.jboss.org/browse/WFLY-11398

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
