### PR TITLE
[WFLY-11429] Avoid hard-coding of the groupId in wildfly-client-all artifact

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -52,7 +52,7 @@
     <dependencies>
 
          <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-client-properties</artifactId>
         </dependency>
 


### PR DESCRIPTION
Use ${project.groupId} instead of org.wildfly to facilitate product branches switching

Jira issue: https://issues.jboss.org/browse/WFLY-11429