### PR TITLE
[WFLY-11547] Inconsistency in JCA Subsystem xsd, boundedqueque is use…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -202,10 +202,10 @@ public class JcaExtension implements Extension {
 
                     for (Property prop : workManager.asPropertyList()) {
                         if (WORKMANAGER_LONG_RUNNING.equals(prop.getName()) && prop.getValue().isDefined() && prop.getValue().asPropertyList().size() != 0) {
-                            ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, prop.getValue().asProperty(), Element.LONG_RUNNING_THREADS.getLocalName(), false);
+                            ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, prop.getValue().asProperty(), Element.LONG_RUNNING_THREADS.getLocalName(), false, true);
                         }
                         if (WORKMANAGER_SHORT_RUNNING.equals(prop.getName()) && prop.getValue().isDefined() && prop.getValue().asPropertyList().size() != 0) {
-                            ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, prop.getValue().asProperty(), Element.SHORT_RUNNING_THREADS.getLocalName(), false);
+                            ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, prop.getValue().asProperty(), Element.SHORT_RUNNING_THREADS.getLocalName(), false, true);
                         }
 
                         if ((JcaDistributedWorkManagerDefinition.DWmParameters.POLICY.getAttribute().getName().equals(prop.getName()) && prop.getValue().isDefined()) ||
@@ -268,10 +268,10 @@ public class JcaExtension implements Extension {
                     JcaWorkManagerDefinition.WmParameters.ELYTRON_ENABLED.getAttribute().marshallAsElement(workManager, writer);
 
                     if (workManager.hasDefined(WORKMANAGER_SHORT_RUNNING))  {
-                        ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, workManager.get(WORKMANAGER_SHORT_RUNNING).asProperty(), Element.SHORT_RUNNING_THREADS.getLocalName(), false);
+                        ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, workManager.get(WORKMANAGER_SHORT_RUNNING).asProperty(), Element.SHORT_RUNNING_THREADS.getLocalName(), false, true);
                     }
                     if (workManager.hasDefined(WORKMANAGER_LONG_RUNNING)) {
-                        ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, workManager.get(WORKMANAGER_LONG_RUNNING).asProperty(), Element.LONG_RUNNING_THREADS.getLocalName(), false);
+                        ThreadsParser.getInstance().writeBoundedQueueThreadPool(writer, workManager.get(WORKMANAGER_LONG_RUNNING).asProperty(), Element.LONG_RUNNING_THREADS.getLocalName(), false, true);
                     }
                     writer.writeEndElement();
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
@@ -89,7 +89,7 @@ public class JcaWorkManagerDefinition extends SimpleResourceDefinition {
     }
 
     static void registerSubModels(ManagementResourceRegistration resourceRegistration, boolean runtimeOnly) {
-        final BoundedQueueThreadPoolAdd shortRunningThreadPoolAdd = new BoundedQueueThreadPoolAdd(false,
+        final BoundedQueueThreadPoolAdd shortRunningThreadPoolAdd = new BoundedQueueThreadPoolAdd(true,
                 ThreadsServices.STANDARD_THREAD_FACTORY_RESOLVER, ThreadsServices.STANDARD_HANDOFF_EXECUTOR_RESOLVER,
                 ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING)) {
             @Override
@@ -104,10 +104,10 @@ public class JcaWorkManagerDefinition extends SimpleResourceDefinition {
             }
         };
         resourceRegistration.registerSubModel(
-                new JCAThreadPoolResourceDefinition(false, runtimeOnly, WORKMANAGER_SHORT_RUNNING, ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING),
-                        CommonAttributes.BOUNDED_QUEUE_THREAD_POOL, shortRunningThreadPoolAdd, ReloadRequiredRemoveStepHandler.INSTANCE));
+                new JCAThreadPoolResourceDefinition(true, runtimeOnly, WORKMANAGER_SHORT_RUNNING, ThreadsServices.EXECUTOR.append(WORKMANAGER_SHORT_RUNNING),
+                        CommonAttributes.BLOCKING_BOUNDED_QUEUE_THREAD_POOL, shortRunningThreadPoolAdd, ReloadRequiredRemoveStepHandler.INSTANCE));
 
-        final BoundedQueueThreadPoolAdd longRunningThreadPoolAdd = new BoundedQueueThreadPoolAdd(false,
+        final BoundedQueueThreadPoolAdd longRunningThreadPoolAdd = new BoundedQueueThreadPoolAdd(true,
                 ThreadsServices.STANDARD_THREAD_FACTORY_RESOLVER, ThreadsServices.STANDARD_HANDOFF_EXECUTOR_RESOLVER,
                 ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING)) {
             @Override
@@ -122,8 +122,8 @@ public class JcaWorkManagerDefinition extends SimpleResourceDefinition {
             }
         };
         resourceRegistration.registerSubModel(
-                new JCAThreadPoolResourceDefinition(false, runtimeOnly, WORKMANAGER_LONG_RUNNING, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING),
-                        CommonAttributes.BOUNDED_QUEUE_THREAD_POOL, longRunningThreadPoolAdd, new BoundedQueueThreadPoolRemove(longRunningThreadPoolAdd)));
+                new JCAThreadPoolResourceDefinition(true, runtimeOnly, WORKMANAGER_LONG_RUNNING, ThreadsServices.EXECUTOR.append(WORKMANAGER_LONG_RUNNING),
+                        CommonAttributes.BLOCKING_BOUNDED_QUEUE_THREAD_POOL, longRunningThreadPoolAdd, new BoundedQueueThreadPoolRemove(longRunningThreadPoolAdd)));
 
     }
 


### PR DESCRIPTION
…d for worker threads

Issue: https://issues.jboss.org/browse/WFLY-11547
Description: The JCA XSD states that a blocking-bounded-queue is being used for the long and short running threads, the CLI shows the description of a bounded-queue instead.
