### PR TITLE
[WFLY-11448] Fix registration of the :check operation

### DIFF
--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/CheckOperation.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/CheckOperation.java
@@ -44,6 +44,7 @@ public class CheckOperation extends AbstractRuntimeOnlyHandler {
             .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .setReplyValueType(ModelType.OBJECT)
+            .setRuntimeOnly()
             .build();
 
     static void register(ManagementResourceRegistration resourceRegistration) {

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthExtension.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthExtension.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -77,7 +78,7 @@ public class MicroProfileHealthExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
         subsystem.registerXMLElementWriter(CURRENT_PARSER);
 
-        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new MicroProfileHealthSubsystemDefinition());
+        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new MicroProfileHealthSubsystemDefinition(context.isRuntimeOnlyRegistrationValid()  && context.getRunningMode() == RunningMode.NORMAL));
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
     }
 

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
@@ -61,13 +61,15 @@ public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDef
             .setAllowExpression(true)
             .build();
     static final AttributeDefinition[] ATTRIBUTES = { SECURITY_ENABLED };
+    private boolean registerRuntimeOperations;
 
-    protected MicroProfileHealthSubsystemDefinition() {
+    protected MicroProfileHealthSubsystemDefinition(boolean registerRuntimeOperations) {
         super(new Parameters(MicroProfileHealthExtension.SUBSYSTEM_PATH,
                 MicroProfileHealthExtension.getResourceDescriptionResolver(MicroProfileHealthExtension.SUBSYSTEM_NAME))
                 .setAddHandler(MicroProfileHealthSubsystemAdd.INSTANCE)
                 .setRemoveHandler(new ServiceRemoveStepHandler(MicroProfileHealthSubsystemAdd.INSTANCE))
                 .setCapabilities(HEALTH_REPORTER_RUNTIME_CAPABILITY, HTTP_CONTEXT_CAPABILITY));
+        this.registerRuntimeOperations = registerRuntimeOperations;
     }
 
     @Override
@@ -79,7 +81,9 @@ public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDef
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
 
-        CheckOperation.register(resourceRegistration);
+        if (registerRuntimeOperations) {
+            CheckOperation.register(resourceRegistration);
+        }
     }
 
 


### PR DESCRIPTION
This operation checks the healthiness of the server and rely on its
runtime service.
Do not register it if the server is not in NORMAL mode (i.e. the
operation is not available in ADMIN_ONLY).

JIRA: https://issues.jboss.org/browse/WFLY-11448