### PR TITLE
[WFLY-11584] Legacy Web migrate op fails if a connector has scheme ht…

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
@@ -29,8 +29,8 @@ public interface WebLogger extends BasicLogger {
     @Message(id = 3, value = "Could not migrate attribute %s from resource %s")
     String couldNotMigrateResource(String attribute, PathAddress node);
 
-    @Message(id = 4, value = "Could not migrate SSL connector as no SSL config is defined")
-    OperationFailedException noSslConfig();
+    @Message(id = 4, value = "No SSL config is defined for connector %s, it will be created as http connector")
+    String noSslConfig(String connector);
 
     @Message(id = 5, value = "Migration failed, see results for more details.")
     String migrationFailed();
@@ -46,4 +46,5 @@ public interface WebLogger extends BasicLogger {
 
     @Message(id = 9, value = "Could not migrate attribute %s from valve %s")
     String couldNotMigrateValveAttribute(String attribute, String valveName);
+
 }

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
@@ -254,6 +254,11 @@ public class WebMigrateTestCase extends AbstractSubsystemTest {
         assertEquals("${prop.max-post-size:2097153}", connector.get(Constants.MAX_POST_SIZE).asString());
         assertEquals("https", connector.get(Constants.REDIRECT_SOCKET).asString());
 
+        //http-proxy connector
+        ModelNode httpProxyConnector = newServer.get(Constants.HTTP_LISTENER, "http-proxy");
+        assertTrue(connector.isDefined());
+        assertEquals("http", httpProxyConnector.get(Constants.SOCKET_BINDING).asString());
+
         //https connector
         ModelNode httpsConnector = newServer.get(Constants.HTTPS_LISTENER, "https");
         String realmName = httpsConnector.get(Constants.SECURITY_REALM).asString();

--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -51,6 +51,20 @@
                        secure="false"
                        executor="some-executor"
                     />
+            <connector name="http-proxy" scheme="https"
+                       protocol="HTTP/1.1"
+                       socket-binding="http"
+                       enabled="${prop.enabled:true}"
+                       enable-lookups="${prop.enable-lookups:false}"
+                       proxy-name="proxy.com"
+                       proxy-port="11433"
+                       max-post-size="${prop.max-post-size:2097153}"
+                       max-save-post-size="${prop.max-save-post-size:512}"
+                       redirect-binding="https"
+                       max-connections="${prop.max-connections:300}"
+                       secure="false"
+                       executor="some-executor"
+                    />
             <connector name="https" scheme="https" protocol="HTTP/1.1" secure="true" socket-binding="https">
                 <ssl certificate-key-file="${file-base}/server.keystore"
                         ca-certificate-file="${file-base}/jsse.keystore"


### PR DESCRIPTION
…tps and no SSL config

Issue: https://issues.jboss.org/browse/WFLY-11584

There is a case were you can have https scheme with no configuration if working with a proxy, https scheme cannot be used to determine if it is using SSL.