### PR TITLE
[WFLY-11603] Fix intermittent exception in MP Config SubsystemDeploymentProcessor

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigProviderService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/ConfigProviderService.java
@@ -25,14 +25,14 @@ package org.wildfly.extension.microprofile.config.smallrye;
 import io.smallrye.config.SmallRyeConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.msc.Service;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
  */
-class ConfigProviderService implements Service {
+class ConfigProviderService implements Service<ConfigProviderResolver> {
 
     private ConfigProviderService() {
 
@@ -52,6 +52,10 @@ class ConfigProviderService implements Service {
     @Override
     public void stop(StopContext context) {
         ConfigProviderResolver.setInstance(null);
+    }
 
+    @Override
+    public ConfigProviderResolver getValue() throws IllegalStateException, IllegalArgumentException {
+        return SmallRyeConfigProviderResolver.INSTANCE;
     }
 }

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/DependencyProcessor.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/DependencyProcessor.java
@@ -30,6 +30,7 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleLoader;
+import org.wildfly.extension.microprofile.config.smallrye.ServiceNames;
 
 /**
  * Add dependencies required by deployment unit to access the Config API (programmatically or using CDI).
@@ -41,6 +42,8 @@ public class DependencyProcessor implements DeploymentUnitProcessor {
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
         addDependencies(deploymentUnit);
+
+        phaseContext.addDeploymentDependency(ServiceNames.CONFIG_PROVIDER, SubsystemDeploymentProcessor.CONFIG_PROVIDER_RESOLVER);
     }
 
     @Override

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/SubsystemDeploymentProcessor.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/deployment/SubsystemDeploymentProcessor.java
@@ -60,11 +60,9 @@ public class SubsystemDeploymentProcessor implements DeploymentUnitProcessor {
                 .addDiscoveredConverters();
         addConfigSourcesFromServices(builder, phaseContext.getServiceRegistry(), module.getClassLoader());
         Config config = builder.build();
-
-        ConfigProviderResolver configProviderResolver = ConfigProviderResolver.instance();
         deploymentUnit.putAttachment(CONFIG, config);
-        deploymentUnit.putAttachment(CONFIG_PROVIDER_RESOLVER, configProviderResolver);
 
+        ConfigProviderResolver configProviderResolver = deploymentUnit.getAttachment(CONFIG_PROVIDER_RESOLVER);
         configProviderResolver.registerConfig(config, module.getClassLoader());
     }
 


### PR DESCRIPTION
Use org.jboss.as.server.deployment.DeploymentPhaseContext#addDeploymentDependency
to inject the ConfigProviderResolver in the SubsystemDeploymentProcess
to ensure the service is properly installed and started.

JIRA: https://issues.jboss.org/browse/WFLY-11603