### PR TITLE
WFLY-11563 Race condition in PersistenceUnitServiceImpl when the service is being stopped

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestEntityManagerFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestEntityManagerFactory.java
@@ -41,6 +41,9 @@ public class TestEntityManagerFactory implements InvocationHandler {
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 
         invocations.add(method.getName());
+        if (method.getName().equals("isOpen")) {
+            return false;
+        }
         return null;
 
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11563

Also needed to update ClassFileTransformerTestCase proxy class (org.jboss.as.test.integration.jpa.mockprovider.classtransformer.TestEntityManagerFactory) to ignore the "isOpen" method call.