### PR TITLE
WFLY-11449 Upgrade JGroups to 4.0.16.Final

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -58,9 +58,6 @@
         timeout_check_interval="5000"/>
     <FD_SOCK/>
     <VERIFY_SUSPECT timeout="5000"/>
-    <ASYM_ENCRYPT
-        asym_keylength="2048"
-    />
     <pbcast.NAKACK2
         xmit_interval="100"
         xmit_table_num_rows="50"

--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <version.org.jboss.ws.spi>3.2.3.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.6.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jdom>1.1.3</version.org.jdom>
-        <version.org.jgroups>4.0.15.Final</version.org.jgroups>
+        <version.org.jgroups>4.0.16.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.2.0.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.6.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-11449

remove workaround for JGRP-2302


