### PR TITLE
[WFLY-10293] IllegalStateException when instantiating CDI bean that i…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/allowedmethods/AllowedMethodsInformation.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/allowedmethods/AllowedMethodsInformation.java
@@ -134,7 +134,7 @@ public class AllowedMethodsInformation {
                 throwException(methodType, invocationType);
             }
         }
-        if (invocationType != InvocationType.CONCURRENT_CONTEXT && !beanManagedTransaction && methodType == MethodType.GET_USER_TRANSACTION) {
+        if (invocationType != InvocationType.CONCURRENT_CONTEXT && invocationType != InvocationType.MESSAGE_DELIVERY && !beanManagedTransaction && methodType == MethodType.GET_USER_TRANSACTION) {
             throw EjbLogger.ROOT_LOGGER.unauthorizedAccessToUserTransaction();
         }
     }

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -490,6 +490,7 @@
                                         <include>org/jboss/as/test/integration/ejb/management/deployments/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/singleton/dependson/mdb/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/messaging/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/timerservice/gettimers/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/jaxr/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/jca/bootstrap/**/*TestCase*.java</include>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/CDI.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/CDI.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.messaging;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.UserTransaction;
+
+@ApplicationScoped
+public class CDI {
+
+    @Resource
+    private UserTransaction userTransaction;
+
+    public void dummyMethod() {
+    }
+
+    public void dummyMethodWithTransaction() throws Exception {
+        userTransaction.begin();
+        userTransaction.commit();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/CmtAccessCdiWithUserTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/CmtAccessCdiWithUserTransactionTestCase.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.messaging;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import javax.jms.TemporaryQueue;
+
+/**
+ * Message driven bean with TransactionManagementType.CONTAINER tries to access cdi bean with reference to userTransaction.
+ * If mdb calls method without userTransaction, it should work. See WFLY-10293 for more details.
+ *
+ * @author Jiri Ondrusek <jondruse@redhat.com>
+ */
+@RunWith(Arquillian.class)
+public class CmtAccessCdiWithUserTransactionTestCase {
+    private static final Logger LOGGER = Logger.getLogger(CmtAccessCdiWithUserTransactionTestCase.class);
+
+    @Resource(mappedName = "java:/JmsXA")
+    private ConnectionFactory factory;
+
+    @Resource(mappedName = MDB.JNDI_NAME)
+    private Queue queue;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "CmtAccessToCdiWithUserTransactionTestCase.war")
+                .addPackage(CmtAccessCdiWithUserTransactionTestCase.class.getPackage())
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        return archive;
+    }
+
+    @Test
+    public void testAcessWithoutUserTransaction() {
+        String result = test(MDB.TXT1);
+        Assert.assertEquals("Method without transaction should be successfully called.", MDB.TXT1, result);
+    }
+
+    @Test
+    public void testAcessWithtUserTransaction() {
+        String result = test(MDB.TXT2);
+        Assert.assertNull("Method with transaction should fail and there should be no returned message.", result);
+    }
+
+    private String test(String msg) {
+        try (JMSContext context = factory.createContext()) {
+            TemporaryQueue replyTo = context.createTemporaryQueue();
+
+            String text = msg;
+            context.createProducer()
+                .setJMSReplyTo(replyTo)
+                .send(queue, text);
+
+            JMSConsumer consumer = context.createConsumer(replyTo);
+            String reply = consumer.receiveBody(String.class, 5000);
+            return reply;
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/MDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/messaging/MDB.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.messaging;
+
+import org.jboss.logging.Logger;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.JMSDestinationDefinitions;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+
+@JMSDestinationDefinitions(
+        value= {
+                @JMSDestinationDefinition(
+                        name = MDB.JNDI_NAME,
+                        interfaceName = "javax.jms.Queue",
+                        destinationName = "WFLY_10293"
+                )
+        }
+)
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = MDB.JNDI_NAME),
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue")})
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class MDB implements MessageListener {
+
+    private static final Logger logger = Logger.getLogger(MDB.class);
+
+    public static final String JNDI_NAME = "java:app/queue/WFLY_10293";
+    public static final String TXT1 = "method";
+    public static final String TXT2 = "methodWithTransaction";
+
+    @Inject
+    JMSContext context;
+
+    @Inject
+    CDI cdi;
+
+    /**
+     * @see MessageListener#onMessage(Message)
+     */
+    public void onMessage(Message message) {
+
+        try {
+            String txt = ((TextMessage)message).getText();
+
+            if(TXT1.equals(txt)) {
+                cdi.dummyMethod();
+            } else {
+                cdi.dummyMethodWithTransaction();
+            }
+
+            final Destination replyTo = message.getJMSReplyTo();
+            // ignore messages that need no reply
+            if (replyTo == null) {
+                return;
+            }
+            //send message to out queue, as a result of successful call
+            context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, ((TextMessage) message).getText());
+        } catch (Exception e) {
+            logger.error(e);
+        }
+    }
+
+}


### PR DESCRIPTION
…s injected into a MDB

Issue https://issues.jboss.org/browse/WFLY-10293

I would like to ask for confirmation if this fix is desired.
I'm allowing access from mdb to cdi with user transaction.
Methods without call of userTransaction will work, methods with call of userTransactions will fail - this seems to be the correct behavior.
I'm not sure whether moving exception throw from access validation to execution is correct and doesn't have other unwanted consequences.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.