### PR TITLE
[WFLY-11529] Expose WildFly metrics in Prometheus HTTP endpoint

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -28,6 +28,7 @@ standalone configurations explicitly sets it to `false` to accept unauthenticate
 * `exposed-subsystems` - a list of strings corresponding to the names of subsystems that exposes their metrics in the HTTP metrics endpoints.
   By default, it is not defined (there will be no metrics exposed by subsystem. The special wildcard `*` can be used to expose metrics from _all_ subsystems. The standalone
   configuration sets this attribute to `*`.
+* `prefix` - A string to prepend to WildFly metrics that are exposed by the HTTP endpoint `/metrics` with the Prometheus output format.
 
 == HTTP Endpoint
 
@@ -70,27 +71,28 @@ If the authentication fails, the  server will reply with a `401 NOT AUTHORIZED` 
 The HTTP endpoint exposes the following metrics:
 
 * Base metrics - Required metrics specified in the MicroProfile 1.1 specification are exposed in the `base`  scope.
-* Vendor metrics - Metrics from WildFly subsystems are exposed in the `vendor` scope
+* Vendor metrics - Vendor-specific metrics (e.g. for memory pools)
 * Application metrics - Metrics from the application and from the deployment's subsystems are exposed in the `application` scope.
+
+The WildFly metrics (that measures activity in the subsystem or application deployments) are exposed only on the `/metrics`
+endpoint with the Prometheus format.
 
 === WildFly Metrics Description
 
-WildFly metrics can appears in two scopes:
+WildFly metrics names is based on the subsystem that provides them as well as the name of the attribute from the management model.
+Their name can also be prepended with a `prefix` (specified on the `/subsystem=microprofile-metrics` resource).
+Other information are stored using labels.
 
-* `vendor` for metrics defined in subsystem resources (e.g. the `bytes-received` attribute of the `/subsystem=undertow/server=default-server/http-listener=default` resource)
-* `applications` for metrics defined in deployment resources (e.g. the `request-count` attribute on the `/deployment=<deployment name>/subsystem=undertow/servlet=<servlet name>` resource).
+For example Undertow exposes a metric attribute `request-count` for every Servlet in an application deployment.
+This attribute will be exposed to Prometheus with the name `wildfly_undertow_request_count`.
+Other information such as the name of the Servlet are added to the labels of the metrics.
 
-The name of the MicroProfile metric is composed of the whole resource address appended by the attribute name.
-For example, `subsystem/undertow/server/default-server/http-listener/default/request-count` and `deployment/example.war/subsystem/undertow/servlet/org.example.MyServlet/request-count` for the two attributes above.
+The [helloworld-rs quickstart](https://github.com/wildfly/quickstart/tree/master/helloworld-rs) creates a JAX-RS application
+that can be deployed in WildFly.
+A corresponding metric will be exposed for it with the name and labels:
 
-==== Tags
+* `wildfly_undertow_request_count{deployment="helloworld-rs.war",servlet="org.jboss.as.quickstarts.rshelloworld.JAXActivator",subdeployment="helloworld-rs.war"}`
 
-WildFly metrics provides tags corresponding to the resource address elements as well as a tag with the attribute name.
-This allows to be able to query all MicroProfile metrics for a subsystem (e.g. `subsystem="undertow"`) or a deployment (e.g. `deployment="example.war`).
-
-For example, the MicroProfile metric registered for the `request-count` attribute on the `/deployment=example.war/subsystem=undertow/servlet=org.example.MyServlet` resource will have the following tags:
-
-* `subsystem="undertow", servlet="org.example.MyServlet", deployment="example.war", attribute="request-count"` (note that the tag order does not preserve order of the resource address)
 
 == Component Reference
 

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -91,12 +91,18 @@ The [helloworld-rs quickstart](https://github.com/wildfly/quickstart/tree/master
 that can be deployed in WildFly.
 A corresponding metric will be exposed for it with the name and labels:
 
-* `wildfly_undertow_request_count{deployment="helloworld-rs.war",servlet="org.jboss.as.quickstarts.rshelloworld.JAXActivator",subdeployment="helloworld-rs.war"}`
+* `wildfly_undertow_request_count_total{deployment="helloworld-rs.war",servlet="org.jboss.as.quickstarts.rshelloworld.JAXActivator",subdeployment="helloworld-rs.war"}`
 
+[NOTE]
+Some subsystems (such as `undertow` or `messaing-activemq`) do not enable their statistics by default
+as they have an impact on performance and memory usage. These subsystems provides a `statistics-enabled` attribute that must
+be set to `true` to enable them.
+For convenience, WildFly standalone configuration provides expression to enable the statistics by setting a
+System property `-Dwildfly.statistics-enabled=true` to enable statistics on the subsystems provided by the configuration.
 
 == Component Reference
 
-The Eclipse MicroProfile Health is implemented by the SmallRye Health project.
+The Eclipse MicroProfile Metrics is implemented by the SmallRye Metrics project.
 
 ****
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
@@ -58,12 +58,12 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
 
     private static final AttributeDefinition EXECUTION_TIME = new SimpleAttributeDefinitionBuilder("execution-time", ModelType.LONG)
             .setUndefinedMetricValue(new ModelNode(0))
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME, AttributeAccess.Flag.COUNTER_METRIC)
             .build();
 
     private static final AttributeDefinition INVOCATIONS = new SimpleAttributeDefinitionBuilder("invocations", ModelType.LONG)
             .setUndefinedMetricValue(new ModelNode(0))
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME, AttributeAccess.Flag.COUNTER_METRIC)
             .build();
 
     private static final AttributeDefinition PEAK_CONCURRENT_INVOCATIONS = new SimpleAttributeDefinitionBuilder("peak-concurrent-invocations", ModelType.LONG)
@@ -77,7 +77,7 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
 
     private static final AttributeDefinition WAIT_TIME = new SimpleAttributeDefinitionBuilder("wait-time", ModelType.LONG)
             .setUndefinedMetricValue(new ModelNode(0))
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME, AttributeAccess.Flag.COUNTER_METRIC)
             .build();
 
     private static final AttributeDefinition METHODS = ObjectTypeAttributeDefinition.Builder.of("methods", EXECUTION_TIME, INVOCATIONS, WAIT_TIME)
@@ -118,13 +118,13 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
     public static final SimpleAttributeDefinition POOL_CREATE_COUNT = new SimpleAttributeDefinitionBuilder("pool-create-count", ModelType.INT, false)
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME, AttributeAccess.Flag.COUNTER_METRIC).build();
     public static final SimpleAttributeDefinition POOL_CURRENT_SIZE = new SimpleAttributeDefinitionBuilder("pool-current-size", ModelType.INT, false)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
     public static final SimpleAttributeDefinition POOL_NAME = new SimpleAttributeDefinitionBuilder("pool-name", ModelType.STRING, true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
     public static final SimpleAttributeDefinition POOL_REMOVE_COUNT = new SimpleAttributeDefinitionBuilder("pool-remove-count", ModelType.INT, false)
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME, AttributeAccess.Flag.COUNTER_METRIC).build();
     public static final SimpleAttributeDefinition POOL_MAX_SIZE = new SimpleAttributeDefinitionBuilder("pool-max-size", ModelType.INT, false)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
 

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2893,6 +2893,15 @@
         </dependency>
 
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-health</artifactId>
             <exclusions>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/prometheus/simpleclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/prometheus/simpleclient/main/module.xml
