### PR TITLE
[WFLY-11421] compensation code is dependent on XTS code - move activates to xts subsystem

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -58,7 +58,6 @@
         <module name="org.wildfly.transaction.client"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.modules"/>
-        <module name="org.jboss.narayana.compensations"/>
         <module name="org.wildfly.security.manager"/>
 
         <!-- Only used if the org.wildfly.undertow.http-invoker capability is present,

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -120,6 +120,11 @@
                     <classifier>api</classifier>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.jboss.narayana.compensations</groupId>
+                    <artifactId>compensations</artifactId>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
 
             <build>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -72,10 +72,6 @@
             <artifactId>narayana-jts-integration</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.narayana.compensations</groupId>
-            <artifactId>compensations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -267,7 +267,6 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(TransactionExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_TRANSACTIONS_EE_CONCURRENCY, new EEConcurrencyContextHandleFactoryProcessor());
                 processorTarget.addDeploymentProcessor(TransactionExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_TRANSACTION_BINDINGS, new TransactionJndiBindingProcessor());
                 processorTarget.addDeploymentProcessor(TransactionExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_TRANSACTIONS, new TransactionDependenciesProcessor());
-                processorTarget.addDeploymentProcessor(TransactionExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_TRANSACTIONS, new CompensationsDependenciesDeploymentProcessor());
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/xts/src/main/java/org/jboss/as/compensations/CompensationsDependenciesDeploymentProcessor.java
+++ b/xts/src/main/java/org/jboss/as/compensations/CompensationsDependenciesDeploymentProcessor.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.txn.subsystem;
+package org.jboss.as.compensations;
 
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
@@ -55,6 +55,7 @@ import com.arjuna.webservices11.wscoor.sei.CoordinationFaultPortTypeImpl;
 import com.arjuna.webservices11.wscoor.sei.RegistrationPortTypeImpl;
 import com.arjuna.webservices11.wscoor.sei.RegistrationResponsePortTypeImpl;
 
+import org.jboss.as.compensations.CompensationsDependenciesDeploymentProcessor;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -236,6 +237,7 @@ class XTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(XTSExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_XTS_SOAP_HANDLERS, new XTSHandlerDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(XTSExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_XTS, new XTSDependenciesDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(XTSExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_XTS_PORTABLE_EXTENSIONS, new GracefulShutdownDeploymentProcessor());
+                processorTarget.addDeploymentProcessor(XTSExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_TRANSACTIONS, new CompensationsDependenciesDeploymentProcessor());
             }
         }, OperationContext.Stage.RUNTIME);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11421

Compensation framework was designed to enrich the XTS functionality with annotations. As the compensations were added as direct dependency to transactions subsystem it makes a discrepancy in its use.

/cc @bstansberry 