### PR TITLE
[WFLY-11602] Add missing configurations to legacy builds

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -91,6 +91,7 @@
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly10.1">
@@ -104,6 +105,7 @@
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly11.0">
@@ -114,6 +116,7 @@
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly12.0">
@@ -124,6 +127,7 @@
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
             </excluded-extensions>
         </host-exclude>
         <host-exclude name="WildFly13.0">
@@ -133,6 +137,13 @@
                 <extension module="org.wildfly.extension.microprofile.config-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.health-smallrye" />
                 <extension module="org.wildfly.extension.microprofile.opentracing-smallrye" />
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
+            </excluded-extensions>
+        </host-exclude>
+        <host-exclude name="WildFly14.0">
+            <host-release id="WildFly14.0"/>
+            <excluded-extensions>
+                <extension module="org.wildfly.extension.microprofile.metrics-smallrye"/>
             </excluded-extensions>
         </host-exclude>
     </host-excludes>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
@@ -11,6 +11,8 @@
                      file-size="102400"
                      min-files="2"/>
 
+            <statistics enabled="${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}" />
+
             <shared-store-master />
 
             <security-setting name="#">

--- a/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default">
+    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"  />


### PR DESCRIPTION
- Missing org.wildfly.extension.microprofile.metrics-smallrye exclusion
- Missing wildfly.undertow.statistics-enabled property to configure the statistics in undertow subsystem in some configurations
- Missing wildfly.messaging-activemq.statistics-enabled property to configure statistics in messaging-activemq subsystem for messaging-activemq-colocated example file

Jira issue: https://issues.jboss.org/browse/WFLY-11602