### PR TITLE
[WFLY-11543] Server-side services outside the transactions subsystem should not use ContextTransactionSynchronizationRegistry

### DIFF
--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.extension.datasources.agroal;
 
+import javax.transaction.TransactionSynchronizationRegistry;
+
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
@@ -82,7 +84,10 @@ class DataSourceOperations {
 
             CapabilityServiceBuilder<AgroalDataSource> serviceBuilder = context.getCapabilityServiceTarget().addCapability(AbstractDataSourceDefinition.DATA_SOURCE_CAPABILITY.fromBaseCapability(datasourceName), dataSourceService);
             serviceBuilder.addCapabilityRequirement(DriverDefinition.AGROAL_DRIVER_CAPABILITY.getDynamicName(driverName), Class.class, dataSourceService.getDriverInjector());
-
+            if (jta) {
+                // TODO add a Stage.MODEL requirement
+                serviceBuilder.addCapabilityRequirement("org.wildfly.transactions.transaction-synchronization-registry", TransactionSynchronizationRegistry.class, dataSourceService.getTransactionSynchronizationRegistryInjector());
+            }
             AbstractDataSourceOperations.setupElytronSecurity(context, factoryModel, dataSourceService, serviceBuilder);
 
             serviceBuilder.install();

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceService.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceService.java
@@ -49,7 +49,6 @@ import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.NameCallback;
@@ -88,6 +87,7 @@ public class DataSourceService implements Service<AgroalDataSource>, Supplier<Ag
     private InjectedValue<Class> driverInjector = new InjectedValue<>();
     private InjectedValue<AuthenticationContext> authenticationContextInjector = new InjectedValue<>();
     private InjectedValue<ExceptionSupplier<CredentialSource, Exception>> credentialSourceSupplierInjector = new InjectedValue<>();
+    private InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryInjector = new InjectedValue<>();
 
     public DataSourceService(String dataSourceName, String jndiName, boolean jta, boolean connectable, boolean xa, AgroalDataSourceConfigurationSupplier dataSourceConfiguration) {
         this.dataSourceName = dataSourceName;
@@ -115,7 +115,7 @@ public class DataSourceService implements Service<AgroalDataSource>, Supplier<Ag
 
         if (jta || xa) {
             TransactionManager transactionManager = ContextTransactionManager.getInstance();
-            TransactionSynchronizationRegistry transactionSynchronizationRegistry = ContextTransactionSynchronizationRegistry.getInstance();
+            TransactionSynchronizationRegistry transactionSynchronizationRegistry = transactionSynchronizationRegistryInjector.getValue();
 
             if (transactionManager == null || transactionSynchronizationRegistry == null) {
                 throw AgroalLogger.SERVICE_LOGGER.missingTransactionManager();
@@ -230,5 +230,9 @@ public class DataSourceService implements Service<AgroalDataSource>, Supplier<Ag
 
     public InjectedValue<ExceptionSupplier<CredentialSource, Exception>> getCredentialSourceSupplierInjector() {
         return credentialSourceSupplierInjector;
+    }
+
+     InjectedValue<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistryInjector() {
+        return transactionSynchronizationRegistryInjector;
     }
 }

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/XADataSourceOperations.java
@@ -23,6 +23,8 @@ package org.wildfly.extension.datasources.agroal;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import javax.transaction.TransactionSynchronizationRegistry;
+
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
 import io.agroal.api.configuration.supplier.AgroalConnectionPoolConfigurationSupplier;
@@ -83,6 +85,8 @@ class XADataSourceOperations extends AbstractAddStepHandler {
 
             CapabilityServiceBuilder<AgroalDataSource> serviceBuilder = context.getCapabilityServiceTarget().addCapability(AbstractDataSourceDefinition.DATA_SOURCE_CAPABILITY.fromBaseCapability(datasourceName), dataSourceService);
             serviceBuilder.addCapabilityRequirement(DriverDefinition.AGROAL_DRIVER_CAPABILITY.getDynamicName(driverName), Class.class, dataSourceService.getDriverInjector());
+            // TODO add a Stage.MODEL requirement
+            serviceBuilder.addCapabilityRequirement("org.wildfly.transactions.transaction-synchronization-registry", TransactionSynchronizationRegistry.class, dataSourceService.getTransactionSynchronizationRegistryInjector());
 
             AbstractDataSourceOperations.setupElytronSecurity(context, factoryModel, dataSourceService, serviceBuilder);
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -33,6 +33,9 @@ import java.security.ProtectionDomain;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import javax.ejb.EJBHome;
 import javax.ejb.EJBLocalHome;
@@ -48,10 +51,6 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
-
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponent;
@@ -86,7 +85,6 @@ import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.authz.Roles;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
@@ -121,6 +119,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
     private final InvocationMetrics invocationMetrics = new InvocationMetrics();
     private final EJBSuspendHandlerService ejbSuspendHandlerService;
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
     private final UserTransaction userTransaction;
     private final ServerSecurityManager serverSecurityManager;
     private final ControlPoint controlPoint;
@@ -181,6 +180,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         this.timeoutInterceptors = Collections.unmodifiableMap(ejbComponentCreateService.getTimeoutInterceptors());
         this.shutDownInterceptorFactory = ejbComponentCreateService.getShutDownInterceptorFactory();
         this.ejbSuspendHandlerService = ejbComponentCreateService.getEJBSuspendHandler();
+        this.transactionSynchronizationRegistry = ejbComponentCreateService.getTransactionSynchronizationRegistry();
         this.userTransaction = ejbComponentCreateService.getUserTransaction();
         this.serverSecurityManager = ejbComponentCreateService.getServerSecurityManager();
         this.controlPoint = ejbComponentCreateService.getControlPoint();
@@ -416,13 +416,8 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         return ContextTransactionManager.getInstance();
     }
 
-    /**
-     * @deprecated Use {@link ContextTransactionSynchronizationRegistry#getInstance()} instead.
-     * @return the value of {@link ContextTransactionSynchronizationRegistry#getInstance()}
-     */
-    @Deprecated
     public TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
-        return ContextTransactionSynchronizationRegistry.getInstance();
+        return transactionSynchronizationRegistry;
     }
 
     public int getTransactionTimeout(final MethodIntf methodIntf, final Method method) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -22,11 +22,6 @@
 
 package org.jboss.as.ejb3.component;
 
-import javax.ejb.TimerService;
-import javax.ejb.TransactionAttributeType;
-import javax.ejb.TransactionManagementType;
-import javax.transaction.UserTransaction;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
@@ -38,6 +33,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+
+import javax.ejb.TimerService;
+import javax.ejb.TransactionAttributeType;
+import javax.ejb.TransactionManagementType;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
 
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponentCreateService;
@@ -97,6 +98,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final String distinctName;
     private final String policyContextID;
 
+    private final InjectedValue<TransactionSynchronizationRegistry> transactionSynchronizationRegistryValue = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPoint = new InjectedValue<>();
     private final InjectedValue<AtomicBoolean> exceptionLoggingEnabled = new InjectedValue<>();
@@ -325,6 +327,14 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     UserTransaction getUserTransaction() {
         return LocalUserTransaction.getInstance();
+    }
+
+    Injector<TransactionSynchronizationRegistry> getTransactionSynchronizationRegistryInjector() {
+        return transactionSynchronizationRegistryValue;
+    }
+
+    TransactionSynchronizationRegistry getTransactionSynchronizationRegistry() {
+        return transactionSynchronizationRegistryValue.getValue();
     }
 
     public Injector<EJBSuspendHandlerService> getEJBSuspendHandlerInjector() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -43,6 +43,7 @@ import javax.ejb.EJBLocalObject;
 import javax.ejb.TimerService;
 import javax.ejb.TransactionAttributeType;
 import javax.ejb.TransactionManagementType;
+import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.core.security.ServerSecurityManager;
@@ -568,7 +569,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                         // add dependency on the local transaction provider
                         serviceBuilder.requires(support.getCapabilityServiceName("org.wildfly.transactions.global-default-local-provider"));
                         // add dependency on TransactionSynchronizationRegistry
-                        serviceBuilder.requires(support.getCapabilityServiceName("org.wildfly.transactions.transaction-synchronization-registry"));
+                        serviceBuilder.addDependency(support.getCapabilityServiceName("org.wildfly.transactions.transaction-synchronization-registry"), TransactionSynchronizationRegistry.class, ejbComponentCreateService.getTransactionSynchronizationRegistryInjector());
                     }
                 });
 

