### PR TITLE
[WFLY-9305]: ActiveMQ Resource Adapter can not lookup destination in …

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
@@ -57,6 +57,8 @@ import static org.jboss.as.ejb3.logging.EjbLogger.ROOT_LOGGER;
 
 import static org.jboss.as.ejb3.component.MethodIntf.MESSAGE_ENDPOINT;
 
+import org.jboss.as.naming.context.NamespaceContextSelector;
+
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
@@ -273,8 +275,12 @@ public class MessageDrivenComponent extends EJBComponent implements PooledCompon
         ClassLoader oldTccl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         try {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-
-            this.endpoint.activate(endpointFactory, activationSpec);
+            NamespaceContextSelector.pushCurrentSelector(this.getNamespaceContextSelector());
+            try {
+                this.endpoint.activate(endpointFactory, activationSpec);
+            } finally {
+                NamespaceContextSelector.popCurrentSelector();
+            }
         } catch (Exception e) {
             throw EjbLogger.ROOT_LOGGER.failedToActivateMdb(getComponentName(), e);
         } finally {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JMSSender.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JMSSender.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.messaging.jms.naming;
+
+import javax.annotation.Resource;
+import javax.ejb.Singleton;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConnectionFactoryDefinition;
+import javax.jms.JMSConnectionFactoryDefinitions;
+import javax.jms.JMSContext;
+import javax.jms.JMSDestinationDefinition;
+import javax.jms.JMSProducer;
+import javax.jms.Queue;
+
+@JMSDestinationDefinition(
+    name = "java:app/jms/queue",
+    interfaceName = "javax.jms.Queue"
+)
+@JMSConnectionFactoryDefinitions(
+    value = {
+        @JMSConnectionFactoryDefinition(
+            name = "java:app/jms/nonXAconnectionFactory",
+            transactional = false,
+             properties = {
+                            "connectors=in-vm",}
+        )
+    }
+)
+@Singleton
+public class JMSSender {
+    @Resource(lookup = "java:app/jms/nonXAconnectionFactory")
+    private ConnectionFactory connectionFactory;
+
+    @Resource(lookup = "java:app/jms/queue")
+    private Queue queue;
+
+    public void sendMessage(String payload) {
+        try (JMSContext context = connectionFactory.createContext()) {
+            JMSProducer producer = context.createProducer();
+            producer.send(queue, payload);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JndiLookupMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JndiLookupMessagingDeploymentTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.naming;
+
+
+
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test to cover https://issues.jboss.org/browse/WFLY-9305
+ * @author Emmanuel Hugonnet (c) 2019 Red Hat, Inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JndiLookupMessagingDeploymentTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static WebArchive createArchive() {
+        return create(WebArchive.class, "JndiMessagingDeploymentTestCase.war")
+                .addClass(MessagingServlet.class)
+                .addClasses(JMSSender.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testSendMessageInClientQueue() throws Exception {
+        sendAndReceiveMessage(true);
+    }
+
+    private void sendAndReceiveMessage(boolean sendToQueue) throws Exception {
+        String text = "test_" + UUID.randomUUID().toString();
+        URL url = new URL(this.url.toExternalForm() + "JndiMessagingDeploymentTestCase?text=" + text);
+        String reply = HttpRequest.get(url.toExternalForm(), 10, TimeUnit.SECONDS);
+
+        assertNotNull(reply);
+        assertEquals(text, reply);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/MessagingServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/MessagingServlet.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.messaging.jms.naming;
+
+
+import java.io.IOException;
+import javax.annotation.Resource;
+
+import javax.inject.Inject;
+import javax.jms.JMSConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+@WebServlet("/JndiMessagingDeploymentTestCase")
+public class MessagingServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private JMSSender jmsSender;
+
+    @Inject
+    @JMSConnectionFactory("java:app/jms/nonXAconnectionFactory")
+    private JMSContext context;
+
+    @Resource(lookup = "java:app/jms/queue")
+    private Queue queue;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        final String text = req.getParameter("text");
+        String reply = sendAndReceiveMessage(text);
+        resp.getWriter().write(reply);
+    }
+
+    private String sendAndReceiveMessage(String text) {
+        JMSConsumer consumer = context.createConsumer(queue);
+        jmsSender.sendMessage(text);
+        return consumer.receiveBody(String.class, 5000);
+    }
+}


### PR DESCRIPTION
…app namespace.

* Passing the NamespaceContextSelector around in the RA to be able to
access it when looking up for the resource.

Jira; https://issues.jboss.org/browse/WFLY-9305