### PR TITLE
Fix the AsciiDoc files in the docs folder that are causing build errors and warnings

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -10,7 +10,7 @@ WildFly team;
 :icons: font
 :source-highlighter: coderay
 
-ifndef::ebook-format[:leveloffset: 1]
+// ifndef::ebook-format[:leveloffset: 1]
 
 (C) 2017 The original authors.
 

--- a/docs/src/main/asciidoc/JavaEE_Tutorial.adoc
+++ b/docs/src/main/asciidoc/JavaEE_Tutorial.adoc
@@ -24,21 +24,36 @@ ifdef::basebackend-html[toc::[]]
 Coming Soon
 
 [IMPORTANT]
-
+====
 This guide is still under development, check back soon!
+====
 
 include::_javaee-guide/Java_API_for_RESTful_Web_Services_(JAX-RS).adoc[]
+
 include::_javaee-guide/Java_Servlet_Technology.adoc[]
+
 include::_javaee-guide/Java_Server_Faces_Technology_(JSF).adoc[]
+
 include::_javaee-guide/Java_Persistence_API_(JPA).adoc[]
+
 include::_javaee-guide/Java_Transaction_API_(JTA).adoc[]
+
 include::_javaee-guide/Managed_Beans.adoc[]
+
 include::_javaee-guide/Contexts_and_Dependency_Injection_(CDI).adoc[]
+
 include::_javaee-guide/Bean_Validation.adoc[]
+
 include::_javaee-guide/Java_Message_Service_API_(JMS).adoc[]
+
 include::_javaee-guide/JavaEE_Connector_Architecture_(JCA).adoc[]
+
 include::_javaee-guide/JavaMail_API.adoc[]
+
 include::_javaee-guide/Java_Authorization_Contract_for_Containers_(JACC).adoc[]
+
 include::_javaee-guide/Java_Authentication_Service_Provider_Interface_for_Containers_(JASPIC).adoc[]
+
 include::_javaee-guide/Enterprise_JavaBeans_Technology_(EJB).adoc[]
+
 include::_javaee-guide/Java_API_for_XML_Web_Services_(JAX-WS).adoc[]

--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -327,13 +327,13 @@ or
 /subsystem=datasources/data-source=ExampleDS:read-resource(include-runtime=true,recursive=true)
 ----
 
-[[deployment]]
+[[cli_deployment]]
 == Deployment
 
 [[cli-deployment-command]]
 === CLI _deployment_ command
 
-In addition to the legacy _deploy_, _undeploy_ and _deployment-info_ commands, 
+In addition to the legacy _deploy_, _undeploy_ and _deployment-info_ commands,
 that stay un-changed, the CLI offers a _deployment_ command that properly
 separates the various use cases encountered when managing deployments. This command
 offers a simpler interface and should be the way to go when managing deployments.
@@ -580,58 +580,58 @@ description of the command.
 
 * _security enable-sasl-management_: To enable SASL authentication (elytron SASL factory) for the
 management interfaces. Calling this command without any option will have the
-effect to associate the out of the box SASL factory to the http-interface. 
+effect to associate the out of the box SASL factory to the http-interface.
 Type _help security enable-sasl-management_ for a complete description of the command.
 
-This command supports a subset of SASL mechanisms such as: EXTERNAL, DIGEST-MD5, 
-JBOSS-LOCAL-USER, SCRAM-*, ... The CLI completer proposes the set of mechanisms that 
-can be properly configured using this command. Each mechanism can be associated 
+This command supports a subset of SASL mechanisms such as: EXTERNAL, DIGEST-MD5,
+JBOSS-LOCAL-USER, SCRAM-*, ... The CLI completer proposes the set of mechanisms that
+can be properly configured using this command. Each mechanism can be associated
 to a property file realm, a file-system realm or a trust-store realm according to its nature.
 
 NB: Once the command is executed, the CLI will reload the server and reconnect to it.
 
 * _security disable-sasl-management_: To disable SASL for the
-management interfaces. If a mechanism is provided, this mechanism will be removed 
-from the factory, the factory will stay associated to the interface. Without mechanism, the 
-factory is no more active on the management interface. Type _help security disable-sasl-management_ 
+management interfaces. If a mechanism is provided, this mechanism will be removed
+from the factory, the factory will stay associated to the interface. Without mechanism, the
+factory is no more active on the management interface. Type _help security disable-sasl-management_
 for a complete description of the command.
 
 * _security reorder-sasl-management_: To re-order the list of SASL mechanisms present
-in the factory. Order of mechanisms is of importance, the first in the list is sent to the client. 
+in the factory. Order of mechanisms is of importance, the first in the list is sent to the client.
 Type _help security reorder-sasl-management_ for a complete description of the command.
 
 * _security enable-http-auth-management_: To enable HTTP authentication (elytron HTTP factory) for the
 management http-interface. Calling this command without any option will have the
-effect to associate the out of the box HTTP Authentication factory to the http-interface. 
+effect to associate the out of the box HTTP Authentication factory to the http-interface.
 Type _help security enable-http-auth-management_ for a complete description of the command.
 
-This command supports a subset of HTTP mechanisms such as: BASIC, CLIENT_CERT, DIGEST, ... 
-The CLI completer proposes the set of mechanisms that can be properly configured 
-using this command. Each mechanism can be associated to a property file realm, 
+This command supports a subset of HTTP mechanisms such as: BASIC, CLIENT_CERT, DIGEST, ...
+The CLI completer proposes the set of mechanisms that can be properly configured
+using this command. Each mechanism can be associated to a property file realm,
 a file-system realm or a trust-store realm according to its nature.
 
 NB: Once the command is executed, the CLI will reload the server and reconnect to it.
 
 * _security disable-http-auth-management_: To disable HTTP Authentication for the
-http management interface. If a mechanism is provided, this mechanism will be removed 
-from the factory, the factory will stay associated to the interface. Without mechanism, the 
-factory is no more active on the management interface. Type _help security disable-http-auth-management_ 
+http management interface. If a mechanism is provided, this mechanism will be removed
+from the factory, the factory will stay associated to the interface. Without mechanism, the
+factory is no more active on the management interface. Type _help security disable-http-auth-management_
 for a complete description of the command.
 
 * _security enable-http-auth-http-server_: To enable HTTP authentication (elytron HTTP factory) for the
 given undertow security domain.
 Type _help security enable-http-auth-http-server_ for a complete description of the command.
 
-This command supports a subset of HTTP mechanisms such as: BASIC, CLIENT_CERT, DIGEST, ... 
-The CLI completer proposes the set of mechanisms that can be properly configured 
-using this command. Each mechanism can be associated to a property file realm, 
+This command supports a subset of HTTP mechanisms such as: BASIC, CLIENT_CERT, DIGEST, ...
+The CLI completer proposes the set of mechanisms that can be properly configured
+using this command. Each mechanism can be associated to a property file realm,
 a file-system realm or a trust-store realm according to its nature.
 
 NB: Once the command is executed, the CLI will reload the server and reconnect to it.
 
 * _security disable-http-auth-http-server_: To disable HTTP Authentication for the
-given undertow security domain. If a mechanism is provided, this mechanism will be removed 
-from the factory, the factory will stay associated to the security domain. Without mechanism, the 
-factory is no more active on the security-domain. Type _help security disable-http-auth-http-server_ 
+given undertow security domain. If a mechanism is provided, this mechanism will be removed
+from the factory, the factory will stay associated to the security domain. Without mechanism, the
+factory is no more active on the security-domain. Type _help security disable-http-auth-http-server_
 for a complete description of the command.
 

--- a/docs/src/main/asciidoc/_admin-guide/Security_Realms_Detailed_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Security_Realms_Detailed_Configuration.adoc
@@ -50,13 +50,13 @@ is used but this should not be relied on and the alias should be set to
 guarantee which entry is used.
 * *key-password* (optional) - The password to load the key entry, if
 omitted the keystore-password will be used instead.
-
++
 [TIP]
-
+====
 If you see the error `UnrecoverableKeyException: Cannot recover key` the
 most likely cause that you need to specify a `key-password` and possible
 even an `alias` as well to ensure only one key is loaded.
-
+====
 
 === <secret />
 
@@ -352,7 +352,7 @@ We only support outbound connections to ldap servers for the authentication proc
 [source, xml]
 ----
 <outbound-connections>
-  <ldap name="..." url="..." search-dn="..." search-credential="..." security-realm="..." initial-context-factory="..." 
+  <ldap name="..." url="..." search-dn="..." search-credential="..." security-realm="..." initial-context-factory="..."
         referrals="..." handles-referrals-for="..." always-send-client-cert="...">
     <properties>
       <property name="..." value="..." />
@@ -379,15 +379,15 @@ context factory, defaults to ' `com.sun.jndi.ldap.LdapCtxFactory`'
 ** *FOLLOW* - Automatically follow any referrals re-using the configuration for this connection.
 ** *THROW* - Throw an exception is a referral is encountered, this allows an alternative connection to be identified to handle the referral.
 * *handles-referrals-for* (optional) - A space separated list of URIs this connection can be used for.
-* *always-send-client-cert* (optional) - By default the server's client certificate is not sent whilst verifying the users credential, if this is set to `true` it will always be sent. 
+* *always-send-client-cert* (optional) - By default the server's client certificate is not sent whilst verifying the users credential, if this is set to `true` it will always be sent.
 
 The optional `<properties/>` element can be used to specify additional properties to be passed in to the `DirContext` when it is created.
 
-The optional `<security-credential-reference />` can be used to reference a credential stored in a credential store as an alternative to 
+The optional `<security-credential-reference />` can be used to reference a credential stored in a credential store as an alternative to
 the `search-credential` attribute.  This element supports the following attributes: -
 
 * *store* (optional) - Reference to the credential store to obtain the search credential from.
 * *alias* (optional) - The alias of the credential in the referenced store.
 * *type* (optional) - The fully qualified class name of the credential type to obtain from the credential store.
 * *clear-text* (optional) - Instead of referencing a credential store this attribute can be used to specify a clear text password.
- 
+

--- a/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Subsystem_configuration.adoc
@@ -40,7 +40,7 @@ include::subsystem-configuration/MicroProfile_Config_SmallRye.adoc[]
 
 include::subsystem-configuration/MicroProfile_Health.adoc[]
 
-include::subsystem-configuration/MicroProfile_Metric.adoc[]
+include::subsystem-configuration/MicroProfile_Metrics.adoc[]
 
 include::subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc[]
 

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
@@ -34,7 +34,7 @@ If a `--git-branch` parameter is added then the repository will be checked out o
 == Remote Git Repository
 
 If a remote Git repository is provided then the server will try to pull from it at boot. If this is the first time we are pulling then local files will be deleted to avoid the pull to fail because of the need to overwrite those existing files.
-The parameter for `--git-repo` can be a URL or a remote alias provided you have manually added it to the local git configuration. 
+The parameter for `--git-repo` can be a URL or a remote alias provided you have manually added it to the local git configuration.
 
 If a `--git-branch` parameter is added then the branch will be pulled, otherwise it will default to `master`.
 
@@ -69,7 +69,7 @@ Sample command line to start the server using the `standalone-full.xml` file pul
 ./standalone.sh --git-repo=https://github.com/wildfly/wildfly-config.git --git-auth=file:///home/ehsavoie/tmp/github-wildfly-config.xml -c standalone-full.xml
 ----
 
-[[snapshots]]
+[[snapshots-git-history]]
 == Snapshots
 
 In addition to the commits taken by the server as described above you

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_history.adoc
@@ -60,7 +60,7 @@ When restarting the server, any existing
 folder within the `standalone_xml_history`, and a new `current` folder
 is created. These timestamped folders are kept for 30 days.
 
-[[snapshots]]
+[[snapshots-file-history]]
 == Snapshots
 
 In addition to the backups taken by the server as described above you

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/JMX.adoc
@@ -115,7 +115,7 @@ their formatters are defined in the global
 `/core-service=management/access=audit` section mentioned in
 <<Audit_logging,Audit logging>>.
 
-[[json-formatter]]
+[[json-formatter-jmx]]
 === JSON Formatter
 
 The same JSON Formatter is used as described in

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Formatters.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging_Formatters.adoc
@@ -13,6 +13,7 @@ The logging subsystem includes 4 types of handlers:
 * <<xml-formatter>>
 * <<custom-formatter>>
 
+[[json-formatter]]
 == JSON Formatter
 
 A formatter used to format log messages in JSON.
@@ -30,6 +31,7 @@ A formatter used to format log messages in JSON.
 meta-data=[@version=1])
 ----
 
+[[pattern-formatter]]
 == Pattern Formatter
 
 A formatter used to format log messages in plain text. The following table describes the format characters for the
@@ -292,6 +294,7 @@ You can also modify the format by placing the optional format modifier between t
 /subsystem=logging/pattern-formatter=DEFAULT:add(color-map="info:cyan,warn:brightyellow,error:brightred,debug:magenta", pattern="%K{level}%d{yyyy-MM-dd'T'HH:mm:ssSSSXXX} %-5p [%c] (%t) %s%e%n")
 ----
 
+[[xml-formatter]]
 == XML Formatter
 
 A formatter used to format log messages in XML.

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -6,7 +6,7 @@ subsystem. In this chapter we are going outline the frequently used
 configuration options. For a more detailed explanation please consult
 the Artemis user guide (See "Component Reference").
 
-[[required-extension]]
+[[required-extension-messaging]]
 == Required Extension
 
 The configuration options discussed in this section assume that the the

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Config_SmallRye.adoc
@@ -4,7 +4,7 @@
 Support for https://microprofile.io/project/eclipse/microprofile-config[Eclipse MicroProfile Config] is provided by
  the _microprofile-config-smallrye_ subsystem.
 
-[[required-extension]]
+[[required-extension-microprofile-config-smallrye]]
 == Required Extension
 
 This extension is included in the standard configurations included in the

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
@@ -4,7 +4,7 @@
 Support for https://microprofile.io/project/eclipse/microprofile-health[Eclipse MicroProfile Health] is provided by
  the _microprofile-health-smallrye_ subsystem.
 
-[[required-extension]]
+[[required-extension-microprofile-health-smallrye]]
 == Required Extension
 
 This extension is included in the standalone configurations included in the

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Metrics.adoc
@@ -4,7 +4,7 @@
 Support for https://microprofile.io/project/eclipse/microprofile-metrics[Eclipse MicroProfile Metrics] is provided by
  the _microprofile-metrics-smallrye_ subsystem.
 
-[[required-extension]]
+[[required-extension-microprofile-metrics-smallrye]]
 == Required Extension
 
 This extension is included in all the standalone configurations included in the

--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
@@ -4,7 +4,7 @@
 Support for https://microprofile.io/project/eclipse/microprofile-opentracing[Eclipse MicroProfile OpenTracing] is
 provided as a Tech Preview feature by the _microprofile-opentracing-smallrye_ subsystem.
 
-[[required-extension]]
+[[required-extension-microprofile-opentracing-smallrye]]
 == Required Extension
 
 This extension is included in the standard configurations included in the WildFly distribution.

--- a/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Application_Client_Reference.adoc
@@ -54,7 +54,7 @@ jboss-ejb-client.properties file rather than a host:
 ./appclient.sh --ejb-client-properties=my-jboss-ejb-client.properties myear.ear#appClient.jar arg1
 ----
 
-[[example]]
+[[example-application-client-reference]]
 == Example
 
 A simple example how to package an application client and use it with

--- a/docs/src/main/asciidoc/_developer-guide/EJB3_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/EJB3_Reference_Guide.adoc
@@ -57,7 +57,7 @@ For example:
 @RunAsPrincipal("MyBean")
 ----
 
-[[security-domain]]
+[[security-domain-ejb3-ref]]
 == Security Domain
 
 Each Enterprise Java Bean ^tm^ can be associated with a security domain.

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_AS7_to_WildFly.adoc
@@ -1,87 +1,55 @@
+:ProductName: WildFly
+:ProductVersion: 10
+:PrevProductName: JBoss AS
+:PrevProductVersion: 7
+
 [[How_do_I_migrate_my_application_from_AS7_to_WildFly]]
-= How do I migrate my application from AS7 to WildFly
+= How do I migrate my application from {PrevProductName} {PrevProductVersion}  to {ProductName} {ProductVersion}
 
 [[about-this-document]]
 == About this Document
 
-The purpose of this guide is to document changes that are needed to
-successfully run and deploy AS 7 applications on WildFly. It provides
-information on to resolve deployment and runtime problems and how to
-prevent changes in application behavior. This is the first step in
-moving to the new platform. Once the application is successfully
-deployed and running on the new platform, plans can be made to upgrade
-individual components to use the new functions and features of WildFly.
+The purpose of this guide is to document changes that are needed to successfully run and deploy {PrevProductName} {PrevProductVersion} applications on {ProductName} {ProductVersion}. It provides information on to resolve deployment and runtime problems and how to prevent changes in application behavior. This is the first step in moving to the new platform. Once the application is successfully deployed and running on the new platform, plans can be made to upgrade individual components to use the new functions and features of {ProductName}.
 
 [[overview-of-wildfly]]
-== Overview of WildFly
+== Overview of {ProductName}
 
-The list of WildFly new functionality is extensive, being the most
-relevant, with respect to server and application migrations:
+The list of {ProductName} new functionality is extensive, being the most relevant, with respect to server and application migrations:
 
-* Java EE7 - WildFly is a certified implementation of Java EE7, meeting
-both the Web and the Full profiles, and already includes support for the
-latest iterations of CDI (1.2) and Web Sockets (1.1).
-* Undertow - A new cutting-edge web server in WildFly, designed for
-maximum throughput and scalability, including environments with over a
-million connections. And the latest web technologies, such as the new
-HTTP/2 standard, are already onboard.
-* Apache ActiveMQ Artemis - WildFly's new JMS broker. Based on an code
-donation from HornetQ, this Apache subproject provides outstanding
-performance based on a proven non-blocking architecture.
-* IronJacamar 1.2 - The latest IronJacamar provides a stable and feature
-rich JCA & Datasources support.
-* JBossWS 5 - The fifth generation of JBossWS, a major leap forward,
-brings new features and performances improvements to WildFly Web
-Services
-* RESTEasy 3 - WildFly includes the latest generation of RESTEasy, which
-goes beyond the standard Java EE REST APIs (JAX-RS 2.0), by also
-providing a number of useful extensions, such as JSON Web Encryption,
-Jackson, Yaml, JSON-P, and Jettison.
-* OpenJDK ORB - WildFly switched the IIOP implementation from JacORB, to
-a downstream branch of the OpenJDK Orb, leading to better
-interoperability with the JVM ORB and the Java EE RI.
-* Feature Rich Clustering - Clustering support was heavily refactored in
-WildFly, and includes several APIs for applications
-* Port Reduction - By utilising HTTP upgrade, WildFly has moved nearly
-all of its protocols to be multiplexed over just two HTTP ports: a
-management port (9990), and an application port (8080).
-* Enhanced Logging - The management API now supports the ability to list
-and view the available log files on a server, or even define custom
-formatters other than the default pattern formatter. Deployment's
-logging setup is also greatly enhanced.
+* Java EE7 - {ProductName} is a certified implementation of Java EE7, meeting both the Web and the Full profiles, and already includes support for the latest iterations of CDI (1.2) and Web Sockets (1.1).
+* Undertow - A new cutting-edge web server in {ProductName}, designed for maximum throughput and scalability, including environments with over a million connections. And the latest web technologies, such as the new HTTP/2 standard, are already onboard.
+* Apache ActiveMQ Artemis - {ProductName}'s new JMS broker. Based on an code donation from HornetQ, this Apache subproject provides outstanding performance based on a proven non-blocking architecture.
+* IronJacamar 1.2 - The latest IronJacamar provides a stable and feature rich JCA & Datasources support.
+* JBossWS 5 - The fifth generation of JBossWS, a major leap forward, brings new features and performances improvements to {ProductName} Web Services
+* RESTEasy 3 - {ProductName} includes the latest generation of RESTEasy, which goes beyond the standard Java EE REST APIs (JAX-RS 2.0), by also providing a number of useful extensions, such as JSON Web Encryption, Jackson, Yaml, JSON-P, and Jettison.
+* OpenJDK ORB - {ProductName} switched the IIOP implementation from JacORB, to a downstream branch of the OpenJDK Orb, leading to better interoperability with the JVM ORB and the Java EE RI.
+* Feature Rich Clustering - Clustering support was heavily refactored in {ProductName}, and includes several APIs for applications
+* Port Reduction - By utilizing HTTP upgrade, {ProductName} has moved nearly all of its protocols to be multiplexed over just two HTTP ports: a management port (9990), and an application port (8080).
+* Enhanced Logging - The management API now supports the ability to list and view the available log files on a server, or even define custom formatters other than the default pattern formatter. Deployment's logging setup is also greatly enhanced.
 
-The support for some technologies was removed, due to the high
-maintenance cost, low community interest, and much better alternative
-solutions:
+The support for some technologies was removed, due to the high maintenance cost, low community interest, and much better alternative solutions:
 
 * CMP EJB - JPA offers a much more performant and flexible API
 * JAX-RPC - JAX-WS offers a much more accurate and complete solution
-* JSR-88 - With very little adoption, the more complete deployment APIs
-provided by vendors are preferred
+* JSR-88 - With very little adoption, the more complete deployment APIs provided by vendors are preferred
 
 [[server-migration]]
 == Server Migration
 
-Migrating an AS7 server to WildFly consists of migrating custom
-configuration files, and some persisted data that may exist.
+Migrating a {PrevProductName} {PrevProductVersion} server to {ProductName} consists of migrating custom configuration files, and some persisted data that may exist.
 
 [[jacorb-subsystem]]
 === JacORB Subsystem
 
-WildFly ORB support is provided by the JDK itself, instead of relying on
-JacORB. A subsystem configuration migration is required.
+{ProductName} ORB support is provided by the JDK itself, instead of relying on JacORB. A subsystem configuration migration is required.
 
 [[jacorb-subsystem-configuration]]
 ==== JacORB Subsystem Configuration
 
-The extension's module *org.jboss.as.jacorb *is replaced by module
-*org.wildfly.iiop-openjdk*, while the subsystem configuration namespace
-*urn:jboss:domain:jacorb:2.0* is replaced by
-*urn:jboss:domain:iiop-openjdk:1.0*.
+The extension's module `org.jboss.as.jacorb` is replaced by module `org.wildfly.iiop-openjdk`, while the subsystem configuration namespace `urn:jboss:domain:jacorb:2.0` is replaced by
+`urn:jboss:domain:iiop-openjdk:1.0`.
 
-The XML configuration of the new subsystem accepts only a subset of the
-legacy elements/attributes. Consider the following example of the JacORB
-subsystem configuration, containing all valid elements and attributes:
+The XML configuration of the new subsystem accepts only a subset of the legacy elements and attributes. Consider the following example of the JacORB subsystem configuration, containing all valid elements and attributes:
 
 [source,xml]
 ----
