### PR TITLE
WFLY-11404 Add journal-file-open-timeout attribute to messaging server

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_6_0.java
@@ -224,6 +224,7 @@ public class MessagingSubsystemParser_6_0 extends PersistentResourceXMLParser {
                                         ServerDefinition.JOURNAL_FILE_SIZE,
                                         ServerDefinition.JOURNAL_MIN_FILES,
                                         ServerDefinition.JOURNAL_POOL_FILES,
+                                        ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT,
                                         ServerDefinition.JOURNAL_COMPACT_PERCENTAGE,
                                         ServerDefinition.JOURNAL_COMPACT_MIN_FILES,
                                         ServerDefinition.JOURNAL_MAX_IO,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -79,8 +79,12 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
         builder.buildAndRegister(registration, new ModelVersion[] { MessagingExtension.VERSION_1_0_0, MessagingExtension.VERSION_2_0_0,
             MessagingExtension.VERSION_3_0_0, MessagingExtension.VERSION_4_0_0, MessagingExtension.VERSION_5_0_0});
     }
-private static void registerTransformers_WF_16(ResourceTransformationDescriptionBuilder subsystem) {
-        ResourceTransformationDescriptionBuilder queue = subsystem.addChildResource(SERVER_PATH).addChildResource(QUEUE_PATH);
+
+    private static void registerTransformers_WF_16(ResourceTransformationDescriptionBuilder subsystem) {
+        ResourceTransformationDescriptionBuilder server = subsystem.addChildResource(SERVER_PATH);
+        rejectDefinedAttributeWithDefaultValue(server, ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT);
+
+        ResourceTransformationDescriptionBuilder queue = server.addChildResource(QUEUE_PATH);
         rejectDefinedAttributeWithDefaultValue(queue, QueueDefinition.ROUTING_TYPE);
 
         ResourceTransformationDescriptionBuilder jmsBridge = subsystem.addChildResource(MessagingExtension.JMS_BRIDGE_PATH);
@@ -90,6 +94,7 @@ private static void registerTransformers_WF_16(ResourceTransformationDescription
         defaultValueAttributeConverter(jmsBridge, JMSBridgeDefinition.MAX_BATCH_SIZE);
         defaultValueAttributeConverter(jmsBridge, JMSBridgeDefinition.MAX_BATCH_TIME);
     }
+
     private static void registerTransformers_WF_15(ResourceTransformationDescriptionBuilder subsystem) {
         ResourceTransformationDescriptionBuilder server = subsystem.addChildResource(MessagingExtension.SERVER_PATH);
         // WFLY-10976 - journal-pool-files default value is 10.

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -64,6 +64,7 @@ import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_COMPACT_MIN_FILES;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_COMPACT_PERCENTAGE;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_DATASOURCE;
+import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_FILE_SIZE;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_JDBC_LOCK_EXPIRATION;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_JDBC_LOCK_RENEW_PERIOD;
@@ -226,6 +227,7 @@ class ServerAdd extends AbstractAddStepHandler {
                         ServerDefinition.JOURNAL_FILE_SIZE,
                         ServerDefinition.JOURNAL_MIN_FILES,
                         ServerDefinition.JOURNAL_POOL_FILES,
+                        ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT,
                         ServerDefinition.JOURNAL_COMPACT_PERCENTAGE,
                         ServerDefinition.JOURNAL_COMPACT_MIN_FILES,
                         ServerDefinition.JOURNAL_MAX_IO,
@@ -596,6 +598,7 @@ class ServerAdd extends AbstractAddStepHandler {
             configuration.setJournalFileSize(JOURNAL_FILE_SIZE.resolveModelAttribute(context, model).asInt());
             configuration.setJournalMinFiles(JOURNAL_MIN_FILES.resolveModelAttribute(context, model).asInt());
             configuration.setJournalPoolFiles(JOURNAL_POOL_FILES.resolveModelAttribute(context, model).asInt());
+            configuration.setJournalFileOpenTimeout(JOURNAL_FILE_OPEN_TIMEOUT.resolveModelAttribute(context, model).asInt());
             configuration.setJournalSyncNonTransactional(JOURNAL_SYNC_NON_TRANSACTIONAL.resolveModelAttribute(context, model).asBoolean());
             configuration.setJournalSyncTransactional(JOURNAL_SYNC_TRANSACTIONAL.resolveModelAttribute(context, model).asBoolean());
             configuration.setLogJournalWriteRate(LOG_JOURNAL_WRITE_RATE.resolveModelAttribute(context, model).asBoolean());
@@ -646,12 +649,6 @@ class ServerAdd extends AbstractAddStepHandler {
             return configuration;
         }
 
-        /**
-         * Process the address settings.
-         *
-         * @param configuration the ActiveMQ configuration
-         * @param params the detyped operation parameters
-         */
         /**
          * Process the address settings.
          *

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -397,6 +397,18 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .build();
     /**
+     * @see ActiveMQDefaultConfiguration#getDefaultJournalFileOpenTimeout()
+     */
+    public static final SimpleAttributeDefinition JOURNAL_FILE_OPEN_TIMEOUT = create("journal-file-open-timeout", INT)
+            .setAttributeGroup("journal")
+            .setXmlName("file-open-timeout")
+            .setDefaultValue(new ModelNode(5))
+            .setRequired(false)
+            .setAllowExpression(true)
+            .setMeasurementUnit(SECONDS)
+            .setRestartAllServices()
+            .build();
+    /**
      * @see ActiveMQDefaultConfiguration#isDefaultJournalSyncNonTransactional
      */
     public static final SimpleAttributeDefinition JOURNAL_SYNC_NON_TRANSACTIONAL = create("journal-sync-non-transactional", BOOLEAN)
@@ -777,7 +789,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             JOURNAL_MESSAGES_TABLE, JOURNAL_BINDINGS_TABLE, JOURNAL_JMS_BINDINGS_TABLE, JOURNAL_LARGE_MESSAGES_TABLE, JOURNAL_PAGE_STORE_TABLE,
             JOURNAL_NODE_MANAGER_STORE_TABLE,
             JOURNAL_SYNC_TRANSACTIONAL, JOURNAL_SYNC_NON_TRANSACTIONAL, LOG_JOURNAL_WRITE_RATE,
-            JOURNAL_FILE_SIZE, JOURNAL_MIN_FILES, JOURNAL_POOL_FILES, JOURNAL_COMPACT_PERCENTAGE, JOURNAL_COMPACT_MIN_FILES, JOURNAL_MAX_IO,
+            JOURNAL_FILE_SIZE, JOURNAL_MIN_FILES, JOURNAL_POOL_FILES, JOURNAL_FILE_OPEN_TIMEOUT, JOURNAL_COMPACT_PERCENTAGE, JOURNAL_COMPACT_MIN_FILES, JOURNAL_MAX_IO,
             PERF_BLAST_PAGES, RUN_SYNC_SPEED_TEST, SERVER_DUMP_INTERVAL, MEMORY_WARNING_THRESHOLD, MEMORY_MEASURE_INTERVAL,
             GLOBAL_MAX_DISK_USAGE, DISK_SCAN_PERIOD, GLOBAL_MAX_MEMORY_SIZE
     };

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -381,6 +381,7 @@ server.journal-min-files=How many journal files to pre-create.
 server.journal-node-manager-store-table=Name of the JDBC table to store the node manager.
 server.journal-page-store-table=Name of the JDBC table to store pages.
 server.journal-pool-files=The number of journal files that can be reused. ActiveMQ will create as many files as needed however when reclaiming files it will shrink back to the value (-1 means no limit).
+server.journal-file-open-timeout=The timeout (in seconds) for opening journal files. Values <= 0 mean fail immediately.
 server.journal-sync-non-transactional=Whether to wait for non transaction data to be synced to the journal before returning a response to the client.
 server.journal-sync-transactional=Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.
 server.journal-type=The type of journal to use.

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_6_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_6_0.xsd
@@ -194,6 +194,7 @@
                     <xs:attribute name="file-size" type="xs:long" />
                     <xs:attribute name="min-files" type="xs:int" />
                     <xs:attribute name="pool-files" type="xs:int" />
+                    <xs:attribute name="file-open-timeout" type="xs:int" />
                     <xs:attribute name="compact-percentage" type="xs:int" />
                     <xs:attribute name="compact-min-files" type="xs:int" />
                     <xs:attribute name="max-io" type="xs:int" />

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_6_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_6_0.xml
@@ -182,6 +182,7 @@
                 file-size="${journal.file.size:102400}"
                 min-files="${journal.min.files:2}"
                 pool-files="${journal.pool.files:5}"
+                file-open-timeout="${journal.file.open.timeout:7}"
                 compact-percentage="${journal.compact.percentage:83}"
                 compact-min-files="${journal.compact.min.files:2}"
                 max-io="${journal.max.io:50}"

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_6_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_6_0_reject_transform.xml
@@ -66,7 +66,8 @@
                  page-store-table="MY_PAGE_STORE"
                  global-max-disk-usage="70"
                  global-max-memory-size="100000"
-                 disk-scan-period="10000"/>
+                 disk-scan-period="10000"
+                 file-open-timeout="7"/>
 
         <replication-colocated>
             <master />


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11404

Adds journal-file-open-timeout attribute to activemq messaging server. The parameter has already been defined on activemq side, this will allow it to be configured from Wildfly configuration.

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [x] Tests were added to cover changes

For new features ensure as well:
- [x] Analysis was done
- [x] Test Plan has been done
- [ ] Tests were verified in advance