### PR TITLE
[WFLY-11399] Disable WildFly metrics

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
@@ -120,11 +120,13 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
         }
 
         modelControllerClient = modelControllerClientFactory.get().createClient(managementExecutor.get());
-        // register metrics from WildFly subsystems in the VENDOR metric registry
-        registerMetrics(rootResource,
-                rootResourceRegistration,
-                MetricRegistries.get(MetricRegistry.Type.VENDOR),
-                Function.identity());
+        // WFLY-11399 - do not expose WildFly metrics as their representation is not correct
+        /*
+         * registerMetrics(rootResource,
+         *        rootResourceRegistration,
+         *        MetricRegistries.get(MetricRegistry.Type.VENDOR),
+         *        Function.identity());
+         */
     }
 
     @Override

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricService.java
@@ -56,12 +56,15 @@ public class DeploymentMetricService implements Service {
 
     @Override
     public void start(StartContext startContext) {
-        MetricRegistry applicationRegistry = MetricRegistries.get(APPLICATION);
-        registeredMetrics = registrationService.get().registerMetrics(rootResource,
-                managementResourceRegistration,
-                applicationRegistry,
-                // prepend the deployment address to the subsystem resource address
-                address -> deploymentAddress.append(address));
+        // WFLY-11399 - do not expose WildFly metrics as their representation is not correct
+        /*
+         * MetricRegistry applicationRegistry = MetricRegistries.get(APPLICATION);
+         * registeredMetrics = registrationService.get().registerMetrics(rootResource,
+         *        managementResourceRegistration,
+         *        applicationRegistry,
+         *        // prepend the deployment address to the subsystem resource address
+         *        address -> deploymentAddress.append(address));
+         */
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -118,8 +119,7 @@ public class MicroProfileMetricsApplicationTestCase {
     @InSequence(2)
     @OperateOnDeployment("MicroProfileMetricsApplicationTestCase")
     public void testApplicationMetricWithPrometheusAfterDeployment(@ArquillianResource URL url) throws Exception {
-        // metrics from deployment subsystems are exposed
-        getPrometheusMetrics(managementClient, "application", true);
+        getPrometheusMetrics(managementClient, "application", false);
 
         String text = performCall(url);
         assertNotNull(text);
@@ -167,6 +167,7 @@ public class MicroProfileMetricsApplicationTestCase {
 
     @Test
     @InSequence(4)
+    @Ignore("WFLY-11399 - do not expose WildFly metrics")
     @OperateOnDeployment("MicroProfileMetricsApplicationTestCase")
     public void testDeploymentWildFlyMetrics(@ArquillianResource URL url) throws Exception {
         // test the request-count metric on the deployment's undertow resources


### PR DESCRIPTION
Disable WildFly metrics (from both subsystems and deployments) as their
representations do not allow metric aggregation.

JIRA: https://issues.jboss.org/browse/WFLY-11399