@@ -109,84 +77,52 @@ subsystem configuration, containing all valid elements and attributes:
 
 Properties that are not supported and have to be removed:
 
-* <orb/>: client-timeout, max-managed-buf-size, max-server-connections,
-outbuf-cache-timeout, outbuf-size, connection retries, retry-interval,
-name,server-timeout
-* <poa/>: queue-min, queue-max, pool-size, max-threads
+* `<orb/>`: `client-timeout`, `max-managed-buf-size`, `max-server-connections`, `outbuf-cache-timeout`, `outbuf-size`, `connection-retries`, `retry-interval`, `name,server-timeout`
+* `<poa/>`: `queue-min`, `queue-max`, `pool-size`, `max-threads`
 
 On-off properties: have to either be removed or in off mode:
 
-* <orb/>: cache-poa-names, cache-typecodes, print-version, use-bom,
-use-imr
-* <interop/>: all except sun
-* <poa/>: monitoring, queue-wait
+* `<orb/>`: `cache-poa-names`, `cache-typecodes`, `print-version`, `use-bom`, `use-imr`
+* `<interop/>`: all except `sun`
+* `<poa/>`: `monitoring`, `queue-wait`
 
-In case the legacy subsystem configuration is available, such
-configuration may be migrated to the new subsystem by invoking its
-`migrate` operation, using the CLI management client:
+In case the legacy subsystem configuration is available, such configuration may be migrated to the new subsystem by invoking its `migrate` operation, using the management CLI:
 
-[source,ruby]
+[source]
 ----
 /subsystem=jacorb:migrate
 ----
 
-There is also a `describe-migration` operation that returns a list of
-all the management operations that are performed to migrate from the
-legacy subsystem to the new one:
+There is also a `describe-migration` operation that returns a list of all the management operations that are performed to migrate from the legacy subsystem to the new one:
 
-[source,ruby]
+[source]
 ----
 /subsystem=jacorb:describe-migration
 ----
 
-Both `migrate` and `describe-migration` will also display a list of
-migration-warnings if there are some resource or attributes that can not
-be migrated automatically. The following is a list of these warnings:
+Both `migrate` and `describe-migration` will also display a list of migration-warnings if there are some resource or attributes that can not be migrated automatically. The following is a list of these warnings:
 
-* Properties X cannot be emulated using OpenJDK ORB and are not
-supported +
-This warning means that mentioned properties are not supported and won't
-be included in the new subsystem configuration. As a result of that
-admin must be aware that any behaviour implied by those properties would
-be inexistent. Admin has to check whether subsystem is able to operate
-correctly without that behaviour on the new server.Unsupported
-properties: cache-poa-names, cache-typecodes,
-chunk-custom-rmi-valuetypes, client-timeout, comet,
-indirection-encoding-disable, iona, lax-boolean-encoding,
-max-managed-buf-size, max-server-connections, max-threads,
-outbuf-cache-timeout, outbuf-size, queue-max, queue-min, poa-monitoring,
-print-version, retries, retry-interval, queue-wait, server-timeout,
-strict-check-on-tc-creation, use-bom, use-imr.
+* Properties X cannot be emulated using OpenJDK ORB and are not supported
++
+This warning means that mentioned properties are not supported and won't be included in the new subsystem configuration. As a result of that admin must be aware that any behavior implied by those properties would be nonexistent. Admin has to check whether subsystem is able to operate
+correctly without that behavior on the new server.Unsupported properties: `cache-poa-names`, `cache-typecodes`, `chunk-custom-rmi-valuetypes`, `client-timeout`, `comet`, `indirection-encoding-disable`, `iona`, `lax-boolean-encoding`, `max-managed-buf-size`, `max-server-connections`, `max-threads`, `outbuf-cache-timeout`, `outbuf-size`, `queue-max`, `queue-min`, `poa-monitoring`, `print-version`, `retries`, `retry-interval`, `queue-wait`, `server-timeout`, `strict-check-on-tc-creation`, `use-bom`, `use-imr`.
 
-* The properties X use expressions. Configuration properties that are
-used to resolve those expressions should be transformed manually to the
-new iiop-openjdk subsystem format +
-Admin has to transform all the configuration files to work correctly
-with the jacorb subsystem. f.e. jacorb has a property giop-minor-version
-whereas openjdk uses property giop-version. Let's suppose we use '1'
-minor version in jacorb and have it configured in standalone.conf file
-as system variable: -Diiop-giop-minor-version=1. Admin is responsible
-for changing this variable to 1.1 after the migration to make sure that
-the new subsystem will work correctly.
+* The properties X use expressions. Configuration properties that are used to resolve those expressions should be transformed manually to the new `iiop-openjdk` subsystem format.
++
+Admin has to transform all the configuration files to work correctly with the `jacorb` subsystem. For example, `jacorb` has a property `giop-minor-version` whereas `iiop-openjdk` uses the property `giop-version`. Let's suppose we use `1` minor version in `jacorb` and have it configured in `standalone.conf` file as system variable: `-Diiop-giop-minor-version=1`. Admin is responsible for changing this variable to 1.1 after the migration to make sure that the new subsystem will work correctly.
 
 [[jboss-web-subsystem]]
 === JBoss Web Subsystem
 
-JBoss Web is replaced by Undertow in WildFly, which means that the
-legacy subsystem configuration should be migrated to WildFly's Undertow
-subsystem configuration.
+JBoss Web is replaced by Undertow in {ProductName}, which means that the legacy subsystem configuration should be migrated to {ProductName}'s Undertow subsystem configuration.
 
 [[jboss-web-subsystem-configuration]]
 ==== JBoss Web Subsystem Configuration
 
-The extension's module *org.jboss.as.web *is replaced by module
-*org.wildfly.extension.undertow*, while the subsystem configuration
-namespace *urn:jboss:domain:web:** is replaced by
-*urn:jboss:domain:undertow:3.0*.
+The extension's module `org.jboss.as.web` is replaced by module `org.wildfly.extension.undertow`, while the subsystem configuration namespace `urn:jboss:domain:web:` is replaced by
+`urn:jboss:domain:undertow:`.
 
-The XML configuration of the new subsystem is relatively different.
-Consider the following example of the JBoss Web subsystem configuration,
-containing all valid elements and attributes:
+The XML configuration of the new subsystem is relatively different. Consider the following example of the JBoss Web subsystem configuration, containing all valid elements and attributes:
 
 [source,xml]
 ----
@@ -308,55 +244,44 @@ containing all valid elements and attributes:
 </subsystem>
 ----
 
-FIXME compare with Undertow, list unsupported features
+// FIXME compare with Undertow, list unsupported features
 
-It's possible to do a migration of the legacy subsystem configuration,
-and related persisted data. , by invoking the legacy's subsystem's
-`migrate` operation, using the CLI management client:
+It is possible to do a migration of the legacy subsystem configuration and related persisted data by invoking the legacy subsystem's `migrate` operation, using the management CLI:
 
-[source,ruby]
+[source]
 ----
 /subsystem=web:migrate
 ----
 
-There is also a `describe-migration` operation that returns a list of
-all the management operations that are performed to migrate from the
-legacy subsystem to the new one:
+There is also a `describe-migration` operation that returns a list of all the management operations that are performed to migrate from the legacy subsystem to the new one:
 
-[source,ruby]
+[source]
 ----
 /subsystem=web:describe-migration
 ----
 
-Both `migrate` and `describe-migration` will also display a list of
-migration-warnings if there are some resource or attributes that can not
-be migrated automatically. The following is a list of these warnings:
+Both `migrate` and `describe-migration` will also display a list of migration-warnings if there are some resource or attributes that can not be migrated automatically. The following is a list of these warnings:
 
-* Could not migrate resource X +
-This warning means that mentioned resource configuration is not
-supported and won't be included in the new subsystem configuration. As a
-result of that admin must be aware that any behaviour implied by those
-resources would be inexistent. Admin has to check whether subsystem is
-able to operate correctly without that behaviour on the new server. +
-FIXME must document which are the resources that trigger this
-* Could not migrate attribute X from resource Y. +
-This warning means that mentioned resource configuration property is not
-supported and won't be included in the new subsystem configuration. As a
-result of that admin must be aware that any behaviour implied by those
-properties would be inexistent. Admin has to check whether subsystem is
-able to operate correctly without that behaviour on the new server. +
-FIXME must document which are the properties that trigger this
+* Could not migrate resource X
++
+This warning means that mentioned resource configuration is not supported and won't be included in the new subsystem configuration. As a result of that admin must be aware that any behavior implied by those resources would be nonexistent. Admin has to check whether subsystem is able to operate correctly without that behavior on the new server.
++
+// FIXME must document which are the resources that trigger this
+
+* Could not migrate attribute X from resource Y.
++
+This warning means that mentioned resource configuration property is not supported and won't be included in the new subsystem configuration. As a result of that admin must be aware that any behavior implied by those properties would be nonexistent. Admin has to check whether subsystem is
+able to operate correctly without that behavior on the new server.
++
+// FIXME must document which are the properties that trigger this
+
 * Could not migrate SSL connector as no SSL config is defined
-* Could not migrate verify-client attribute %s to the Undertow
-equivalent
+* Could not migrate verify-client attribute %s to the Undertow equivalent
 * Could not migrate verify-client expression %s
-* Could not migrate valve X +
-This warning means that mentioned valve configuration is not supported
-and won't be included in the new subsystem configuration. As a result of
-that admin must be aware that any behaviour implied by those resources
-would be inexistent. Admin has to check whether subsystem is able to
-operate correctly without that behaviour on the new server. This warning
-may happen for :
+* Could not migrate valve X
++
+This warning means that mentioned valve configuration is not supported and won't be included in the new subsystem configuration. As a result of that admin must be aware that any behavior implied by those resources would be nonexistent. Admin has to check whether subsystem is able to operate correctly without that behavior on the new server. This warning may happen for:
+
 ** org.apache.catalina.valves.RemoteAddrValve : must have at least one
 allowed or denied value.
 ** org.apache.catalina.valves.RemoteHostValve : must have at least one
@@ -367,33 +292,25 @@ allowed or denied value.
 ** org.apache.catalina.authenticator.SSLAuthenticator
 ** org.apache.catalina.authenticator.SpnegoAuthenticator
 ** custom valves
-* Could not migrate attribute X from valve Y +
-This warning means that mentioned valve configuration property is not
-supported and won't be included in the new subsystem configuration. As a
-result of that admin must be aware that any behaviour implied by those
-properties would be inexistent. Admin has to check whether subsystem is
-able to operate correctly without that behaviour on the new server. This
-warning may happen for :
-** org.apache.catalina.valves.AccessLogValve : if you use the following
-parameters _resolveHosts_, _fileDateFormat_, _renameOnRotate_,
-_encoding_, _locale_, _requestAttributesEnabled_, _buffered_.
-** org.apache.catalina.valves.ExtendedAccessLogValve : if you use the
-following parameters _resolveHosts_, _fileDateFormat_, _renameOnRotate_,
-_encoding_, _locale_, _requestAttributesEnabled_, _buffered_.
-** org.apache.catalina.valves.RemoteIpValve:
-*** if _remoteIpHeader_ is defined and isn't set to "x-forwarded-for".
-*** if _protocolHeader_ is defined and isn't set to "x-forwarded-proto".
-*** if you use the following parameters _httpServerPort_ and
-_httpsServerPort_ .
+* Could not migrate attribute X from valve Y
++
+This warning means that mentioned valve configuration property is not supported and won't be included in the new subsystem configuration. As a result of that admin must be aware that any behavior implied by those properties would be nonexistent. Admin has to check whether subsystem is
+able to operate correctly without that behavior on the new server. This warning may happen for :
 
-Also, please note that Undertow doesn't support JBoss Web *valves*, but
-some of these may be migrated to Undertow handlers, and JBoss Web
-subsystem's `migrate` operation do that too.
+** `org.apache.catalina.valves.AccessLogValve` : if you use the following parameters `resolveHosts`, `fileDateFormat`, `renameOnRotate`,
+`encoding`, `locale`, `requestAttributesEnabled`, `buffered`.
+** `org.apache.catalina.valves.ExtendedAccessLogValve` : if you use the following parameters `resolveHosts`, `fileDateFormat`, `renameOnRotate`, `encoding`, `locale`, `requestAttributesEnabled`, `buffered`.
+** `org.apache.catalina.valves.RemoteIpValve`:
+*** if `remoteIpHeader` is defined and isn't set to "x-forwarded-for".
+*** if `protocolHeader` is defined and isn't set to "x-forwarded-proto".
+*** if you use the following parameters `httpServerPort` and `httpsServerPort` .
+
+Also, note that Undertow doesn't support JBoss Web `valves`, but some of these may be migrated to Undertow handlers, and JBoss Web subsystem's `migrate` operation do that too.
 
 Here is a list of those valves and their corresponding Undertow handler:
 
 [cols=",",options="header"]
-|=======================================================================
+|===
 |Valve |Handler
 
 |org.apache.catalina.valves.AccessLogValve
@@ -422,19 +339,15 @@ Here is a list of those valves and their corresponding Undertow handler:
 
 |org.apache.catalina.valves.CrawlerSessionManagerValve
 |io.undertow.servlet.handlers.CrawlerSessionManagerHandler
-|=======================================================================
+|===
 
-The *org.apache.catalina.valves.JDBCAccessLogValve* can't be
-automatically migrated to *io.undertow.server.handlers.JDBCLogHandler*
-as the expectations differ. +
-The migration can be done manually thought :
+The `org.apache.catalina.valves.JDBCAccessLogValve` can't be automatically migrated to `io.undertow.server.handlers.JDBCLogHandler` as the expectations differ.
 
-1.  create the driver module and add the driver to the list of available
-drivers
-2.  create a datasource pointing to the database where the log entries
-are going to be stored
-3.  add an *expression-filter* definition with the following expression:
-"jdbc-access-log(datasource='datasource-jndi-name')
+The migration can be done manually though :
+
+.  Create the driver module and add the driver to the list of available drivers
+.  Create a datasource pointing to the database where the log entries are going to be stored
+.  Add an `expression-filter` definition with the following expression: "jdbc-access-log(datasource='datasource-jndi-name")
 +
 [source,xml]
 ----
@@ -461,213 +374,149 @@ should become:
                <password>password</password>
             </security>
         </datasource>
-...
+        ...
         <drivers>
             <driver name="mysql" module="com.mysql">
                 <driver-class>com.mysql.jdbc.Driver</driver-class>
             </driver>
-...
+        ...
         </drivers>
     </datasources>
 </subsystem>
 ...
 <subsystem xmlns="urn:jboss:domain:undertow:3.1" default-virtual-host="default-virtual-host" default-servlet-container="myContainer"
            default-server="some-server" instance-id="some-id" statistics-enabled="true">
-...
+    ...
     <server name="some-server" default-host="other-host" servlet-container="myContainer">
-...
+    ...
         <host name="other-host" alias="www.mysite.com, ${prop.value:default-alias}" default-web-module="something.war" disable-console-redirect="true">
             <location name="/" handler="welcome-content" />
             <filter-ref name="jdbc-access"/>
         </host>
     </server>
-...
+    ...
     <filters>
         <expression-filter name="jdbc-access" expression="jdbc-access-log(datasource='java:jboss/datasources/accessLogDS')" />
-...
+    ...
     </filters>
  
 </subsystem>
 ----
 
-Please note that any custom valve won't be migrated at all and will just
-be removed from the configuration. +
-Also the authentication related valves are to be replaced by Undertow
-authentication mechanisms, and this have to be done manually.
+Note that any custom valve won't be migrated at all and will just be removed from the configuration.
 
-FIXME how this last "manual" replacement is done? Need whole process
-documented and concrete example
+Also the authentication related valves are to be replaced by Undertow authentication mechanisms, and this have to be done manually.
+
+// FIXME how this last "manual" replacement is done? Need whole process documented and concrete example
 
 [[websockets]]
 ==== WebSockets
 
-In AS7, to use WebSockets, you had to configure the 'http' *connector*
-in the *web* subsystem of the server configuration file to use the NIO2
-protocol. The following is an example of the Management CLI command to
-configure WebSockets in the previous releases.
+In {PrevProductName} {PrevProductVersion}, to use WebSockets, you had to configure the 'http' `connector` in the `web` subsystem of the server configuration file to use the NIO2 protocol. The following is an example of the management CLI command to configure WebSockets in the previous releases.
 
-[source,ruby]
+[source]
 ----
 /subsystem=web/connector=http/:write-attribute(name=protocol,value=org.apache.coyote.http11.Http11NioProtocol)
 ----
 
-WebSockets are a requirement of the Java EE 7 specification and the
-default configuration is included in WildFly. More complex WebSocket
-configuration is done in the *servlet-container* of the *undertow*
-subsystem of the server configuration file.
+WebSockets are a requirement of the Java EE 7 specification and the default configuration is included in {ProductName}. More complex WebSocket configuration is done in the `servlet-container` of the `undertow` subsystem of the server configuration file.
 
-You no longer need to configure the server for default WebSocket
-support. +
-FIXME isn't <websockets /> required for that?
+You no longer need to configure the server for default WebSocket support.
+
+// FIXME isn't <websockets /> required for that?
 
 [[messaging-subsystem]]
 === Messaging Subsystem
 
-WildFly JMS support is provided by ActiveMQ Artemis, instead of HornetQ.
-It's possible to do a migration of the legacy subsystem configuration,
-and related persisted data.
+{ProductName} JMS support is provided by ActiveMQ Artemis, instead of HornetQ. It's possible to do a migration of the legacy subsystem configuration, and related persisted data.
 
 [[messaging-subsystem-configuration]]
 ==== Messaging Subsystem Configuration
 
-The extension's module *org.jboss.as.messaging* is replaced by module
-*org.wildfly.extension.messaging-activemq*, while the subsystem
-configuration namespace *urn:jboss:domain:messaging:3.0* is replaced by
-*urn:jboss:domain:messaging-activemq:1.0*.
+The extension's module `org.jboss.as.messaging` is replaced by module `org.wildfly.extension.messaging-activemq`, while the subsystem configuration namespace `urn:jboss:domain:messaging:3.0` is replaced by `urn:jboss:domain:messaging-activemq:1.0`.
 
 [[management-model]]
 ===== Management model
 
-In most cases, an effort was made to keep resource and attribute names
-as similar as possible to those used in previous releases. The following
-table lists some of the changes.
+In most cases, an effort was made to keep resource and attribute names as similar as possible to those used in previous releases. The following table lists some of the changes.
 
 [cols=",",options="header"]
-|=====================================
+|===
 |HornetQ name |ActiveMQ name
 |hornetq-server |server
 |hornetq-serverType |serverType
 |connectors |connector
 |discovery-group-name |discovery-group
-|=====================================
+|===
 
-The management operations invoked on the new messaging-subsystem starts
-with `/subsystem=messaging-activemq/server=X` while the legacy messaging
-subsystem was at `/subsystem=messaging/hornetq-server=X`.
+The management operations invoked on the new messaging-subsystem starts with `/subsystem=messaging-activemq/server=X` while the legacy `messaging` subsystem was at `/subsystem=messaging/hornetq-server=X`.
 
-In case the legacy subsystem configuration is available, such
-configuration may be migrated to the new subsystem by invoking its
-`migrate` operation, using the CLI management client:
+In case the legacy subsystem configuration is available, such configuration may be migrated to the new subsystem by invoking its `migrate` operation, using the management CLI:
 
-[source,ruby]
+[source]
 ----
 /subsystem=messaging:migrate
 ----
 
-There is also a `describe-migration` operation that returns a list of
-all the management operations that are performed to migrate from the
-legacy subsystem to the new one:
+There is also a `describe-migration` operation that returns a list of all the management operations that are performed to migrate from the legacy subsystem to the new one:
 
-[source,ruby]
+[source]
 ----
 /subsystem=messaging:describe-migration
 ----
 
-Both `migrate` and `describe-migration` will also display a list of
-migration-warnings if there are some resource or attributes that can not
-be migrated automatically. The following is a list of these warnings:
+Both `migrate` and `describe-migration` will also display a list of migration-warnings if there are some resource or attributes that can not be migrated automatically. The following is a list of these warnings:
 
-* The migrate operation can not be performed: the server must be in
-admin-only mode +
-The `migrate` operation requires starting the server in admin-only mode,
-which is done by adding parameter `--admin-only` to the server start
-command, e.g.
+* The migrate operation can not be performed: the server must be in admin-only mode
 +
-[source,bash]
+The `migrate` operation requires starting the server in admin-only mode, which is done by adding parameter `--admin-only` to the server start command, e.g.
++
+[source]
 ----
 ./standalone.sh --admin-only
 ----
 
-* Can not migrate attribute local-bind-address from resource X. Use
-instead the socket-attribute to configure this broadcast-group.
-* Can not migrate attribute local-bind-port from resource X. Use instead
-the socket-binding attribute to configure this broadcast-group.
-* Can not migrate attribute group-address from resource X. Use instead
-the socket-binding attribute to configure this broadcast-group.
-* Can not migrate attribute group-port from resource X. Use instead the
-socket-binding attribute to configure this broadcast-group. +
-Broadcast-group resources no longer accept local-bind-address,
-local-bind-port, group-address, group-port attributes. It only accepts a
-socket-binding. The warning notifies that resource X has an unsupported
-attribute. The user will have to set the socket-binding attribute on the
-resource and ensures it corresponds to a defined socket-binding
+* Can not migrate attribute local-bind-address from resource X. Use instead the socket-attribute to configure this broadcast-group.
+* Can not migrate attribute local-bind-port from resource X. Use instead the socket-binding attribute to configure this broadcast-group.
+* Can not migrate attribute group-address from resource X. Use instead the socket-binding attribute to configure this broadcast-group.
+* Can not migrate attribute group-port from resource X. Use instead the socket-binding attribute to configure this broadcast-group.
++
+Broadcast-group resources no longer accept local-bind-address, local-bind-port, group-address, group-port attributes. It only accepts a socket-binding. The warning notifies that resource X has an unsupported attribute. The user will have to set the socket-binding attribute on the resource and ensures it corresponds to a defined socket-binding
 resource.
 
-* Classes providing the %s are discarded during the migration. To use
-them in the new messaging-activemq subsystem, you will have to extend
-the Artemis-based Interceptor. +
-Messaging interceptors support is significantly different in WildFly 10,
-any interceptors configured in the legacy subsystem are discarded during
-migration. Please refer to the Messaging Interceptors section to learn
-how to migrate legacy Messaging interceptors.
+* Classes providing the %s are discarded during the migration. To use them in the new `messaging-activemq` subsystem, you will have to extend the Artemis-based Interceptor.
++
+Messaging interceptors support is significantly different in {ProductName} {ProductVersion}, any interceptors configured in the legacy subsystem are discarded during migration. See  the <<messaging-interceptors, Messaging Interceptors>> section to learn how to migrate legacy Messaging interceptors.
 