--- a/ejb3/src/test/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptorTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptorTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.as.ejb3.concurrency.AccessTimeoutDetails;
 import org.jboss.ejb.client.SessionID;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -71,7 +70,6 @@ public class StatefulSessionSynchronizationInterceptorTestCase {
      * association should be gone (and thus it is ready for another tx).
      */
     @Test
-    @Ignore("WFLY-10176: Relies on obsolete details of component implementation")
     public void testDifferentTx() throws Exception {
         final Interceptor interceptor = new StatefulSessionSynchronizationInterceptor(true);
         final InterceptorContext context = new InterceptorContext();

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderHandler.java
@@ -87,7 +87,7 @@ public class PersistenceProviderHandler {
                 if (adapterClass != null) {
                     try {
                         adaptor = (PersistenceProviderAdaptor) deploymentModuleClassLoader.loadClass(adapterClass).newInstance();
-                        adaptor.injectJtaManager(JtaManagerImpl.getInstance());
+                        adaptor.injectJtaManager(new JtaManagerImpl(deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY)));
                         adaptor.injectPlatform(platform);
                         ArrayList<PersistenceProviderAdaptor> adaptorList = new ArrayList<>();
                         adaptorList.add(adaptor);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/JtaManagerImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/JtaManagerImpl.java
@@ -27,27 +27,23 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.jpa.spi.JtaManager;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 /**
  * passes the TM and TSR into the persistence provider integration classes
  *
  * @author Scott Marlow
  */
-public class JtaManagerImpl implements JtaManager {
+public final class JtaManagerImpl implements JtaManager {
 
-    private static final JtaManagerImpl instance = new JtaManagerImpl();
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
 
-    private JtaManagerImpl() {
-    }
-
-    public static JtaManagerImpl getInstance() {
-        return instance;
+    public JtaManagerImpl(TransactionSynchronizationRegistry transactionSynchronizationRegistry) {
+        this.transactionSynchronizationRegistry = transactionSynchronizationRegistry;
     }
 
     @Override
     public TransactionSynchronizationRegistry getSynchronizationRegistry() {
-        return ContextTransactionSynchronizationRegistry.getInstance();
+        return transactionSynchronizationRegistry;
     }
 
     @Override

--- a/weld/jpa/src/main/java/org/jboss/as/weld/services/bootstrap/WeldJpaInjectionServices.java
+++ b/weld/jpa/src/main/java/org/jboss/as/weld/services/bootstrap/WeldJpaInjectionServices.java
@@ -36,6 +36,7 @@ import javax.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.as.jpa.container.PersistenceUnitSearch;
 import org.jboss.as.jpa.container.TransactionScopedEntityManager;
+import org.jboss.as.jpa.processor.JpaAttachments;
 import org.jboss.as.jpa.service.PersistenceUnitServiceImpl;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.weld.logging.WeldLogger;
@@ -48,7 +49,6 @@ import org.jboss.weld.injection.spi.ResourceReferenceFactory;
 import org.jboss.weld.injection.spi.helpers.SimpleResourceReference;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.transaction.client.ContextTransactionManager;
-import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
 
 public class WeldJpaInjectionServices implements JpaInjectionServices {
 
@@ -82,7 +82,7 @@ public class WeldJpaInjectionServices implements JpaInjectionServices {
         //now we have the service controller, as this method is only called at runtime the service should
         //always be up
         final PersistenceUnitServiceImpl persistenceUnitService = (PersistenceUnitServiceImpl) serviceController.getValue();
-        return new EntityManagerResourceReferenceFactory(scopedPuName, persistenceUnitService.getEntityManagerFactory(), context, ContextTransactionSynchronizationRegistry.getInstance(), ContextTransactionManager.getInstance());
+        return new EntityManagerResourceReferenceFactory(scopedPuName, persistenceUnitService.getEntityManagerFactory(), context, deploymentUnit.getAttachment(JpaAttachments.TRANSACTION_SYNCHRONIZATION_REGISTRY), ContextTransactionManager.getInstance());
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11543

Server-side services need to use the TSR provided as an MSC Service by the transaction subsystem, as it provides important synchronization ordering behavior that direct use of ContextTransactionSynchronizationRegistry bypasses.

Note that this PR at this point is NOT necessarily a fix for this issue. It's a possible fix, and is definitely something we regard as the correct thing to do, but we are not certain this problem is the WFLY-11543 problem.