### PR TITLE
[WFCORE-4227] Add documentation about the ability of the CLI SSL securi…

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -566,6 +566,11 @@ Do you confirm y/n :y
 ----
 NB: Once the command is executed, the CLI will reload the server and reconnect to it.
 
+This command can also obtain the certificates from the Let's Encrypt certificate authority
+by use of the --lets-encrypt parameter.
+Besides the mentioned workflow the user will be prompted to specify more information
+(eg: account key store, certificate authority account) to obtain the certificate from Let's Encrypt.
+
 * _security disable-ssl-management_: To disable SSL (elytron SSLContext) for the
 management interfaces. Type _help security disable-ssl-management_ for
 a complete description of the command.
@@ -573,6 +578,11 @@ a complete description of the command.
 * _security enable-ssl-http-server_: To enable SSL (elytron SSLContext) for the
 _undertow_ server. The same wizard as the _enable-ssl-management_ action is available.
 Type _help security enable-ssl-http-server_ for a complete description of the command.
+
+This command can also obtain the certificates from the Let's Encrypt certificate authority
+by use of the --lets-encrypt parameter.
+Besides the mentioned workflow the user will be prompted to specify more information
+(eg: account key store, certificate authority account) to obtain the certificate from Let's Encrypt.
 
 * _security disable-ssl-http-server_: To disable SSL (elytron SSLContext) for the
 _undertow_ server. Type _help security disable-ssl-http-server_ for a complete


### PR DESCRIPTION
…ty commands to obtain a server certificate from Let's Encrypt

WFCORE issue: https://issues.jboss.org/browse/WFCORE-4227
EAP issue: https://issues.jboss.org/browse/EAP7-1100
Analysis document: wildfly/wildfly-proposals#156
WFCORE PR: https://github.com/wildfly/wildfly-core/pull/3618/files

Please do not merge before https://issues.jboss.org/browse/EAP7-1150 is fixed.

Description: Add documentation for the ability of the CLI SSL security commands to obtain a server certificate from Let's Encrypt.