-* Can not migrate the HA configuration of X. Its shared-store and backup
-attributes holds expressions and it is not possible to determine
-unambiguously how to create the corresponding ha-policy for the
-messaging-activemq's server. +
-If the hornetq-server X's shared-store or backup attributes hold an
-expression, such as $\{xxx}, then it's not possible to determine the
-actual ha-policy of the migrated server. In that case, we discard it and
-the user will have to add the correct ha-policy afterwards (ha-policy is
-a single resource underneath the messaging-activemq's server resource).
+* Can not migrate the HA configuration of X. Its shared-store and backup attributes holds expressions and it is not possible to determine unambiguously how to create the corresponding ha-policy for the `messaging-activemq` server.
++
+If the `hornetq-server` X's shared-store or backup attributes hold an expression, such as $\{xxx}, then it's not possible to determine the actual ha-policy of the migrated server. In that case, we discard it and the user will have to add the correct `ha-policy` afterwards. The `ha-policy` is a single resource underneath the `messaging-activemq` server resource.
 
-* Can not migrate attribute local-bind-address from resource X. Use
-instead the socket-binding attribute to configure this
-discovery-group.Can not migrate attribute local-bind-port from resource
-X. Use instead the socket-binding attribute to configure this
-discovery-group.
-* Can not migrate attribute group-address from resource X. Use instead
-the socket-binding attribute to configure this discovery-group.
-* Can not migrate attribute group-port from resource X. Use instead the
-socket-binding attribute to configure this discovery-group. +
-discovery-group resources no longer accept local-bind-address,
-local-bind-port, group-address, group-port attributes. It only accepts a
-socket-binding. The warning notifies that resource X has an unsupported
-attribute. +
-The user will have to set the socket-binding attribute on the resource
-and ensures it corresponds to a defined socket-binding resource.
+* Can not migrate attribute local-bind-address from resource X. Use instead the socket-binding attribute to configure this discovery-group.Can not migrate attribute local-bind-port from resource X. Use instead the socket-binding attribute to configure this discovery-group.
+* Can not migrate attribute group-address from resource X. Use instead the socket-binding attribute to configure this discovery-group.
 
-* Can not create a legacy-connection-factory based on connection-factory
-X. It uses a HornetQ in-vm connector that is not compatible with Artemis
-in-vm connector +
-Legacy subsystem's remote connection-factory resources are migrated into
-legacy-connection-factory resources, to allow old EAP6 clients to
-connect to EAP7. However a connection-factory using in-vm will not be
-migrated, because a in-vm client will be based on EAP7, not EAP 6. In
-other words, legacy-connection-factory are created only when the CF is
-using remote connectors, and this warning notifies about in-vm
-connection-factory X not migrated.
+* Can not migrate attribute group-port from resource X. Use instead the socket-binding attribute to configure this discovery-group.
++
+The `discovery-group` resources no longer accept `local-bind-address`, `local-bind-port`, `group-address`, `group-port` attributes. It only accepts a `socket-binding`. The warning notifies that resource X has an unsupported attribute.
++
+The user will have to set the socket-binding attribute on the resource and ensures it corresponds to a defined socket-binding resource.
 
-* Can not migrate attribute X from resource Y. The attribute uses an
-expression that can be resolved differently depending on system
-properties. After migration, this attribute must be added back with an
-actual value instead of the expression. +
-This warning appears when the migration logic needs to know the concrete
-value of attribute X during migration, but instead such value includes
-an expression that's can't be resolved, so the actual value can not be
-determined, and the attribute is discarded. It happens in several cases,
+* Can not create a legacy-connection-factory based on connection-factory X. It uses a HornetQ in-vm connector that is not compatible with Artemis in-vm connector
++
+Legacy subsystem's remote connection-factory resources are migrated into legacy-connection-factory resources, to allow old EAP6 clients to connect to EAP7. However a connection-factory using in-vm will not be migrated, because a in-vm client will be based on EAP7, not EAP 6. In other words, legacy-connection-factory are created only when the CF is using remote connectors, and this warning notifies about in-vm connection-factory X not migrated.
+
+* Can not migrate attribute X from resource Y. The attribute uses an expression that can be resolved differently depending on system properties. After migration, this attribute must be added back with an actual value instead of the expression.
++
+This warning appears when the migration logic needs to know the concrete value of attribute X during migration, but instead such value includes an expression that's can't be resolved, so the actual value can not be determined, and the attribute is discarded. It happens in several cases,
 for instance:
-** cluster-connection forward-when-no-consumers. This boolean attribute
-has been replaced by the message-load-balancing-type attribute (which is
-an enum of OFF, STRICT, ON_DEMAND)
-** broadcast-group and discovery-group's jgroups-stack and
-jgroups-channel attributes. They reference other resources and we no
-longer accept expressions for them.
++
+** cluster-connection forward-when-no-consumers. This boolean attribute has been replaced by the message-load-balancing-type attribute (which is an enum of OFF, STRICT, ON_DEMAND)
+** broadcast-group and discovery-group's jgroups-stack and jgroups-channel attributes. They reference other resources and we no longer accept expressions for them.
 
-* Can not migrate attribute X from resource Y. This attribute is not
-supported by the new messaging-activemq subsystem. +
-Some attributes are no longer supported in the new messaging-activemq
-subsystem and are simply discarded:
+* Can not migrate attribute X from resource Y. This attribute is not supported by the new `messaging-activemq` subsystem.
++
+Some attributes are no longer supported in the new `messaging-activemq` subsystem and are simply discarded:
++
 ** hornetq-server's failback-delay
 ** http-connector's use-nio attribute
 ** http-acceptor's use-nio attribute
@@ -677,29 +526,16 @@ subsystem and are simply discarded:
 [[xml-configuration]]
 ===== XML Configuration
 
-The XML configuration has changed significantly with the new
-messaging-activemq subsystem to provide a XML scheme more consistent
-with other WildFly subsystems. +
-It is not advised to change the XML configuration of the legacy
-messaging subsystem to conform to the new messaging-activemq subsystem.
-Instead, invoke the legacy subsystem `migrate` operation. This operation
-will write the XML configuration of the new *messaging-activemq*
-subsystem as a part of its execution.
+The XML configuration has changed significantly with the new `messaging-activemq` subsystem to provide a XML scheme more consistent with other {ProductName} subsystems.
+
+It is not advised to change the XML configuration of the legacy `messaging` subsystem to conform to the new `messaging-activemq` subsystem. Instead, invoke the legacy subsystem `migrate` operation. This operation will write the XML configuration of the new `messaging-activemq` subsystem as a part of its execution.
 
 [[messaging-interceptors]]
 ===== Messaging Interceptors
 
-Messaging Interceptors are significantly different in EAP 7, requiring
-both code and configuration changes by the user. In concrete the
-interceptor base Java class is now
-*org.apache.artemis.activemq.api.core.interceptor.Interceptor*, and the
-user interceptor implementation classes may now be loaded by any server
-module. Note that prior to EAP 7 the interceptor classes could only be
-installed by adding these to the HornetQ module, thus requiring the user
-to change such module XML descriptor, its *module.xml*. +
-With respect to the server XML configuration, the user must now specify
-the module to load its interceptors in the new *messaging-activemq*
-subsystem XML config, e.g:
+Messaging Interceptors are significantly different in {ProductName} {ProductVersion}, requiring both code and configuration changes by the user. In concrete the interceptor base Java class is now `org.apache.artemis.activemq.api.core.interceptor.Interceptor`, and the user interceptor implementation classes may now be loaded by any server module. Note that prior to {ProductName} {ProductVersion} the interceptor classes could only be installed by adding these to the HornetQ module, thus requiring the user to change such module XML descriptor, its `module.xml`.
+
+With respect to the server XML configuration, the user must now specify the module to load its interceptors in the new `messaging-activemq` subsystem XML config, e.g:
 
 [source,xml]
 ----
@@ -721,22 +557,19 @@ subsystem XML config, e.g:
 [[jms-destinations]]
 ===== JMS Destinations
 
-In previous releases, JMS destination queues were configured in the
-<jms-destinations> element under the hornetq-server section of the
-*messaging* subsystem.
+In previous releases, JMS destination queues were configured in the `<jms-destinations>` element under the hornetq-server section of the `messaging` subsystem.
 
 [source,xml]
 ----
 <jms-destinations>
-<jms-queue name="testQueue">
-<entry name="queue/test"/>
-<entry name="java:jboss/exported/jms/queue/test"/>
-</jms-queue>
+    <jms-queue name="testQueue">
+        <entry name="queue/test"/>
+        <entry name="java:jboss/exported/jms/queue/test"/>
+    </jms-queue>
 </jms-destinations>
 ----
 
-In WildFly, the JMS destination queue is configured in the default
-server of the messaging-activemq subsystem.
+In {ProductName}, the JMS destination queue is configured in the default server of the `messaging-activemq` subsystem.
 
 [source,xml]
 ----
@@ -746,38 +579,31 @@ server of the messaging-activemq subsystem.
 [[messaging-logging]]
 ==== Messaging Logging
 
-The prefix of messaging log messages in WildFly is *WFLYMSGAMQ*, instead
-of *WFLYMSG*.
+The prefix of messaging log messages in {ProductName} is `WFLYMSGAMQ`, instead of `WFLYMSG`.
 
 [[messaging-data]]
 ==== Messaging Data
 
-The location of the messaging data has been changed in the new
-messaging-activemq subsystem:
+The location of the messaging data has been changed in the new `messaging-activemq` subsystem:
 
 * messagingbindings/ -> activemq/bindings/
 * messagingjournal/ -> activemq/journal/
 * messaginglargemessages/ -> activemq/largemessages/
 * messagingpaging/ -> activemq/paging/
 
-To migrate legacy messaging data, you will have to export the
-directories used by the legacy messaging subsystem and import them into
-the new subsystem's server by using its `import-journal operation:`
+To migrate legacy messaging data, you will have to export the directories used by the legacy `messaging` subsystem and import them into the new subsystem's server by using its `import-journal` operation:
 
-[source,xml]
+[source]
 ----
 /subsystem=messaging-activemq/server=default:import-journal(file=<path to XML dump>)
 ----
 
-The XML dump is a XML file generated by HornetQ `XmlDataExporter` util
-class.
+The XML dump is a XML file generated by HornetQ `XmlDataExporter` util class.
 
 [[application-migration]]
 == Application Migration
 
-Before you migrate your application, you should be aware that some
-features that were available in previous releases are now deprecated or
-missing.
+Before you migrate your application, you should be aware that some features that were available in previous releases are now deprecated or missing.
 
 [[ejbs]]
 === EJBs
@@ -785,13 +611,9 @@ missing.
 [[cmp-entity-ejbs]]
 ==== CMP Entity EJBs
 
-Container-Managed Persistence entity beans support is optional in Java
-EE 7, and WildFly does not provide support for these.
+Container-Managed Persistence entity beans support is optional in Java EE 7, and {ProductName} does not provide support for these.
 
-CMP entity beans are defined in the *ejb-jar.xml* descriptor, in
-concrete an entity bean is CMP only if the *<entity/>*'s child element
-named *persistence-type* is included and has a value of *Container*. An
-example:
+CMP entity beans are defined in the `ejb-jar.xml` descriptor, in concrete an entity bean is CMP only if the `<entity/>` child element named `persistence-type` is included and has a value of `Container`. An example:
 
 [source,xml]
 ----
@@ -822,55 +644,44 @@ CMP entity beans should be replaced by JPA entities.
 [[default-remote-connection-port]]
 ===== Default Remote Connection Port
 
-The default remote connection port has changed from '4447' to '8080'.
+The default remote connection port has changed from `4447` to `8080`.
 
-In JBoss AS7, the *jboss-ejb-client.properties* file looked similar to
+In {PrevProductName} {PrevProductVersion}, the `jboss-ejb-client.properties` file looked similar to
 the following:
-
-....
+[source]
+----
 remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 remote.connections=default
 remote.connection.default.host=localhost
 remote.connection.default.port=4447
 remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
-....
+----
 
-In WildFly, the properties file looks like this:
-
-....
+In {ProductName}, the properties file looks like this:
+[source]
+----
 remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 remote.connections=default
 remote.connection.default.host=localhost
 remote.connection.default.port=8080
 remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
-....
+----
 
 [[default-connector]]
 ===== Default Connector
 
-In WildFly, the default connector has changed from "remoting" to
-"http-remoting". This change impacts clients that use libraries from one
-release of JBoss and to connect to server in a different release.
+In {ProductName}, the default connector has changed from `remoting` to `http-remoting`. This change impacts clients that use libraries from one release of JBoss and to connect to server in a different release.
 
-* If a client application uses the EJB client library from JBoss AS 7
-and wants to connect to WildFly 10 server, the server must be configured
-to expose a remoting connector on a port other than "8080". The client
-must then connect using that newly configured connector.
+* If a client application uses the EJB client library from {PrevProductName} {PrevProductVersion} and wants to connect to {ProductName} {ProductVersion} server, the server must be configured to expose a remoting connector on a port other than `8080`. The client must then connect using that newly configured connector.
 
-* A client application that uses the EJB client library from WildFly 10
-and wants to connect to a JBoss AS 7 server must be aware that the
-server instance does not use the http-remoting connector and instead
-uses a remoting connector. This is achieved by defining a new
-client-side connection property.
+* A client application that uses the EJB client library from {ProductName} {ProductVersion} and wants to connect to a {PrevProductName} {PrevProductVersion} server must be aware that the server instance does not use the http-remoting connector and instead uses a remoting connector. This is achieved by defining a new client-side connection property.
 +
-....
+[source]
+----
 remote.connection.default.protocol=remote
-....
+----
 
-External applications using JNDI, to remotely lookup up EJBs in a
-WildFly 10 server, may also need to be migrated, please refer to
-<<remote-jndi-clients,#Remote
-JNDI Clients>> section for further information.
+External applications using JNDI, to remotely lookup up EJBs in a {ProductName} {ProductVersion} server, may also need to be migrated, see  <<remote-jndi-clients,#Remote JNDI Clients>> section for further information.
 
 [[jms]]
 === JMS
@@ -878,23 +689,14 @@ JNDI Clients>> section for further information.
 [[proprietary-jms-resource-definitions]]
 ==== Proprietary JMS Resource Definitions
 
-The proprietary XML descriptors, previously used to setup JMS resources,
-are deprecated in WildFly. Java EE 7 (section EE.5.18) standardised such
-functionality.
+The proprietary XML descriptors, previously used to setup JMS resources, are deprecated in {ProductName}. Java EE 7 (section EE.5.18) standardized such functionality.
 
-The deprecated descriptors are files bundled in the application package,
-which name ends with *-jms.xml*. +
-Their namespace has been changed to
-*urn:jboss:messaging-activemq-deployment:1.0*.
+The deprecated descriptors are files bundled in the application package, which name ends with `-jms.xml`. Their namespace has been changed to `urn:jboss:messaging-activemq-deployment:1.0`.
 
 [[external-jms-clients]]
 ==== External JMS Clients
 
-JMS Resources are remotely looked up using JNDI, and looking up
-resources in a WildFly 10 server may require changes in the application
-code, please refer to
-<<remote-jndi-clients,#Remote
-JNDI Clients>> section for further information.
+JMS Resources are remotely looked up using JNDI, and looking up resources in a {ProductName} {ProductVersion} server may require changes in the application code, see  <<remote-jndi-clients,#Remote JNDI Clients>> section for further information.
 
 [[jpa-and-hibernate]]
 === JPA (and Hibernate)
@@ -902,15 +704,11 @@ JNDI Clients>> section for further information.
 [[applications-that-plan-to-use-hibernate-orm-5.0]]
 ==== Applications That Plan to Use Hibernate ORM 5.0
 
-WildFly ships with Hibernate ORM 5.0 and those libraries are implicitly
-added to the application classpath when a persistence.xml is detected
-during deployment. If your application uses JPA, it will default to
-using the Hibernate ORM 5.0 libraries.
+{ProductName} ships with Hibernate ORM 5.0 and those libraries are implicitly added to the application classpath when a `persistence.xml` is detected during deployment. If your application uses JPA, it will default to using the Hibernate ORM 5.0 libraries.
 
 Hibernate ORM 5.0 introduces:
 
-* Redesigned metamodel - Complete replacement for the current
-org.hibernate.mapping code
+* Redesigned metamodel - Complete replacement for the current `org.hibernate.mapping` code
 * Query parser - Improved query parser based on Antlr 3/4
 * Multi-tenancy improvements - Discriminator-based multi-tenancy
 * Follow-on fetches - Two-phase loading via LoadPlans/EntityGraphs
@@ -918,27 +716,16 @@ org.hibernate.mapping code
 [[applications-that-currently-use-hibernate-orm-4.0---4.3]]
 ==== Applications that currently use Hibernate ORM 4.0 - 4.3
 
-If your application needs second-level cache enabled, you should migrate
-to Hibernate ORM 5.0, which is integrated with Infinispan 8.0.
-Applications written with Hibernate ORM 4.x can still use Hibernate 4.x
-if you define a custom JBoss module with Hibernate 4.x JARs and exclude
-the Hibernate 5 classes from your application. It is recommended that
-you migrate your application to use Hibernate 5.
+If your application needs second-level cache enabled, you should migrate to Hibernate ORM 5.0, which is integrated with Infinispan 8.0. Applications written with Hibernate ORM 4.x can still use Hibernate 4.x if you define a custom JBoss module with Hibernate 4.x JARs and exclude the Hibernate 5 classes from your application. It is recommended that you migrate your application to use Hibernate 5.
 
-For information about the changes implemented between Hibernate 4 and
-Hibernate 5, see
+For information about the changes implemented between Hibernate 4 and Hibernate 5, see
 https://github.com/hibernate/hibernate-orm/blob/master/migration-guide.adoc
 
 [[applications-that-currently-use-hibernate-3]]
 ==== Applications that currently use Hibernate 3
 
-The integration classes that made it easier to use Hibernate 3 in AS 7
-were removed from WildFly 10. If your application still uses Hibernate 3
-libraries, it is strongly recommended that you migrate your application
-to use Hibernate 5 as Hibernate 3 will no longer work in WildFly without
-a lot of effort. If you can not migrate to Hibernate 5, you must define
-a custom JBoss Module for the Hibernate 3 classes and exclude the
-Hibernate 5 classes from your application.
+The integration classes that made it easier to use Hibernate 3 in {PrevProductName} {PrevProductVersion} were removed from {ProductName} {ProductVersion}. If your application still uses Hibernate 3 libraries, it is strongly recommended that you migrate your application to use Hibernate 5 as Hibernate 3 will no longer work in {ProductName} without
+a lot of effort. If you can not migrate to Hibernate 5, you must define a custom JBoss Module for the Hibernate 3 classes and exclude the Hibernate 5 classes from your application.
 
 [[web-applications]]
 === Web Applications
@@ -946,18 +733,11 @@ Hibernate 5 classes from your application.
 [[jboss-web-valves]]
 ==== JBoss Web Valves
 
-Undertow does not support the JBoss Web Valve functionality. This can be
-replaced by Undertow Handlers (see
-http://undertow.io/undertow-docs/undertow-docs-1.3.0/index.html#undertow-handler-authors-guide
-for more).
+Undertow does not support the JBoss Web Valve functionality. This can be replaced by Undertow Handlers. See the http://undertow.io/undertow-docs/undertow-docs-1.3.0/index.html#undertow-handler-authors-guide[Undertow Handler Authors Guide] for more information.
 
-List of valves that were provided with JBoss Web, together with a
-corresponding Undertow handler, is provided above, in the section on the
-JBoss Web subsystem.
+List of valves that were provided with JBoss Web, together with a corresponding Undertow handler, is provided above, in the section on the JBoss Web subsystem.
 
-JBoss Web Valves are specified in the proprietary *jboss-web.xml*
-descriptor, through *<valve />* element(s). These can be replaced using
-the *<http-handler />* element(s). For example:
+JBoss Web Valves are specified in the proprietary `jboss-web.xml` descriptor, through `<valve />` element(s). These can be replaced using the `<http-handler />` element(s). For example:
 
 [source,xml]
 ----
@@ -987,29 +767,16 @@ can be replaced by
 [[cxf-spring-webservices]]
 ==== CXF Spring Webservices
 
-The setup of web service's endpoints and clients, through a Spring XML
-descriptor, driving a CXF bus creation, is no longer supported in
-WildFly.
+The setup of web service's endpoints and clients, through a Spring XML descriptor, driving a CXF bus creation, is no longer supported in {ProductName}.
 
-Any application containing a jbossws-cxf.xml must migrate all
-functionality specified in such XML descriptor, mostly already supported
-by the JAX-WS specification, included in Java EE 7. It is still possible
-to rely on direct Apache CXF API usage, loosing the Java EE portability
-of the application, for instance when specific Apache CXF
-functionalities are needed. Please refer to the Apache CXF Integration
-document for further information.
+Any application containing a `jbossws-cxf.xml` must migrate all functionality specified in such XML descriptor, mostly already supported by the JAX-WS specification, included in Java EE 7. It is still possible to rely on direct Apache CXF API usage, loosing the Java EE portability of the application, for instance when specific Apache CXF functionalities are needed. See the Apache CXF Integration document for further information.
 
 [[jax-rpc]]
 ==== JAX-RPC
 
-JAX-RPC is an API for building Web services and clients that used remote
-procedure calls (RPC) and XML, which was deprecated in Java EE 6, and is
-no longer supported by WildFly.
+JAX-RPC is an API for building Web services and clients that used remote procedure calls (RPC) and XML, which was deprecated in Java EE 6, and is no longer supported by {ProductName}.
 
-JAX-RPC Web Services may be identified by the presence of the XML
-descriptor named web services.xml, containing a
-*<webservice-description/>* element that includes a child element named
-*<jaxrpc-mapping-file/>*. An example:
+JAX-RPC Web Services may be identified by the presence of the XML descriptor named `webservices.xml`, containing a `<webservice-description/>` element that includes a child element named `<jaxrpc-mapping-file/>`. An example:
 
 [source,xml]
 ----
@@ -1032,22 +799,18 @@ descriptor named web services.xml, containing a
 </webservices>
 ----
 
-Applications using JAX-RPC should be migrated to use JAX-WS, the current
-Java EE standard web service framework.
+Applications using JAX-RPC should be migrated to use JAX-WS, the current Java EE standard web service framework.
 
 [[jax-rs-2.0]]
 ==== JAX-RS 2.0
 
-JSR 339: JAX-RS 2.0: The Java API for RESTful Web Services specification
-is located here: https://jcp.org/en/jsr/detail?id=339
+JSR 339: JAX-RS 2.0: The Java API for RESTful Web Services specification is located at https://jcp.org/en/jsr/detail?id=339
 
-Some changes to the `MessageBodyWriter` interface may represent a
-backward incompatible change with respect to JAX-RS 1.X.
+Some changes to the `MessageBodyWriter` interface may represent a backward incompatible change with respect to JAX-RS 1.X.
 
-Be sure to define an @Produces or @Consumes for your endpoints. Failure
-to do so may result in an error similar to the following.
+Be sure to define an `@Produces` or `@Consumes` for your endpoints. Failure to do so may result in an error similar to the following.
 
-[source,xml]
+[source]
 ----
 org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure: Could not find MessageBodyWriter for response object of type: <OBJECT> of media type: <CONTENT_TYPE>
 ----
@@ -1055,13 +818,8 @@ org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure: Could not find MessageB
 [[rest-client-api]]
 ==== REST Client API
 
-Some REST Client API classes and methods are deprecated, for example:
-org.jboss.resteasy.client.ClientRequest and
-org.jboss.resteasy.client.ClientResponse. Instead, use
-https://docs.jboss.org/resteasy/docs/3.0-rc-1/javadocs/index.html?org/jboss/resteasy/client/jaxrs/ResteasyClient.html[﻿org.jboss.resteasy.client.jaxrs.ResteasyClient]
-and javax.ws.rs.core.Response. See the `resteasy-jaxrs-client
-quickstart` for an example of an external JAX-RS RestEasy client that
-interacts with a JAX-RS Web service.
+Some REST Client API classes and methods are deprecated, for example: `org.jboss.resteasy.client.ClientRequest` and `org.jboss.resteasy.client.ClientResponse`. Instead, use
+https://docs.jboss.org/resteasy/docs/3.0-rc-1/javadocs/index.html?org/jboss/resteasy/client/jaxrs/ResteasyClient.html[﻿`org.jboss.resteasy.client.jaxrs.ResteasyClient`] and `javax.ws.rs.core.Response`. See the `resteasy-jaxrs-client` quickstart for an example of an external JAX-RS RestEasy client that interacts with a JAX-RS Web service.
 
 [[application-clustering]]
 === Application Clustering
@@ -1069,164 +827,115 @@ interacts with a JAX-RS Web service.
 [[ha-singleton]]
 ==== HA Singleton
 
-JBoss AS7 introduced singleton services - a mechanism for installing an
-service such that it would only start on one node in the cluster at a
-time, a HA Singleton. Such mechanism required usage of a private JBoss
-EAP Clustering API, designed around the class
-*org.jboss.as.clustering.singleton.SingletonService*, and was documented
-in detail at
-https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html/Development_Guide/Implement_an_HA_Singleton.html
-, and while not difficult to implement, the installation process
-suffered from a couple shortcomings:
+{PrevProductName} {PrevProductVersion} introduced singleton services - a mechanism for installing an service such that it would only start on one node in the cluster at a time, a HA Singleton. Such mechanism required usage of a private {ProductName} Clustering API, designed around the class `org.jboss.as.clustering.singleton.SingletonService`, and was documented in detail at
+https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html/Development_Guide/Implement_an_HA_Singleton.html, and while not difficult to implement, the installation process suffered from a couple shortcomings:
 
-* Installing multiple singleton services within a single deployment
-caused the deployer to hang.
-* Installing a singleton service required the user to specify several
-private module dependencies in /META-INF/MANIFEST.MF
+* Installing multiple singleton services within a single deployment caused the deployer to hang.
+* Installing a singleton service required the user to specify several private module dependencies in `/META-INF/MANIFEST.MF`
 
-WildFly 10 introduces a new public API for building such services, which
-significantly simplifies the process, and solves the issues found in the
-legacy solution. The JBoss EAP 7 Quickstart application named
-*cluster-ha-singleton* examples a HA Singleton implementation using the
-new API, and may be found at
-https://github.com/jboss-developer/jboss-eap-quickstarts/tree/7.0.x-develop/cluster-ha-singleton
+{ProductName} {ProductVersion} introduces a new public API for building such services, which significantly simplifies the process, and solves the issues found in the legacy solution. The {ProductName} {ProductVersion} Quickstart application named `cluster-ha-singleton` examples a HA Singleton implementation using the new API, and may be found at https://github.com/jboss-developer/jboss-eap-quickstarts/tree/7.0.x-develop/cluster-ha-singleton
 . +
-FIXME: community URLs instead
+// FIXME: community URLs instead
 
 [[stateful-session-ejb-clustering]]
 ==== Stateful Session EJB Clustering
 
-WildFly 10 no longer requires Stateful Session EJBs to use the
-*org.jboss.ejb3.annotation.Clustered* annotation to enable clustering
-behaviour. By default, if the server is started using an HA profile, the
-state of your SFSBs will be replicated automatically. Disabling this
-behaviour is achievable on a per-EJB basis, by annotating your bean
-using *@Stateful(passivationCapable=false)*, which is new to the EJB 3.2
-specification; or globally through the configuration of the EJB3
-subsystem, in the server configuration.
+{ProductName} {ProductVersion} no longer requires Stateful Session EJBs to use the `org.jboss.ejb3.annotation.Clustered` annotation to enable clustering behavior. By default, if the server is started using an HA profile, the state of your SFSBs will be replicated automatically. Disabling this behavior is achievable on a per-EJB basis, by annotating your bean using `@Stateful(passivationCapable=false)`, which is new to the EJB 3.2 specification; or globally through the configuration of the EJB3 subsystem, in the server configuration.
 
-Note that the *@Clustered* annotation, if used by an application, is
-simply ignored, the application deployment will not fail.
+Note that the `@Clustered` annotation, if used by an application, is simply ignored, the application deployment will not fail.
 
 [[web-session-clustering]]
 ==== Web Session Clustering
 
-WildFly 10 introduces a new web session clustering implementation,
-replacing the one found in AS7, which has been around for ages (since
-JBoss AS 3.2!), and was tightly coupled to the legacy JBoss Web
-subsystem source code. The most relevant changes in the new
-implementation are:
+{ProductName} {ProductVersion} introduces a new web session clustering implementation, replacing the one found in {PrevProductName} {PrevProductVersion}, which has been around for ages (since JBoss AS 3.2!), and was tightly coupled to the legacy JBoss Web subsystem source code. The most relevant changes in the new implementation are:
 
-* Introduction of a proper session manager SPI, and an Infinispan
-implementation of it, decoupled from the web subsystem implementation
-* Sessions are implemented as a facade over one or more cache entries,
-which means that the container's session manager itself does not retain
-a separate reference to each HttpSession
-* Pessimistic locking of cache entries effectively ensures that only a
-single client on a single node ever accesses a given session at any
-given time
-* Usage of cache entry grouping, instead of atomic maps, to ensure that
-multiple cache entries belonging to the same session are co-located.
-* Session operations within a request only ever use a single
-batch/transaction. This results in fewer RPCs per request.
-* Support for write-through cache stores, as well as passivation-only
-cache stores.
+* Introduction of a proper session manager SPI, and an Infinispan implementation of it, decoupled from the web subsystem implementation
+* Sessions are implemented as a facade over one or more cache entries, which means that the container's session manager itself does not retain a separate reference to each HttpSession
+* Pessimistic locking of cache entries effectively ensures that only a single client on a single node ever accesses a given session at any given time
+* Usage of cache entry grouping, instead of atomic maps, to ensure that multiple cache entries belonging to the same session are co-located.
+* Session operations within a request only ever use a single batch/transaction. This results in fewer RPCs per request.
+* Support for write-through cache stores, as well as passivation-only cache stores.
 
-With respect to applications, the new web session clustering
-implementation deprecates/reinterprets much of the related
-configuration, which is included in JBoss's proprietary web application
-XML descriptor, *jboss-web.xml*:
+With respect to applications, the new web session clustering implementation deprecates/reinterprets much of the related configuration, which is included in JBoss's proprietary web application
+XML descriptor, `jboss-web.xml`:
 
-* *<max-active-sessions/>* +
-Previously, session creation would fail if an additional session would
-cause the number of active sessions to exceed the value specified by <
-*max-active-sessions/>*. +
-In the new implementation, *<max-active-sessions/>* is used to enable
-session passivation. If session creation would cause the number of
-active sessions to exceed *<max-active-sessions/>*, then the oldest
-session known to the session manager will passivate to make room for the
-new session.
+* `<max-active-sessions/>`
++
+Previously, session creation would fail if an additional session would cause the number of active sessions to exceed the value specified by `<max-active-sessions/>`.
++
+In the new implementation, `<max-active-sessions/>` is used to enable session passivation. If session creation would cause the number of active sessions to exceed `<max-active-sessions/>`, then the oldest session known to the session manager will passivate to make room for the new session.
 
-* *<passivation-config/>* +
-This configuration element and its sub-elements are no longer used in
-WildFly.
+* `<passivation-config/>`
++
+This configuration element and its sub-elements are no longer used in {ProductName}.
 
-* *<use-session-passivation/>* +
-Previously, passivation was enabled via this attribute, yet in the new
-implementation, passivation is enabled by specifying a non-negative
-value for *<max-active-sessions/>*.
+* `<use-session-passivation/>`
++
+Previously, passivation was enabled via this attribute, yet in the new implementation, passivation is enabled by specifying a non-negative value for `<max-active-sessions/>`.
 
-* *<passivation-min-idle-time/>* +
-Previously, sessions needed to be active for at least a specific amount
-of time before becoming a candidate for passivation. This could cause
-session creation to fail, even when passivation was enabled. +
-The new implementation does not support this logic and thus avoids this
-DoS vulnerability.
+* `<passivation-min-idle-time/>`
++
+Previously, sessions needed to be active for at least a specific amount of time before becoming a candidate for passivation. This could cause session creation to fail, even when passivation was enabled.
++
+The new implementation does not support this logic and thus avoids this DoS vulnerability.
 
-* *<passivation-max-idle-time/>* +
-Previously, a session would be passivated after it was idle for a
-specific amount of time. +
-The new implementation does not support eager passivation - only lazy
-passivation. Sessions are only passivated when necessary to comply with
-*<max-active-sessions/>*.
+* `<passivation-max-idle-time/>`
++
+Previously, a session would be passivated after it was idle for a specific amount of time.
++
+The new implementation does not support eager passivation - only lazy passivation. Sessions are only passivated when necessary to comply with `<max-active-sessions/>`.
 
-* *<replication-config/>* +
-The new implementation deprecates a number of sub-elements:
+* `<replication-config/>`
++
+The new implementation deprecates a number of sub-elements.
 
-* *<replication-trigger/>* +
-Previously, session attributes could be treated as either mutable or
-immutable depending on the values specified by *<replication-trigger/>*:
-** SET treated all attributes as immutable, requiring a separate
-HttpSession.setAttribute(...) to indicate that the value changed.
+* `<replication-trigger/>`
++
+Previously, session attributes could be treated as either mutable or immutable depending on the values specified by `<replication-trigger/>`:
+
+** SET treated all attributes as immutable, requiring a separate `HttpSession.setAttribute(...)` to indicate that the value changed.
 ** SET_AND_GET treated all session attributes as mutable.
-** SET_AND_NON_PRIMITIVE_GET recognised a small set of types (i.e.
-strings and boxed primitives) as immutable, and assumed that any other
-attribute was mutable. +
-The new implementation replaces this configuration option with a single,
-robust strategy. Session attributes are assumed to be mutable unless one
-of the following is true:
+** SET_AND_NON_PRIMITIVE_GET recognized a small set of types, for example strings and boxed primitives, as immutable, and assumed that any other attribute was mutable.
++
+The new implementation replaces this configuration option with a single, robust strategy. Session attributes are assumed to be mutable unless one of the following is true:
+
 ** The value is a known immutable value:
+
 *** null
-*** java.util.Collections.EMPTY_LIST, EMPTY_MAP, EMPTY_SET
+*** `java.util.Collections.EMPTY_LIST`, `EMPTY_MAP`, `EMPTY_SET`
+
 ** The value type is or implements a known immutable type:
-*** Boolean, Byte, Character, Double, Float, Integer, Long, Short
-*** java.lang.Enum, StackTraceElement, String
-*** java.io.File, java.nio.file.Path
-*** java.math.BigDecimal, BigInteger, MathContext
-*** java.net.InetAddress, InetSocketAddress, URI, URL
-*** java.security.Permission
-*** java.util.Currency, Locale, TimeZone, UUID
-** The value type is annotated with
-@org.wildfly.clustering.web.annotation.Immutable
 
-* *<use-jk/>* +
-Previously, the instance-id of the node handling a given request was
-appended to the jsessionid (for use by load balancers such as mod_jk,
-mod_proxy_balancer, mod_cluster, etc.) depending on the value specified
-for *<use-jk/>*. In the new implementation, the instance-id, if defined,
-is always appended to the jsessionid.
+*** `Boolean`, `Byte`, `Character`, `Double`, `Float`, `Integer`, `Long`, `Short`
+*** `java.lang.Enum`, `StackTraceElement`, `String`
+*** `java.io.File`, `java.nio.file.Path`
+*** `java.math.BigDecimal`, `BigInteger`, `MathContext`
+*** `java.net.InetAddress`, `InetSocketAddress`, `URI`, `URL`
+*** `java.security.Permission`
+*** `java.util.Currency`, `Locale`, `TimeZone`, `UUID`
 
-* *<max-unreplicated-interval/>* +
-Previously, this configuration option was an optimization that would
-prevent the replicate of a session's timestamp if no session attribute
-was changed. While this sounds nice, in practice it doesn't prevent any
-RPCs, since session access requires cache transaction RPCs regardless of
-whether any session attributes changed. In the new implementation, the
-timestamp of a session is replicated on every request. This prevents
-stale session meta data following failover.
+** The value type is annotated with `@org.wildfly.clustering.web.annotation.Immutable`
 
-* *<snapshot-mode/>* +
-Previously, one could configure *<snapshot-mode/>* as INSTANT or
-INTERVAL. Infinispan's replication queue renders this configuration
-option obsolete.
+* `<use-jk/>`
++
+Previously, the `instance-id` of the node handling a given request was appended to the `jsessionid`, for use by load balancers such as mod_jk, mod_proxy_balancer, mod_cluster, etc., depending on the value specified for `<use-jk/>`. In the new implementation, the `instance-id`, if defined, is always appended to the `jsessionid`.
 
-* *<snapshot-interval/>* +
-Only relevant for *<snapshot-mode>INTERVAL</snapshot-mode>*. See above.
+* `<max-unreplicated-interval/>`
++
+Previously, this configuration option was an optimization that would prevent the replicate of a session's timestamp if no session attribute was changed. While this sounds nice, in practice it doesn't prevent any RPCs, since session access requires cache transaction RPCs regardless of
+whether any session attributes changed. In the new implementation, the timestamp of a session is replicated on every request. This prevents stale session meta data following failover.
 
-* *<session-notification-policy/>* +
-Previously, the value defined by this attribute defined a policy for
-triggering session events. In the new implementation, this behaviour is
-spec-driven and not configurable.
+* `<snapshot-mode/>`
++
+Previously, one could configure `<snapshot-mode/>` as INSTANT or INTERVAL. Infinispan's replication queue renders this configuration option obsolete.
+
+* `<snapshot-interval/>`
++
+Only relevant for `<snapshot-mode>INTERVAL</snapshot-mode>`. See above.
+
+* `<session-notification-policy/>`
++
+Previously, the value defined by this attribute defined a policy for triggering session events. In the new implementation, this behavior is spec-driven and not configurable.
 
 [[other-specifications-and-frameworks]]
 === Other Specifications and Frameworks
@@ -1234,15 +943,12 @@ spec-driven and not configurable.
 [[remote-jndi-clients]]
 ==== Remote JNDI Clients
 
-WildFly 10's default JNDI Provider URL has changed, which means that
-external applications, using JNDI to lookup remote resources, for
-instance an EJB or a JMS Queue, may need to change the value for the
-JNDI *InitialContext* environment's property named
-*java.naming.provider.url*. The default URL scheme is now
-*http-remoting*, and the default URL port is now *8080*.
+{ProductName} {ProductVersion}'s default JNDI Provider URL has changed, which means that external applications, using JNDI to lookup remote resources, for instance an EJB or a JMS Queue, may need to change the value for the JNDI `InitialContext` environment's property named
+`java.naming.provider.url`. The default URL scheme is now
+`http-remoting`, and the default URL port is now `8080`.
 
-As an example, considering the application server host is *localhost*,
-then clients previously accessing JBoss AS7 would use
+As an example, considering the application server host is `localhost`,
+then clients previously accessing {ProductName} {ProductVersion} would use
 
 [source,java]
 ----
@@ -1250,7 +956,7 @@ java.naming.factory.initial=org.jboss.naming.remote.client.InitialContextFactory
 java.naming.provider.url=remote://localhost:4447
 ----
 
-while clients now accessing WildFly should use instead
+while clients now accessing {ProductName} should use instead
 
 [source, java]
 ----
@@ -1261,20 +967,11 @@ java.naming.provider.url=http-remoting://localhost:8080
 [[jsr-88]]
 ==== JSR-88
 
-The specification which aimed to standardise deployment tasks got very
-little adoption, due to much more "feature rich" proprietary solutions
-already included in every vendor application server. It was no surprise
-that JSR-88 support was dropped from Java EE 7, and WildFly followed
-that and dropped support too.
+The specification which aimed to standardize deployment tasks got very little adoption, due to much more "feature rich" proprietary solutions already included in every vendor application server. It was no surprise that JSR-88 support was dropped from Java EE 7, and {ProductName} followed that and dropped support too.
 
-A JSR-88 deployment plan is identified by a XML descriptor named
-*deployment-plan.xml*, bundled in a zip/jar archive.
+A JSR-88 deployment plan is identified by a XML descriptor named `deployment-plan.xml`, bundled in a zip/jar archive.
 
 [[module-dependencies]]
 ==== Module Dependencies
 
-Applications defining dependencies to WildFly modules, through the
-application's package MANIFEST.MF or jboss-deployment-structure.xml, may
-be referencing missing modules. When migrating an application, relying
-on such functionality, the presence of the referenced modules should be
-validated in advance.
+Applications defining dependencies to {ProductName} modules, through the application's package `MANIFEST.MF` or `jboss-deployment-structure.xml`, may be referencing missing modules. When migrating an application, relying on such functionality, the presence of the referenced modules should be validated in advance.

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebLogic_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebLogic_to_WildFly.adoc
@@ -10,10 +10,10 @@ WildFly.
 Feel free to add content in any way you prefer. You do not need to
 follow the template below. This is a work in progress.
 
-[[introduction]]
+[[introduction-weblogic-migration]]
 == Introduction
 
-[[about-this-guide]]
+[[about-this-guide-weblogic-migration]]
 === About this Guide
 
 The purpose of this document is to guide you through the planning

--- a/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebSphere_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/How_do_I_migrate_my_application_from_WebSphere_to_WildFly.adoc
@@ -10,10 +10,10 @@ WildFly.
 Feel free to add content in any way you prefer. You do not need to
 follow the template below. This is a work in progress.
 
-[[introduction]]
+[[introduction-websphere-migration]]
 == Introduction
 
-[[about-this-guide]]
+[[about-this-guide-websphere-migration]]
 === About this Guide
 
 The purpose of this document is to guide you through the planning

--- a/docs/src/main/asciidoc/_developer-guide/Migrate_Order_Application_from_EAP5.1_to_WildFly.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Migrate_Order_Application_from_EAP5.1_to_WildFly.adoc
@@ -15,7 +15,7 @@ In addition to application code changes, modifications were made to the
 way the EAR was packaged. This is because WildFly removed support of
 some proprietary features that were available in EAP 5.1.
 
-[[summary-of-changes]]
+[[summary-of-changes-migrate-order-application]]
 == Summary of changes
 
 [[code-changes]]
@@ -243,7 +243,7 @@ Class-Path: OrderManagerEJB.jar
 The `Class-Path` entry tells the application to look in the
 `OrderManagerEJB.jar` file for the injected beans.
 
-[[summary]]
+[[summary-migrate-order-application]]
 === Summary
 
 Although the existing EAR structure could have worked with additional

--- a/docs/src/main/asciidoc/_developer-guide/Migrate_Seam_2_Booking_EAR_Binaries_-_Step_by_Step.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Migrate_Seam_2_Booking_EAR_Binaries_-_Step_by_Step.adoc
@@ -1,7 +1,6 @@
 [[Migrate_Seam_2_Booking_EAR_Binaries_-_Step_by_Step]]
 = Seam 2 Booking Application - Migration of Binaries from EAP5.1 to
 WildFly
-=========================================================================
 
 This is a step-by-step how-to guide on porting the Seam Booking
 application binaries from EAP5.1 to WildFly {wildflyVersion}. Although there are better
@@ -18,47 +17,44 @@ them.
 == Step 1: Build and deploy the EAP5.1 version of the Seam Booking
 application
 
-1.  Build the EAR
+.  Build the EAR
 +
-[source, java]
+[source]
 ----
-    cd /EAP5_HOME/jboss-eap5.1/seam/examples/booking
-    ~/tools/apache-ant-1.8.2/bin/ant explode
-  
+cd /EAP5_HOME/jboss-eap5.1/seam/examples/booking
+~/tools/apache-ant-1.8.2/bin/ant explode
 ----
 
-* Copy the EAR to the JBOSS_HOME deployments directory:
+. Copy the EAR to the JBOSS_HOME deployments directory:
 +
-[source, java]
+[source]
 ----
-    cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.ear AS7_HOME/standalone/deployments/
-    cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.war AS7_HOME/standalone/deployments/jboss-seam.ear
-    cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.jar AS7_HOME/standalone/deployments/jboss-seam.ear
-  
+cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.ear AS7_HOME/standalone/deployments/
+cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.war AS7_HOME/standalone/deployments/jboss-seam.ear
+cp -r EAP5_HOME/jboss-eap-5.1/seam/examples/booking/exploded-archives/jboss-seam-booking.jar AS7_HOME/standalone/deployments/jboss-seam.ear
 ----
-* Start the WildFly server and check the log. You will see:
+. Start the WildFly server and check the log. You will see:
 +
-[source, java]
+[source]
 ----
-    INFO [org.jboss.as.deployment] (DeploymentScanner-threads - 1) Found jboss-seam-booking.ear in deployment directory. To trigger deployment create a file called jboss-seam-booking.ear.dodeploy
-  
+INFO [org.jboss.as.deployment] (DeploymentScanner-threads - 1) Found jboss-seam-booking.ear in deployment directory. To trigger deployment create a file called jboss-seam-booking.ear.dodeploy
 ----
-* Create an empty file with the name `jboss-seam-booking.ear.dodeploy`
+. Create an empty file with the name `jboss-seam-booking.ear.dodeploy`
 and copy it into the deployments directory. In the log, you will now see
 the following, indicating that it is deploying:
 +
-[source, java]
+[source]
 ----
-    INFO [org.jboss.as.server.deployment] (MSC service thread 1-1) Starting deployment of "jboss-seam-booking.ear"
-    INFO [org.jboss.as.server.deployment] (MSC service thread 1-3) Starting deployment of "jboss-seam-booking.jar"
-    INFO [org.jboss.as.server.deployment] (MSC service thread 1-6) Starting deployment of "jboss-seam.jar"
-    INFO [org.jboss.as.server.deployment] (MSC service thread 1-2) Starting deployment of "jboss-seam-booking.war"
-  
+INFO [org.jboss.as.server.deployment] (MSC service thread 1-1) Starting deployment of "jboss-seam-booking.ear"
+INFO [org.jboss.as.server.deployment] (MSC service thread 1-3) Starting deployment of "jboss-seam-booking.jar"
+INFO [org.jboss.as.server.deployment] (MSC service thread 1-6) Starting deployment of "jboss-seam.jar"
+INFO [org.jboss.as.server.deployment] (MSC service thread 1-2) Starting deployment of "jboss-seam-booking.war"
 ----
-* At this point, you will first encounter your first deployment error.
+
+. At this point, you will first encounter your first deployment error.
 In the next section, we will step through each issue and how to debug
 and resolve it.
-+
+
 [[step-2-debug-and-resolve-deployment-errors-and-exceptions]]
 == Step 2: Debug and resolve deployment errors and exceptions
 
@@ -68,7 +64,7 @@ javax.faces.FacesException
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR \[org.jboss.msc.service.fail\] (MSC service thread 1-1) MSC00001: Failed to start service jboss.deployment.subunit."jboss-seam-booking.ear"."jboss-seam-booking.war".POST_MODULE:
 org.jboss.msc.service.StartException in service jboss.deployment.subunit."jboss-seam-booking.ear"."jboss-seam-booking.war".POST_MODULE:
@@ -92,10 +88,10 @@ Find the module name for that class in the `AS7_HOME/modules` directory
 by looking for a path that matches the missing class. In this case, you
 will find 2 modules that match:
 
-[source, java]
+[source]
 ----
-    javax/faces/api/main
-    javax/faces/api/1.2
+javax/faces/api/main
+javax/faces/api/1.2
 ----
 
 Both modules have the same module name: "javax.faces.api" but one in the
@@ -107,7 +103,7 @@ main, so we need to be able to specify one and exclude the other. To do
 this, we create a `jboss-deployment-structure.xml` file in the EAR
 `META-INF/` directory that contains the following data:
 
-[source, java]
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -125,23 +121,23 @@ this, we create a `jboss-deployment-structure.xml` file in the EAR
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-+
+
 In the "deployment" section, we add the dependency for the
 `javax.faces.api` for the JSF 1.2 module. We also add the dependency for
 the JSF 1.2 module in the sub-deployment section for the WAR and exclude
 the module for JSF 2.0.
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy` file in the same directory.
-+
+
 [[next-issue-java.lang.classnotfoundexception-org.apache.commons.logging.log]]
 === Next Issue: java.lang.ClassNotFoundException:
 org.apache.commons.logging.Log
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-8) MSC00001: Failed to start service jboss.deployment.unit."jboss-seam-booking.ear".INSTALL:
 org.jboss.msc.service.StartException in service jboss.deployment.unit."jboss-seam-booking.ear".INSTALL:
@@ -149,14 +145,14 @@ Failed to process phase INSTALL of deployment "jboss-seam-booking.ear"
     (.. additional logs removed ...)
 Caused by: java.lang.ClassNotFoundException: org.apache.commons.logging.Log from [Module "deployment.jboss-seam-booking.ear.jboss-seam-booking.war:main" from Service Module Loader]
 ----
-+
+
 [[what-it-means-1]]
 ==== What it means:
 
 The ClassNotFoundException indicates a missing dependency. In this case,
 it can not find the class `org.apache.commons.logging.Log` and you need
 to explicitly add the dependency.
-+
+
 [[how-to-resolve-it-1]]
 ==== How to resolve it:
 
@@ -169,14 +165,14 @@ case, you will find one module that matches the path
 Modify the `jboss-deployment-structure.xml` to add the module dependency
 to the deployment section of the file.
 
-[source, java]
+[source, xml]
 ----
 <module name="org.apache.commons.logging" export="true"/>
 ----
-+
+
 The `jboss-deployment-structure.xml` should now look like this:
-+
-[source, java]
+
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -195,30 +191,30 @@ The `jboss-deployment-structure.xml` should now look like this:
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.classnotfoundexception-org.dom4j.documentexception]]
 === Next Issue: java.lang.ClassNotFoundException:
 org.dom4j.DocumentException
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[default-host].[/seam-booking]] (MSC service thread 1-3) Exception sending context initialized event to listener instance of class org.jboss.seam.servlet.SeamListener: java.lang.NoClassDefFoundError: org/dom4j/DocumentException
     (... additional logs removed ...)
 Caused by: java.lang.ClassNotFoundException: org.dom4j.DocumentException from [Module "deployment.jboss-seam-booking.ear.jboss-seam.jar:main" from Service Module Loader]
 ----
-+
+
 [[what-it-means-2]]
 ==== What it means:
 
 Again, the ClassNotFoundException indicates a missing dependency. In
 this case, it can not find the class `org.dom4j.DocumentException`.
-+
+
 [[how-to-resolve-it-2]]
 ==== How to resolve it:
 
@@ -228,14 +224,14 @@ for the `org/dom4j/DocumentException`. The module name is "org.dom4j".
 Modify the `jboss-deployment-structure.xml` to add the module dependency
 to the deployment section of the file.
 
-[source, java]
+[source, xml]
 ----
 <module name="org.dom4j" export="true"/>
 ----
-+
+
 The `jboss-deployment-structure.xml` file should now look like this:
-+
-[source, java]
+
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -255,31 +251,31 @@ The `jboss-deployment-structure.xml` file should now look like this:
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.classnotfoundexception-org.hibernate.validator.invalidvalue]]
 === Next Issue: java.lang.ClassNotFoundException:
 org.hibernate.validator.InvalidValue
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[default-host].[/seam-booking]] (MSC service thread 1-6) Exception sending context initialized event to listener instance of class org.jboss.seam.servlet.SeamListener: java.lang.RuntimeException: Could not create Component: org.jboss.seam.international.statusMessages
     (... additional logs removed ...)
 Caused by: java.lang.ClassNotFoundException: org.hibernate.validator.InvalidValue from [Module "deployment.jboss-seam-booking.ear.jboss-seam.jar:main" from Service Module Loader]
 ----
-+
+
 [[what-it-means-3]]
 ==== What it means:
 
 Again, the ClassNotFoundException indicates a missing dependency. In
 this case, it can not find the class
 `org.hibernate.validator.InvalidValue`.
-+
+
 [[how-to-resolve-it-3]]
 ==== How to resolve it:
 
@@ -292,7 +288,7 @@ deployment. We will look for the JAR that contains the missing class in
 the `EAP5_HOME/jboss-eap-5.1/seam/lib/` directory. To do this, open a
 console and type the following:
 
-[source, java]
+[source]
 ----
 cd EAP5_HOME/jboss-eap-5.1/seam/lib
 grep 'org.hibernate.validator.InvalidValue' `find . -name '*.jar'`
@@ -305,26 +301,26 @@ The result shows:
 Binary file ./hibernate-validator.jar matches
 Binary file ./test/hibernate-all.jar matches
 ----
-+
+
 In this case, we need to copy the `hibernate-validator.jar` to the
 `jboss-seam-booking.ear/lib/` directory:
-+
-[source, java]
+
+[source]
 ----
 cp EAP5_HOME/jboss-eap-5.1/seam/lib/hibernate-validator.jar jboss-seam-booking.ear/lib
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.instantiationexception-org.jboss.seam.jsf.seamapplicationfactory]]
 === Next Issue: java.lang.InstantiationException:
 org.jboss.seam.jsf.SeamApplicationFactory
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 INFO  [javax.enterprise.resource.webcontainer.jsf.config] (MSC service thread 1-7) Unsanitized stacktrace from failed start...: com.sun.faces.config.ConfigurationException: Factory 'javax.faces.application.ApplicationFactory' was not configured properly.
  at com.sun.faces.config.processor.FactoryConfigProcessor.verifyFactoriesExist(FactoryConfigProcessor.java:296) [jsf-impl-2.0.4-b09-jbossorg-4.jar:2.0.4-b09-jbossorg-4]
@@ -340,14 +336,14 @@ Caused by: java.lang.InstantiationException: org.jboss.seam.jsf.SeamApplicationF
  at javax.faces.FactoryFinder.getImplGivenPreviousImpl(FactoryFinder.java:604) [jsf-api-1.2_13.jar:1.2_13-b01-FCS]
  ... 16 more
 ----
-+
+
 [[what-it-means-4]]
 ==== What it means:
 
 The com.sun.faces.config.ConfigurationException and
 java.lang.InstantiationException indicate a dependency issue. In this
 case, it is not as obvious.
-+
+
 [[how-to-resolve-it-4]]
 ==== How to resolve it:
 
@@ -364,7 +360,7 @@ to the deployment section of the file. We also need to add it to the WAR
 subdeployment and exclude the JSF 2.0 module. The file should now look
 like this:
 
-[source, java]
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -387,31 +383,31 @@ like this:
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.classnotfoundexception-org.apache.commons.collections.arraystack]]
 === Next Issue: java.lang.ClassNotFoundException:
 org.apache.commons.collections.ArrayStack
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.apache.catalina.core.ContainerBase.[jboss.web].[default-host].[/seam-booking]] (MSC service thread 1-1) Exception sending context initialized event to listener instance of class com.sun.faces.config.ConfigureListener: java.lang.RuntimeException: com.sun.faces.config.ConfigurationException: CONFIGURATION FAILED! org.apache.commons.collections.ArrayStack from [Module "deployment.jboss-seam-booking.ear:main" from Service Module Loader]
     (... additional logs removed ...)
-Caused by: java.lang.ClassNotFoundException: org.apache.commons.collections.ArrayStack from [Module "deployment.jboss-seam-booking.ear:main" from Service Module Loader] 
+Caused by: java.lang.ClassNotFoundException: org.apache.commons.collections.ArrayStack from [Module "deployment.jboss-seam-booking.ear:main" from Service Module Loader]
 ----
-+
+
 [[what-it-means-5]]
 ==== What it means:
 
 Again, the ClassNotFoundException indicates a missing dependency. In
 this case, it can not find the class
 `org.apache.commons.collections.ArrayStack`.
-+
+
 [[how-to-resolve-it-5]]
 ==== How to resolve it:
 
@@ -422,14 +418,14 @@ for the `org/apache/commons/collections` path. The module name is
 Modify the `jboss-deployment-structure.xml` to add the module dependency
 to the deployment section of the file.
 
-[source, java]
+[source, xml]
 ----
 <module name="org.apache.commons.collections" export="true"/>
 ----
-+
+
 The `jboss-deployment-structure.xml` file should now look like this:
-+
-[source, java]
+
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -453,23 +449,23 @@ The `jboss-deployment-structure.xml` file should now look like this:
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-services-with-missingunavailable-dependencies]]
 === Next Issue: Services with missing/unavailable dependencies
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.jboss.as.deployment] (DeploymentScanner-threads - 2) {"Composite operation failed and was rolled back. Steps that failed:" => {"Operation step-2" => {"Services with missing/unavailable dependencies" => ["jboss.deployment.subunit.\"jboss-seam-booking.ear\".\"jboss-seam-booking.jar\".component.AuthenticatorAction.START missing [ jboss.naming.context.java.comp.jboss-seam-booking.\"jboss-seam-booking.jar\".AuthenticatorAction.\"env/org.jboss.seam.example.booking.AuthenticatorAction/em\" ]","jboss.deployment.subunit.\"jboss-seam-booking.ear\".\"jboss-seam-booking.jar\".component.HotelSearchingAction.START missing [ jboss.naming.context.java.comp.jboss-seam-booking.\"jboss-seam-booking.jar\".HotelSearchingAction.\"env/org.jboss.seam.example.booking.HotelSearchingAction/em\" ]","
 <... additional logs removed ...>
 "jboss.deployment.subunit.\"jboss-seam-booking.ear\".\"jboss-seam-booking.jar\".component.BookingListAction.START missing [ jboss.naming.context.java.comp.jboss-seam-booking.\"jboss-seam-booking.jar\".BookingListAction.\"env/org.jboss.seam.example.booking.BookingListAction/em\" ]","jboss.persistenceunit.\"jboss-seam-booking.ear/jboss-seam-booking.jar#bookingDatabase\" missing [ jboss.naming.context.java.bookingDatasource ]"]}}}
 ----
-+
+
 [[what-it-means-6]]
 ==== What it means:
 
@@ -478,13 +474,13 @@ look that the text within the brackets after "missing".
 
 In this case you see:
 
-[source, java]
+[source]
 ----
 missing [ jboss.naming.context.java.comp.jboss-seam-booking.\"jboss-seam-booking.jar\".AuthenticatorAction.\"env/org.jboss.seam.example.booking.AuthenticatorAction/em\" ]
 ----
-+
+
 The "/em" indicates an Entity Manager and datasource issue.
-+
+
 [[how-to-resolve-it-6]]
 ==== How to resolve it:
 
@@ -499,23 +495,23 @@ that the jndi-name for the example database is
 Modify the `jboss-seam-booking.jar/META-INF/persistence.xml` file to
 comment the existing jta-data-source element and replace it as follows:
 
-[source, java]
+[source, xml]
 ----
 <!-- <jta-data-source>java:/bookingDatasource</jta-data-source> -->
 <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.classnotfoundexception-org.hibernate.cache.hashtablecacheprovider]]
 === Next Issue: java.lang.ClassNotFoundException:
 org.hibernate.cache.HashtableCacheProvider
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-4) MSC00001: Failed to start service jboss.persistenceunit."jboss-seam-booking.ear/jboss-seam-booking.jar#bookingDatabase": org.jboss.msc.service.StartException in service jboss.persistenceunit."jboss-seam-booking.ear/jboss-seam-booking.jar#bookingDatabase": Failed to start service
  at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1786)
@@ -536,13 +532,13 @@ Caused by: java.lang.ClassNotFoundException: org.hibernate.cache.HashtableCacheP
  at org.jboss.modules.ModuleClassLoader.findClass(ModuleClassLoader.java:191)
  (... log messages removed ...)
 ----
-+
+
 [[what-it-means-7]]
 ==== What it means:
 
 The ClassNotFoundException indicates a missing dependency. In this case,
 it can not find the class org.hibernate.cache.HashtableCacheProvider.
-+
+
 [[how-to-resolve-it-7]]
 ==== How to resolve it:
 
@@ -553,39 +549,39 @@ for the JAR that contains the missing class in the
 
 To do this, open a console and type the following:
 
-[source, java]
+[source]
 ----
 cd EAP5_HOME/jboss-eap-5.1/seam/lib
 grep 'org.hibernate.validator.InvalidValue' `find . -name '*.jar'`
 ----
-+
+
 The result shows:
-+
-[source, java]
+
+[source]
 ----
 Binary file ./hibernate-core.jar matches
 Binary file ./test/hibernate-all.jar matches
 ----
-+
+
 In this case, we need to copy the `hibernate-core.jar` to the
 `jboss-seam-booking.ear/lib/` directory:
-+
-[source, java]
+
+[source]
 ----
 cp EAP5_HOME/jboss-eap-5.1/seam/lib/hibernate-core.jar jboss-seam-booking.ear/lib
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[next-issue-java.lang.classcastexception-org.hibernate.cache.hashtablecacheprovider]]
 === Next Issue: java.lang.ClassCastException:
 org.hibernate.cache.HashtableCacheProvider
 
 When you deploy the application, the log contains the following error:
 
-[source, java]
+[source]
 ----
 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-2) MSC00001: Failed to start service jboss.persistenceunit."jboss-seam-booking.ear/jboss-seam-booking.jar#bookingDatabase": org.jboss.msc.service.StartException in service jboss.persistenceunit."jboss-seam-booking.ear/jboss-seam-booking.jar#bookingDatabase": Failed to start service
  at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1786)
@@ -606,7 +602,7 @@ Caused by: java.lang.ClassCastException: org.hibernate.cache.HashtableCacheProvi
  at org.hibernate.cache.internal.bridge.RegionFactoryCacheProviderBridge.<init>(RegionFactoryCacheProviderBridge.java:65)
  ... 20 more
 ----
-+
+
 [[what-it-means-8]]
 ==== What it means:
 
@@ -630,7 +626,7 @@ from the persistence.xml file, it will force the Seam application to
 bundle the old Hibernate libraries, resulting in ClassCastExceptions, In
 WildFly, you should move away from using HashtableCacheProvider and use
 Infinispan instead.
-+
+
 [[how-to-resolve-it-8]]
 ==== How to resolve it:
 
@@ -638,15 +634,15 @@ In WildFly, you need to comment out the hibernate.cache.provider_class
 property in the `jboss-seam-booking.jar/META-INF persistence.xml` file
 as follows:
 
-[source, java]
+[source, xml]
 ----
 <!-- <property name="hibernate.cache.provider_class" value="org.hibernate.cache.HashtableCacheProvider"/> -->
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy file` in the same directory.
-+
+
 [[no-more-issues-deployment-errors-should-be-resolved]]
 === No more issues: Deployment errors should be resolved
 
@@ -655,7 +651,7 @@ you access the URL " http://localhost:8080/seam-booking/" in a browser
 and attempt "Account Login", you will get a runtime error "The page
 isn't redirecting properly". In the next section, we will step through
 each runtime issue and how to debug and resolve it.
-+
+
 [[step-3-debug-and-resolve-runtime-errors-and-exceptions]]
 == Step 3: Debug and resolve runtime errors and exceptions
 
@@ -667,7 +663,7 @@ The application deploys successfully, but when you access the URL "
 http://localhost:8080/seam-booking/" in a browser, you get "The page
 isn't redirecting properly" and the log contains the following error:
 
-[source, java]
+[source]
 ----
 SEVERE [org.jboss.seam.jsf.SeamPhaseListener] (http--127.0.0.1-8080-1) swallowing exception: java.lang.IllegalStateException: Could not start transaction
  at org.jboss.seam.jsf.SeamPhaseListener.begin(SeamPhaseListener.java:598) [jboss-seam.jar:]
@@ -693,7 +689,7 @@ follow the new rules.
 To debug this, look earlier in the server log trace to what JNDI binding
 were used. Looking at the server log we see this:
 
-[source, java]
+[source]
 ----
 15:01:16,138 INFO  [org.jboss.as.ejb3.deployment.processors.EjbJndiBindingsDeploymentUnitProcessor] (MSC service thread 1-1) JNDI bindings for session bean named RegisterAction in deployment unit subdeployment "jboss-seam-booking.jar" of deployment "jboss-seam-booking.ear" are as follows:
  
@@ -774,12 +770,12 @@ bindings. In the log, note the EJB JNDI bindings all start with
 
 Replace the <core:init> element as follows:
 
-[source, java]
+[source, xml]
 ----
 <!--     <core:init jndi-pattern="jboss-seam-booking/#{ejbName}/local" debug="true" distributable="false"/> -->
 <core:init jndi-pattern="java:app/jboss-seam-booking.jar/#{ejbName}" debug="true" distributable="false"/>
 ----
-+
+
 Next, we need to add the EjbSynchronizations and TimerServiceDispatcher
 JNDI bindings. Add the following component elements to the file:
 +
@@ -788,10 +784,10 @@ JNDI bindings. Add the following component elements to the file:
 <component class="org.jboss.seam.transaction.EjbSynchronizations" jndi-name="java:app/jboss-seam/EjbSynchronizations"/>
 <component class="org.jboss.seam.async.TimerServiceDispatcher" jndi-name="java:app/jboss-seam/TimerServiceDispatcher"/>
 ----
-+
+
 The components.xml file should now look like this:
-+
-[source, java]
+
+[source, xml]
 ----
 <?xml version="1.0" encoding="UTF-8"?>
 <components xmlns="http://jboss.com/products/seam/components"
@@ -822,22 +818,22 @@ The components.xml file should now look like this:
             jndi-name="java:app/jboss-seam/TimerServiceDispatcher"/>
 </components>
 ----
-+
+
 Redeploy the application by deleting the
 `standalone/deployments/jboss-seam-booking.ear.failed` file and creating
 a blank `jboss-seam-booking.ear.dodeploy` file in the same directory.
-+
+
 At this point, the application should deploy and run without error. When
 you access the URL " http://localhost:8080/seam-booking/" in a browser,
 you will be able to login successfully.
-+
+
 [[step-4-access-the-application]]
 == Step 4: Access the application
 
 Access the URL " http://localhost:8080/seam-booking/" in a browser and
 login with demo/demo. You should the Booking welcome page.
 +
-[[summary-of-changes]]
+[[summary-of-changes-migrate-seam2-application]]
 == Summary of Changes
 
 Although it would be much more efficient to determine dependencies in
@@ -848,11 +844,11 @@ how to debug and resolve them.
 The following is a summary of changes made to the application when
 migrating it to WildFly:
 
-1.  We created a `jboss-deployment-structure.xml` file in the EAR's
+.  We created a `jboss-deployment-structure.xml` file in the EAR's
 `META-INF/` directory. We added "dependencies" and "exclusions" to
 resolve ClassNotFoundExceptions. This file contains the following data:
 +
-[source, java]
+[source, xml]
 ----
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.0">
   <deployment>
@@ -876,49 +872,51 @@ resolve ClassNotFoundExceptions. This file contains the following data:
   </sub-deployment>
 </jboss-deployment-structure>
 ----
-* We copied the following JARs from the
+
+. We copied the following JARs from the
 `EAP5_HOME/jboss-eap-5.1/seam/lib/` directory to the
 `jboss-seam-booking.ear/lib/` directory to resolve
 ClassNotFoundExceptions:
 +
-[source, java]
+[source]
 ----
 hibernate-core.jar
 hibernate-validator.jar
 ----
-* We modified the \{\{jboss-seam-booking.jar/META-INF/persistence.xml}
+
+. We modified the \{\{jboss-seam-booking.jar/META-INF/persistence.xml}
 file as follows.
-1.  First, we changed the jta-data-source element to use the Example
+..  First, we changed the jta-data-source element to use the Example
 database that ships with AS7:
 +
-[source, java]
+[source, xml]
 ----
 <!-- <jta-data-source>java:/bookingDatasource</jta-data-source> -->
 <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
 ----
-2.  Next, we commented out the hibernate.cache.provider_class property:
+..  Next, we commented out the hibernate.cache.provider_class property:
 +
-[source, java]
+[source, xml]
 ----
 <!-- <property name="hibernate.cache.provider_class" value="org.hibernate.cache.HashtableCacheProvider"/> -->
 ----
-* We modified the WAR's lib/components.xml file to use the new JNDI
+. We modified the WAR's lib/components.xml file to use the new JNDI
 bindings
-1.  We replaced the <core:init> existing element as follows:
+..  We replaced the <core:init> existing element as follows:
 +
-[source, java]
+[source, xml]
 ----
 <!-- <core:init jndi-pattern="jboss-seam-booking/#{ejbName}/local" debug="true" distributable="false"/> -->
 <core:init jndi-pattern="java:app/jboss-seam-booking.jar/#{ejbName}" debug="true" distributable="false"/>
 ----
-2.  We added component elements for the "EjbSynchronizations" and
+..  We added component elements for the "EjbSynchronizations" and
 "TimerServiceDispatcher" JNDI bindings
 +
-[source, java]
+[source, xml]
 ----
- <component class="org.jboss.seam.transaction.EjbSynchronizations" jndi-name="java:app/jboss-seam/EjbSynchronizations"/>
- <component class="org.jboss.seam.async.TimerServiceDispatcher" jndi-name="java:app/jboss-seam/TimerServiceDispatcher"/>
+<component class="org.jboss.seam.transaction.EjbSynchronizations" jndi-name="java:app/jboss-seam/EjbSynchronizations"/>
+<component class="org.jboss.seam.async.TimerServiceDispatcher" jndi-name="java:app/jboss-seam/TimerServiceDispatcher"/>
 ----
-* The unmodified EAR from EAP 5.1 (jboss-seam-booking-eap51.ear.tar.gz)
+. The unmodified EAR from EAP 5.1 (jboss-seam-booking-eap51.ear.tar.gz)
 and the EAR as modified to run on AS7
 (jboss-seam-booking-as7.ear.tar.gz) are attached to this document.

--- a/docs/src/main/asciidoc/_developer-guide/Remote_EJB_invocations_via_JNDI_-_EJB_client_API_or_remote-naming_project.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/Remote_EJB_invocations_via_JNDI_-_EJB_client_API_or_remote-naming_project.adoc
@@ -297,7 +297,7 @@ client API project for doing EJB lookups ( <<EJB_invocations_from_a_remote_clien
 invocations from a remote client using JNDI>>) as against using
 remote-naming project for doing the same thing.
 
-[[summary]]
+[[summary-remote-ejb-invocations]]
 == Summary
 
 That pretty much covers whatever is important to know, in the

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/ActAs_WS-Trust_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/ActAs_WS-Trust_Scenario.adoc
@@ -98,7 +98,7 @@ service endpoint, targetNamespace, portType, binding name, and service.
 </definitions>
 ----
 
-[[web-service-interface]]
+[[web-service-interface-actas-ws-trust]]
 === Web Service Interface
 
 The web service provider interface class, ActAsServiceIface, is a simple
@@ -122,7 +122,7 @@ public interface ActAsServiceIface
 }
 ----
 
-[[web-service-implementation]]
+[[web-service-implementation-actas-ws-trust]]
 === Web Service Implementation
 
 The web service provider implementation class, ActAsServiceImpl, is a
@@ -228,7 +228,7 @@ public class ActAsServiceImpl implements ActAsServiceIface
 }
 ----
 
-[[actascallbackhandler]]
+[[actascallbackhandler-actas-ws-trust]]
 === ActAsCallbackHandler
 
 ActAsCallbackHandler is a callback handler for the WSS4J Crypto API. It
@@ -262,7 +262,7 @@ public class ActAsCallbackHandler extends PasswordCallbackHandler {
 }
 ----
 
-[[usernametokencallbackhandler]]
+[[usernametokencallbackhandler-actas-ws-trust]]
 === UsernameTokenCallbackHandler
 
 The ActAs and OnBeholdOf sub-elements of the RequestSecurityToken are
@@ -431,7 +431,7 @@ public class UsernameTokenCallbackHandler implements CallbackHandler {
 }
 ----
 
-[[crypto-properties-and-keystore-files]]
+[[crypto-properties-and-keystore-files-actas-ws-trust]]
 === Crypto properties and keystore files
 
 The ActAs service must provide its own credentials. The requisite
@@ -446,7 +446,7 @@ org.apache.ws.security.crypto.merlin.keystore.alias=myactaskey
 org.apache.ws.security.crypto.merlin.keystore.file=actasstore.jks
 ....
 
-[[manifest.mf]]
+[[manifest-mf-actas-ws-trust-actas-ws-trust]]
 === MANIFEST.MF
 
 When deployed on WildFly this application requires access to the JBossWs
@@ -462,7 +462,7 @@ Created-By: 1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client, org.apache.cxf.impl
 ....
 
-[[security-token-service]]
+[[security-token-service-actas-ws-trust]]
 == Security Token Service
 
 This section examines the STS elements from the basic WS-Trust scenario
@@ -472,7 +472,7 @@ components are.
 * STS's implementation class.
 * STSCallbackHandler class
 
-[[sts-implementation-class]]
+[[sts-implementation-class-actas-ws-trust]]
 === STS Implementation class
 
 The initial description of SampleSTS can be found
@@ -571,7 +571,7 @@ public class SampleSTS extends SecurityTokenServiceProvider
 }
 ----
 
