### PR TITLE
WFLY-11616 Add privileged block to Principal retrieval when SM is pre…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltinInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/builtin/CDIBuiltinInjectionTestCase.java
@@ -31,12 +31,10 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,12 +46,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class CDIBuiltinInjectionTestCase {
-
-    @BeforeClass
-    public static void skipSecurityManager() {
-        // TODO https://issues.jboss.org/browse/WFLY-11616
-        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
-    }
 
     @Deployment(testable = false)
     public static Archive<?> deploy() {

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldSecurityServices.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/WeldSecurityServices.java
@@ -81,7 +81,11 @@ public class WeldSecurityServices implements Service, SecurityServices {
         final Object securityManager = securityManagerSupplier != null ? securityManagerSupplier.get() : null;
         if (securityManager == null)
             throw WeldLogger.ROOT_LOGGER.securityNotEnabled();
-        return ((ServerSecurityManager) securityManager).getCallerPrincipal();
+        if (WildFlySecurityManager.isChecking()) {
+            return AccessController.doPrivileged((PrivilegedAction<Principal>) ((ServerSecurityManager) securityManager)::getCallerPrincipal);
+        } else {
+            return ((ServerSecurityManager)securityManager).getCallerPrincipal();
+        }
     }
 
     @Override


### PR DESCRIPTION
…sent.

JIRA - https://issues.jboss.org/browse/WFLY-11616

When injecting `Principal` with SM enabled, there was a permission check failure. Specification (at least CDI one) doesn't talk at all about any required permissions so I simply added a privileged block to handle this.

With this change in place, `CDIBuiltinInjectionTestCase` passes with `-Dsecurity.manager=true`.