### PR TITLE
[WFLY-11588] eliminates overrides of SimpleResourceDefinition.registerCapabilities

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemDefinition.java
@@ -112,8 +112,10 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     BatchSubsystemDefinition(final boolean registerRuntimeOnly) {
-        super(SUBSYSTEM_PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver(), BatchSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(SUBSYSTEM_PATH, BatchResourceDescriptionResolver.getResourceDescriptionResolver())
+                .setAddHandler(BatchSubsystemAdd.INSTANCE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(Capabilities.BATCH_CONFIGURATION_CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -161,11 +163,6 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
                 service.setRestartOnResume(value.asBoolean());
             }
         });
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(Capabilities.BATCH_CONFIGURATION_CAPABILITY);
     }
 
     /**

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
@@ -68,8 +68,10 @@ public class BatchThreadPoolResourceDefinition extends SimpleResourceDefinition 
     private final boolean registerRuntimeOnly;
 
     public BatchThreadPoolResourceDefinition(final boolean registerRuntimeOnly) {
-        super(PATH, BatchThreadPoolDescriptionResolver.INSTANCE,
-                BatchThreadPoolAdd.INSTANCE, BatchThreadPoolRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(PATH, BatchThreadPoolDescriptionResolver.INSTANCE)
+                .setAddHandler(BatchThreadPoolAdd.INSTANCE)
+                .setRemoveHandler(BatchThreadPoolRemove.INSTANCE)
+                .addCapabilities(Capabilities.THREAD_POOL_CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -80,11 +82,6 @@ public class BatchThreadPoolResourceDefinition extends SimpleResourceDefinition 
         if (registerRuntimeOnly) {
             new UnboundedQueueThreadPoolMetricsHandler(BatchServiceNames.BASE_BATCH_THREAD_POOL_NAME).registerAttributes(resourceRegistration);
         }
-    }
-
-    @Override
-    public void registerCapabilities(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(Capabilities.THREAD_POOL_CAPABILITY);
     }
 
     static class BatchThreadPoolAdd extends UnboundedQueueThreadPoolAdd {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
@@ -110,6 +110,7 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        super.registerCapabilities(resourceRegistration);
         if (!deployed)
             resourceRegistration.registerCapability(Capabilities.DATA_SOURCE_CAPABILITY);
     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
@@ -101,6 +101,8 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        super.registerCapabilities(resourceRegistration);
+
         if (!deployed)
             resourceRegistration.registerCapability(org.jboss.as.connector._private.Capabilities.DATA_SOURCE_CAPABILITY);
     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaDistributedWorkManagerDefinition.java
@@ -85,6 +85,7 @@ public class JcaDistributedWorkManagerDefinition extends SimpleResourceDefinitio
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration registration) {
+        super.registerCapabilities(registration);
         for (DWmCapabilities capability : EnumSet.allOf(DWmCapabilities.class)) {
             registration.registerCapability(capability.getRuntimeCapability());
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -47,7 +47,6 @@ import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfigura
  */
 public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
-    public static final EJB3RemoteResourceDefinition INSTANCE = new EJB3RemoteResourceDefinition();
     public static final String EJB_REMOTE_CAPABILITY_NAME = "org.wildfly.ejb.remote";
 
     static final RuntimeCapability<Void> EJB_REMOTE_CAPABILITY = RuntimeCapability.Builder.of(EJB_REMOTE_CAPABILITY_NAME).setServiceType(Void.class).build();
@@ -90,13 +89,15 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
         ATTRIBUTES = Collections.unmodifiableMap(map);
     }
 
+    public static final EJB3RemoteResourceDefinition INSTANCE = new EJB3RemoteResourceDefinition();
 
     private EJB3RemoteResourceDefinition() {
         super(new Parameters(EJB3SubsystemModel.REMOTE_SERVICE_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.REMOTE))
                 .setAddHandler(EJB3RemoteServiceAdd.INSTANCE)
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
-                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES));
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .addCapabilities(EJB_REMOTE_CAPABILITY));
     }
 
     @Override