-[[stscallbackhandler]]
+[[stscallbackhandler-actas-ws-trust]]
 === STSCallbackHandler
 
 The user, alice, and corresponding password was required to be added for
@@ -603,7 +603,7 @@ public class STSCallbackHandler extends PasswordCallbackHandler
 }
 ----
 
-[[web-service-requester]]
+[[web-service-requester-actas-ws-trust]]
 == Web service requester
 
 This section examines the ws-requester elements from the basic WS-Trust
@@ -612,7 +612,7 @@ example. The component is
 
 * ActAs web service requester implementation class
 
-[[web-service-requester-implementation]]
+[[web-service-requester-implementation-actas-ws-trust]]
 === Web service requester Implementation
 
 The ActAs ws-requester, the client, uses standard procedures for

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/OnBehalfOf_WS-Trust_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/OnBehalfOf_WS-Trust_Scenario.adoc
@@ -104,7 +104,7 @@ name, and service.
 </definitions>
 ----
 
-[[web-service-interface]]
+[[web-service-interface-onbehalfo-ws-trust]]
 === Web Service Interface
 
 The web service provider interface class, OnBehalfOfServiceIface, is a
@@ -128,7 +128,7 @@ public interface OnBehalfOfServiceIface
 }
 ----
 
-[[web-service-implementation]]
+[[web-service-implementation-onbehalfo-ws-trust]]
 === Web Service Implementation
 
 The web service provider implementation class, OnBehalfOfServiceImpl, is
