### PR TITLE
[WFLY-11577] Upgrade WildFly Core 8.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>8.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11577

---


### Release Notes - WildFly Core - Version 8.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4260'>WFCORE-4260</a>] -         Upgrade license plugin to 2.0.0.Beta2
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4239'>WFCORE-4239</a>] -         WARN if system-property is already set and is being overridden
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4257'>WFCORE-4257</a>] -         Eliminate finalizers in the core codebase
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1632'>WFCORE-1632</a>] -         Server processing request isn&#39;t stopped immediately but waits for request processing to finish
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4206'>WFCORE-4206</a>] -         Elytron extension module has un-used optional dependency
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4223'>WFCORE-4223</a>] -         IllegalArgumentException when add a server-ssl-sni-context with no host-context-map
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4253'>WFCORE-4253</a>] -         SNICombinedWithALPNTestCase fails with security manager on Java 11
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4262'>WFCORE-4262</a>] -         product-info command throws java.lang.IllegalArgumentException if patching subsystem is not available
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4265'>WFCORE-4265</a>] -         Latest DB2 11.1 JDBC driver requires additional IBM JDK system dependency
</li>
</ul>
                                            