### PR TITLE
[WFLY-11592] Missing microprofile-metrics-smallrye subsystem in some configuration files

### DIFF
--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -28,6 +28,7 @@
         <subsystem supplement="ha">messaging-activemq.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem supplement="${mod_cluster.supplement}">mod_cluster.xml</subsystem>
         <subsystem>naming.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -27,6 +27,7 @@
         <subsystem>messaging-activemq.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem>naming.xml</subsystem>
         <subsystem>pojo.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -25,6 +25,7 @@
         <subsystem>mail.xml</subsystem>
         <subsystem>microprofile-config-smallrye.xml</subsystem>
         <subsystem>microprofile-health-smallrye.xml</subsystem>
+        <subsystem>microprofile-metrics-smallrye.xml</subsystem>
         <subsystem>microprofile-opentracing-smallrye.xml</subsystem>
         <subsystem supplement="${mod_cluster.supplement}">mod_cluster.xml</subsystem>
         <subsystem>naming.xml</subsystem>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-azure-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-azure-ha.xml
@@ -121,4 +121,5 @@
         </feature>
     </feature-group>
     <feature-group name="health"/>
+    <feature-group name="metrics" />
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/feature_groups/standalone-ec2-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-ec2-ha.xml
@@ -121,6 +121,7 @@
         </feature>
     </feature-group>
     <feature-group name="health"/>
+    <feature-group name="metrics" />
 
     <!-- <feature-group name="elytron-permissions-workaround"/> -->
 </feature-group-spec>


### PR DESCRIPTION
Legacy-builds and standard builds have microprofile-metrics-smallrye missing in some configuration files. 

Jira issue: https://issues.jboss.org/browse/WFLY-11592