@@ -22,31 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.wildfly.extension.microprofile.metrics-smallrye">
+<module xmlns="urn:jboss:module:1.8" name="io.prometheus.simpleclient">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.wildfly:wildfly-microprofile-metrics-smallrye}"/>
+        <artifact name="${io.prometheus:simpleclient}"/>
+        <artifact name="${io.prometheus:simpleclient_common}"/>
     </resources>
-
-    <dependencies>
-        <module name="io.prometheus.simpleclient" />
-        <module name="io.smallrye.metrics" export="true"/>
-        <module name="io.undertow.core"/>
-        <module name="javax.api"/>
-        <module name="org.eclipse.microprofile.metrics.api" />
-        <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.core-security"/>
-        <module name="org.jboss.as.server"/>
-        <module name="org.jboss.modules"/>
-        <module name="org.jboss.msc"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
-        <module name="org.wildfly.extension.microprofile.config-smallrye" />
-        <module name="javax.enterprise.api" />
-        <module name="javax.annotation.api" />
-    </dependencies>
 </module>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -238,6 +238,16 @@
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>

--- a/galleon-pack/src/main/resources/feature_groups/metrics.xml
+++ b/galleon-pack/src/main/resources/feature_groups/metrics.xml
@@ -3,5 +3,6 @@
     <feature spec="subsystem.microprofile-metrics-smallrye">
       <param name="security-enabled" value="false"/>
       <param name="exposed-subsystems" value="[*]" />
+      <param name="prefix" value="${wildfly.metrics.prefix:wildfly}" />
     </feature>
 </feature-group-spec>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -25,6 +25,7 @@ package org.wildfly.extension.messaging.activemq;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.BYTES;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 import static org.jboss.as.controller.registry.AttributeAccess.Flag.RESTART_ALL_SERVICES;
 import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.jboss.dmr.ModelType.DOUBLE;
