### PR TITLE
[WFLY-11454] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.metadata.appclient

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
@@ -33,24 +33,6 @@
 
     <dependencies>
         <module name="org.jboss.metadata.common"/>
-        <module name="javax.annotation.api"/>
         <module name="javax.api"/>
-        <module name="javax.ejb.api" optional="true"/>
-        <module name="javax.interceptor.api" optional="true"/>
-        <module name="javax.jws.api" optional="true"/>
-        <module name="javax.persistence.api" optional="true"/>
-        <module name="javax.servlet.api" optional="true"/>
-        <module name="javax.servlet.jsp.api" optional="true"/>
-        <module name="javax.xml.bind.api" optional="true"/>
-        <module name="javax.xml.ws.api" optional="true"/>
-        <module name="org.jboss.ejb3" optional="true"/>
-        <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.logging"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api" optional="true"/>
-        <module name="javax.xml.rpc.api" optional="true"/>
-        <module name="javax.rmi.api" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Remove dependencies that were being exported previously by `javax.ejb.api`. Additionally, cleaned up unused dependencies.
- There are no first level dependencies on any of those dependencies in `org.jboss.metadata:jboss-metadata-appclient`
- There are no imported services and the resource exposed by `org.jboss.metadata.appclient` does not load any service.
- I have not found any external activation that requires any of the removed dependencies.

Jira issue: https://issues.jboss.org/browse/WFLY-11454