### PR TITLE
Finish ignoring for fixing tests when the security manager is enabled

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate2LCacheStatsTestCase.java
@@ -37,6 +37,7 @@ import org.hibernate.stat.Statistics;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -87,6 +88,8 @@ public class Hibernate2LCacheStatsTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/Hibernate4NativeAPIProviderTestCase.java
@@ -30,6 +30,7 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -76,6 +77,8 @@ public class Hibernate4NativeAPIProviderTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/HibernateNativeAPITransactionTestCase.java
@@ -30,6 +30,7 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -76,6 +77,8 @@ public class HibernateNativeAPITransactionTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/envers/Hibernate4NativeAPIEnversTestCase.java
@@ -30,6 +30,7 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -75,6 +76,8 @@ public class Hibernate4NativeAPIEnversTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/naturalid/HibernateNativeAPINaturalIdTestCase.java
@@ -31,6 +31,7 @@ import javax.naming.NamingException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -90,6 +91,8 @@ public class HibernateNativeAPINaturalIdTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/secondlevelcache/HibernateSecondLevelCacheTestCase.java
@@ -33,6 +33,7 @@ import javax.sql.DataSource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -81,6 +82,8 @@ public class HibernateSecondLevelCacheTestCase {
 
     @BeforeClass
     public static void beforeClass() throws NamingException {
+        // TODO This can be re-looked at once HHH-13188 is resolved. This may require further changes in Hibernate.
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         iniCtx = new InitialContext();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/classfiletransformertest/ClassFileTransformerTestCase.java
@@ -34,9 +34,11 @@ import org.jboss.as.test.integration.jpa.hibernate.Employee;
 import org.jboss.as.test.integration.jpa.hibernate.SFSB1;
 import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSession;
 import org.jboss.as.test.integration.jpa.hibernate.SFSBHibernateSessionFactory;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -63,6 +65,12 @@ public class ClassFileTransformerTestCase {
         );
         jar.addAsManifestResource(ClassFileTransformerTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         return jar;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // See WFLY-11359
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @ArquillianResource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/EESecurityAuthMechanismTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jaspi/EESecurityAuthMechanismTestCase.java
@@ -17,9 +17,11 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.jacc.propagation.Manage;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,6 +55,11 @@ public class EESecurityAuthMechanismTestCase {
         war.addClasses(SimpleHttpAuthenticationMechanism.class, SimpleIdentityStore.class);
         return war;
 
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/EjbXACMLAuthorizationModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/EjbXACMLAuthorizationModuleTestCase.java
@@ -40,9 +40,11 @@ import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.as.test.integration.security.common.ejb3.Hello;
 import org.jboss.as.test.integration.security.common.ejb3.HelloBean;
 import org.jboss.as.test.shared.integration.ejb.security.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,6 +72,11 @@ public class EjbXACMLAuthorizationModuleTestCase {
     @Deployment
     public static JavaArchive deploymentCustomXACMLAuthz() throws IllegalArgumentException, IOException {
         return createJar("test-custom-xacml.jar", SecurityDomain.DEFAULT_NAME);
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPInteroperabilityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPInteroperabilityTestCase.java
@@ -40,6 +40,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.security.xacml.core.JBossPDP;
 import org.jboss.security.xacml.core.model.context.ActionType;
@@ -63,6 +64,7 @@ import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -103,6 +105,11 @@ public class JBossPDPInteroperabilityTestCase {
                 + "/med-example-request.xml");
 
         return jar;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPServletInitializationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/JBossPDPServletInitializationTestCase.java
@@ -30,9 +30,11 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -61,6 +63,11 @@ public class JBossPDPServletInitializationTestCase {
         XACMLTestUtils.addJBossDeploymentStructureToArchive(war);
         XACMLTestUtils.addXACMLPoliciesToArchive(war);
         return war;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/WebXACMLAuthorizationModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/WebXACMLAuthorizationModuleTestCase.java
@@ -40,10 +40,12 @@ import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServ
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -87,6 +89,11 @@ public class WebXACMLAuthorizationModuleTestCase {
     @Deployment(name = "CustomXACML")
     public static WebArchive deploymentCustomXACML() throws IllegalArgumentException, IOException {
         return createWar(SECURITY_DOMAIN_CUSTOM, "custom-xacml-web-test.war");
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/AbstractMicroProfileConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/AbstractMicroProfileConfigTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.microprofile.config.smallrye;
+
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.PropertyPermission;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class AbstractMicroProfileConfigTestCase {
+
+    /**
+     * Creates the following permissions for config tests:
+     * <ul>
+     * <li>A read {@link PropertyPermission} for each name</li>
+     * <li>A {@code getenv} permission for each name</li>
+     * <li>A {@code getenv} permission for each name replacing any dots {@code .} with an underscore {@code _}</li>
+     * <li>A {@code getenv} permission for each name converted to upper case</li>
+     * <li>A {@code getenv} permission for each name converted to upper case replacing any dots {@code .}
+     * with an underscore {@code _}
+     * </li>
+     * </ul>
+     *
+     * @param names the names to create the permissions for
+     *
+     * @return the set of permissions
+     */
+    protected static Permission[] createPermissions(final String... names) {
+        final Collection<Permission> permissions = new ArrayList<>(names.length * 2);
+        for (String name : names) {
+            permissions.add(new PropertyPermission(name, "read"));
+            permissions.add(new RuntimePermission("getenv." + name));
+            permissions.add(new RuntimePermission("getenv." + name.replace('.', '_')));
+            permissions.add(new RuntimePermission("getenv." + name.toUpperCase(Locale.ROOT)));
+            permissions.add(new RuntimePermission("getenv." + name.replace('.', '_').toUpperCase(Locale.ROOT)));
+        }
+        return permissions.toArray(new Permission[0]);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
@@ -25,15 +25,10 @@ package org.wildfly.test.integration.microprofile.config.smallrye.app;
 import static org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils.assertTextContainsProperty;
 
 import java.net.URL;
-import java.security.Permission;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Locale;
 import java.util.Optional;
-import java.util.PropertyPermission;
 import java.util.Set;
 
 import org.apache.http.HttpResponse;
@@ -54,6 +49,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.config.smallrye.AbstractMicroProfileConfigTestCase;
 import org.wildfly.test.integration.microprofile.config.smallrye.SubsystemConfigSourceTask;
 
 /**
@@ -63,16 +59,16 @@ import org.wildfly.test.integration.microprofile.config.smallrye.SubsystemConfig
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(SubsystemConfigSourceTask.class)
-public class MicroProfileConfigTestCase {
+public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileConfigTestCase.war")
-                .addClasses(TestApplication.class)
+                .addClasses(TestApplication.class, AbstractMicroProfileConfigTestCase.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(MicroProfileConfigTestCase.class.getPackage(),
                         "microprofile-config.properties", "microprofile-config.properties")
-                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(createEnvPermission(
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(createPermissions(
                         "my.prop",
                         "my.other.prop",
                         SubsystemConfigSourceTask.MY_PROP_FROM_SUBSYSTEM_PROP_NAME,
@@ -365,17 +361,5 @@ public class MicroProfileConfigTestCase {
             // not defined anywhere...
             assertTextContainsProperty(text, SubsystemConfigSourceTask.PROPERTIES_PROP_NAME5, "Custom file property not defined!");
         }
-    }
-
-    private static Permission[] createEnvPermission(final String... names) {
-        final Collection<Permission> permissions = new ArrayList<>(names.length * 2);
-        for (String name : names) {
-            permissions.add(new PropertyPermission(name, "read"));
-            permissions.add(new RuntimePermission("getenv." + name));
-            permissions.add(new RuntimePermission("getenv." + name.replace('.', '_')));
-            permissions.add(new RuntimePermission("getenv." + name.toUpperCase(Locale.ROOT)));
-            permissions.add(new RuntimePermission("getenv." + name.replace('.', '_').toUpperCase(Locale.ROOT)));
-        }
-        return permissions.toArray(new Permission[0]);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/converter/MicroProfileConfigConvertersTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/converter/MicroProfileConfigConvertersTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -40,6 +41,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.config.smallrye.AbstractMicroProfileConfigTestCase;
 import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 
 /**
@@ -48,15 +50,17 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(SetupTask.class)
-public class MicroProfileConfigConvertersTestCase {
+public class MicroProfileConfigConvertersTestCase extends AbstractMicroProfileConfigTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileConfigConvertersTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class)
+                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsWebInfResource(TestApplication.class.getPackage(), "jboss-deployment-structure.xml",
-                        "jboss-deployment-structure.xml");
+                        "jboss-deployment-structure.xml")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(createPermissions(
+                        "int_converted_to_102_by_priority_of_custom_converter")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/ConfigSourceFromClassTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source/ConfigSourceFromClassTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -41,6 +42,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.config.smallrye.AbstractMicroProfileConfigTestCase;
 import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 
 /**
@@ -51,15 +53,20 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(SetupTask.class)
-public class ConfigSourceFromClassTestCase {
+public class ConfigSourceFromClassTestCase extends AbstractMicroProfileConfigTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceFromClassTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class)
+                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsWebInfResource(ConfigSourceFromClassTestCase.class.getPackage(), "jboss-deployment-structure.xml",
-                        "jboss-deployment-structure.xml");
+                        "jboss-deployment-structure.xml")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(createPermissions(
+                        CustomConfigSource.PROP_NAME,
+                        CustomConfigSource.PROP_NAME_OVERRIDEN_BY_SERVICE_LOADER,
+                        CustomConfigSourceServiceLoader.PROP_NAME
+                )), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/ConfigSourceProviderFromClassTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/management/config_source_provider/ConfigSourceProviderFromClassTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -41,6 +42,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.config.smallrye.AbstractMicroProfileConfigTestCase;
 import org.wildfly.test.integration.microprofile.config.smallrye.management.config_source.CustomConfigSource;
 import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 
@@ -52,13 +54,15 @@ import org.wildfly.test.integration.microprofile.config.smallrye.AssertUtils;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup(SetupTask.class)
-public class ConfigSourceProviderFromClassTestCase {
+public class ConfigSourceProviderFromClassTestCase extends AbstractMicroProfileConfigTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ConfigSourceProviderFromClassTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addClasses(TestApplication.class, TestApplication.Resource.class, AbstractMicroProfileConfigTestCase.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        createPermissions(CustomConfigSource.PROP_NAME)),"permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -109,6 +110,7 @@ public class RemoteLocalCallProfileTestCase {
 
     @BeforeClass
     public static void printSysProps() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
         log.trace("System properties:\n" + System.getProperties());
     }
 


### PR DESCRIPTION
This should be the final changes to either ignore failing tests when the security manager is enabled or fix the tests to work with the security manager. A CI job with the security manager enabled is running https://ci.wildfly.org/viewLog.html?buildId=135239.

- https://issues.jboss.org/browse/WFLY-11346
- https://issues.jboss.org/browse/WFLY-9464
- https://issues.jboss.org/browse/WFLY-11348
- https://issues.jboss.org/browse/WFLY-11359
- https://issues.jboss.org/browse/WFLY-6184
- https://issues.jboss.org/browse/WFLY-11357