@@ -234,6 +235,7 @@ public interface CommonAttributes {
     AttributeDefinition MESSAGES_ADDED = create("messages-added", LONG)
             .setStorageRuntime()
             .setUndefinedMetricValue(new ModelNode(0))
+            .setFlags(COUNTER_METRIC)
             .build();
 
     /**

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -71,6 +71,14 @@
             <artifactId>wildfly-undertow</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_common</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld</artifactId>
         </dependency>

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricCollector.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricCollector.java
@@ -1,0 +1,283 @@
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.PathAddress.EMPTY_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.wildfly.extension.microprofile.metrics.UnitConverter.unitSuffix;
+import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.GaugeMetricFamily;
+import org.jboss.as.controller.LocalModelControllerClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+public class MetricCollector {
+
+
+    private final PrometheusCollector prometheusCollector;
+    private final boolean exposeAnySubsystem;
+    private String globalPrefix;
+    private final List<String> exposedSubsystems;
+    private final LocalModelControllerClient modelControllerClient;
+
+    public MetricCollector(LocalModelControllerClient modelControllerClient, ImmutableManagementResourceRegistration managementResourceRegistration, List<String> exposedSubsystems, String globalPrefix) {
+        this.modelControllerClient = modelControllerClient;
+        this.exposedSubsystems = exposedSubsystems;
+        this.exposeAnySubsystem = exposedSubsystems.remove("*");
+        this.globalPrefix = globalPrefix;
+        this.prometheusCollector = new PrometheusCollector();
+        collectMetricFamilies(managementResourceRegistration, EMPTY_ADDRESS, prometheusCollector);
+        this.prometheusCollector.register(CollectorRegistry.defaultRegistry);
+    }
+
+    void close() {
+        CollectorRegistry.defaultRegistry.unregister(prometheusCollector);
+    }
+
+    // collect metrics from the resources
+    MetricRegistration collectResourceMetrics(final Resource resource,
+                                              ImmutableManagementResourceRegistration managementResourceRegistration,
+                                              Function<PathAddress, PathAddress> resourceAddressResolver) {
+        MetricRegistration registration = new MetricRegistration();
+        collectResourceMetrics0(resource, managementResourceRegistration, EMPTY_ADDRESS, resourceAddressResolver, registration);
+        return registration;
+    }
+
+    private void collectResourceMetrics0(final Resource current,
+                                        ImmutableManagementResourceRegistration managementResourceRegistration,
+                                         PathAddress address,
+                                         Function<PathAddress, PathAddress> resourceAddressResolver,
+                                        MetricRegistration registration) {
+        if (!isExposingMetrics(address)) {
+            return;
+        }
+
+        Map<String, AttributeAccess> attributes = managementResourceRegistration.getAttributes(address);
+        if (attributes == null) {
+            return;
+        }
+
+        ModelNode resourceDescription = null;
+        for (Map.Entry<String, AttributeAccess> entry : attributes.entrySet()) {
+            String attributeName = entry.getKey();
+
+            AttributeAccess attributeAccess = entry.getValue();
+            if (!isCollectibleMetric(attributeAccess)) {
+                continue;
+            }
+
+            if (resourceDescription == null) {
+                DescriptionProvider modelDescription = managementResourceRegistration.getModelDescription(address);
+                resourceDescription = modelDescription.getModelDescription(Locale.getDefault());
+            }
+            PathAddress resourceAddress = resourceAddressResolver.apply(address);
+            MeasurementUnit unit = attributeAccess.getAttributeDefinition().getMeasurementUnit();
+            MetricMetadata metricMetadata = new MetricMetadata(attributeName, resourceAddress, unit, globalPrefix);
+            String attributeDescription = resourceDescription.get(ATTRIBUTES, attributeName, DESCRIPTION).asStringOrNull();
+            GaugeMetricFamily gaugeMetricFamily = new GaugeMetricFamily(metricMetadata.metricName, attributeDescription, metricMetadata.labelNames);
+            Supplier<Optional<Collector.MetricFamilySamples.Sample>> sampleSupplier = () -> {
+                final ModelNode readAttributeOp = new ModelNode();
+                readAttributeOp.get(OP).set(READ_ATTRIBUTE_OPERATION);
+                readAttributeOp.get(OP_ADDR).set(resourceAddress.toModelNode());
+                readAttributeOp.get(ModelDescriptionConstants.INCLUDE_UNDEFINED_METRIC_VALUES).set(true);
+                readAttributeOp.get(NAME).set(attributeName);
+                ModelNode response = modelControllerClient.execute(readAttributeOp);
+                String error = getFailureDescription(response);
+                if (error != null) {
+                    throw LOGGER.unableToReadAttribute(attributeName, address, error);
+                }
+                ModelNode result = response.get(RESULT);
+                if (result.isDefined()) {
+                    try {
+                        double initialValue = result.asDouble();
+                        double scaledValue = UnitConverter.scaleToBase(initialValue, unit);
+                        return Optional.of(new Collector.MetricFamilySamples.Sample(metricMetadata.metricName, metricMetadata.labelNames, metricMetadata.labelValues, scaledValue));
+                    } catch (Exception e) {
+                        throw LOGGER.unableToConvertAttribute(attributeName, address, e);
+                    }
+                }
+                return Optional.empty();
+            };
+            prometheusCollector.addMetricFamilySampleSupplier(gaugeMetricFamily, sampleSupplier);
+            registration.addUnregistrationTask(() -> prometheusCollector.removeMetricFamilySampleSupplier(metricMetadata.metricName, sampleSupplier));
+        }
+
+        for (String type : current.getChildTypes()) {
+            if (current.hasChildren(type)) {
+                for (Resource.ResourceEntry entry : current.getChildren(type)) {
+                    final PathElement pathElement = entry.getPathElement();
+                    final PathAddress childAddress = address.append(pathElement);
+                    collectResourceMetrics0(entry, managementResourceRegistration, childAddress, resourceAddressResolver, registration);
+                }
+            }
+        }
+    }
+
+    private boolean isExposingMetrics(PathAddress address) {
+        // root resource
+        if (address.size() == 0) {
+            return true;
+        }
+        if (address.getElement(0).getKey().equals(DEPLOYMENT)) {
+            return true;
+        }
+        if (address.getElement(0).getKey().equals(SUBSYSTEM)) {
+            String subsystemName = address.getElement(0).getValue();
+            return exposeAnySubsystem || exposedSubsystems.contains(subsystemName);
+        }
+        // do not expose metrics for resources outside the subsystems and deployments.
+        return false;
+    }
+
+    private void collectMetricFamilies(ImmutableManagementResourceRegistration managementResourceRegistration,
+                                       final PathAddress address,
+                                       PrometheusCollector collector) {
+        if (!isExposingMetrics(address)) {
+            return;
+        }
+
+        ModelNode resourceDescription = null;
+        Map<String, AttributeAccess> attributes = managementResourceRegistration.getAttributes(address);
+        for (Map.Entry<String, AttributeAccess> entry : attributes.entrySet()) {
+            String attributeName = entry.getKey();
+            AttributeAccess attributeAccess = entry.getValue();
+            if (!isCollectibleMetric(attributeAccess)) {
+                LOGGER.debugf("Type %s is not supported for MicroProfile Metrics, the attribute %s on %s will not be registered.",
+                        attributeAccess.getAttributeDefinition().getType(), attributeName, address);
+                continue;
+            }
+            if (resourceDescription == null) {
+                DescriptionProvider modelDescription = managementResourceRegistration.getModelDescription(address);
+                resourceDescription = modelDescription.getModelDescription(Locale.getDefault());
+            }
+            MetricMetadata metricMetadata = new MetricMetadata(attributeName, address, attributeAccess.getAttributeDefinition().getMeasurementUnit(), globalPrefix);
+            String attributeDescription = resourceDescription.get(ATTRIBUTES, attributeName, DESCRIPTION).asStringOrNull();
+            GaugeMetricFamily gaugeMetricFamily = new GaugeMetricFamily(metricMetadata.metricName, attributeDescription, metricMetadata.labelNames);
+            collector.addMetricFamilySamples(gaugeMetricFamily);
+        }
+
+        for (PathElement childAddress : managementResourceRegistration.getChildAddresses(address)) {
+            collectMetricFamilies(managementResourceRegistration, address.append(childAddress), collector);
+        }
+    }
+
+    private boolean isCollectibleMetric(AttributeAccess attributeAccess) {
+        if (attributeAccess.getAccessType() == AttributeAccess.AccessType.METRIC
+                && attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME) {
+            // handle only metrics with simple numerical types
+            ModelType type = attributeAccess.getAttributeDefinition().getType();
+            if (type == ModelType.INT ||
+                    type == ModelType.LONG ||
+                    type == ModelType.DOUBLE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getFailureDescription(ModelNode result) {
+        if (result.hasDefined(FAILURE_DESCRIPTION)) {
+            return result.get(FAILURE_DESCRIPTION).toString();
+        }
+        return null;
+    }
+
+    public static final class MetricRegistration {
+
+        private final List<Runnable> unregistrationTasks = new ArrayList<>();
+
+        MetricRegistration() {
+        }
+
+        public void unregister() {
+            for (Runnable task : unregistrationTasks) {
+                task.run();
+            }
+        }
+
+        private void addUnregistrationTask(Runnable task) {
+            unregistrationTasks.add(task);
+        }
+    }
+
+    private static class MetricMetadata {
+
+        private static final Pattern SNAKE_CASE_PATTERN = Pattern.compile("(?<=[a-z])[A-Z]");
+
+        private final String metricName;
+        private final List<String> labelNames;
+        private final List<String> labelValues;
+
+        MetricMetadata(String attributeName, PathAddress address, MeasurementUnit unit, String globalPrefix) {
+            String metricPrefix = "";
+            labelNames = new ArrayList<>();
+            labelValues = new ArrayList<>();
+            for (PathElement element: address) {
+                String key = element.getKey();
+                String value = element.getValue();
+                // prepend the subsystem or statistics name to the attribute
+                if (key.equals(SUBSYSTEM) || key.equals("statistics")) {
+                    metricPrefix += value + "_";
+                    continue;
+                }
+                labelNames.add(getPrometheusMetricName(key, null));
+                labelValues.add(value);
+            }
+            // if the resource address defines a deployment (without subdeployment),
+            if (labelNames.contains(DEPLOYMENT)  && !labelNames.contains(SUBDEPLOYMENT)) {
+                labelNames.add(SUBDEPLOYMENT);
+                labelValues.add(labelValues.get(labelNames.indexOf(DEPLOYMENT)));
+            }
+            if (globalPrefix != null && !globalPrefix.isEmpty()) {
+                metricPrefix = globalPrefix + "_" + metricPrefix;
+            }
+            metricName = getPrometheusMetricName(metricPrefix + attributeName, unit);
+        }
+
+        private static String getPrometheusMetricName(String name, MeasurementUnit unit) {
+            String out = (name + unitSuffix(unit)).replaceAll("[^\\w]+","_");
+            out = decamelize(out);
+            return out;
+        }
+
+
+        private static String decamelize(String in) {
+            Matcher m = SNAKE_CASE_PATTERN.matcher(in);
+            StringBuffer sb = new StringBuffer();
+            while (m.find()) {
+                m.appendReplacement(sb, "_" + m.group().toLowerCase());
+            }
+            m.appendTail(sb);
+            return sb.toString().toLowerCase();
+        }
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
@@ -21,18 +21,6 @@
  */
 package org.wildfly.extension.microprofile.metrics;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNIT;
 import static org.wildfly.extension.microprofile.config.smallrye.ServiceNames.CONFIG_PROVIDER;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.CLIENT_FACTORY_CAPABILITY;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.MANAGEMENT_EXECUTOR;
@@ -40,37 +28,20 @@ import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubs
 import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import io.smallrye.metrics.ExtendedMetadata;
 import io.smallrye.metrics.MetricRegistries;
 import io.smallrye.metrics.setup.JmxRegistrar;
-import org.eclipse.microprofile.metrics.Gauge;
-import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.MetricUnits;
 import org.jboss.as.controller.LocalModelControllerClient;
 import org.jboss.as.controller.ModelControllerClientFactory;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.StartContext;
@@ -83,12 +54,15 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
     private final Resource rootResource;
     private final Supplier<ModelControllerClientFactory> modelControllerClientFactory;
     private final Supplier<Executor> managementExecutor;
-    private final List<String> exposedSubsystems;
-    private final boolean exposeAnySubsystem;
+    private List<String> exposedSubsystems;
+    private String globalPrefix;
+    private MetricCollector metricCollector;
     private JmxRegistrar jmxRegistrar;
     private LocalModelControllerClient modelControllerClient;
 
-    static void install(OperationContext context, List<String> exposedSubsystems) {
+    private MetricCollector.MetricRegistration registration;
+
+    static void install(OperationContext context, List<String> exposedSubsystems, String prefix) {
         ImmutableManagementResourceRegistration rootResourceRegistration = context.getRootResourceRegistration();
         Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
 
@@ -96,18 +70,18 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
         Supplier<ModelControllerClientFactory> modelControllerClientFactory = serviceBuilder.requires(context.getCapabilityServiceName(CLIENT_FACTORY_CAPABILITY, ModelControllerClientFactory.class));
         Supplier<Executor> managementExecutor = serviceBuilder.requires(context.getCapabilityServiceName(MANAGEMENT_EXECUTOR, Executor.class));
         serviceBuilder.requires(CONFIG_PROVIDER);
-        MetricsRegistrationService service = new MetricsRegistrationService(rootResourceRegistration, rootResource, modelControllerClientFactory, managementExecutor, exposedSubsystems);
+        MetricsRegistrationService service = new MetricsRegistrationService(rootResourceRegistration, rootResource, modelControllerClientFactory, managementExecutor, exposedSubsystems, prefix);
         serviceBuilder.setInstance(service)
                 .install();
     }
 
-    public MetricsRegistrationService(ImmutableManagementResourceRegistration rootResourceRegistration, Resource rootResource, Supplier<ModelControllerClientFactory> modelControllerClientFactory, Supplier<Executor> managementExecutor, List<String> exposedSubsystems) {
+    public MetricsRegistrationService(ImmutableManagementResourceRegistration rootResourceRegistration, Resource rootResource, Supplier<ModelControllerClientFactory> modelControllerClientFactory, Supplier<Executor> managementExecutor, List<String> exposedSubsystems, String globalPrefix) {
         this.rootResourceRegistration = rootResourceRegistration;
         this.rootResource = rootResource;
         this.modelControllerClientFactory = modelControllerClientFactory;
         this.managementExecutor = managementExecutor;
         this.exposedSubsystems = exposedSubsystems;
-        this.exposeAnySubsystem = exposedSubsystems.remove("*");
+        this.globalPrefix = globalPrefix;
     }
 
     @Override
@@ -120,13 +94,10 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
         }
 
         modelControllerClient = modelControllerClientFactory.get().createClient(managementExecutor.get());
-        // WFLY-11399 - do not expose WildFly metrics as their representation is not correct
-        /*
-         * registerMetrics(rootResource,
-         *        rootResourceRegistration,
-         *        MetricRegistries.get(MetricRegistry.Type.VENDOR),
-         *        Function.identity());
-         */
+
+        metricCollector = new MetricCollector(modelControllerClient, rootResourceRegistration, exposedSubsystems, globalPrefix);
+
+        registration = metricCollector.collectResourceMetrics(rootResource, rootResourceRegistration, Function.identity());
     }
 
     @Override
@@ -139,7 +110,11 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
             }
         }
 
