### PR TITLE
[WFLY-11455] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.narayana.txframework

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -33,26 +33,11 @@
     </resources>
 
     <dependencies>
-        <module name="javax.ejb.api" />
-        <module name="org.jboss.jts" />
-        <module name="javax.xml.ws.api" />
-        <module name="org.jboss.weld.api" />
-        <module name="org.jboss.weld.core" />
+        <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.xts" />
-        <module name="javax.transaction.api" />
-        <module name="org.jboss.logging" />
         <module name="org.jboss.resteasy.resteasy-jaxrs" />
-        <module name="javax.ws.rs.api" />
         <module name="javax.servlet.api" />
-        <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api"  export="true" />
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.api"/>
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
-        <module name="org.omg.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Althoug it is a deprecated module, we can clean up unused dependencies beside of those that were being exported by `javax.ejb.api.` I have not found direct uses from `org.jboss.narayana.txframework:txframework` on any of the removed dependencies. 

Jira issue: https://issues.jboss.org/browse/WFLY-11455

cc: @ochaloup 