@@ -243,7 +243,7 @@ public class OnBehalfOfServiceImpl implements OnBehalfOfServiceIface
 }
 ----
 
-[[onbehalfofcallbackhandler]]
+[[onbehalfofcallbackhandler-onbehalfo-ws-trust]]
 === OnBehalfOfCallbackHandler
 
 OnBehalfOfCallbackHandler is a callback handler for the WSS4J Crypto
@@ -280,7 +280,7 @@ public class OnBehalfOfCallbackHandler extends PasswordCallbackHandler {
 }
 ----
 
-[[web-service-requester]]
+[[web-service-requester-onbehalfo-ws-trust]]
 == Web service requester
 
 This section examines the ws-requester elements from the basic WS-Trust
@@ -289,7 +289,7 @@ example. The component is
 
 * OnBehalfOf web service requester implementation class
 
-[[web-service-requester-implementation]]
+[[web-service-requester-implementation-onbehalfo-ws-trust]]
 === Web service requester Implementation
 
 The OnBehalfOf ws-requester, the client, uses standard procedures for

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/Predefined_client_and_endpoint_configurations.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/Predefined_client_and_endpoint_configurations.adoc
@@ -204,7 +204,7 @@ is to add a dependency to the module containing the handler class in one
 of the modules which are already automatically set as dependencies to
 any deployment, for instance `org.jboss.ws.spi`.
 
