### PR TITLE
Final (hopefully) security manager test suite fixes/ignores

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/ClassFileTransformerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/ClassFileTransformerTestCase.java
@@ -34,11 +34,13 @@ import javax.naming.InitialContext;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -95,6 +97,13 @@ public class ClassFileTransformerTestCase {
                         "   \n" +
                         "</ejb-jar>");
     }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // See WFLY-11359
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+    }
+
 
     @ArquillianResource
     private InitialContext iniCtx;

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/META-INF/permissions.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/META-INF/permissions.xml
@@ -23,6 +23,16 @@
         <actions>read</actions>
     </permission>
     <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>java.net.preferIPv4Stack</name>
+        <actions>read</actions>
+    </permission>
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>java.net.preferIPv6Addresses</name>
+        <actions>read</actions>
+    </permission>
+    <permission>
         <class-name>java.lang.RuntimePermission</class-name>
         <name>createClassLoader</name>
     </permission>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/permissions.xml
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WEB-INF/permissions.xml
@@ -19,6 +19,16 @@
         <actions>read</actions>
     </permission>
     <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>java.net.preferIPv4Stack</name>
+        <actions>read</actions>
+    </permission>
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>java.net.preferIPv6Addresses</name>
+        <actions>read</actions>
+    </permission>
+    <permission>
         <class-name>java.lang.RuntimePermission</class-name>
         <name>createClassLoader</name>
     </permission>


### PR DESCRIPTION
These tests failed on the first test run with `-DallTests` https://ci.wildfly.org/viewLog.html?buildId=135432&buildTypeId=WF_PullRequest_LinuxSm&tab=buildResultsDiv. I missed the second `ClassFileTransformerTestCase` which seems to be intermittent. The web services ones only failed with `-Dipv6` which I didn't not run the original PR with.