+        registration.unregister();
+        metricCollector.close();
+
         modelControllerClient.close();
+
         jmxRegistrar = null;
     }
 
@@ -148,173 +123,9 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
         return this;
     }
 
-    public Set<String> registerMetrics(Resource rootResource,
-                                       ImmutableManagementResourceRegistration managementResourceRegistration,
-                                       MetricRegistry metricRegistry,
-                                       Function<PathAddress, PathAddress> resourceAddressResolver) {
-        Map<PathAddress, Map<String, ModelNode>> metrics = findMetrics(rootResource, managementResourceRegistration);
-        Set<String> registeredMetrics = registerMetrics(metrics, metricRegistry, resourceAddressResolver);
-        return registeredMetrics;
-    }
-
-
-    private Map<PathAddress, Map<String, ModelNode>> findMetrics(Resource rootResource, ImmutableManagementResourceRegistration managementResourceRegistration) {
-        Map<PathAddress, Map<String, ModelNode>> metrics = new HashMap<>();
-        collectMetrics(rootResource, managementResourceRegistration, PathAddress.EMPTY_ADDRESS, metrics);
-        return metrics;
-    }
-
-    private void collectMetrics(final Resource current, ImmutableManagementResourceRegistration managementResourceRegistration, final PathAddress address, Map<PathAddress, Map<String, ModelNode>> collectedMetrics) {
-
-        if (!isExposingMetrics(address)) {
-            return;
-        }
-
-        Map<String, AttributeAccess> attributes = managementResourceRegistration.getAttributes(address);
-        ModelNode description = null;
-        for (Map.Entry<String, AttributeAccess> entry : attributes.entrySet()) {
-            String attributeName = entry.getKey();
-            AttributeAccess attributeAccess = entry.getValue();
-            if (attributeAccess.getAccessType() == AttributeAccess.AccessType.METRIC
-                    && attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME) {
-                if (description == null) {
-                    DescriptionProvider modelDescription = managementResourceRegistration.getModelDescription(address);
-                    description = modelDescription.getModelDescription(Locale.getDefault());
-                }
-
-                Map<String, ModelNode> metricsForResource = collectedMetrics.get(address);
-                if (metricsForResource == null) {
-                    metricsForResource = new HashMap<>();
-                }
-                metricsForResource.put(attributeName, description.get(ATTRIBUTES, attributeName));
-                collectedMetrics.put(address, metricsForResource);
-            }
-        }
-
-        for (String type : current.getChildTypes()) {
-            if (current.hasChildren(type)) {
-                for (Resource.ResourceEntry entry : current.getChildren(type)) {
-                    final PathElement pathElement = entry.getPathElement();
-                    final PathAddress childAddress = address.append(pathElement);
-                    collectMetrics(entry, managementResourceRegistration, childAddress, collectedMetrics);
-                }
-            }
-        }
-    }
-
-    public Set<String> registerMetrics(Map<PathAddress, Map<String, ModelNode>> metrics, MetricRegistry registry, Function<PathAddress, PathAddress> resourceAddressResolver) {
-        Set<String> registeredMetricNames = new HashSet<>();
-
-        for (Map.Entry<PathAddress, Map<String, ModelNode>> entry : metrics.entrySet()) {
-            PathAddress resourceAddress = resourceAddressResolver.apply(entry.getKey());
-            for (Map.Entry<String, ModelNode> wildflyMetric : entry.getValue().entrySet()) {
-                String attributeName = wildflyMetric.getKey();
-                ModelNode attributeDescription = wildflyMetric.getValue();
-
-                String metricName = resourceAddress.toPathStyleString().substring(1) + "/" + attributeName;
-                String unit = attributeDescription.get(UNIT).asString(MetricUnits.NONE).toLowerCase();
-                String description = attributeDescription.get(DESCRIPTION).asStringOrNull();
-
-                // fill the MP Metric tags with the address key/value pairs (that will be not preserve order)
-                // and an attribute=<attributeName> tag
-                HashMap<String, String> tags = new HashMap<>();
-                for (PathElement element: resourceAddress) {
-                    tags.put(element.getKey(), element.getValue());
-                }
-                tags.put(ATTRIBUTE, attributeName);
-
-                Metadata metadata = new ExtendedMetadata(metricName, attributeName + " for " + resourceAddress.toHttpStyleString(), description, MetricType.GAUGE, unit);
-                metadata.setTags(tags);
-
-                ModelType type = attributeDescription.get(TYPE).asType();
-
-                switch (type) {
-                    // simple numerical type
-                    case BIG_DECIMAL:
-                    case BIG_INTEGER:
-                    case DOUBLE:
-                    case INT:
-                    case LONG:
-                        break;
-                    case BYTES:
-                    case LIST:
-                    case OBJECT:
-                    case PROPERTY:
-                    case EXPRESSION:
-                    case BOOLEAN:
-                    case STRING:
-                    case TYPE:
-                    case UNDEFINED:
-                    default:
-                        LOGGER.debugf("Type %s is not supported for MicroProfile Metrics, the attribute %s on %s will not be registered.", type, attributeName, resourceAddress);
-                        continue;
-                }
-                Metric metric = new Gauge() {
-                    @Override
-                    public Number getValue() {
-                        final ModelNode readAttributeOp = new ModelNode();
-                        readAttributeOp.get(OP).set(READ_ATTRIBUTE_OPERATION);
-                        readAttributeOp.get(OP_ADDR).set(resourceAddress.toModelNode());
-                        readAttributeOp.get(ModelDescriptionConstants.INCLUDE_UNDEFINED_METRIC_VALUES).set(true);
-                        readAttributeOp.get(NAME).set(attributeName);
-                        ModelNode response = modelControllerClient.execute(readAttributeOp);
-                        String error = getFailureDescription(response);
-                        if (error != null) {
-                            registry.remove(metricName);
-                            throw LOGGER.unableToReadAttribute(attributeName, resourceAddress, error);
-                        }
-                        ModelNode result = response.get(RESULT);
-                        if (result.isDefined()) {
-                            try {
-                                switch (type) {
-                                    case INT:
-                                        return result.asInt();
-                                    case LONG:
-                                        return result.asLong();
-                                    default:
-                                        // handle other numerical types as Double
-                                        return result.asDouble();
-                                }
-                            } catch (Exception e) {
-                                throw LOGGER.unableToConvertAttribute(attributeName, resourceAddress, e);
-                            }
-                        } else {
-                            registry.remove(metricName);
-                            throw LOGGER.undefinedMetric(attributeName, resourceAddress);
-                        }
-                    }
-                };
-                registry.register(metadata, metric);
-                registeredMetricNames.add(metadata.getName());
-            }
-        }
-        return registeredMetricNames;
-    }
-
-    private boolean isExposingMetrics(PathAddress address) {
-        // root resource
-        if (address.size() == 0) {
-            return true;
-        }
-        if (address.getElement(0).getKey().equals(SUBSYSTEM)) {
-            String subsystemName = address.getElement(0).getValue();
-            return exposeAnySubsystem || exposedSubsystems.contains(subsystemName);
-        }
-        // do not expose metrics for resources outside the subsystems.
-        return false;
-    }
-
-    private boolean isMetric(AttributeAccess attributeAccess) {
-        if (attributeAccess.getAccessType() == AttributeAccess.AccessType.METRIC && attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME) {
-            return true;
-        }
-        return false;
-    }
-
-    private String getFailureDescription(ModelNode result) {
-        if (result.hasDefined(FAILURE_DESCRIPTION)) {
-            return result.get(FAILURE_DESCRIPTION).toString();
-        }
-        return null;
+    public MetricCollector.MetricRegistration registerMetrics(Resource rootResource,
+                                                              ImmutableManagementResourceRegistration managementResourceRegistration,
+                                                              Function<PathAddress, PathAddress> resourceAddressResolver) {
+        return metricCollector.collectResourceMetrics(rootResource, managementResourceRegistration, resourceAddressResolver);
     }
 }

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsTransformers.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsTransformers.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.transform.description.RejectAttributeChecker.DEFINED;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsExtension.SUBSYSTEM_NAME;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsExtension.VERSION_1_0_0;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.PREFIX;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+
+public class MetricsTransformers implements ExtensionTransformerRegistration {
+    @Override
+    public String getSubsystemName() {
+        return SUBSYSTEM_NAME;
+    }
+
+    @Override
+    public void registerTransformers(SubsystemTransformerRegistration subsystemTransformerRegistration) {
+        ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemTransformerRegistration.getCurrentSubsystemVersion());
+
+        registerTransformers_EAP_7_2_0(chainedBuilder.createBuilder(subsystemTransformerRegistration.getCurrentSubsystemVersion(), VERSION_1_0_0));
+
+        chainedBuilder.buildAndRegister(subsystemTransformerRegistration, new ModelVersion[]{ VERSION_1_0_0 });
+
+    }
+
+    private void registerTransformers_EAP_7_2_0(ResourceTransformationDescriptionBuilder builder) {
+        ResourceTransformationDescriptionBuilder subsystem = builder.addChildResource(MicroProfileMetricsExtension.SUBSYSTEM_PATH);
+        rejectDefinedAttributeWithDefaultValue(subsystem, PREFIX);
+    }
+
+    /**
+     * Reject the attributes if they are defined or discard them if they are undefined or set to their default value.
+     */
+    private static void rejectDefinedAttributeWithDefaultValue(ResourceTransformationDescriptionBuilder builder, AttributeDefinition... attrs) {
+        for (AttributeDefinition attr : attrs) {
+            builder.getAttributeBuilder()
+                    .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(attr.getDefaultValue()), attr)
+                    .addRejectCheck(DEFINED, attr);
+        }
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsExtension.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsExtension.java
@@ -52,9 +52,10 @@ public class MicroProfileMetricsExtension implements Extension {
     private static final String RESOURCE_NAME = MicroProfileMetricsExtension.class.getPackage().getName() + ".LocalDescriptions";
 
     protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
-    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_1_0_0;
+    protected static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_2_0_0;
 
-    private static final MicroProfileMetricsParser_1_0 CURRENT_PARSER = new MicroProfileMetricsParser_1_0();
+    private static final MicroProfileMetricsParser_2_0 CURRENT_PARSER = new MicroProfileMetricsParser_2_0();
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefix) {
         return getResourceDescriptionResolver(true, keyPrefix);
@@ -69,7 +70,7 @@ public class MicroProfileMetricsExtension implements Extension {
             }
             prefix.append(kp);
         }