-[[examples]]
+[[examples-predefined-endpoint]]
 ===== Examples
 
 .JBoss AS 7.2 default configurations

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/SAML_Bearer_Assertion_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/SAML_Bearer_Assertion_Scenario.adoc
@@ -236,7 +236,7 @@ security settings are provided in the comments in the listing below.
 </definitions>
 ----
 
-[[ssl-configuration]]
+[[ssl-configuration-saml-bearer]]
 === SSL configuration
 
 This web service is using https, therefore the JBoss server must be
@@ -264,7 +264,7 @@ Here is an example of an SSL connector declaration.
   ...
 ----
 
-[[web-service-interface]]
+[[web-service-interface-saml-bearer]]
 === Web service Interface
 
 The web service provider interface class, BearerIface, is a simple
@@ -288,7 +288,7 @@ public interface BearerIface
 }
 ----
 
-[[web-service-implementation]]
+[[web-service-implementation-saml-bearer]]
 === Web service Implementation
 
 The web service provider implementation class, BearerImpl, is a simple
@@ -346,7 +346,7 @@ public class BearerImpl implements BearerIface
 }
 ----
 
-[[crypto-properties-and-keystore-files]]
+[[crypto-properties-and-keystore-files-saml-bearer]]
 === Crypto properties and keystore files
 
 WSS4J's Crypto implementation is loaded and configured via a Java
@@ -368,7 +368,7 @@ org.apache.ws.security.crypto.merlin.keystore.alias=myservicekey
 org.apache.ws.security.crypto.merlin.keystore.file=servicestore.jks
 ....
 
-[[manifest.mf]]
+[[manifest-mf-saml-bearer]]
 === MANIFEST.MF
 
 When deployed on WildFly this application requires access to the JBossWs
@@ -376,13 +376,13 @@ and CXF APIs provided in module org.jboss.ws.cxf.jbossws-cxf-client. The
 dependency statement directs the server to provide them at deployment.
 
 ....
-Manifest-Version: 1.0  
-Ant-Version: Apache Ant 1.8.2  
-Created-By: 1.7.0_25-b15 (Oracle Corporation)  
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.8.2
+Created-By: 1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client
 ....
 
-[[bearer-security-token-service]]
+[[bearer-security-token-service-saml-bearer]]
 == Bearer Security Token Service
 
 This section examines the crucial elements in providing the Security
@@ -396,7 +396,7 @@ components that will be discussed are.
 * Crypto properties and keystore files
 * MANIFEST.MF
 
-[[security-domain]]
+[[security-domain-saml-bearer]]
 === Security Domain
 
 The STS requires a JBoss security domain be configured. The
@@ -430,28 +430,28 @@ jboss-web.xml
 
 [source,xml]
 ----
-<?xml version="1.0" encoding="UTF-8"?>  
-<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN" ">  
-<jboss-web>  
-  <security-domain>java:/jaas/JBossWS-trust-sts</security-domain>  
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN" ">
+<jboss-web>
+  <security-domain>java:/jaas/JBossWS-trust-sts</security-domain>
 </jboss-web>
 ----
 
 jbossws-users.properties
 
 ....
-# A sample users.properties file for use with the UsersRolesLoginModule  
+# A sample users.properties file for use with the UsersRolesLoginModule
 alice=clarinet
 ....
 
 jbossws-roles.properties
 
 ....
-# A sample roles.properties file for use with the UsersRolesLoginModule  
+# A sample roles.properties file for use with the UsersRolesLoginModule
 alice=friend
 ....
 
-[[stss-wsdl]]
+[[stss-wsdl-saml-bearer]]
 === STS's WSDL
 
 [source,xml]
@@ -859,7 +859,7 @@ alice=friend
 </wsdl:definitions>
 ----
 
-[[stss-implementation-class]]
+[[stss-implementation-class-saml-bearer]]
 === STS's implementation class
 
 The Apache CXF's STS, SecurityTokenServiceProvider, is a web service
@@ -985,7 +985,7 @@ public class SampleSTSBearer extends SecurityTokenServiceProvider
 }
 ----
 
-[[stsbearercallbackhandler]]
+[[stsbearercallbackhandler-saml-bearer]]
 === STSBearerCallbackHandler
 
 STSBearerCallbackHandler is a callback handler for the WSS4J Crypto API.
@@ -1019,7 +1019,7 @@ public class STSBearerCallbackHandler extends PasswordCallbackHandler
 }
 ----
 
-[[crypto-properties-and-keystore-files-1]]
+[[crypto-properties-and-keystore-files-saml-bearer-1]]
 === Crypto properties and keystore files
 
 WSS4J's Crypto implementation is loaded and configured via a Java
@@ -1034,13 +1034,13 @@ self signed certificates for myservicekey and mystskey. _Self signed
 certificates are not appropriate for production use._
 
 ....
-org.apache.ws.security.crypto.provider=org.apache.ws.security.components.crypto.Merlin  
+org.apache.ws.security.crypto.provider=org.apache.ws.security.components.crypto.Merlin
 org.apache.ws.security.crypto.merlin.keystore.type=jks
 org.apache.ws.security.crypto.merlin.keystore.password=stsspass
 org.apache.ws.security.crypto.merlin.keystore.file=stsstore.jks
 ....
 
-[[manifest.mf-1]]
+[[manifest-mf-saml-bearer-1]]
 === MANIFEST.MF
 
 When deployed on WildFly, this application requires access to the
@@ -1051,13 +1051,13 @@ configuration in the `SampleSTS` constructor. The dependency statement
 directs the server to provide them at deployment.
 
 ....
-Manifest-Version: 1.0  
-Ant-Version: Apache Ant 1.8.2  
-Created-By: 1.7.0_25-b15 (Oracle Corporation)  
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.8.2
+Created-By: 1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl
 ....
 
-[[web-service-requester]]
+[[web-service-requester-saml-bearer]]
 == Web service requester
 
 This section examines the crucial elements in calling a web service that
@@ -1068,7 +1068,7 @@ The components that will be discussed are.
 * ClientCallbackHandler
 * Crypto properties and keystore files
 
-[[web-service-requester-implementation]]
+[[web-service-requester-implementation-saml-bearer]]
 === Web service requester Implementation
 
 The ws-requester, the client, uses standard procedures for creating a
@@ -1127,7 +1127,7 @@ ActAs and OnBehalfOf examples.
   proxy.sayHello();
 ----
 
-[[clientcallbackhandler]]
+[[clientcallbackhandler-saml-bearer]]
 === ClientCallbackHandler
 
 https://docs.jboss.org/author/display/JBWS/WS-Trust+and+STS#WS-TrustandSTS-ClientCallbackHandler
@@ -1176,7 +1176,7 @@ public class ClientCallbackHandler implements CallbackHandler {
 }
 ----
 
-[[crypto-properties-and-keystore-files-2]]
+[[crypto-properties-and-keystore-files-saml-bearer-2]]
 === Crypto properties and keystore files
 
 https://docs.jboss.org/author/display/JBWS/WS-Trust+and+STS#WS-TrustandSTS-RequesterCryptopropertiesandkeystorefiles

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/SAML_Holder-Of-Key_Assertion_Scenario.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/SAML_Holder-Of-Key_Assertion_Scenario.adoc
@@ -239,7 +239,7 @@ security settings are provided in the comments in the listing below.
 </definitions>
 ----
 
-[[ssl-configuration]]
+[[ssl-configuration-saml-holder]]
 === SSL configuration
 
 https://docs.jboss.org/author/display/JBWS/WS-Trust+and+STS#WS-TrustandSTS-SSLconfiguration
@@ -268,7 +268,7 @@ Here is an example of an SSL connector declaration.
 ...
 ----
 
-[[web-service-interface]]
+[[web-service-interface-saml-holder]]
 === Web service Interface
 
 The web service provider interface class, HolderOfKeyIface, is a simple
@@ -291,7 +291,7 @@ public interface HolderOfKeyIface {
 }
 ----
 
-[[web-service-implementation]]
+[[web-service-implementation-saml-holder]]
 === Web service Implementation
 
 The web service provider implementation class, HolderOfKeyImpl, is a
@@ -352,7 +352,7 @@ public class HolderOfKeyImpl implements HolderOfKeyIface
 }
 ----
 
-[[crypto-properties-and-keystore-files]]
+[[crypto-properties-and-keystore-files-saml-holder]]
 === Crypto properties and keystore files
 
 WSS4J's Crypto implementation is loaded and configured via a Java
@@ -374,7 +374,7 @@ org.apache.ws.security.crypto.merlin.keystore.alias=myservicekey
 org.apache.ws.security.crypto.merlin.keystore.file=servicestore.jks
 ....
 
-[[manifest.mf]]
+[[manifest-mf-saml-holder]]
 === MANIFEST.MF
 
 https://docs.jboss.org/author/display/JBWS/WS-Trust+and+STS#WS-TrustandSTS-MANIFEST.MF
@@ -390,7 +390,7 @@ Created-By:1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client
 ....
 
-[[security-token-service]]
+[[security-token-service-saml-holder]]
 == Security Token Service
 
 This section examines the crucial elements in providing the Security
@@ -404,7 +404,7 @@ The components that will be discussed are.
 * Crypto properties and keystore files
 * MANIFEST.MF
 
-[[security-domain]]
+[[security-domain-saml-holder]]
 === Security Domain
 
 The STS requires a JBoss security domain be configured. The
@@ -469,7 +469,7 @@ jbossws-roles.properties
 alice=friend
 ....
 
-[[stss-wsdl]]
+[[stss-wsdl-saml-holder]]
 === STS's WSDL
 
 [source,xml]
@@ -809,7 +809,7 @@ alice=friend
 </wsdl:definitions>
 ----
 
-[[stss-implementation-class]]
+[[stss-implementation-class-saml-holder]]
 === STS's implementation class
 
 The Apache CXF's STS, SecurityTokenServiceProvider, is a web service
@@ -937,7 +937,7 @@ public class SampleSTSHolderOfKey extends SecurityTokenServiceProvider
 }
 ----
 
-[[holderofkeycallbackhandler]]
+[[holderofkeycallbackhandler-saml-holder]]
 === HolderOfKeyCallbackHandler
 
 STSHolderOfKeyCallbackHandler is a callback handler for the WSS4J Crypto
@@ -975,7 +975,7 @@ public class STSHolderOfKeyCallbackHandler extends PasswordCallbackHandler
 }
 ----
 
-[[crypto-properties-and-keystore-files-1]]
+[[crypto-properties-and-keystore-files-saml-holder-1]]
 === Crypto properties and keystore files
 
 WSS4J's Crypto implementation is loaded and configured via a Java
@@ -996,7 +996,7 @@ org.apache.ws.security.crypto.merlin.keystore.password=stsspass
 org.apache.ws.security.crypto.merlin.keystore.file=stsstore.jks
 ....
 
-[[manifest.mf-1]]
+[[manifest-mf-saml-holder-1]]
 === MANIFEST.MF
 
 When deployed on WildFly, this application requires access to the
@@ -1013,7 +1013,7 @@ Created-By:1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl
 ....
 
-[[web-service-requester]]
+[[web-service-requester-saml-holder]]
 == Web service requester
 
 This section examines the crucial elements in calling a web service that
@@ -1024,7 +1024,7 @@ scenario. The components that will be discussed are.
 * ClientCallbackHandler
 * Crypto properties and keystore files
 
-[[web-service-requester-implementation]]
+[[web-service-requester-implementation-saml-holder]]
 === Web service requester Implementation
 
 The ws-requester, the client, uses standard procedures for creating a
@@ -1084,7 +1084,7 @@ ctx.put(SecurityConstants.STS_TOKEN_USE_CERT_FOR_KEYINFO + ".it", "true");
 proxy.sayHello();
 ----
 
-[[clientcallbackhandler]]
+[[clientcallbackhandler-saml-holder]]
 === ClientCallbackHandler
 
 ClientCallbackHandler is a callback handler for the WSS4J Crypto API. It
@@ -1131,7 +1131,7 @@ public class ClientCallbackHandler implements CallbackHandler {
 }
 ----
 
-[[crypto-properties-and-keystore-files-2]]
+[[crypto-properties-and-keystore-files-saml-holder-2]]
 === Crypto properties and keystore files
 
 WSS4J's Crypto implementation is loaded and configured via a Java

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/SOAP_over_JMS.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/SOAP_over_JMS.adoc
@@ -73,7 +73,7 @@ The endpoint classes can be deployed as part of _jar_ or _war_ archives.
 The _web.xml_ descriptor in _war_ archives doesn't need any entry for
 JMS endpoints.
 
-[[examples]]
+[[examples-soap-over-jms]]
 == Examples
 
 [[jms-endpoint-only-deployment]]

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Addressing.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Addressing.adoc
@@ -62,13 +62,13 @@ Similarly, on client side users do not need to manually specify the
 able to properly process the WS-Addressing policy in the consumed WSDL
 and turn on addressing as requested.
 
-[[example]]
+[[example-ws-addressing]]
 == Example
 
 Here is an example showing how to simply enable WS-Addressing through
 WS-Policy.
 
-[[endpoint]]
+[[endpoint-ws-addressing]]
 === Endpoint
 
 A simple JAX-WS endpoint is prepared using a java-first approach;
@@ -139,7 +139,7 @@ like this:
 </wsdl:definitions>
 ----
 
-[[client]]
+[[client-addressing]]
 === Client
 
 Since the WS-Policy engine is on by default, the client side code is

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Reliable_Messaging.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Reliable_Messaging.adoc
@@ -31,13 +31,13 @@ are available in the
 http://cxf.apache.org/docs/wsrmconfiguration.html[Apache CXF
 documentation].
 
-[[example]]
+[[example-ws-reliable-messaging]]
 == Example
 
 In this example we configure WS-Reliable Messaging endpoint and client
 through the WS-Policy support.
 
-[[endpoint]]
+[[endpoint-ws-reliable-messaging]]
 === Endpoint
 
 We go with a contract-first approach, so we start by creating a proper
@@ -174,7 +174,7 @@ web.xml the usual way and deploy to the application server. The
 webservices stack automatically detects the policies and enables
 WS-Reliable Messaging.
 
-[[client]]
+[[client-ws-reliable-messaging]]
 === Client
 
 The endpoint advertises his RM capabilities (and requirements) through

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Security.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Security.adoc
@@ -250,7 +250,7 @@ public class ServiceImpl implements ServiceIface {
 }
 ----
 
-[[examples]]
+[[examples-ws-security]]
 == Examples
 
 In this section some sample of WS-Security service endpoints and clients
@@ -268,7 +268,7 @@ requirements and choosing the most suitable security policy for them.
 [[signature-and-encryption]]
 === Signature and encryption
 
-[[endpoint]]
+[[endpoint-ws-security]]
 ==== Endpoint
 
 First of all you need to create the web service endpoint using JAX-WS.
@@ -579,7 +579,7 @@ Created-By: 17.0-b16 (Sun Microsystems Inc.)
 Dependencies: org.apache.ws.security
 ....
 
-[[client]]
+[[client-ws-security]]
 ==== Client
 
 You start by consuming the published WSDL contract using the _wsconsume_
@@ -672,7 +672,7 @@ So, here follows an example of WS-SecurityPolicy endpoint using Username
 Token Profile for authenticating through the application server security
 domain system.
 
