### PR TITLE
[WFLY-11347]: Tests from org.jboss.as.test.integration.messaging fails with security manager.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notClosingInjectedContext/NotClosingInjectedContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notClosingInjectedContext/NotClosingInjectedContextTestCase.java
@@ -64,6 +64,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import static org.jboss.as.test.shared.TimeoutUtil.adjust;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.BeforeClass;
+
 /**
  * Test for issue https://issues.jboss.org/browse/WFLY-10531 (based on reproducer created by Gunter Zeilinger <gunterze@gmail.com>.
  *
@@ -79,9 +82,6 @@ public class NotClosingInjectedContextTestCase {
 
     private static final PathAddress LOG_FILE_ADDRESS = PathAddress.pathAddress()
             .append(SUBSYSTEM, "logging");
-
-    private static final PathAddress SEEVER_LOG_FILE_ADDRESS = LOG_FILE_ADDRESS
-            .append("log-file", "server.log");
 
     @Resource(mappedName = "java:/JmsXA")
     private ConnectionFactory factory;
@@ -105,6 +105,12 @@ public class NotClosingInjectedContextTestCase {
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller\n"), "MANIFEST.MF");
 
         return archive;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        /* https://issues.jboss.org/browse/WFLY-11561 is tracking this */
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @After

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceDefinitionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/JMSResourceDefinitionsTestCase.java
@@ -35,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 import static org.jboss.shrinkwrap.api.ArchivePaths.create;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 
 import javax.ejb.EJB;
 import javax.jms.JMSException;
@@ -46,6 +47,7 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.test.integration.security.common.VaultHandler;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -141,6 +143,8 @@ public class JMSResourceDefinitionsTestCase {
                 .addPackage(MessagingBean.class.getPackage())
                 .addAsManifestResource(
                         MessagingBean.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
                         create("beans.xml"));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
@@ -186,6 +188,8 @@ public class ExternalMessagingDeploymentRemoteTestCase {
         return create(WebArchive.class, "ClientMessagingDeploymentTestCase.war")
                 .addClass(MessagingServlet.class)
                 .addClasses(QueueMDB.class, TopicMDB.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentTestCase.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +42,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
@@ -149,6 +151,8 @@ public class ExternalMessagingDeploymentTestCase {
         return create(WebArchive.class, "ClientMessagingDeploymentTestCase.war")
                 .addClass(MessagingServlet.class)
                 .addClasses(QueueMDB.class, TopicMDB.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSQueueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSQueueTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.messaging.jms.external;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 import javax.annotation.Resource;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -41,10 +42,12 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
+import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -138,6 +141,10 @@ public class SendToExternalJMSQueueTestCase {
         return ShrinkWrap.create(JavaArchive.class, "test.jar")
                 .addPackage(JMSOperations.class.getPackage())
                 .addClass(SendToExternalJMSQueueTestCase.SetupTask.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        RemotingPermission.CREATE_ENDPOINT,
+                        RemotingPermission.CONNECT,
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
                         ArchivePaths.create("beans.xml"));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSTopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSTopicTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.messaging.jms.external;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 import javax.annotation.Resource;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -41,10 +42,12 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
+import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -136,6 +139,10 @@ public class SendToExternalJMSTopicTestCase {
         return ShrinkWrap.create(JavaArchive.class, "test.jar")
                 .addPackage(JMSOperations.class.getPackage())
                 .addClass(SendToExternalJMSTopicTestCase.SetupTask.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        RemotingPermission.CREATE_ENDPOINT,
+                        RemotingPermission.CONNECT,
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
                         ArchivePaths.create("beans.xml"));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalPooledConnectionFactoryStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalPooledConnectionFactoryStatisticsTestCase.java
@@ -29,6 +29,7 @@ import static org.jboss.shrinkwrap.api.ArchivePaths.create;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.net.SocketPermission;
 
 import javax.naming.Context;
 
@@ -41,6 +42,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
@@ -118,6 +120,8 @@ public class ExternalPooledConnectionFactoryStatisticsTestCase {
         return ShrinkWrap.create(JavaArchive.class, "PooledConnectionFactoryStatisticsTestCase.jar")
                 .addClass(ConnectionHoldingBean.class)
                 .addClass(RemoteConnectionHolding.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsManifestResource(EmptyAsset.INSTANCE, create("beans.xml"));
     }
 


### PR DESCRIPTION
* Fixing the failing tests except NotClosingInjectedContextTestCase.
* Creating https://issues.jboss.org/browse/WFLY-11561 to track the fact
that NotClosingInjectedContextTestCase is not fixed.

2nd commit:
 * Fixing NotClosingInjectedContextTestCase

Jira: https://issues.jboss.org/browse/WFLY-11347
        https://issues.jboss.org/browse/WFLY-11561