-        return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, MicroProfileMetricsParser_1_0.class.getClassLoader(), true, useUnprefixedChildTypes);
+        return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, MicroProfileMetricsExtension.class.getClassLoader(), true, useUnprefixedChildTypes);
     }
 
     @Override
@@ -83,6 +84,7 @@ public class MicroProfileMetricsExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileMetricsParser_1_0.NAMESPACE, CURRENT_PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileMetricsParser_1_0.NAMESPACE, MicroProfileMetricsParser_1_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MicroProfileMetricsParser_2_0.NAMESPACE, CURRENT_PARSER);
     }
 }

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsParser_2_0.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsParser_2_0.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.microprofile.metrics;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+public class MicroProfileMetricsParser_2_0 extends PersistentResourceXMLParser {
+    /**
+     * The name space used for the {@code subsystem} element
+     */
+    public static final String NAMESPACE = "urn:wildfly:microprofile-metrics-smallrye:2.0";
+
+    private static final PersistentResourceXMLDescription xmlDescription;
+
+    static {
+        xmlDescription = builder(MicroProfileMetricsExtension.SUBSYSTEM_PATH, NAMESPACE)
+                .addAttributes(
+                        MicroProfileMetricsSubsystemDefinition.SECURITY_ENABLED,
+                        MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS,
+                        MicroProfileMetricsSubsystemDefinition.PREFIX)
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return xmlDescription;
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -65,8 +65,9 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         final boolean securityEnabled = MicroProfileMetricsSubsystemDefinition.SECURITY_ENABLED.resolveModelAttribute(context, model).asBoolean();
         List<String> exposedSubsystems = MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS.unwrap(context, model);
+        String prefix = MicroProfileMetricsSubsystemDefinition.PREFIX.resolveModelAttribute(context, model).asStringOrNull();
 
-        MetricsRegistrationService.install(context, exposedSubsystems);
+        MetricsRegistrationService.install(context, exposedSubsystems, prefix);
         MetricsContextService.install(context, securityEnabled);
 
         MicroProfileMetricsLogger.LOGGER.activatingSubsystem();

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -69,7 +69,13 @@ public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDe
             .setRestartAllServices()
             .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = { SECURITY_ENABLED, EXPOSED_SUBSYSTEMS };
+    static final AttributeDefinition PREFIX = SimpleAttributeDefinitionBuilder.create("prefix", ModelType.STRING)
+            .setRequired(false)
+            .setRestartAllServices()
+            .setAllowExpression(true)
+            .build();
+
+    static final AttributeDefinition[] ATTRIBUTES = { SECURITY_ENABLED, EXPOSED_SUBSYSTEMS, PREFIX };
 
     protected MicroProfileMetricsSubsystemDefinition() {
         super(new SimpleResourceDefinition.Parameters(MicroProfileMetricsExtension.SUBSYSTEM_PATH,

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/PrometheusCollector.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/PrometheusCollector.java
@@ -10,7 +10,6 @@ import java.util.function.Supplier;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
-import io.prometheus.client.GaugeMetricFamily;
 
 public class PrometheusCollector extends Collector implements Collector.Describable {
 
@@ -26,7 +25,7 @@ public class PrometheusCollector extends Collector implements Collector.Describa
         }
     }
 
-    void addMetricFamilySampleSupplier(GaugeMetricFamily mfs, Supplier<Optional<Sample>> sampleSupplier) {
+    void addMetricFamilySampleSupplier(MetricFamilySamples mfs, Supplier<Optional<Sample>> sampleSupplier) {
         if (!metricNames.containsKey(mfs.name)) {
             addMetricFamilySamples(mfs);
         }

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/PrometheusCollector.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/PrometheusCollector.java
@@ -1,0 +1,69 @@
+package org.wildfly.extension.microprofile.metrics;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.GaugeMetricFamily;
+
+public class PrometheusCollector extends Collector implements Collector.Describable {
+
+    // mapping between the metric name and the MetricFamilySamples that provides its values
+    private Map<String, MetricFamilySamples> metricNames = new TreeMap<>();
+    // each MetricFamilySamples has list of Sample's supplier (that can be optional) if the underlying metric value is undefined.
+    private Map<String, List<Supplier<Optional<Sample>>>> metricFamilyMap = new HashMap();
+
+    public void addMetricFamilySamples(MetricFamilySamples mfs) {
+        if (!metricNames.containsKey(mfs.name)) {
+            metricNames.put(mfs.name, mfs);
+            metricFamilyMap.put(mfs.name, new ArrayList<>());
+        }
+    }
+
+    void addMetricFamilySampleSupplier(GaugeMetricFamily mfs, Supplier<Optional<Sample>> sampleSupplier) {
+        if (!metricNames.containsKey(mfs.name)) {
+            addMetricFamilySamples(mfs);
+        }
+        metricFamilyMap.get(mfs.name).add(sampleSupplier);
+    }
+
+    void removeMetricFamilySampleSupplier(String metricName, Supplier<Optional<Sample>> sampleSupplier) {
+        List<Supplier<Optional<Sample>>> suppliers = metricFamilyMap.get(metricName);
+        if (suppliers != null) {
+            suppliers.remove(sampleSupplier);
+        }
+    }
+
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<MetricFamilySamples> samples = new ArrayList<>();
+        for (Map.Entry<String, List<Supplier<Optional<Sample>>>> entry : metricFamilyMap.entrySet()) {
+            String metricName = entry.getKey();
+            MetricFamilySamples mfs = metricNames.get(metricName);
+            mfs.samples.clear();
+            for (Supplier<Optional<Sample>> sampleSupplier : entry.getValue()) {
+                Optional<Sample> sample = sampleSupplier.get();
+                if (sample.isPresent()) {
+                    mfs.samples.add(sample.get());
+                }
+            }
+            if (!mfs.samples.isEmpty()) {
+                samples.add(mfs);
+            }
+        }
+        return samples;
+    }
+
+    @Override
+    public List<MetricFamilySamples> describe() {
+        return new ArrayList<>(metricNames.values());
+    }
+
+}

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/UnitConverter.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/UnitConverter.java
@@ -1,0 +1,105 @@
+package org.wildfly.extension.microprofile.metrics;
+
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+
+public class UnitConverter {
+
+    static double scaleToBase(double initialValue, MeasurementUnit unit) {
+        if (unit == null) {
+            return initialValue;
+        }
+
+        final double ratio;
+        switch (unit) {
+            case BITS:
+                ratio = 1 / 8;
+                break;
+            case KILOBITS:
+                ratio = 1_000 / 8;
+                break;
+            case MEGABITS:
+                ratio = 1_000_000 / 8;
+                break;
+            case GIGABITS:
+                ratio = 1_000_000_000 / 8;
+                break;
+            case TERABITS:
+                ratio = 1_000_000_000_000L / 8;
+                break;
+            case PETABITS:
+                ratio = 1_000_000_000_000_000L / 8;
+                break;
+            case KILOBYTES:
+                ratio = 1_000;
+                break;
+            case MEGABYTES:
+                ratio = 1_000_000;
+                break;
+            case GIGABYTES:
+                ratio = 1_000_000_000;
+                break;
+            case TERABYTES:
+                ratio = 1_000_000_000_000L;
+                break;
+            case PETABYTES:
+                ratio = 1_000_000_000_000_000L;
+                break;
+            case NANOSECONDS:
+                ratio = 0.000_000_001;
+                break;
+            case MICROSECONDS:
+                ratio = 0.000_001;
+                break;
+            case MILLISECONDS:
+            case EPOCH_MILLISECONDS:
+                ratio = 0.001;
+                break;
+            case MINUTES:
+                ratio = 60;
+                break;
+            case HOURS:
+                ratio = 3600;
+                break;
+            case DAYS:
+                ratio = 24 * 3600;
+                break;
+            default:
+                ratio = 1.0;
+        }
+
+        return initialValue * ratio;
+    }
+
+    static String unitSuffix(MeasurementUnit unit) {
+        if (unit == null) {
+            return "";
+        }
+        switch (unit) {
+            case BYTES:
+            case KILOBYTES:
+            case MEGABYTES:
+            case GIGABYTES:
+            case TERABYTES:
+            case PETABYTES:
+            case BITS:
+            case KILOBITS:
+            case MEGABITS:
+            case GIGABITS:
+            case TERABITS:
+            case PETABITS:
+                return "_bytes";
+            case EPOCH_MILLISECONDS:
+            case EPOCH_SECONDS:
+            case NANOSECONDS:
+            case MICROSECONDS:
+            case MILLISECONDS:
+            case SECONDS:
+            case MINUTES:
+            case HOURS:
+            case DAYS:
+                return "_seconds";
+            default:
+                return "";
+        }
+    }
+}

--- a/microprofile/metrics-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/microprofile/metrics-smallrye/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,23 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2017, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+org.wildfly.extension.microprofile.metrics.MetricsTransformers

--- a/microprofile/metrics-smallrye/src/main/resources/org/wildfly/extension/microprofile/metrics/LocalDescriptions.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/org/wildfly/extension/microprofile/metrics/LocalDescriptions.properties
@@ -1,5 +1,6 @@
 microprofile-metrics-smallrye=WildFly Extension for Eclipse MicroProfile Metrics With SmallRye
 microprofile-metrics-smallrye.add=Add the subsystem
+microprofile-metrics-smallrye.prefix=Prefix prepended to the name of the WildFly metrics exposed by the HTTP endpoints.
 microprofile-metrics-smallrye.remove=Remove the subsystem
 microprofile-metrics-smallrye.security-enabled=True if authentication is required to access the HTTP endpoint on the HTTP management interface.
-microprofile-metrics-smallrye.exposed-subsystems=The names of the subsystems that exposes their metrics in the vendor scope (or '*' to expose any subystem metrics).
+microprofile-metrics-smallrye.exposed-subsystems=The names of the WildFly subsystems that exposes their metrics (or '*' to expose any subystem metrics).

--- a/microprofile/metrics-smallrye/src/main/resources/schema/wildfly-microprofile-metrics-smallrye_2_0.xsd
+++ b/microprofile/metrics-smallrye/src/main/resources/schema/wildfly-microprofile-metrics-smallrye_2_0.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:wildfly:microprofile-metrics-smallrye:2.0"
+           xmlns="urn:wildfly:microprofile-metrics-smallrye:2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:attribute name="security-enabled" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if authentication is required to access the HTTP endpoint on the HTTP management interface.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="exposed-subsystems" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        The names of the WildFly subsystems (separated by spaces) that exposes their metrics (or '*' to expose any subystem metrics).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="prefix" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Prefix prepended to the name of the WildFly metrics exposed by the HTTP endpoints.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/microprofile/metrics-smallrye/src/main/resources/subsystem-templates/microprofile-metrics-smallrye.xml
+++ b/microprofile/metrics-smallrye/src/main/resources/subsystem-templates/microprofile-metrics-smallrye.xml
@@ -3,8 +3,8 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.microprofile.metrics-smallrye</extension-module>
-    <subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:1.0"
+    <subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:2.0"
                security-enabled="false"
-               exposed-subsystems="*">
-    </subsystem>
+               exposed-subsystems="*"
+               prefix="${wildfly.metrics.prefix:wildfly}" />
 </config>

--- a/microprofile/metrics-smallrye/src/test/java/org/wildfly/extension/microprofile/metrics/Subsystem_2_0_ParsingTestCase.java
+++ b/microprofile/metrics-smallrye/src/test/java/org/wildfly/extension/microprofile/metrics/Subsystem_2_0_ParsingTestCase.java
@@ -30,21 +30,20 @@ import java.util.Properties;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
  */
-public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
+public class Subsystem_2_0_ParsingTestCase extends AbstractSubsystemBaseTest {
 
-    public Subsystem_1_0_ParsingTestCase() {
+    public Subsystem_2_0_ParsingTestCase() {
         super(MicroProfileMetricsExtension.SUBSYSTEM_NAME, new MicroProfileMetricsExtension());
     }
 
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_1_0.xml");
+        return readResource("subsystem_2_0.xml");
     }
 
     @Override
@@ -56,17 +55,13 @@ public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws IOException {
-        return "schema/wildfly-microprofile-metrics-smallrye_1_0.xsd";
+        return "schema/wildfly-microprofile-metrics-smallrye_2_0.xsd";
     }
 
     protected Properties getResolvedProperties() {
         return System.getProperties();
     }
 
-    @Override
-    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
-        return super.standardSubsystemTest(configId, false);
-    }
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
@@ -74,4 +69,5 @@ public class Subsystem_1_0_ParsingTestCase extends AbstractSubsystemBaseTest {
                 HTTP_EXTENSIBILITY_CAPABILITY,
                 MANAGEMENT_EXECUTOR);
     }
+
 }

--- a/microprofile/metrics-smallrye/src/test/resources/org/wildfly/extension/microprofile/metrics/subsystem_2_0.xml
+++ b/microprofile/metrics-smallrye/src/test/resources/org/wildfly/extension/microprofile/metrics/subsystem_2_0.xml
@@ -1,0 +1,4 @@
+<subsystem xmlns="urn:wildfly:microprofile-metrics-smallrye:2.0"
+           security-enabled="${security-enabled:true}"
+           exposed-subsystems="undertow transactions"
+           prefix="${wildfly.metrics.prefix:wildfly}"/>

--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
         <version.io.opentracing.tracerresolver>0.1.5</version.io.opentracing.tracerresolver>
         <version.io.opentracing.servlet>0.1.0</version.io.opentracing.servlet>
         <version.io.reactivex.rxjava>2.2.2</version.io.reactivex.rxjava>
+        <version.io.prometheus.simpleclient>0.6.0</version.io.prometheus.simpleclient>
         <version.io.smallrye.smallrye-config>1.3.4</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-metrics>1.1.2</version.io.smallrye.smallrye-metrics>
@@ -1509,6 +1510,19 @@
                 <groupId>io.opentracing.contrib</groupId>
                 <artifactId>opentracing-concurrent</artifactId>
                 <version>${version.io.opentracing.concurrent}</version>
+            </dependency>
+
+
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient</artifactId>
+                <version>${version.io.prometheus.simpleclient}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.prometheus</groupId>
+                <artifactId>simpleclient_common</artifactId>
+                <version>${version.io.prometheus.simpleclient}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
@@ -31,7 +31,10 @@ public class MetricsHelper {
     }
 
     private static String getMetrics(ManagementClient managementClient, String accept, String scope, boolean metricMustExist) throws IOException {
-        final String url = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/metrics/" + scope;
+        String url = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + "/metrics";
+        if (scope != null && !scope.isEmpty()) {
+            url += "/" + scope;
+        }
 
         try (CloseableHttpClient client = HttpClients.createDefault()) {
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
@@ -199,7 +199,7 @@ public class MicroProfileMetricsApplicationTestCase {
     }
 
     private void checkRequestCount(int expectedCount, boolean deploymentMetricMustExist) throws IOException {
-        String prometheusMetricName = "wildfly_undertow_request_count";
+        String prometheusMetricName = "wildfly_undertow_request_count_total";
 
         String metrics = getPrometheusMetrics(managementClient, "", true);
         for (String line : metrics.split("\\R")) {

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TxStatsHandler.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TxStatsHandler.java
@@ -23,6 +23,8 @@
 package org.jboss.as.txn.subsystem;
 
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.NANOSECONDS;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.GAUGE_METRIC;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -49,16 +51,16 @@ public class TxStatsHandler extends AbstractRuntimeOnlyHandler {
 
     public enum TxStat {
 
-        NUMBER_OF_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_NESTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_NESTED_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_HEURISTICS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_HEURISTICS, ModelType.LONG, true).build()),
-        NUMBER_OF_COMMITTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_COMMITTED_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_ABORTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_ABORTED_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_INFLIGHT_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_INFLIGHT_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_TIMED_OUT_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_TIMED_OUT_TRANSACTIONS, ModelType.LONG, true).build()),
-        NUMBER_OF_APPLICATION_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_APPLICATION_ROLLBACKS, ModelType.LONG, true).build()),
-        NUMBER_OF_RESOURCE_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_RESOURCE_ROLLBACKS, ModelType.LONG, true).build()),
-        NUMBER_OF_SYSTEM_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_SYSTEM_ROLLBACKS, ModelType.LONG, true).build()),
+        NUMBER_OF_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_TRANSACTIONS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_NESTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_NESTED_TRANSACTIONS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_HEURISTICS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_HEURISTICS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_COMMITTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_COMMITTED_TRANSACTIONS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_ABORTED_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_ABORTED_TRANSACTIONS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_INFLIGHT_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_INFLIGHT_TRANSACTIONS, ModelType.LONG, true).setFlags(GAUGE_METRIC).build()),
+        NUMBER_OF_TIMED_OUT_TRANSACTIONS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_TIMED_OUT_TRANSACTIONS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_APPLICATION_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_APPLICATION_ROLLBACKS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_RESOURCE_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_RESOURCE_ROLLBACKS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
+        NUMBER_OF_SYSTEM_ROLLBACKS(SimpleAttributeDefinitionBuilder.create(CommonAttributes.NUMBER_OF_SYSTEM_ROLLBACKS, ModelType.LONG, true).setFlags(COUNTER_METRIC).build()),
         AVERAGE_COMMIT_TIME(SimpleAttributeDefinitionBuilder.create(CommonAttributes.AVERAGE_COMMIT_TIME, ModelType.LONG, true)
                 .setMeasurementUnit(NANOSECONDS)
                 .build());

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -25,6 +25,7 @@ package org.wildfly.extension.undertow;
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.SECONDS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -398,9 +399,15 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
         ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("active-sessions", ModelType.INT)
                 .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
         EXPIRED_SESSIONS(new SimpleAttributeDefinitionBuilder("expired-sessions", ModelType.INT)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setUndefinedMetricValue(new ModelNode(0))
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         SESSIONS_CREATED(new SimpleAttributeDefinitionBuilder("sessions-created", ModelType.INT)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setUndefinedMetricValue(new ModelNode(0))
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         //DUPLICATED_SESSION_IDS(new SimpleAttributeDefinition("duplicated-session-ids", ModelType.INT, false)),
         SESSION_AVG_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-avg-alive-time", ModelType.INT)
                 .setUndefinedMetricValue(new ModelNode(0))
@@ -413,7 +420,10 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
                 .setStorageRuntime()
                 .build()),
         REJECTED_SESSIONS(new SimpleAttributeDefinitionBuilder("rejected-sessions", ModelType.INT)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setUndefinedMetricValue(new ModelNode(0))
+                .setStorageRuntime()
+                .setFlags(COUNTER_METRIC)
+                .build()),
         MAX_ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("max-active-sessions", ModelType.INT)
                 .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
         HIGHEST_SESSION_COUNT(new SimpleAttributeDefinitionBuilder("highest-session-count", ModelType.INT)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.undertow;
 
 import static org.jboss.as.controller.client.helpers.MeasurementUnit.MILLISECONDS;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 
 import io.undertow.server.handlers.MetricsHandler;
 import io.undertow.servlet.api.DeploymentInfo;
@@ -67,10 +68,12 @@ public class DeploymentServletDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition TOTAL_REQUEST_TIME = new SimpleAttributeDefinitionBuilder("total-request-time", ModelType.LONG)
             .setUndefinedMetricValue(new ModelNode(0))
             .setMeasurementUnit(MILLISECONDS)
+            .setFlags(COUNTER_METRIC)
             .setStorageRuntime()
             .build();
     static final SimpleAttributeDefinition REQUEST_COUNT = new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG)
             .setUndefinedMetricValue(new ModelNode(0))
+            .setFlags(COUNTER_METRIC)
             .setStorageRuntime()
             .build();
     static final SimpleListAttributeDefinition SERVLET_MAPPINGS = new SimpleListAttributeDefinition.Builder("mappings", new SimpleAttributeDefinitionBuilder("mapping", ModelType.STRING).setRequired(false).build())

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.wildfly.extension.undertow;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.registry.AttributeAccess.Flag.COUNTER_METRIC;
 import static org.wildfly.extension.undertow.Capabilities.REF_IO_WORKER;
 import static org.wildfly.extension.undertow.Capabilities.REF_SOCKET_BINDING;
 
@@ -167,18 +168,32 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
 
     public enum ConnectorStat {
         REQUEST_COUNT(new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setUndefinedMetricValue(new ModelNode(0))
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         BYTES_SENT(new SimpleAttributeDefinitionBuilder("bytes-sent", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0))
                 .setMeasurementUnit(MeasurementUnit.BYTES)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         BYTES_RECEIVED(new SimpleAttributeDefinitionBuilder("bytes-received", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0))
                 .setMeasurementUnit(MeasurementUnit.BYTES)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         ERROR_COUNT(new SimpleAttributeDefinitionBuilder("error-count", ModelType.LONG)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setUndefinedMetricValue(new ModelNode(0))
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime().build()),
         PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("processing-time", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0))
                 .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
-                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+                .setFlags(COUNTER_METRIC)
+                .setStorageRuntime()
+                .build()),
         MAX_PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("max-processing-time", ModelType.LONG)
                 .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
                 .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build());


### PR DESCRIPTION
* add WildFly metrics (from subsystems and deployments) to the /metrics
  HTTP endpoint (only in the Prometheus text format)
* Use io.prometheus simpleclient 0.6.0 to collect the metrics and write
  them in TextFormat on the /metrics HTTP endpoint
* Name and labels of metrics are built based on the resource path
  address and the attribute name (plus an optional prefix that is set
  to `wildfly` in the standalone profiles).
* Update Admin guide

JIRA: https://issues.jboss.org/browse/WFLY-11529
Dev analysis: wildfly/wildfly-proposals#170