### PR TITLE
[WFLY-11417] Validate requirement for modules previously exported by javax.ejb.api on ejb3 related modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -113,9 +113,6 @@
         <!-- Needed for EJB over HTTP support-->
         <module name="io.undertow.core" />
 
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api"/>
         <module name="javax.rmi.api"/>
 
         <module name="org.wildfly.common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -43,11 +43,6 @@
         <module name="org.wildfly.security.elytron-private"/>
         <module name="javax.transaction.api"/>
 
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
         <module name="org.jboss.modules"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
@@ -38,13 +38,5 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river"/>
         <module name="org.jboss.metadata.ejb"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Removes unused dependencies that were being previously exported by `javax.ejb.ap`i from `org.jboss.as.ejb3`, `org.jboss.ejb3` and `org.jboss.ejb-client`

Some notes: 
- I found several additional dependencies in `org.jboss.as.ejb3` and `org.jboss.ejb3` that are unrelated with `javax.ejb.api` but can be removed, I'll use a differen issue to cover them.
- The resource exposed by `org.jboss.ejb3` module is only a set of interfaces that don't have direct dependencies on any module inside of `org.jboss.ejb3`. I remove here only the modules related with `javax.ejb.api`, but it is likey all of them can be removed.

Jira issue: https://issues.jboss.org/browse/WFLY-11417

CC: @fl4via @dmlloyd 