### PR TITLE
[WFLY-11471] Add expressions to enable statistics

### DIFF
--- a/connector/src/main/resources/subsystem-templates/datasources.xml
+++ b/connector/src/main/resources/subsystem-templates/datasources.xml
@@ -4,7 +4,7 @@
    <extension-module>org.jboss.as.connector</extension-module>
    <subsystem xmlns="urn:jboss:domain:datasources:5.0">
        <datasources>
-           <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+           <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
                <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                <driver>h2</driver>
                <security>

--- a/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -208,6 +208,10 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.ajp.port:8009}", "8009");
         result = result.replace("${jboss.mcmp.port:8090}", "8090");
         result = result.replace("${jboss.deployment.scanner.rollback.on.failure:false}", "false");
+        result = result.replace("${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
         return result;
     }
 }

--- a/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -208,6 +208,10 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.ajp.port:8009}", "8009");
         result = result.replace("${jboss.mcmp.port:8090}", "8090");
         result = result.replace("${jboss.deployment.scanner.rollback.on.failure:false}", "false");
+        result = result.replace("${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
         return result;
     }
 }

--- a/galleon-pack/src/main/resources/feature_groups/datasources.xml
+++ b/galleon-pack/src/main/resources/feature_groups/datasources.xml
@@ -17,6 +17,7 @@
             <param name="driver-name" value="h2"/>
             <param name="user-name" value="sa"/>
             <param name="password" value="sa"/>
+            <param name="statistics-enabled" value="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}" />
         </feature>
     </feature>
 

--- a/galleon-pack/src/main/resources/feature_groups/messaging-activemq.xml
+++ b/galleon-pack/src/main/resources/feature_groups/messaging-activemq.xml
@@ -3,6 +3,7 @@
     <feature spec="subsystem.messaging-activemq">
         <feature spec="subsystem.messaging-activemq.server">
             <param name="server" value="default"/>
+            <param name="statistics-enabled" value="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
             <feature spec="subsystem.messaging-activemq.server.http-connector">
                 <param name="http-connector" value="http-connector"/>
                 <param name="socket-binding" value="http"/>

--- a/galleon-pack/src/main/resources/feature_groups/transactions.xml
+++ b/galleon-pack/src/main/resources/feature_groups/transactions.xml
@@ -7,6 +7,7 @@
         <param name="process-id-uuid" value="true"/>
         <param name="object-store-path" value="tx-object-store"/>
         <param name="object-store-relative-to" value="jboss.server.data.dir"/>
+        <param name="statistics-enabled" value="${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
         <feature spec="subsystem.transactions.log-store.log-store"/>
     </feature>
     <feature spec="subsystem.elytron.permission-set.permissions">

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -5,7 +5,10 @@
     <subsystem xmlns="urn:jboss:domain:messaging-activemq:5.0">
 
         <server name="default">
+
             <?CLUSTERED?>
+
+            <statistics enabled="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}" />
 
             <security-setting name="#">
                 <role name="guest"

--- a/servlet-galleon-pack/src/main/resources/feature_groups/undertow-base.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/undertow-base.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="undertow-base" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.undertow">
+        <param name="statistics-enabled" value="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}" />
+
         <feature spec="subsystem.undertow.buffer-cache">
             <param name="buffer-cache" value="default" />
         </feature>

--- a/transactions/src/main/resources/subsystem-templates/transactions.xml
+++ b/transactions/src/main/resources/subsystem-templates/transactions.xml
@@ -9,6 +9,7 @@
            </process-id>
        </core-environment>
        <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+       <coordinator-environment statistics-enabled="${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
        <object-store path="tx-object-store" relative-to="jboss.server.data.dir"/>
        <?JTS?>
 

--- a/undertow/src/main/resources/subsystem-templates/undertow.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other">
+    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <?AJP?>


### PR DESCRIPTION
* Add expressions to the features that provides statistics to enable
them using System properties
  * wildfly.statistics-enabled - Enable all statistics
  * wildfly.undertow.statistics-enabled - Enable Undertow statistics
  * wildfly.transactions.statistics-enabled - Enable Transactions
    statistics
  * wildfly.messaging-activemq.statistics-enabled - Enable Artemis
    statistics
  * wildfly.datasources.statistics-enabled - Enable Datasource
    statistics

The specific system properties (e.g.
wildfly.undertow.statistics-enabled) have precedence over the general
one (wildfly.statistics-enabled).

By default, these expressions resolves to false.

These expressions only applies to resources defined in the shipped
profiles. If a new datasource resource is created, its
`statistics-enabled` attribute will not be set to this expression.

JIRA: https://issues.jboss.org/browse/WFLY-11471