### PR TITLE
[WFLY-11444] Remove unused dependencies from org.jboss.ejb3

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
@@ -26,17 +26,4 @@
         <artifact name="${org.jboss.ejb3:jboss-ejb3-ext-api}"/>
     </resources>
 
-    <dependencies>
-        <module name="javax.ejb.api"/>
-        <module name="javax.persistence.api"/>
-        <module name="javax.interceptor.api"/>
-        <!-- EJBUtilities class needs it -->
-        <module name="org.jboss.common-beans"/>
-        <!-- org.jboss.util.deadlock.ApplicationDeadlockException -->
-        <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
-        <module name="org.jboss.marshalling.river"/>
-        <module name="org.jboss.metadata.ejb"/>
-    </dependencies>
 </module>


### PR DESCRIPTION
jboss-ejb3-ext-api only depends on java.se, that means these dependencies can be removed.

Jira issue: https://issues.jboss.org/browse/WFLY-11444