### PR TITLE
[WFLY-11506] Add required org.jboss.weld.core to transaction related modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -55,6 +55,7 @@
         <!-- need this to get the SPIProviderResolver  -->
         <module name="org.jboss.ws.spi"/>
         <module name="org.jboss.jandex"/>
+        <module name="org.jboss.weld.core" />
         <module name="org.jboss.modules"/>
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.as.ejb3"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
@@ -43,6 +43,7 @@
         <module name="org.apache.activemq.artemis.journal"/>
         <module name="javax.orb.api"/>
         <module name="javax.enterprise.api"/>
+        <module name="org.jboss.weld.core"/>
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api" export="true" />
         <module name="org.wildfly.transaction.client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -37,6 +37,7 @@
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.xts" />
         <module name="org.jboss.resteasy.resteasy-jaxrs" />
+        <module name="org.jboss.weld.core" />
         <module name="javax.servlet.api" />
         <module name="javax.interceptor.api"  export="true" />
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -55,7 +55,7 @@
         <module name="javax.annotation.api"/>
         <!-- this is needed to ensure the JaxWS endpoint classes canb refer to HttpServletRequest etc -->
         <module name="javax.servlet.api"/>
-
+        <module name="org.jboss.weld.core" />
         <module name="org.jboss.logging" />
         <module name="org.jboss.narayana.compensations" export="true" />
         <module name="org.jboss.narayana.txframework" export="true" />

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/CdiBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/CdiBean.java
@@ -1,8 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.as.test.integration.weld.jta;
 
 import javax.annotation.Resource;
 import javax.enterprise.context.ApplicationScoped;
+import javax.transaction.Status;
 import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.Transactional;
 
 @ApplicationScoped
 public class CdiBean {
@@ -14,4 +34,12 @@ public class CdiBean {
         return transactionSynchronizationRegistry != null;
     }
 
+    @Transactional
+    public boolean isTransactionActive() {
+        return transactionSynchronizationRegistry.getTransactionStatus() == Status.STATUS_ACTIVE;
+    }
+
+    public boolean isTransactionInactive() {
+        return transactionSynchronizationRegistry.getTransactionStatus() == Status.STATUS_NO_TRANSACTION;
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/TransactionSynchronizationRegistryInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/TransactionSynchronizationRegistryInjectionTestCase.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jboss.as.test.integration.weld.jta;
 
 import javax.inject.Inject;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/TransactionalCdiEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jta/TransactionalCdiEarTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.weld.jta;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that the Transactional annotation works in a CDI Bean which is in an ear deployment.
+ * <p>
+ * This is a test case for WFLY-11506 that requires standalone.xml server configuration. Notice that if you are using
+ * -Dtest= system property to run this test, the result could end up in a false negative because Wildfly uses
+ * standalone-full.xml configuration file to run individual tests, and this variant includes the org.jboss.jts module in
+ * the ear classpath via MessagingDependencyProcessor, making the issue not reproducible.
+ *
+ * @author Yeray Borges
+ */
+@RunWith(Arquillian.class)
+public class TransactionalCdiEarTestCase {
+
+    @Inject
+    CdiBean cdiBean;
+
+    @Deployment
+    public static EnterpriseArchive deployment(){
+        final String deployName = TransactionalCdiEarTestCase.class.getSimpleName();
+
+        final WebArchive warModule = ShrinkWrap.create(WebArchive.class, deployName + ".war")
+                .addClasses(CdiBean.class, TransactionalCdiEarTestCase.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deployName + ".ear")
+                .addAsModule(warModule);
+
+        return ear;
+    }
+
+    @Test
+    public void testIfTransactionIsActive() {
+        Assert.assertTrue(cdiBean.isTransactionActive());
+    }
+
+    @Test
+    public void testIfTransactionIsInactive() {
+        Assert.assertTrue(cdiBean.isTransactionInactive());
+    }
+
+}


### PR DESCRIPTION
`org.jboss.weld.core` is a required module for transactions. Without that module, the uses of @transaction annotation does not work correctly when the deployment is packaged in an ear.

This patch reverts the removal of this module made as in a previous release and adds a test case to prevent this problem in the future.

Jira issue: https://issues.jboss.org/browse/WFLY-11506

CC: @ochaloup 
