### PR TITLE
WFLY-11434 Set the iiop bound port of the socket binding

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaORBService.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaORBService.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
+import org.jboss.as.network.ManagedBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.msc.inject.Injector;
@@ -110,6 +111,8 @@ public class CorbaORBService implements Service<ORB> {
                 properties.setProperty(ORBConstants.SERVER_HOST_PROPERTY, address.getAddress().getHostAddress());
                 properties.setProperty(ORBConstants.SERVER_PORT_PROPERTY, String.valueOf(address.getPort()));
                 properties.setProperty(ORBConstants.PERSISTENT_SERVER_PORT_PROPERTY, String.valueOf(address.getPort()));
+
+                socketBinding.getSocketBindings().getNamedRegistry().registerBinding(ManagedBinding.Factory.createSimpleManagedBinding(socketBinding));
             }
             if (sslSocketBinding != null) {
                 InetSocketAddress address = this.iiopSSLSocketBindingInjector.getValue().getSocketAddress();
@@ -121,6 +124,8 @@ public class CorbaORBService implements Service<ORB> {
                 if (!properties.containsKey(Constants.ORB_ADDRESS)) {
                     properties.setProperty(Constants.ORB_ADDRESS, address.getAddress().getHostAddress());
                 }
+
+                sslSocketBinding.getSocketBindings().getNamedRegistry().registerBinding(ManagedBinding.Factory.createSimpleManagedBinding(sslSocketBinding));
             }
 
             // initialize the ORB - the thread context classloader needs to be adjusted as the ORB classes are loaded via reflection.
@@ -155,6 +160,15 @@ public class CorbaORBService implements Service<ORB> {
     public void stop(StopContext context) {
         if (IIOPLogger.ROOT_LOGGER.isDebugEnabled()) {
             IIOPLogger.ROOT_LOGGER.debugf("Stopping service %s", context.getController().getName().getCanonicalName());
+        }
+
+        final SocketBinding socketBinding = iiopSocketBindingInjector.getOptionalValue();
+        final SocketBinding sslSocketBinding = iiopSSLSocketBindingInjector.getOptionalValue();
+        if (socketBinding != null) {
+            socketBinding.getSocketBindings().getNamedRegistry().unregisterBinding(socketBinding.getName());
+        }
+        if (sslSocketBinding != null) {
+            sslSocketBinding.getSocketBindings().getNamedRegistry().unregisterBinding(sslSocketBinding.getName());
         }
         // stop the ORB asynchronously.
         final ORBDestroyer destroyer = new ORBDestroyer(this.orb, context);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/socketbindings/SocketBindingBoundPortsTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/socketbindings/SocketBindingBoundPortsTestCase.java
@@ -1,0 +1,116 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.smoke.socketbindings;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+
+/**
+ * Test if the /socket-binding=* runtime attributes shows the open ports as bound.
+ *
+ * @author Claudio Miranda
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SocketBindingBoundPortsTestCase {
+
+    private static final String BOUND ="bound";
+    private static final String BOUND_PORT ="bound-port";
+    private static final String STANDARD_SOCKETS = "standard-sockets";
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Test
+    public void testHttpBoundSocket() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add(SOCKET_BINDING_GROUP, "standard-sockets").add(SOCKET_BINDING, "http");
+        address.protect();
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        operation.get(OP_ADDR).set(address);
+        ModelNode response = execute(operation);
+        ModelNode result = response.get(RESULT);
+        Assert.assertTrue("http socket binding is not set as bound.", result.get(BOUND).asBoolean());
+        Assert.assertEquals(result.get(BOUND_PORT).asInt(), 8080);
+    }
+
+    @Test
+    public void testHttpsBoundSocket() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add(SOCKET_BINDING_GROUP, STANDARD_SOCKETS).add(SOCKET_BINDING, "https");
+        address.protect();
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        operation.get(OP_ADDR).set(address);
+        ModelNode response = execute(operation);
+        ModelNode result = response.get(RESULT);
+        Assert.assertTrue("https socket binding is not set as bound.", result.get(BOUND).asBoolean());
+        Assert.assertEquals(result.get(BOUND_PORT).asInt(), 8443);
+    }
+
+    @Test
+    public void testIiopBoundSocket() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add(SOCKET_BINDING_GROUP, "standard-sockets").add(SOCKET_BINDING, "iiop");
+        address.protect();
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        operation.get(OP_ADDR).set(address);
+        ModelNode response = execute(operation);
+        ModelNode result = response.get(RESULT);
+        Assert.assertTrue("iiop socket binding is not set as bound.", result.get(BOUND).asBoolean());
+        Assert.assertEquals(result.get(BOUND_PORT).asInt(), 3528);
+    }
+
+    /**
+     * Executes the operation and returns the result if successful. Else throws an exception
+     */
+    private ModelNode execute(final ModelNode operation) throws
+            IOException {
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        if (result.hasDefined(ClientConstants.OUTCOME) && ClientConstants.SUCCESS.equals(
+                result.get(ClientConstants.OUTCOME).asString())) {
+            return result;
+        } else if (result.hasDefined(ClientConstants.FAILURE_DESCRIPTION)) {
+            final String failureDesc = result.get(ClientConstants.FAILURE_DESCRIPTION).toString();
+            throw new RuntimeException(failureDesc);
+        } else {
+            throw new RuntimeException("Operation not successful; outcome = " + result.get(ClientConstants.OUTCOME));
+        }
+    }
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11434

iiop and iiop-ssl socket binding doesn't show the runtime attributes bound, bound-address, bound-port as set, making it difficult to map the open ports to the socket bindings when the server is launched with a port offset.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
