### PR TITLE
[WFLY-11388] User is not informed about incorrect values in exposed-s…

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -63,6 +63,8 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
             }
         }, RUNTIME);
 
+        MicroProfileMetricsSubsystemDefinition.validExposedSubsystems(context, model);
+
         final boolean securityEnabled = MicroProfileMetricsSubsystemDefinition.SECURITY_ENABLED.resolveModelAttribute(context, model).asBoolean();
         List<String> exposedSubsystems = MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS.unwrap(context, model);
 

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
@@ -25,7 +25,9 @@ package org.wildfly.extension.microprofile.metrics._private;
 import static org.jboss.logging.Logger.Level.INFO;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -66,4 +68,8 @@ public interface MicroProfileMetricsLogger extends BasicLogger {
 
     @Message(id = 5, value = "Metric attribute %s on %s is undefined and will not be exposed.")
     IllegalStateException undefinedMetric(String attributeName, PathAddress address);
+
+    @Message(id = 6, value = "Exposed subsystems: '%s' for microprofile-metrics-smallrye are unknown.")
+    OperationFailedException unknownSubsystems(List<String> subsystems);
+
 }


### PR DESCRIPTION
…ubsystems for MP Metrics

Jira: https://issues.jboss.org/browse/WFLY-11388

- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

The proposed fix will check exposed-subsystems on both server boots and update on the exposed-subsystems attribute.
