### PR TITLE
[WFLY-11587] Fix Weld integration with legacy security

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -58,11 +58,11 @@
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
+        <!-- Only needed if capability 'org.wildfly.legacy-security.server-security-manager' is present -->
+        <module name="org.jboss.as.core-security" optional="true" />
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.wildfly.security.elytron-private"/>
-        <!-- Only needed if capability 'org.wildfly.legacy-security' is present -->
-        <module name="org.jboss.as.security" optional="true" />
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.invocation"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltInApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltInApplication.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.builtin;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/cdibuiltin")
+public class CDIBuiltInApplication extends Application {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltinInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltinInjectionTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.builtin;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that CDI injection of built-in beans works.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class CDIBuiltinInjectionTestCase {
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        // TODO https://issues.jboss.org/browse/WFLY-11616
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+    }
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class,"cdibuiltin.war");
+        war.addClasses(CDIBuiltInApplication.class, CDIResource.class);
+        war.add(EmptyAsset.INSTANCE, "WEB-INF/beans.xml");
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    private String performCall(String urlPattern) throws Exception {
+        return HttpRequest.get(url + urlPattern, 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testJaxRsWithNoApplication() throws Exception {
+        String result = performCall("cdibuiltin/cdiInject");
+        assertEquals("anonymous", result);
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIResource.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.builtin;
+
+import java.security.Principal;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("cdiInject")
+@Produces({"text/plain"})
+public class CDIResource {
+
+    @Inject
+    Principal principal;
+
+    @GET
+    public String getMessage() {
+        return principal.getName();
+    }
+}


### PR DESCRIPTION
1) Correct SecuritySubsystemRootResourceDefinition so it actually registers the org.wildfly.legacy-security.server-security-manager capability
2) Correct the module import as ServerSecurityManager is not from the security subsystem module, it's from WildFly Core's org.jboss.as.core.security.

https://issues.jboss.org/browse/WFLY-11587

