### PR TITLE
[WFLY-11352] WildFly registers multiple distinct drivers for current MySQL driver jar

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
@@ -58,6 +58,7 @@ public final class DriverProcessor implements DeploymentUnitProcessor {
         if (module != null && servicesAttachment != null) {
             final ModuleClassLoader classLoader = module.getClassLoader();
             final List<String> driverNames = servicesAttachment.getServiceImplementations(Driver.class.getName());
+            int idx = 0;
             for (String driverClassName : driverNames) {
                 try {
                     final Class<? extends Driver> driverClass = classLoader.loadClass(driverClassName).asSubclass(Driver.class);
@@ -74,9 +75,10 @@ public final class DriverProcessor implements DeploymentUnitProcessor {
                                 Integer.valueOf(minorVersion));
                     }
                     String driverName = deploymentUnit.getName();
-                    if ((driverName.contains(".") && ! driverName.endsWith(".jar")) || driverNames.size() != 1) {
+                    if ((driverName.contains(".") && ! driverName.endsWith(".jar")) || idx != 0) {
                         driverName += "_" + driverClassName + "_" + majorVersion + "_" + minorVersion;
                     }
+                    idx ++;
                     InstalledDriver driverMetadata = new InstalledDriver(driverName, driverClass.getName(), null, null, majorVersion,
                             minorVersion, compliant);
                     DriverService driverService = new DriverService(driverMetadata, driver);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver2.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Test JDBC driver
+ */
+public class TestDriver2 implements Driver {
+  /**
+   * {@inheritDoc}
+   */
+  public Connection connect(String url, Properties info) throws SQLException {
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean acceptsURL(String url) throws SQLException {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    Driver driver = DriverManager.getDriver(url);
+    return driver.getPropertyInfo(url, info);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public int getMajorVersion() {
+    return 1;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public int getMinorVersion() {
+    return 1;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean jdbcCompliant() {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    throw new SQLFeatureNotSupportedException();
+  }
+}


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-11352

- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

In case there are multiple JDBC drivers specified in `META-INF/services/java.sql.Driver`, the first one will be used as the main Driver just like there is only one Driver specified. The following ones are following name convention like below as they were now:

`driver-name` = `deploymentName + "_" + driverClassName + "_" + majorVersion + "_" + minorVersion;`