-[[endpoint-1]]
+[[endpoint-ws-security-1]]
 ==== Endpoint
 
 As in the other example, we start with a wsdl contract containing the
@@ -963,7 +963,7 @@ Created-By: 17.0-b16 (Sun Microsystems Inc.)
 Dependencies: org.apache.ws.security,org.apache.cxf
 ....
 
-[[client-1]]
+[[client-ws-security-1]]
 ==== Client
 
 Here too you start by consuming the published WSDL contract using the

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Trust_and_STS.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Trust_and_STS.adoc
@@ -194,7 +194,7 @@ listing below.
       <soap:address location="http://@jboss.bind.address@:8080/jaxws-samples-wsse-policy-trust/SecurityService"/>
     </port>
   </service>
- 
+
   <wsp:Policy wsu:Id="AsymmetricSAML2Policy">
         <wsp:ExactlyOne>
             <wsp:All>
@@ -202,7 +202,7 @@ listing below.
         The wsam:Addressing element, indicates that the endpoints of this
         web service MUST conform to the WS-Addressing specification.  The
         attribute wsp:Optional="false" enforces this assertion.
-  -->               
+  -->
                 <wsam:Addressing wsp:Optional="false">
                     <wsp:Policy />
                 </wsam:Addressing>
@@ -213,13 +213,13 @@ listing below.
         the message and the recipient's public key is used to encrypt the message.
         The recipient of the message will use it's private key to decrypt it and
         initiator's public key to verify the signature.
-  -->              
+  -->
                 <sp:AsymmetricBinding>
                     <wsp:Policy>
   <!--
         The sp:InitiatorToken element specifies the elements required in
         generating the initiator request to the ws-provider's service.
-  -->                              
+  -->
                         <sp:InitiatorToken>
                             <wsp:Policy>
   <!--
@@ -228,7 +228,7 @@ listing below.
         sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
         attribute instructs the runtime to include the initiator's public key
         with every message sent to the recipient.
-        
+
         The sp:RequestSecurityTokenTemplate element directs that all of the
         children of this element will be copied directly into the body of the
         RequestSecurityToken (RST) message that is sent to the STS when the
@@ -246,7 +246,7 @@ listing below.
   <!--
         The sp:Issuer element defines the STS's address and endpoint information
         This information is used by the STSClient.
-  -->                                   
+  -->
                                     <sp:Issuer>
                                         <wsaws:Address>http://@jboss.bind.address@:8080/jaxws-samples-wsse-policy-trust-sts/SecurityTokenService</wsaws:Address>
                                         <wsaws:Metadata xmlns:wsdli="http://www.w3.org/2006/01/wsdl-instance"
@@ -264,11 +264,11 @@ listing below.
         expected from the recipient.  The
         sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never">
         attribute indicates that the initiator's public key will never be included
-        in the reply messages.  
+        in the reply messages.
  
         The sp:WssX509V3Token10 element indicates that an X509 Version 3 token
         should be used in the message.
-  -->                       
+  -->
                         <sp:RecipientToken>
                             <wsp:Policy>
                                 <sp:X509Token
@@ -285,7 +285,7 @@ listing below.
      items to the security header.  The sp:Lax sub-element indicates items
      are added to the security header in any order that conforms to
      WSS: SOAP Message Security.
--->                       
+-->
                         <sp:Layout>
                             <wsp:Policy>
                                 <sp:Lax />
@@ -296,7 +296,7 @@ listing below.
  <!--
      The sp:AlgorithmSuite element, requires the Basic256 algorithm suite
      be used in performing cryptographic operations.
--->                      
+-->
                         <sp:AlgorithmSuite>
                             <wsp:Policy>
                                 <sp:Basic256 />
@@ -309,7 +309,7 @@ listing below.
     to be supported by the STS.  These particular elements generally refer
     to how keys are referenced within the SOAP envelope.  These are normally
     handled by CXF.
--->               
+-->
                 <sp:Wss11>
                     <wsp:Policy>
                         <sp:MustSupportRefIssuerSerial />
@@ -318,11 +318,11 @@ listing below.
                     </wsp:Policy>
                 </sp:Wss11>
 <!--
-    The sp:Trust13 element declares controls for WS-Trust 1.3 options.  
+    The sp:Trust13 element declares controls for WS-Trust 1.3 options.
     They are policy assertions related to exchanges specifically with
     client and server challenges and entropy behaviors.  Again these are
     normally handled by CXF.
--->               
+-->
                 <sp:Trust13>
                     <wsp:Policy>
                         <sp:MustSupportIssuedTokens />
@@ -333,7 +333,7 @@ listing below.
             </wsp:All>
         </wsp:ExactlyOne>
     </wsp:Policy>
-    
+
     <wsp:Policy wsu:Id="Input_Policy">
         <wsp:ExactlyOne>
             <wsp:All>
@@ -353,7 +353,7 @@ listing below.
             </wsp:All>
         </wsp:ExactlyOne>
     </wsp:Policy>
-    
+
     <wsp:Policy wsu:Id="Output_Policy">
         <wsp:ExactlyOne>
             <wsp:All>
@@ -524,7 +524,7 @@ org.apache.ws.security.crypto.merlin.keystore.alias=myservicekey
 org.apache.ws.security.crypto.merlin.keystore.file=servicestore.jks
 ....
 
-[[manifest.mf]]
+[[manifest-mf-ws-trust]]
 ==== MANIFEST.MF
 
 When deployed on WildFly this application requires access to the JBossWs
@@ -532,9 +532,9 @@ and CXF APIs provided in module org.jboss.ws.cxf.jbossws-cxf-client. The
 dependency statement directs the server to provide them at deployment.
 
 ....
-Manifest-Version: 1.0  
-Ant-Version: Apache Ant 1.8.2  
-Created-By: 1.7.0_25-b15 (Oracle Corporation)  
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.8.2
+Created-By: 1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client
 ....
 
@@ -645,7 +645,7 @@ listing below.
     WS_Trust specification.  The wsdl:portType defines the endpoints
     supported in the STS implementation.  This WSDL defines all operations
     that an STS implementation can support.
--->      
+-->
   <wsdl:portType name="STS">
     <wsdl:operation name="Cancel">
       <wsdl:input wsam:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Cancel" message="tns:RequestSecurityTokenMsg"/>
@@ -758,13 +758,13 @@ listing below.
           </wsdl:output>
       </wsdl:operation>
   </wsdl:binding>
- 
+
   <wsdl:service name="SecurityTokenService">
       <wsdl:port name="UT_Port" binding="tns:UT_Binding">
          <soap:address location="http://localhost:8080/SecurityTokenService/UT" />
       </wsdl:port>
   </wsdl:service>
- 
+
   <wsp:Policy wsu:Id="UT_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -772,13 +772,13 @@ listing below.
     The sp:UsingAddressing element, indicates that the endpoints of this
     web service conforms to the WS-Addressing specification.  More detail
     can be found here: [http://www.w3.org/TR/2006/CR-ws-addr-wsdl-20060529]
--->  
+-->
             <wsap10:UsingAddressing/>
 <!--
     The sp:SymmetricBinding element indicates that security is provided
     at the SOAP layer and any initiator must authenticate itself by providing
     WSS UsernameToken credentials.
--->            
+-->
             <sp:SymmetricBinding
                xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
                <wsp:Policy>
@@ -794,7 +794,7 @@ listing below.
     sub-element declares that the Username token presented by the initiator
     should be compliant with Web Services Security UsernameToken Profile
     1.0 specification. [ http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0.pdf ]
--->                      
+-->
                   <sp:ProtectionToken>
                      <wsp:Policy>
                         <sp:X509Token
@@ -810,7 +810,7 @@ listing below.
 <!--
     The sp:AlgorithmSuite element, requires the Basic256 algorithm suite
     be used in performing cryptographic operations.
--->                  
+-->
                   <sp:AlgorithmSuite>
                      <wsp:Policy>
                         <sp:Basic256 />
@@ -821,7 +821,7 @@ listing below.
     items to the security header.  The sp:Lax sub-element indicates items
     are added to the security header in any order that conforms to
     WSS: SOAP Message Security.
--->                 
+-->
                   <sp:Layout>
                      <wsp:Policy>
                         <sp:Lax />
@@ -834,15 +834,15 @@ listing below.
             </sp:SymmetricBinding>
 <!--
     The sp:SignedSupportingTokens element declares that the security header
-    of messages must contain a sp:UsernameToken and the token must be signed.  
+    of messages must contain a sp:UsernameToken and the token must be signed.
     The attribute IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient"
     on sp:UsernameToken indicates that the token MUST be included in all
     messages sent from initiator to the recipient and that the token MUST
-    NOT be included in messages sent from the recipient to the initiator.  
+    NOT be included in messages sent from the recipient to the initiator.
     And finally the element sp:WssUsernameToken10 is a policy assertion
     indicating the Username token should be as defined in  Web Services
     Security UsernameToken Profile 1.0
--->            
+-->
             <sp:SignedSupportingTokens
                xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
                <wsp:Policy>
@@ -859,7 +859,7 @@ listing below.
     to be supported by the STS.  These particular elements generally refer
     to how keys are referenced within the SOAP envelope.  These are normally
     handled by CXF.
--->            
+-->
             <sp:Wss11
                xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
                <wsp:Policy>
@@ -870,11 +870,11 @@ listing below.
                </wsp:Policy>
             </sp:Wss11>
 <!--
-    The sp:Trust13 element declares controls for WS-Trust 1.3 options.  
+    The sp:Trust13 element declares controls for WS-Trust 1.3 options.
     They are policy assertions related to exchanges specifically with
     client and server challenges and entropy behaviors.  Again these are
     normally handled by CXF.
--->            
+-->
             <sp:Trust13
                xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
                <wsp:Policy>
@@ -886,7 +886,7 @@ listing below.
          </wsp:All>
       </wsp:ExactlyOne>
    </wsp:Policy>
-   
+
    <wsp:Policy wsu:Id="Input_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -915,7 +915,7 @@ listing below.
          </wsp:All>
       </wsp:ExactlyOne>
    </wsp:Policy>
-   
+
    <wsp:Policy wsu:Id="Output_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -1017,13 +1017,13 @@ http://coheigea.blogspot.it/2011/10/apache-cxf-sts-documentation-part-iv.html[he
 [source, java]
 ----
 package org.jboss.test.ws.jaxws.samples.wsse.policy.trust;
- 
+
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
- 
+
 import javax.xml.ws.WebServiceProvider;
- 
+
 import org.apache.cxf.annotations.EndpointProperties;
 import org.apache.cxf.annotations.EndpointProperty;
 import org.apache.cxf.interceptor.InInterceptors;
@@ -1035,7 +1035,7 @@ import org.apache.cxf.sts.service.StaticService;
 import org.apache.cxf.sts.token.provider.SAMLTokenProvider;
 import org.apache.cxf.sts.token.validator.SAMLTokenValidator;
 import org.apache.cxf.ws.security.sts.provider.SecurityTokenServiceProvider;
- 
+
 @WebServiceProvider(serviceName = "SecurityTokenService",
       portName = "UT_Port",
       targetNamespace = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/",
@@ -1046,7 +1046,7 @@ import org.apache.cxf.ws.security.sts.provider.SecurityTokenServiceProvider;
       @EndpointProperty(key = "ws-security.callback-handler", value = "org.jboss.test.ws.jaxws.samples.wsse.policy.trust.STSCallbackHandler"),
       //to let the JAAS integration deal with validation through the interceptor below
       @EndpointProperty(key = "ws-security.validate.token", value = "false")
-        
+
 })
 @InInterceptors(interceptors = {"org.jboss.wsf.stack.cxf.security.authentication.SubjectCreatingPolicyInterceptor"})
 public class SampleSTS extends SecurityTokenServiceProvider
@@ -1054,13 +1054,13 @@ public class SampleSTS extends SecurityTokenServiceProvider
    public SampleSTS() throws Exception
    {
       super();
- 
+
       StaticSTSProperties props = new StaticSTSProperties();
       props.setSignaturePropertiesFile("stsKeystore.properties");
       props.setSignatureUsername("mystskey");
       props.setCallbackHandlerClass(STSCallbackHandler.class.getName());
       props.setIssuer("DoubleItSTSIssuer");
- 
+
       List<ServiceMBean> services = new LinkedList<ServiceMBean>();
       StaticService service = new StaticService();
       service.setEndpoints(Arrays.asList(
@@ -1069,16 +1069,16 @@ public class SampleSTS extends SecurityTokenServiceProvider
               "http://\\[0:0:0:0:0:0:0:1\\]:(\\d)*/jaxws-samples-wsse-policy-trust/SecurityService"
               ));
       services.add(service);
- 
+
       TokenIssueOperation issueOperation = new TokenIssueOperation();
       issueOperation.setServices(services);
       issueOperation.getTokenProviders().add(new SAMLTokenProvider());
       issueOperation.setStsProperties(props);
- 
+
       TokenValidateOperation validateOperation = new TokenValidateOperation();
       validateOperation.getTokenValidators().add(new SAMLTokenValidator());
       validateOperation.setStsProperties(props);
- 
+
       this.setIssueOperation(issueOperation);
       this.setValidateOperation(validateOperation);
    }
@@ -1133,13 +1133,13 @@ self signed certificates for myservicekey and mystskey. _Self signed
 certificates are not appropriate for production use._
 
 ....
-org.apache.ws.security.crypto.provider=org.apache.ws.security.components.crypto.Merlin  
+org.apache.ws.security.crypto.provider=org.apache.ws.security.components.crypto.Merlin
 org.apache.ws.security.crypto.merlin.keystore.type=jks
 org.apache.ws.security.crypto.merlin.keystore.password=stsspass
 org.apache.ws.security.crypto.merlin.keystore.file=stsstore.jks
 ....
 
-[[manifest.mf-1]]
+[[manifest-mf-ws-trust-1]]
 ==== MANIFEST.MF
 
 When deployed on WildFly, this application requires access to the
@@ -1150,13 +1150,13 @@ configuration in the `SampleSTS` constructor. The dependency statement
 directs the server to provide them at deployment.
 
 ....
-Manifest-Version: 1.0  
-Ant-Version: Apache Ant 1.8.2  
-Created-By: 1.7.0_25-b15 (Oracle Corporation)  
+Manifest-Version: 1.0
+Ant-Version: Apache Ant 1.8.2
+Created-By: 1.7.0_25-b15 (Oracle Corporation)
 Dependencies: org.jboss.ws.cxf.jbossws-cxf-client,org.apache.cxf.impl
 ....
 
-[[security-domain]]
+[[security-domain-ws-trust]]
 ==== Security Domain
 
 The STS requires a JBoss security domain be configured. The
@@ -1190,24 +1190,24 @@ jboss-web.xml
 
 [source,xml]
 ----
-<?xml version="1.0" encoding="UTF-8"?>  
-<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN" ">  
-<jboss-web>  
-  <security-domain>java:/jaas/JBossWS-trust-sts</security-domain>  
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE jboss-web PUBLIC "-//JBoss//DTD Web Application 2.4//EN" ">
+<jboss-web>
+  <security-domain>java:/jaas/JBossWS-trust-sts</security-domain>
 </jboss-web>
 ----
 
 jbossws-users.properties
 
 ....
-# A sample users.properties file for use with the UsersRolesLoginModule  
+# A sample users.properties file for use with the UsersRolesLoginModule
 alice=clarinet
 ....
 
 jbossws-roles.properties
 
 ....
-# A sample roles.properties file for use with the UsersRolesLoginModule  
+# A sample roles.properties file for use with the UsersRolesLoginModule
 alice=friend
 ....
 
@@ -1274,46 +1274,46 @@ not have the ".it" suffix.
 
 [source, java]
 ----
-QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy", "SecurityService");  
-URL wsdlURL = new URL(serviceURL + "?wsdl");  
-Service service = Service.create(wsdlURL, serviceName);  
-ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);  
- 
-// set the security related configuration information for the service "request"  
-Map<String, Object> ctx = ((BindingProvider) proxy).getRequestContext();  
-ctx.put(SecurityConstants.CALLBACK_HANDLER, new ClientCallbackHandler());  
+QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wssecuritypolicy", "SecurityService");
+URL wsdlURL = new URL(serviceURL + "?wsdl");
+Service service = Service.create(wsdlURL, serviceName);
+ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);
+
+// set the security related configuration information for the service "request"
+Map<String, Object> ctx = ((BindingProvider) proxy).getRequestContext();
+ctx.put(SecurityConstants.CALLBACK_HANDLER, new ClientCallbackHandler());
 ctx.put(SecurityConstants.SIGNATURE_PROPERTIES,
    Thread.currentThread().getContextClassLoader().getResource(
-   "META-INF/clientKeystore.properties"));  
+   "META-INF/clientKeystore.properties"));
 ctx.put(SecurityConstants.ENCRYPT_PROPERTIES,
    Thread.currentThread().getContextClassLoader().getResource(
-   "META-INF/clientKeystore.properties"));  
-ctx.put(SecurityConstants.SIGNATURE_USERNAME, "myclientkey");  
-ctx.put(SecurityConstants.ENCRYPT_USERNAME, "myservicekey");  
- 
- 
-//-- Configuration settings that will be transfered to the STSClient  
-// "alice" is the name provided for the WSS Username. Her password will  
-// be retreived from the ClientCallbackHander by the STSClient.  
-ctx.put(SecurityConstants.USERNAME + ".it", "alice");  
-ctx.put(SecurityConstants.CALLBACK_HANDLER + ".it", new ClientCallbackHandler());  
+   "META-INF/clientKeystore.properties"));
+ctx.put(SecurityConstants.SIGNATURE_USERNAME, "myclientkey");
+ctx.put(SecurityConstants.ENCRYPT_USERNAME, "myservicekey");
+
+
+//-- Configuration settings that will be transfered to the STSClient
+// "alice" is the name provided for the WSS Username. Her password will
+// be retreived from the ClientCallbackHander by the STSClient.
+ctx.put(SecurityConstants.USERNAME + ".it", "alice");
+ctx.put(SecurityConstants.CALLBACK_HANDLER + ".it", new ClientCallbackHandler());
 ctx.put(SecurityConstants.ENCRYPT_PROPERTIES + ".it",
    Thread.currentThread().getContextClassLoader().getResource(
-   "META-INF/clientKeystore.properties"));  
-ctx.put(SecurityConstants.ENCRYPT_USERNAME + ".it", "mystskey");  
-// alias name in the keystore to get the user's public key to send to the STS  
-ctx.put(SecurityConstants.STS_TOKEN_USERNAME + ".it", "myclientkey");  
-// Crypto property configuration to use for the STS  
+   "META-INF/clientKeystore.properties"));
+ctx.put(SecurityConstants.ENCRYPT_USERNAME + ".it", "mystskey");
+// alias name in the keystore to get the user's public key to send to the STS
+ctx.put(SecurityConstants.STS_TOKEN_USERNAME + ".it", "myclientkey");
+// Crypto property configuration to use for the STS
 ctx.put(SecurityConstants.STS_TOKEN_PROPERTIES + ".it",
    Thread.currentThread().getContextClassLoader().getResource(
-   "META-INF/clientKeystore.properties"));  
-// write out an X509Certificate structure in UseKey/KeyInfo  
-ctx.put(SecurityConstants.STS_TOKEN_USE_CERT_FOR_KEYINFO + ".it", "true");  
-// Setting indicates the  STSclient should not try using the WS-MetadataExchange  
-// call using STS EPR WSA address when the endpoint contract does not contain  
-// WS-MetadataExchange info.  
-ctx.put("ws-security.sts.disable-wsmex-call-using-epr-address", "true");  
-   
+   "META-INF/clientKeystore.properties"));
+// write out an X509Certificate structure in UseKey/KeyInfo
+ctx.put(SecurityConstants.STS_TOKEN_USE_CERT_FOR_KEYINFO + ".it", "true");
+// Setting indicates the  STSclient should not try using the WS-MetadataExchange
+// call using STS EPR WSA address when the endpoint contract does not contain
+// WS-MetadataExchange info.
+ctx.put("ws-security.sts.disable-wsmex-call-using-epr-address", "true");
+
 proxy.sayHello();
 ----
 
@@ -1330,31 +1330,31 @@ jbossws-users.properties.
 
 [source, java]
 ----
-package org.jboss.test.ws.jaxws.samples.wsse.policy.trust.shared;  
- 
-import java.io.IOException;  
-import javax.security.auth.callback.Callback;  
-import javax.security.auth.callback.CallbackHandler;  
-import javax.security.auth.callback.UnsupportedCallbackException;  
-import org.apache.ws.security.WSPasswordCallback;  
- 
-public class ClientCallbackHandler implements CallbackHandler {  
- 
-    public void handle(Callback[] callbacks) throws IOException,  
-            UnsupportedCallbackException {  
-        for (int i = 0; i < callbacks.length; i++) {  
-            if (callbacks[i] instanceof WSPasswordCallback) {  
-                WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];  
-                if ("myclientkey".equals(pc.getIdentifier())) {  
-                    pc.setPassword("ckpass");  
-                    break;  
-                } else if ("alice".equals(pc.getIdentifier())) {  
-                    pc.setPassword("clarinet");  
-                    break;  
-                }  
-            }  
-        }  
-    }  
+package org.jboss.test.ws.jaxws.samples.wsse.policy.trust.shared;
+
+import java.io.IOException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import org.apache.ws.security.WSPasswordCallback;
+
+public class ClientCallbackHandler implements CallbackHandler {
+
+    public void handle(Callback[] callbacks) throws IOException,
+            UnsupportedCallbackException {
+        for (int i = 0; i < callbacks.length; i++) {
+            if (callbacks[i] instanceof WSPasswordCallback) {
+                WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
+                if ("myclientkey".equals(pc.getIdentifier())) {
+                    pc.setPassword("ckpass");
+                    break;
+                } else if ("alice".equals(pc.getIdentifier())) {
+                    pc.setPassword("clarinet");
+                    break;
+                }
+            }
+        }
+    }
 }
 ----
 
@@ -1467,7 +1467,7 @@ such must match the `PicketLinkSTS` implementation:
       </xs:complexType>
     </xs:schema>
   </wsdl:types>
- 
+
   <wsdl:message name="RequestSecurityTokenMsg">
     <wsdl:part name="request" element="wst:RequestSecurityToken" />
   </wsdl:message>
@@ -1475,7 +1475,7 @@ such must match the `PicketLinkSTS` implementation:
     <wsdl:part name="responseCollection"
             element="wst:RequestSecurityTokenResponseCollection"/>
   </wsdl:message>
- 
+
   <wsdl:portType name="SecureTokenService">
     <wsdl:operation name="IssueToken">
       <wsdl:input wsap10:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" message="tns:RequestSecurityTokenMsg"/>
@@ -1502,7 +1502,7 @@ such must match the `PicketLinkSTS` implementation:
       <soap12:address location="http://localhost:8080/picketlink-sts/PicketLinkSTS"/>
     </wsdl:port>
   </wsdl:service>
