### PR TITLE
 [WFLY-11416] Add non-heap memory metrics + WFLY-11409

### DIFF
--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -50,6 +50,11 @@ memory.committedHeap.displayName: Committed Heap Memory
 memory.committedHeap.description: Displays the amount of memory that is committed for the Java virtual machine to use.
 memory.committedHeap.type: gauge
 memory.committedHeap.unit: bytes
+memory.committedNonHeap.mbean: java.lang:type=Memory/NonHeapMemoryUsage#committed
+memory.committedNonHeap.displayName: Committed Non Heap Memory
+memory.committedNonHeap.description: Displays the amount of memory that is committed for the Java virtual machine to use.
+memory.committedNonHeap.type: gauge
+memory.committedNonHeap.unit: bytes
 memory.maxHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#max
 memory.maxHeap.displayName: Max Heap Memory
 memory.maxHeap.description: Displays the maximum amount of memory in bytes that can be used for memory management.
@@ -60,11 +65,21 @@ memory.maxHeap.type: gauge
 #memory.maxHeap.        value: memory
 #memory.maxHeap.      - key: type
 #memory.maxHeap.        value: heap
+memory.maxNonHeap.mbean: java.lang:type=Memory/NonHeapMemoryUsage#max
+memory.maxNonHeap.displayName: Max Non Heap Memory
+memory.maxNonHeap.description: Displays the maximum amount of memory in bytes that can be used for memory management.
+memory.maxNonHeap.unit: bytes
+memory.maxNonHeap.type: gauge
 memory.usedHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#used
 memory.usedHeap.displayName: Used Heap Memory
 memory.usedHeap.description: Displays the amount of used memory.
 memory.usedHeap.type: gauge
 memory.usedHeap.unit: bytes
+memory.usedNonHeap.mbean: java.lang:type=Memory/NonHeapMemoryUsage#used
+memory.usedNonHeap.displayName: Used Non Heap Memory
+memory.usedNonHeap.description: Displays the amount of used memory.
+memory.usedNonHeap.type: gauge
+memory.usedNonHeap.unit: bytes
 thread.count.mbean: java.lang:type=Threading/ThreadCount
 thread.count.description: Number of currently deployed threads
 thread.count.unit: none

--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -46,10 +46,13 @@ jvm.uptime.unit: milliseconds
 jvm.uptime.description: Displays the uptime of the Java virtual machine
 jvm.uptime.mbean: java.lang:type=Runtime/Uptime
 memory.committedHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#committed
+memory.committedHeap.displayName: Committed Heap Memory
+memory.committedHeap.description: Displays the amount of memory that is committed for the Java virtual machine to use.
 memory.committedHeap.type: gauge
 memory.committedHeap.unit: bytes
 memory.maxHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#max
-memory.maxHeap.description: Number of threads started for this server
+memory.maxHeap.displayName: Max Heap Memory
+memory.maxHeap.description: Displays the maximum amount of memory in bytes that can be used for memory management.
 memory.maxHeap.unit: bytes
 memory.maxHeap.type: gauge
 #memory.maxHeap.    labels:
@@ -58,6 +61,8 @@ memory.maxHeap.type: gauge
 #memory.maxHeap.      - key: type
 #memory.maxHeap.        value: heap
 memory.usedHeap.mbean: java.lang:type=Memory/HeapMemoryUsage#used
+memory.usedHeap.displayName: Used Heap Memory
+memory.usedHeap.description: Displays the amount of used memory.
 memory.usedHeap.type: gauge
 memory.usedHeap.unit: bytes
 thread.count.mbean: java.lang:type=Threading/ThreadCount


### PR DESCRIPTION
Non-heap memory metrics (committed/used/max) are read from the
NonHeapMemoryUsage attribute from the java.lang:type=Memory MBean.

JIRA: https://issues.jboss.org/browse/WFLY-11416