### PR TITLE
[WFLY-11460] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.as.webservices

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -43,7 +43,6 @@
         <module name="javax.jws.api"/>
         <module name="javax.servlet.api"/>
         <module name="javax.xml.ws.api"/>
-        <module name="org.jboss.ejb3"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.metadata.common"/>
@@ -60,7 +59,6 @@
         <module name="org.jboss.as.security"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.web-common"/>
-        <module name="org.jboss.threads"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.vfs"/>
@@ -73,11 +71,7 @@
         <module name="io.undertow.core" />
         <module name="io.undertow.servlet"/>
         <module name="org.wildfly.transaction.client"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
         <module name="javax.transaction.api"/>
         <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Clean up unused module dependencies in `org.jboss.as.webservices`

jira issue: https://issues.jboss.org/browse/WFLY-11460

CC: @asoldano @rsearls When you have a chance, would you mind validating these removals? Thx!