@@ -112,10 +113,5 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
         super.registerChildren(resourceRegistration);
         // register channel-creation-options as sub model for EJB remote service
         resourceRegistration.registerSubModel(new RemoteConnectorChannelCreationOptionResource());
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration registration) {
-        registration.registerCapability(EJB_REMOTE_CAPABILITY);
     }
 }

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPRootDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -40,7 +41,6 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -433,19 +433,15 @@ class IIOPRootDefinition extends PersistentResourceDefinition {
     public static final IIOPRootDefinition INSTANCE = new IIOPRootDefinition();
 
     private IIOPRootDefinition() {
-        super(IIOPExtension.PATH_SUBSYSTEM, IIOPExtension.getResourceDescriptionResolver(), new IIOPSubsystemAdd(ALL_ATTRIBUTES),
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(IIOPExtension.PATH_SUBSYSTEM, IIOPExtension.getResourceDescriptionResolver())
+                .setAddHandler(new IIOPSubsystemAdd(ALL_ATTRIBUTES))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(IIOP_CAPABILITY));
     }
 
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return ALL_ATTRIBUTES;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-        resourceRegistration.registerCapability(IIOP_CAPABILITY);
     }
 
     private enum AuthMethodValues {

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
@@ -60,6 +60,7 @@ public class JSR77ManagementRootResource extends PersistentResourceDefinition {
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        super.registerCapabilities(resourceRegistration);
         if (appclient) {
             resourceRegistration.registerCapability(JSR77_APPCLIENT_CAPABILITY);
         } else {

--- a/legacy/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebConnectorDefinition.java
@@ -230,6 +230,8 @@ public class WebConnectorDefinition extends ModelOnlyResourceDefinition {
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        super.registerCapabilities(resourceRegistration);
+
         resourceRegistration.registerCapability(FAKE_UNDERTOW_LISTENER_CAPABILITY);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupDefinition.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -106,10 +107,10 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     BroadcastGroupDefinition(boolean registerRuntimeOnly) {
-        super(MessagingExtension.BROADCAST_GROUP_PATH,
-                MessagingExtension.getResourceDescriptionResolver(CommonAttributes.BROADCAST_GROUP),
-                BroadcastGroupAdd.INSTANCE,
-                BroadcastGroupRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(MessagingExtension.BROADCAST_GROUP_PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.BROADCAST_GROUP))
+                .setAddHandler(BroadcastGroupAdd.INSTANCE)
+                .setRemoveHandler(BroadcastGroupRemove.INSTANCE)
+                .addCapabilities(CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -174,10 +175,5 @@ public class BroadcastGroupDefinition extends PersistentResourceDefinition {
         availableConnectors.addAll(activeMQServerResource.getChildrenNames(CommonAttributes.REMOTE_CONNECTOR));
         availableConnectors.addAll(activeMQServerResource.getChildrenNames(CommonAttributes.CONNECTOR));
         return availableConnectors;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration registration) {
-        registration.registerCapability(CAPABILITY);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupDefinition.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -96,9 +97,10 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     protected DiscoveryGroupDefinition(final boolean registerRuntimeOnly, final boolean subsystemResource) {
-        super(new Parameters(PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.DISCOVERY_GROUP))
+        super(new SimpleResourceDefinition.Parameters(PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.DISCOVERY_GROUP))
                 .setAddHandler(DiscoveryGroupAdd.INSTANCE)
-                .setRemoveHandler(DiscoveryGroupRemove.INSTANCE));
+                .setRemoveHandler(DiscoveryGroupRemove.INSTANCE)
+                .addCapabilities(CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -115,10 +117,5 @@ public class DiscoveryGroupDefinition extends PersistentResourceDefinition {
                 registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
             }
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration registration) {
-        registration.registerCapability(CAPABILITY);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -40,8 +40,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.JournalType;
@@ -49,6 +49,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -787,10 +788,10 @@ public class ServerDefinition extends PersistentResourceDefinition {
     private final boolean registerRuntimeOnly;
 
     ServerDefinition(boolean registerRuntimeOnly) {
-        super(MessagingExtension.SERVER_PATH,
-                MessagingExtension.getResourceDescriptionResolver(CommonAttributes.SERVER),
-                ServerAdd.INSTANCE,
-                ServerRemove.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(MessagingExtension.SERVER_PATH, MessagingExtension.getResourceDescriptionResolver(CommonAttributes.SERVER))
+                .setAddHandler(ServerAdd.INSTANCE)
+                .setRemoveHandler(ServerRemove.INSTANCE)
+                .addCapabilities(Capabilities.ACTIVEMQ_SERVER_CAPABILITY));
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
@@ -815,11 +816,6 @@ public class ServerDefinition extends PersistentResourceDefinition {
         if (registerRuntimeOnly) {
             ActiveMQServerControlHandler.INSTANCE.registerAttributes(resourceRegistration);
         }
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(Capabilities.ACTIVEMQ_SERVER_CAPABILITY);
     }
 
     @Override

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemRootResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemRootResourceDefinition.java
@@ -73,6 +73,8 @@ public class NamingSubsystemRootResourceDefinition extends SimpleResourceDefinit
 
     @Override
     public void registerCapabilities(ManagementResourceRegistration registration) {
+        super.registerCapabilities(registration);
+
         for (Capability capability : EnumSet.allOf(Capability.class)) {
             RuntimeCapability<?> definition = capability.getDefinition();
             registration.registerCapability(definition);

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/RemoteNamingResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.naming.subsystem;
 
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
  * A {@link org.jboss.as.controller.ResourceDefinition} for JNDI bindings
@@ -37,14 +36,9 @@ public class RemoteNamingResourceDefinition extends SimpleResourceDefinition {
     public static final RemoteNamingResourceDefinition INSTANCE = new RemoteNamingResourceDefinition();
 
     private RemoteNamingResourceDefinition() {
-        super(NamingSubsystemModel.REMOTE_NAMING_PATH,
-                NamingExtension.getResourceDescriptionResolver(NamingSubsystemModel.REMOTE_NAMING),
-                RemoteNamingAdd.INSTANCE, RemoteNamingRemove.INSTANCE);
+        super(new Parameters(NamingSubsystemModel.REMOTE_NAMING_PATH, NamingExtension.getResourceDescriptionResolver(NamingSubsystemModel.REMOTE_NAMING))
+                .setAddHandler(RemoteNamingAdd.INSTANCE)
+                .setRemoveHandler(RemoteNamingRemove.INSTANCE)
+                .addCapabilities(REMOTE_NAMING_CAPABILITY));
     }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(REMOTE_NAMING_CAPABILITY);
-    }
-
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecuritySubsystemRootResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecuritySubsystemRootResourceDefinition.java
@@ -120,11 +120,6 @@ public class SecuritySubsystemRootResourceDefinition extends SimpleResourceDefin
         resourceRegistration.registerReadWriteAttribute(INITIALIZE_JACC, null, new ReloadRequiredWriteAttributeHandler(INITIALIZE_JACC));
     }
 
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SECURITY_SUBSYSTEM);
-    }
-
     private static class SecuritySubsystemAdd extends AbstractBoottimeAddStepHandler {
         private static final String AUTHENTICATION_MANAGER = ModuleName.PICKETBOX.getName() + ":" + ModuleName.PICKETBOX.getSlot()
                 + ":" + JBossCachedAuthenticationManager.class.getName();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ByteBufferPoolDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ByteBufferPoolDefinition.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.DefaultByteBufferPool;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -12,9 +14,9 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.Service;
@@ -22,9 +24,6 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-
-import io.undertow.connector.ByteBufferPool;
-import io.undertow.server.DefaultByteBufferPool;
 
 public class ByteBufferPoolDefinition extends PersistentResourceDefinition {
 
@@ -97,16 +96,11 @@ public class ByteBufferPoolDefinition extends PersistentResourceDefinition {
     public static final ByteBufferPoolDefinition INSTANCE = new ByteBufferPoolDefinition();
 
     private ByteBufferPoolDefinition() {
-        super(UndertowExtension.BYTE_BUFFER_POOL_PATH,
-                UndertowExtension.getResolver(Constants.BYTE_BUFFER_POOL),
-                new BufferPoolAdd(),
-                new ReloadRequiredRemoveStepHandler()
-        );
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(UNDERTOW_BUFFER_POOL_RUNTIME_CAPABILITY);
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.BYTE_BUFFER_POOL_PATH,
+                UndertowExtension.getResolver(Constants.BYTE_BUFFER_POOL))
+                .setAddHandler(new BufferPoolAdd())
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(UNDERTOW_BUFFER_POOL_RUNTIME_CAPABILITY));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -33,13 +33,13 @@ import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.web.host.WebHost;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -99,9 +99,11 @@ class HostDefinition extends PersistentResourceDefinition {
     ));
 
     private HostDefinition() {
-        super(UndertowExtension.HOST_PATH, UndertowExtension.getResolver(Constants.HOST),
-                HostAdd.INSTANCE,
-                new HostRemove());
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.HOST_PATH, UndertowExtension.getResolver(Constants.HOST))
+                .setAddHandler(HostAdd.INSTANCE)
+                .setRemoveHandler(new HostRemove())
+                .addCapabilities(HOST_CAPABILITY,
+                        WebHost.CAPABILITY));
     }
 
     @Override
@@ -114,9 +116,4 @@ class HostDefinition extends PersistentResourceDefinition {
         return CHILDREN;
     }
 
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(HOST_CAPABILITY);
-        resourceRegistration.registerCapability(WebHost.CAPABILITY);
-    }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -224,8 +225,8 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
     }
 
     public ListenerResourceDefinition(PathElement pathElement) {
-        super(new PersistentResourceDefinition.Parameters(pathElement, UndertowExtension.getResolver(Constants.LISTENER))
-                .setCapabilities(LISTENER_CAPABILITY));
+        super(new SimpleResourceDefinition.Parameters(pathElement, UndertowExtension.getResolver(Constants.LISTENER))
+                .addCapabilities(LISTENER_CAPABILITY));
     }
 
     public Collection<AttributeDefinition> getAttributes() {
@@ -314,11 +315,6 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             return null;
         }
         return listenerSC.getValue();
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(LISTENER_CAPABILITY);
     }
 
     private static class EnabledAttributeHandler extends AbstractWriteAttributeHandler<Boolean> {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/LocationDefinition.java
@@ -32,10 +32,10 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.undertow.filters.FilterRefDefinition;
@@ -60,17 +60,15 @@ class LocationDefinition extends PersistentResourceDefinition {
 
 
     private LocationDefinition() {
-        super(UndertowExtension.PATH_LOCATION,
-                UndertowExtension.getResolver(Constants.HOST, Constants.LOCATION),
-                LocationAdd.INSTANCE,
-                new ServiceRemoveStepHandler(LocationAdd.INSTANCE) {
-
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.PATH_LOCATION, UndertowExtension.getResolver(Constants.HOST, Constants.LOCATION))
+                .setAddHandler(LocationAdd.INSTANCE)
+                .setRemoveHandler( new ServiceRemoveStepHandler(LocationAdd.INSTANCE) {
                     @Override
                     protected ServiceName serviceName(String name, PathAddress address) {
                         return LOCATION_CAPABILITY.getCapabilityServiceName(address);
                     }
-                }
-        );
+                })
+                .addCapabilities(LOCATION_CAPABILITY));
     }
 
     @Override
@@ -81,10 +79,5 @@ class LocationDefinition extends PersistentResourceDefinition {
     @Override
     public List<? extends PersistentResourceDefinition> getChildren() {
         return CHILDREN;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(LOCATION_CAPABILITY);
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServerDefinition.java
@@ -31,8 +31,8 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.web.host.CommonWebServer;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -66,7 +66,10 @@ class ServerDefinition extends PersistentResourceDefinition {
     static final ServerDefinition INSTANCE = new ServerDefinition();
 
     private ServerDefinition() {
-        super(UndertowExtension.SERVER_PATH, UndertowExtension.getResolver(Constants.SERVER), new ServerAdd(), ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.SERVER_PATH, UndertowExtension.getResolver(Constants.SERVER))
+                .setAddHandler(new ServerAdd())
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(SERVER_CAPABILITY, CommonWebServer.CAPABILITY));
     }
 
     @Override
@@ -78,12 +81,5 @@ class ServerDefinition extends PersistentResourceDefinition {
     @Override
     protected List<? extends PersistentResourceDefinition> getChildren() {
         return CHILDREN;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-        resourceRegistration.registerCapability(SERVER_CAPABILITY);
-        resourceRegistration.registerCapability(CommonWebServer.CAPABILITY);
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
@@ -34,12 +34,12 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -228,10 +228,10 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
     }
 
     private ServletContainerDefinition() {
-        super(UndertowExtension.PATH_SERVLET_CONTAINER,
-                UndertowExtension.getResolver(Constants.SERVLET_CONTAINER),
-                ServletContainerAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.PATH_SERVLET_CONTAINER, UndertowExtension.getResolver(Constants.SERVLET_CONTAINER))
+                .setAddHandler(ServletContainerAdd.INSTANCE)
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(SERVLET_CONTAINER_CAPABILITY));
     }
 
     @Override
@@ -242,10 +242,5 @@ class ServletContainerDefinition extends PersistentResourceDefinition {
     @Override
     public List<? extends PersistentResourceDefinition> getChildren() {
         return CHILDREN;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SERVLET_CONTAINER_CAPABILITY);
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowRootDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowRootDefinition.java
@@ -38,6 +38,7 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -117,10 +118,10 @@ class UndertowRootDefinition extends PersistentResourceDefinition {
     public static final UndertowRootDefinition INSTANCE = new UndertowRootDefinition();
 
     private UndertowRootDefinition() {
-        super(UndertowExtension.SUBSYSTEM_PATH,
-                UndertowExtension.getResolver(),
-                new UndertowSubsystemAdd(APPLICATION_SECURITY_DOMAIN.getKnownSecurityDomainPredicate()),
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.SUBSYSTEM_PATH, UndertowExtension.getResolver())
+                .setAddHandler(new UndertowSubsystemAdd(APPLICATION_SECURITY_DOMAIN.getKnownSecurityDomainPredicate()))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .addCapabilities(UNDERTOW_CAPABILITY, HTTP_INVOKER_RUNTIME_CAPABILITY));
     }
 
     @Override
@@ -131,13 +132,6 @@ class UndertowRootDefinition extends PersistentResourceDefinition {
     @Override
     public List<? extends PersistentResourceDefinition> getChildren() {
         return Arrays.asList(CHILDREN);
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        super.registerCapabilities(resourceRegistration);
-        resourceRegistration.registerCapability(UNDERTOW_CAPABILITY);
-        resourceRegistration.registerCapability(HTTP_INVOKER_RUNTIME_CAPABILITY);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/WebsocketsDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/WebsocketsDefinition.java
@@ -39,10 +39,10 @@ import org.jboss.as.controller.RestartParentResourceAddHandler;
 import org.jboss.as.controller.RestartParentResourceRemoveHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceName;
@@ -108,15 +108,10 @@ class WebsocketsDefinition extends PersistentResourceDefinition {
 
 
     private WebsocketsDefinition() {
-        super(UndertowExtension.PATH_WEBSOCKETS,
-                UndertowExtension.getResolver(UndertowExtension.PATH_WEBSOCKETS.getKeyValuePair()),
-                new WebsocketsAdd(),
-                new WebsocketsRemove());
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(WEBSOCKET_CAPABILITY);
+        super(new SimpleResourceDefinition.Parameters(UndertowExtension.PATH_WEBSOCKETS, UndertowExtension.getResolver(UndertowExtension.PATH_WEBSOCKETS.getKeyValuePair()))
+                .setAddHandler(new WebsocketsAdd())
+                .setRemoveHandler(new WebsocketsRemove())
+                .addCapabilities(WEBSOCKET_CAPABILITY));
     }
 
     @Override


### PR DESCRIPTION
Configure capabilities using
org.jboss.as.controller.SimpleResourceDefinition.Parameters#addCapabilities
instead of overriding SimpleResourceDefinition.registerCapabilities
(unless a specific treatment is required).

When registerCapabilities is overridden, always call
super.registerCapabilities()

JIRA: https://issues.jboss.org/browse/WFLY-11588