### PR TITLE
[WFLY-11555] Only restore the old policy if this service did initialise the policy.

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityBootstrapService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityBootstrapService.java
@@ -182,7 +182,7 @@ public class SecurityBootstrapService implements Service<Void> {
         handlerKeys.remove(SecurityConstants.SUBJECT_CONTEXT_KEY);
 
         // Install the policy provider that existed on startup
-        if (jaccPolicy != null)
+        if (initializeJacc && jaccPolicy != null)
             Policy.setPolicy(oldPolicy);
     }
 


### PR DESCRIPTION
The following issue meant that if JACC initialisation was toggled between reloads when running with a SecurityManager the global Policy could be inadvertently cleared breaking all further permission checks: -

https://issues.jboss.org/browse/WFLY-11555

