### PR TITLE
[WFLY-11443] Explicitly exclude Netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1880,6 +1880,10 @@
                         <groupId>org.jboss.logmanager</groupId>
                         <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -1918,6 +1922,10 @@
                 <artifactId>artemis-server</artifactId>
                 <version>${version.org.apache.activemq.artemis}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
                         <artifactId>*</artifactId>


### PR DESCRIPTION
Excludes the Netty transitive dependencies comming from artemis.

Jira issue: https://issues.jboss.org/browse/WFLY-11443

CC: @kabir 