### PR TITLE
[WFLY-11452] Clean up jboss-modules dependencies from Weld beanvalidation, transaction and webservices

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/beanvalidation/main/module.xml
@@ -39,12 +39,10 @@
         <module name="org.jboss.as.weld.common" />
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.security"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.extension.bean-validation"/>
-        <module name="org.hibernate.validator.cdi" />
         <module name="javax.enterprise.api"/>
         <module name="javax.validation.api"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -39,9 +39,6 @@
         <module name="org.jboss.as.weld.common" />
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.elytron-private"/>
-        <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="javax.transaction.api"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/webservices/main/module.xml
@@ -41,10 +41,7 @@
         <module name="org.jboss.as.webservices.server.integration"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.modules"/>
-        <module name="org.jboss.msc"/>
         <module name="javax.enterprise.api"/>
     </dependencies>
 


### PR DESCRIPTION
Clean up some unused jboss modules dependencies in Weld. 

`org.jboss.weld.api` and `org.jboss.weld.spi` in `org.jboss.as.weld.beanvalidation` and `org.jboss.weld.api` in `org.jboss.as.weld.transactions` and `org.jboss.as.weld.webservices` seem that can be removed too, but I'm not completely sure. I leave them out from this clean, after all they belong to Weld.

Jira issue: https://issues.jboss.org/browse/WFLY-11452

CC @manovotn when you have a chance, could you review these changes?