### PR TITLE
[WFLY-11405] Remove unused dependencies in org.jboss.as.ee

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -41,8 +41,6 @@
         <module name="javax.enterprise.concurrent.api"/>
         <module name="javax.el.api"/>
         <module name="javax.interceptor.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.xml.ws.api" optional="true"/>
         <module name="org.glassfish.javax.enterprise.concurrent"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>


### PR DESCRIPTION
Remove `javax.transaction.api` and `javax.xml.ws.api` from `org.jboss.as.ee` because they are not being used:

- There are no direct dependencies to any class managed by those modules from wildfly-ee resource.
- Those modules are not exporting services that can be loaded by any other class.
- Although there are some getClassLoader().loadClass calls in some classes in wildfly-ee.jar, those loadClass calls are done using the Deployment Unit module class loader, where the removed modules are added by other deployment processors in previous phases.

Jira issue: https://issues.jboss.org/browse/WFLY-11405