### PR TITLE
[WFLY-11467] Validate requirement for modules previously exported by javax.ejb.api on org.jboss.iiop-client

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
@@ -33,12 +33,6 @@
         <module name="javax.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.omg.api"/>
-        <module name="javax.interceptor.api"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
-        <module name="javax.transaction.api"/>
-        <module name="javax.xml.rpc.api"/>
         <module name="javax.rmi.api"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Clean up dependencies in `org.jboss.iiop-client` that were being previously exported by `javax.ejb.api` . Additionally I have found `javax.interceptor.api` is not longer required in this module, so I remove it from there too.

Jira issue: https://issues.jboss.org/browse/WFLY-11467

CC: @tadamski When you have a chance, would you mind verifing these removals?