- 
+
   <wsp:Policy wsu:Id="UT_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -1568,7 +1568,7 @@ such must match the `PicketLinkSTS` implementation:
          </wsp:All>
       </wsp:ExactlyOne>
    </wsp:Policy>
- 
+
    <wsp:Policy wsu:Id="Input_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -1597,7 +1597,7 @@ such must match the `PicketLinkSTS` implementation:
          </wsp:All>
       </wsp:ExactlyOne>
    </wsp:Policy>
- 
+
    <wsp:Policy wsu:Id="Output_policy">
       <wsp:ExactlyOne>
          <wsp:All>
@@ -1626,7 +1626,7 @@ such must match the `PicketLinkSTS` implementation:
          </wsp:All>
       </wsp:ExactlyOne>
    </wsp:Policy>
- 
+
 </wsdl:definitions>
 ----
 

--- a/docs/src/main/asciidoc/_developer-guide/wsconsume.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/wsconsume.adoc
@@ -40,7 +40,7 @@ will need to manually add the wsdlLocation to the @WebService annotation
 on your web service implementation and not the service endpoint
 interface.
 
-[[examples]]
+[[examples-wsconsume]]
 === Examples
 
 Generate artifacts in Java class form only:
@@ -73,7 +73,7 @@ Generate source and class files using multiple binding files:
 wsconsume -k -b wsdl-binding.xml -b schema1-binding.xml -b schema2-binding.xml
 ....
 
-[[maven-plugin]]
+[[maven-plugin-wsconsume]]
 == Maven Plugin
 
 The wsconsume tools is included in the
@@ -131,7 +131,7 @@ etc.Example<argLine>-Djava.endorsed.dirs=...</argLine> |none
 the underlying stack and endorsed dirs if any
 |=======================================================================
 
-[[examples-1]]
+[[examples-wsconsume-1]]
 === Examples
 
 You can use _wsconsume_ in your own project build simply referencing the
@@ -258,7 +258,7 @@ _JBossWS_ stack dependency to avoid that.
 Up to version 1.1.2.Final, the _artifactId_ of the plugin was
 *maven-jaxws-tools-plugin*.
 
-[[ant-task]]
+[[ant-task-wsconsume]]
 == Ant Task
 
 The _wsconsume_ Ant task ( _org.jboss.ws.tools.ant.WSConsumeTask_) has
@@ -323,7 +323,7 @@ Also, the following nested elements are supported:
 |jvmarg |Allows setting of custom jvm arguments | 
 |=================================================
 
-[[examples-2]]
+[[examples-wsconsume-2]]
 === Examples
 
 Generate JAX-WS source and classes in a separate JVM with separate

--- a/docs/src/main/asciidoc/_developer-guide/wsprovide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/wsprovide.adoc
@@ -6,7 +6,7 @@ generates portable JAX-WS artifacts for a service endpoint
 implementation. It also has the option to "provide" the abstract
 contract for offline usage.
 
-[[command-line-tool]]
+[[command-line-tool-wsprovide]]
 == Command Line Tool
 
 The command line tool has the following usage:
@@ -27,7 +27,7 @@ options:
   -t, --show-traces           Show full exception stack traces
 ....
 
-[[examples]]
+[[examples-wsprovide]]
 === Examples
 
 Generating wrapper classes for portable artifacts in the "generated"
@@ -49,7 +49,7 @@ Using an endpoint that references other jars
 wsprovide -o generated -c application1.jar:application2.jar foo.Endpoint
 ....
 
-[[maven-plugin]]
+[[maven-plugin-wsprovide]]
 == Maven Plugin
 
 The _wsprovide_ tools is included in the
@@ -90,7 +90,7 @@ be added to classpath
 |endpointClass |Service Endpoint Implementation. | 
 |=======================================================================
 
-[[examples-1]]
+[[examples-wsprovide-1]]
 === Examples
 
 You can use _wsprovide_ in your own project build simply referencing the
@@ -183,7 +183,7 @@ _JBossWS_ stack dependency to avoid that.
 Up to version 1.1.2.Final, the _artifactId_ of the plugin was
 *maven-jaxws-tools-plugin*.
 
-[[ant-task]]
+[[ant-task-wsprovide]]
 == Ant Task
 
 The wsprovide ant task ( _org.jboss.ws.tools.ant.WSProvideTask_) has the
@@ -219,7 +219,7 @@ following attributes:
 implementation. |"."
 |=======================================================================
 
-[[examples-2]]
+[[examples-wsprovide-2]]
 === Examples
 
 Executing wsprovide in verbose mode with separate output directories for

--- a/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
+++ b/docs/src/main/asciidoc/_extras/Getting_Started_Developing_Applications_Presentation_Demo.adoc
@@ -44,66 +44,67 @@ demonstrate the various ways you can deploy apps to JBoss AS 7.
 [[using-maven]]
 === Using Maven
 
-1.  Start JBoss AS 7 from the console
+. Start JBoss AS 7 from the console
 +
-[source, java]
+[source]
 ----
-$JBOSS_HOME/bin/standalone.sh
+$ JBOSS_HOME/bin/standalone.sh
 ----
 
-* Deploy the app using Maven
+. Deploy the app using Maven
 +
-[source, java]
+[source]
 ----
-mvn clean package jboss-as:deploy
+$ mvn clean package jboss-as:deploy
 ----
-
++
 [IMPORTANT]
-
+====
 The quickstarts use the jboss-as maven plugin to deploy and undeploy
 applications. This plugin uses the JBoss AS Native Java Detyped
 Management API to communicate with the server. The Detyped API is used
 by management tools to control an entire domain of servers, and exposes
 only a small number of types, allowing for backwards and forwards
 compatibility.
+====
 
-Show the app has deployed in the terminal
-
+. Show the app has deployed in the terminal.
++
 Visit http://localhost:8080/jboss-as-helloworld
 
-Undeploy the app using Maven
-
-[source, java]
+. Undeploy the app using Maven
++
+[source]
 ----
-mvn jboss-as:undeploy
+$ mvn jboss-as:undeploy
 ----
 
 [[using-the-command-line-interface-cli]]
 === Using the Command Line Interface (CLI)
 
-1.  Start JBoss AS 7 from the console (if not already running)
+.  Start JBoss AS 7 from the console (if not already running)
 +
-[source, java]
+[source]
 ----
-$JBOSS_HOME/bin/standalone.sh
-----
-
-Build the war
-
-[source, java]
-----
-mvn clean package
+$ JBOSS_HOME/bin/standalone.sh
 ----
 
-Start the CLI
-
-[source, java]
+. Build the war
++
+[source]
 ----
-$JBOSS_HOME/bin/jboss-admin.sh --connect
+$ mvn clean package
 ----
 
+. Start the CLI
++
+[source]
+----
+$ JBOSS_HOME/bin/jboss-admin.sh --connect
+----
++
 [IMPORTANT]
-
++
 The command line also uses the Deptyped Management API to communicate
 with the server. It's designed to be as "unixy" as possible, allowing
 you to "cd" into nodes, with full tab completion etc. The CLI allows you
@@ -111,109 +112,113 @@ to deploy and undeploy applications, create JMS queues, topics etc.,
 create datasources (normal and XA). It also fully supports the domain
 node.
 
-Deploy the app
+. Deploy the app
++
+[source]
+----
+$ deploy target/jboss-as-helloworld.war
+----
 
+. Show the app has deployed
++
 [source, java]
 ----
-deploy target/jboss-as-helloworld.war
-----
-
-Show the app has deployed
-
-[source, java]
-----
-undeploy jboss-as-helloworld.war
+$ undeploy jboss-as-helloworld.war
 ----
 
 [[using-the-web-management-interface]]
 === Using the web management interface
 
-1.  Start JBoss AS 7 from the console (if not already running)
+.  Start JBoss AS 7 from the console (if not already running)
 +
-[source, java]
+[source]
 ----
-$JBOSS_HOME/bin/standalone.sh
-----
-
-Build the war
-
-[source, java]
-----
-mvn clean package
+$ JBOSS_HOME/bin/standalone.sh
 ----
 
-Open up the web management interface http://localhost:9990/console
+. Build the war
++
+[source]
+----
+$ mvn clean package
+----
 
+. Open up the web management interface http://localhost:9990/console
++
 [IMPORTANT]
-
-The web maangement interface offers the same functionality as the CLI
+====
+The web management interface offers the same functionality as the CLI
 (and again uses the Detyped Management API), but does so using a pretty
 GWT interface! You can set up virtual servers, interrogate sub systems
 and more.
+====
 
-Navigate `Manage Deployments -> Add content`. Click on choose file and
+. Navigate `Manage Deployments -> Add content`. Click on choose file and
 locate `helloworld/target/jboss-as-helloworld.war`.
 
-Click `Next` and `Finish` to upload the war to the server.
+. Click `Next` and `Finish` to upload the war to the server.
 
-Now click `Enable` and `Ok` to start the application
+. Now click `Enable` and `Ok` to start the application
 
-Switch to the console to show it deployed
+. Switch to the console to show it deployed
 
-Now click `Remove`
+. Now click `Remove`
 
 [[using-the-filesystem]]
 === Using the filesystem
 
-1.  Start JBoss AS 7 from the console (if not already running)
+.  Start JBoss AS 7 from the console (if not already running)
 +
-[source, java]
+[source]
 ----
-$JBOSS_HOME/bin/standalone.sh
-----
-
-Build the war
-
-[source, java]
-----
-mvn clean package
+$ JBOSS_HOME/bin/standalone.sh
 ----
 
+. Build the war
++
+[source]
+----
+$ mvn clean package
+----
++
 [IMPORTANT]
-
+====
 Of course, you can still use the good ol' file system to deploy. Just
 copy the file to `$JBOSS_HOME/standalone/deployments`.
+====
 
-Copy the war
-
-[source, java]
+. Copy the war
++
+[source]
 ----
-cp target/jboss-as-helloworld.war $JBOSS_HOME/standalone/deployments
+$ cp target/jboss-as-helloworld.war $JBOSS_HOME/standalone/deployments
 ----
 
-Show the war deployed
-
+. Show the war deployed
++
 [IMPORTANT]
-
+====
 The filesystem deployment uses marker files to indicate the status of a
 deployment. As this deployment succeeded we get a
 `$JBOSS_HOME/standalone/deployments/jboss-as-helloworld.war.deployed`
 file. If the deployment failed, you would get a `.failed` file etc.
+====
 
-Undeploy the war
-
-[source, java]
+. Undeploy the war
++
+[source]
 ----
 rm $JBOSS_HOME/standalone/deployments/jboss-as-helloworld.war.deployed
 ----
 
-Show the deployment stopping!
+. Show the deployment stopping!
 
-Start and stop the appserver, show that the deployment really is gone!
-
+. Start and stop the app server, show that the deployment really is gone!
++
 [IMPORTANT]
-
+====
 This gives you much more precise control over deployments than before
+====
 
 [[using-eclipse]]
 === Using Eclipse
@@ -236,14 +241,14 @@ This gives you much more precise control over deployments than before
 [[digging-into-the-app]]
 === Digging into the app
 
-1.  Open up the helloworld quickstart in Eclipse, and open up
+.  Open up the helloworld quickstart in Eclipse, and open up
 `src/main/webapp`.
-2.  Point out that we don't require a `web.xml` anymore!
-3.  Show `beans.xml` and explain it's a marker file used to JBoss AS to
+.  Point out that we don't require a `web.xml` anymore!
+.  Show `beans.xml` and explain it's a marker file used to JBoss AS to
 enable CDI (open it, show that it is empty)
-4.  Show `index.html`, and explain it is just used to kick the user into
+.  Show `index.html`, and explain it is just used to kick the user into
 the app (open it, show the meta-refresh)
-5.  Open up the `pom.xm` - and emphasise that it's pretty simple.
+.  Open up the `pom.xm` - and emphasise that it's pretty simple.
 ..  There is no parent pom, everything for the build is *here*
 ..  Show that we are enabling the JBoss Maven repo - explain you can do
 this in your POM or in system wide ( `settings.xml`)
@@ -259,7 +264,7 @@ not packaging this stuff!
 ..  Show the plugin sections - nothing that exciting here, the war
 plugin is out of date and requires you to provide `web.xml` icon:smile-o[role="yellow"]
 , configure the JBoss AS Maven Plugin, set the Java version to 6.
-6.  Open up `src/main/java` and open up the `HelloWorldServlet`.
+.  Open up `src/main/java` and open up the `HelloWorldServlet`.
 ..  Point out the `@WebServlet` - explain this one annotation removes
 about 8 lines of XML - no need to separately map a path either. This is
 much more refactor safe
@@ -305,12 +310,12 @@ Emphasize the lack of them!
 
 No need to open any of them, just point them out
 
-1.  `web.xml` - don't need it!
-2.  `beans.xml` - as before, marker file
-3.  `faces-config.xml` - nice feature from AS7 - we can just put
+.  `web.xml` - don't need it!
+.  `beans.xml` - as before, marker file
+.  `faces-config.xml` - nice feature from AS7 - we can just put
 `faces-config.xml` into the WEB-INF and it enables JSF (inspiration from
 CDI)
-4.  `pom.xml` we saw this before, this time it's the same but adds in
+.  `pom.xml` we saw this before, this time it's the same but adds in
 JSF API
 
 [[views]]
@@ -376,14 +381,14 @@ how to use EJB for declarative TX control.
 [[run-the-app-1]]
 === Run the app
 
-1.  Start JBoss AS in Eclipse
-2.  Deploy it using Eclipse - just right click on the app, choose
+.  Start JBoss AS in Eclipse
+.  Deploy it using Eclipse - just right click on the app, choose
 `Run As -> Run On Server`
-3.  Select the AS 7 instance you want to use
-4.  Hit finish
-5.  Load the app at http://localhost:8080/jboss-as-login
-6.  Login as admin/admin
-7.  Create a new user
+.  Select the AS 7 instance you want to use
+.  Hit finish
+.  Load the app at http://localhost:8080/jboss-as-login
+.  Login as admin/admin
+.  Create a new user
 
 [[deployment-descriptors]]
 === Deployment Descriptors
@@ -484,15 +489,15 @@ Validation as well. We add in Arquillian for testing.
 [[run-the-app-2]]
 === Run the app
 
-1.  Start JBoss AS in Eclipse
-2.  Deploy it using Eclipse - just right click on the app, choose
+.  Start JBoss AS in Eclipse
+.  Deploy it using Eclipse - just right click on the app, choose
 `Run As -> Run On Server`
-3.  Select the AS 7 instance you want to use
-4.  Hit finish
-5.  Load the app at http://localhost:8080/jboss-as-kitchensink
-6.  Register a member - make sure to enter an invalid email and phone -
+.  Select the AS 7 instance you want to use
+.  Hit finish
+.  Load the app at http://localhost:8080/jboss-as-kitchensink
+.  Register a member - make sure to enter an invalid email and phone -
 show bean validation at work
-7.  Click on the member URL and show the output from JAX-RS
+.  Click on the member URL and show the output from JAX-RS
 
 [[bean-validation]]
 === Bean Validation
@@ -520,35 +525,36 @@ layer and in your views
 ..  `@GET` methods are auto transformed to XML using JAXB
 .  And that is it!
 
-[[arquillian]]
+[[arquillian-getting-started]]
 === Arquillian
 
-1.  Make sure JBoss AS is running
-2.  [source, bash]
+.  Make sure JBoss AS is running
++
+[source]
 ----
 mvn clean test -Parq-jbossas-remote
 ----
 
-1.  Explain the difference between managed and remote
+.  Explain the difference between managed and remote
 
-Make sure JBoss AS is stopped
-
-[source, bash]
+. Make sure JBoss AS is stopped
++
+[source]
 ----
 mvn clean test -Parq-jbossas-managed
 ----
 
-Start JBoss AS in Eclipse
+. Start JBoss AS in Eclipse
 
-Update the project to use the `arq-jbossas-remote` profile
+. Update the project to use the `arq-jbossas-remote` profile
 
-Run the test from Eclipse
-
-1.  Right click on test, `Run As -> JUnit Test`
-
+. Run the test from Eclipse
++
+Right click on test, `Run As -> JUnit Test`
++
 `MemberRegistrationTest.java`
 
-1.  Discuss micro deployments
-2.  Explain Arquilian allows you to use injection
-3.  Explain that Arquillian allows you to concentrate just on your test
+.  Discuss micro deployments
+.  Explain Arquilian allows you to use injection
+.  Explain that Arquillian allows you to concentrate just on your test
 logic

--- a/docs/src/main/asciidoc/_high-availability/Clustering_API.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_API.adoc
@@ -24,7 +24,7 @@ The Group service provides the following capabilities:
 WildFly creates a Group instance for every defined channel defined in the JGroups subsystem, as well as a local implementation.
 The local Group implementation is effectively a singleton membership containing only the current node.
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/group/ee") // A Group representing the cluster of the "ee" channel
 private Group group;
@@ -40,7 +40,7 @@ Most users should use the "default" alias, which references either:
 * A non-clustered Group, if the JGroups subsystem is not present
 
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/group/default")
 private Group group;
@@ -54,7 +54,7 @@ Additionally, WildFly creates a Group alias for every Infinispan cache-container
 This is useful when using a Group within the context of an Infinispan cache.
 
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/group/server") // Backed by the transport of the "server" cache-container
 private Group group;
@@ -97,7 +97,7 @@ isSingleton():: Indicates whether the groups membership is non-clustered, i.e. w
 
 A distributed "Hello world" example that prints joiners and leavers of a group membership:
 
-[code,java]
+[source,java]
 ----
 public class MyGroupListener implements GroupListener {
     @Resource(lookup = "java:jboss/clustering/group/default") // <1>
@@ -142,7 +142,7 @@ A command dispatcher is a mechanism for dispatching commands to be executed on m
 
 A command dispatcher is created from a CommandDispatcherFactory, an instance of which is created for every defined channel defined in the JGroups subsystem, as well as a local implementation.
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/dispatcher/ee") // A command dispatcher factory backed by the "ee" channel
 private CommandDispatcherFactory factory;
@@ -158,7 +158,7 @@ Most users should use the "default" alias, which references either:
 * A non-clustered CommandDispatcherFactory, if the JGroups subsystem is not present
 
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/dispatcher/default")
 private CommandDispatcherFactory factory;
@@ -172,7 +172,7 @@ Additionally, WildFly creates a CommandDispatcherFactory alias for every Infinis
 This is useful in the case where a CommandDispatcher is used to communicate with members on which a given cache is deployed.
 
 e.g.
-[code,java]
+[source,java]
 ----
 @Resource(lookup = "java:jboss/clustering/dispatcher/server") // Backed by the transport of the "server" cache-container
 private CommandDispatcherFactory factory;
@@ -214,7 +214,7 @@ To demonstrate how to use a CommandDispatcher, let's create a distributed "hello
 
 First, let's create a simple HelloWorld interface which enables the caller to send a specific message to the entire group:
 
-[code,java]
+[source,java]
 ----
 public interface HelloWorld {
     void send(String message);
@@ -225,7 +225,7 @@ Next, we need to define a local command execution context.
 This should encapsulate any local information we need to make available to the execution of any command received by our CommandDispatcher.
 For demonstration purposes, let's make this a separate interface:
 
-[code,java]
+[source,java]
 ----
 public interface LocalContext {
     Node getLocalMember();
@@ -234,7 +234,7 @@ public interface LocalContext {
 
 Next we create a "hello world" Command that contains a message from the sender, and responds with a message of its own.
 
-[code,java]
+[source,java]
 ----
 public class HelloWorldCommand implements Command<String, LocalContext> {
     private final String message;
@@ -253,7 +253,7 @@ public class HelloWorldCommand implements Command<String, LocalContext> {
 
 Finally, we create a @Singleton EJB that implements our HelloWorld interface:
 
-[code,java]
+[source,java]
 ----
 @Singleton
 @Startup

--- a/docs/src/main/asciidoc/_high-availability/ha-singleton/Singleton_deployments.adoc
+++ b/docs/src/main/asciidoc/_high-availability/ha-singleton/Singleton_deployments.adoc
@@ -11,7 +11,7 @@ a.k.a. "
 https://docs.jboss.org/jbossclustering/cluster_guide/5.1/html/deployment.chapt.html#d0e1220[deploy-hasingleton]",
 feature of AS6 and earlier.
 
-[[usage]]
+[[usage-singleton-deployments]]
 == Usage
 
 A deployment indicates that it should be deployed as a singleton via a

--- a/docs/src/main/asciidoc/_javaee-guide/Java_API_for_RESTful_Web_Services_(JAX-RS).adoc
+++ b/docs/src/main/asciidoc/_javaee-guide/Java_API_for_RESTful_Web_Services_(JAX-RS).adoc
@@ -1,8 +1,9 @@
-[[Java_API_for_RESTful_Web_Services_(JAX-RS)]]
+[[Java_API_for_RESTful_Web_Services_JAX-RS]]
 = Java API for RESTful Web Services (JAX-RS)
+
 ifdef::env-github[:imagesdir: ../]
 
-[[content]]
+[[content-java-api-restful-web-services]]
 == Content
 
 [[tutorial-overview]]

--- a/docs/src/main/asciidoc/_javaee-guide/Java_Servlet_Technology.adoc
+++ b/docs/src/main/asciidoc/_javaee-guide/Java_Servlet_Technology.adoc
@@ -7,7 +7,7 @@ Coming Soon
 
 This guide is still under development, check back soon!
 
-[[content]]
+[[content-java-servlet-technology]]
 == Content
 
 [[asynchronous-support]]

--- a/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
+++ b/docs/src/main/asciidoc/_testsuite/WildFly_Integration_Testsuite_User_Guide.adoc
@@ -444,7 +444,7 @@ properties. Whole set is included in all server startup parameters.
 
 Example:
 
-[source, java]
+[source]
 ----
 ./integration-tests.sh clean install -Dintegration.module -DallTests \
 \"-Dsecurity.manager.other=-Djava.security.manager \
@@ -491,7 +491,7 @@ done using `jacoco:report` Ant task in `maven-ant-plugin` since JaCoCo's
 maven report goal doesn't support getting classes outside
 target/classes.
 
-[[usage]]
+[[usage-integration-testsuite]]
 ==== Usage
 
 [source, bash]
@@ -523,7 +523,7 @@ To have most stable build process, it should start with:
 
 To use , you may use these commands:
 
-[source, java]
+[source]
 ----
 mvn clean install -DskipTests -DallTests  ## ...to clean all testsuite modules.
 mvn dependency:purge-local-repository build-helper:remove-project-artifact -Dbuildhelper.removeAll


### PR DESCRIPTION
When you run 'mvn clean install' from the 'docs/' folder, the build is now clean with no errors or warnings.

You might want to review this with the '-w' switch to ignore white space changes.

Let me know if I need to create a JIRA for this one.
