### PR TITLE
[WFLY-11361] - fix LookupTest to work with secmgr

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/remotelookup/LookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/remotelookup/LookupTestCase.java
@@ -22,7 +22,10 @@
 
 package org.jboss.as.test.integration.ee.remotelookup;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertNotNull;
+
+import java.net.SocketPermission;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -35,6 +38,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -54,6 +58,9 @@ public class LookupTestCase {
     public static Archive<?> deployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "deploy.jar");
         jar.addClass(StatelessBean.class);
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                    new SocketPermission(TestSuiteEnvironment.getHttpAddress() + ":" + TestSuiteEnvironment.getHttpPort(), "resolve")
+                ), "permissions.xml");
         return jar;
     }
 
@@ -78,6 +85,7 @@ public class LookupTestCase {
     private void lookupConnectionFactory(Context context, String name) throws Exception {
         ConnectionFactory cf = (ConnectionFactory) context.lookup(name);
         assertNotNull(cf);
+        //"java.net.SocketPermission" "localhost" "resolve"
         Connection conn = cf.createConnection("guest", "guest");
         conn.close();
     }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11361