### PR TITLE
[WFLY-11349] Ignore clustering tests that fail when the security mana…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -12,9 +12,11 @@ import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetriev
 import org.jboss.as.test.clustering.cluster.provider.bean.ServiceProviderRetrieverBean;
 import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -38,6 +40,12 @@ public class ServiceProviderRegistrationTestCase extends AbstractClusteringTestC
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
         ejbJar.addPackage(ServiceProviderRetriever.class.getPackage());
         return ejbJar;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @Test

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ConcurrentFineWebFailoverTestCase.java
@@ -28,9 +28,11 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 
 /**
  * @author Radoslav Husar
@@ -61,6 +63,12 @@ public class ConcurrentFineWebFailoverTestCase extends AbstractWebFailoverTestCa
     @TargetsContainer(NODE_3)
     public static Archive<?> deployment3() {
         return createDeployment();
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     private static Archive<?> createDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/FineWebFailoverTestCase.java
@@ -27,9 +27,11 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 
 /**
  * @author Radoslav Husar
@@ -59,6 +61,12 @@ public class FineWebFailoverTestCase extends AbstractWebFailoverTestCase {
     @TargetsContainer(NODE_3)
     public static Archive<?> deployment3() {
         return createDeployment();
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     private static Archive<?> createDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
@@ -42,10 +42,12 @@ import org.jboss.as.test.clustering.cluster.web.DistributableTestCase;
 import org.jboss.as.test.clustering.cluster.web.async.servlet.AsyncServlet;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -78,6 +80,12 @@ public class AsyncServletTestCase extends AbstractClusteringTestCase {
         war.setWebXML(SimpleServlet.class.getPackage(), "web.xml");
         war.addAsWebInfResource(DistributableTestCase.class.getPackage(), "jboss-web_fine.xml", "jboss-web.xml");
         return war;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @Test

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/FineSessionExpirationTestCase.java
@@ -24,8 +24,10 @@ package org.jboss.as.test.clustering.cluster.web.expiration;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
@@ -43,6 +45,12 @@ public class FineSessionExpirationTestCase extends SessionExpirationTestCase {
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     static WebArchive getDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/FineSessionPassivationTestCase.java
@@ -24,8 +24,10 @@ package org.jboss.as.test.clustering.cluster.web.passivation;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
@@ -43,6 +45,12 @@ public class FineSessionPassivationTestCase extends SessionPassivationTestCase {
     @TargetsContainer(NODE_2)
     public static Archive<?> deployment1() {
         return getDeployment();
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     static WebArchive getDeployment() {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/xsite/XSiteSimpleTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.clustering.CLIServerSetupTask;
 import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
 import org.jboss.as.test.http.util.TestHttpClientUtils;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -118,6 +119,8 @@ public class XSiteSimpleTestCase extends AbstractClusteringTestCase {
 
     @BeforeClass
     public static void beforeClass() {
+        // TODO  this should be removed when WFLY-11539 (Infinispan upgrade) is merged
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Assume.assumeFalse("Disable on Windows+IPv6 until CI environment is fixed", Util.checkForWindows() && (Util.getIpStackType() == StackType.IPv6));
             return null;


### PR DESCRIPTION
…ger is enabled. Once Infinispan is upgraded these can be reenabled. See WFLY-11539.

https://issues.jboss.org/browse/WFLY-11349

This does not fix the tests. An Infinispan upgrade will be needed. This just ignores tests that don't work with the security manager enabled.