### PR TITLE
[WFLY-10995] Upgrade Netty from 4.1.25.Final to 4.1.29.Final.

### DIFF
--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>jcip-annotations</artifactId>
         </dependency>
         <dependency>
+            <!-- This is only required for the InfinispanExtension to initialize Netty's InternalLoggerFactory -->
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
         </dependency>

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -23,6 +23,8 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.EnumSet;
 
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.JdkLoggerFactory;
 import org.jboss.as.clustering.controller.ContextualSubsystemRegistration;
 import org.jboss.as.clustering.controller.descriptions.SubsystemResourceDescriptionResolver;
 import org.jboss.as.controller.Extension;
@@ -46,6 +48,8 @@ public class InfinispanExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
+        // Initialize the Netty logger factory
+        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
         SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, InfinispanModel.CURRENT.getVersion());
 
         new InfinispanSubsystemResourceDefinition().register(new ContextualSubsystemRegistration(registration, context));

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -38,6 +38,8 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>
+        <!-- The io.netty module is only require to initialize Netty's InternalLoggingFactory -->
+        <module name="io.netty"/>
         <module name="io.reactivex.rxjava2.rxjava"/>
         <module name="net.jcip"/>
         <module name="org.infinispan" services="import"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -56,6 +56,8 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_S
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SHARED_STORE_SLAVE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SLAVE;
 
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.JdkLoggerFactory;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
@@ -206,6 +208,8 @@ public class MessagingExtension implements Extension {
 
     @Override
     public void initialize(ExtensionContext context) {
+        // Initialize the Netty logger factory
+        InternalLoggerFactory.setDefaultFactory(JdkLoggerFactory.INSTANCE);
         final SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
         subsystemRegistration.registerXMLElementWriter(CURRENT_PARSER);
 

--- a/pom.xml
+++ b/pom.xml
@@ -238,7 +238,7 @@
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
         <version.io.jaegertracing>0.30.6</version.io.jaegertracing>
-        <version.io.netty>4.1.25.Final</version.io.netty>
+        <version.io.netty>4.1.29.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.1.0</version.io.opentracing.concurrent>
         <version.io.opentracing.jaxrs2>0.1.7</version.io.opentracing.jaxrs2>


### PR DESCRIPTION
There was also a required change to explicitly set the InternalLoggerFactory to avoid a class loading warning logged.

JIRA: https://issues.jboss.org/browse/WFLY-10995