### PR TITLE
WFLY-11626 Reduce unnecessary per-request array allocation/copies when parsing jsessionid

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodec.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodec.java
@@ -40,20 +40,14 @@ public class DistributableSessionIdentifierCodec implements SessionIdentifierCod
         this.routing = routing;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String encode(String sessionId) {
-        String route = this.locator.locate(sessionId);
+    public CharSequence encode(CharSequence sessionId) {
+        String route = this.locator.locate(sessionId.toString());
         return (route != null) ? this.routing.format(sessionId, route) : sessionId;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String decode(String encodedSessionId) {
+    public CharSequence decode(CharSequence encodedSessionId) {
         return this.routing.parse(encodedSessionId).getKey();
     }
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecTestCase.java
@@ -49,7 +49,7 @@ public class DistributableSessionIdentifierCodecTestCase {
 
         when(this.locator.locate(sessionId)).thenReturn(null);
 
-        String result = this.codec.encode(sessionId);
+        CharSequence result = this.codec.encode(sessionId);
 
         assertSame(sessionId, result);
 
@@ -72,7 +72,7 @@ public class DistributableSessionIdentifierCodecTestCase {
 
         when(this.routing.parse(encodedSessionId)).thenReturn(new SimpleImmutableEntry<>(sessionId, route));
 
-        String result = this.codec.decode(encodedSessionId);
+        CharSequence result = this.codec.decode(encodedSessionId);
 
         assertSame(sessionId, result);
     }

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
@@ -44,5 +44,6 @@
         <module name="org.jboss.metadata.web"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
+        <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpInvokerHostService.java
@@ -88,7 +88,7 @@ class HttpInvokerHostService implements Service<HttpInvokerHostService> {
             exchange.addResponseCommitListener(ex -> {
                 Cookie cookie = ex.getResponseCookies().get(JSESSIONID);
                 if(cookie != null ) {
-                    cookie.setValue(codec.encode(cookie.getValue()));
+                    cookie.setValue(codec.encode(cookie.getValue()).toString());
                 }
             });
             handler.handleRequest(exchange);

--- a/web-common/src/main/java/org/jboss/as/web/session/CompositeCharSequence.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/CompositeCharSequence.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.session;
+
+import java.nio.CharBuffer;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A {@link CharSequence} composed of other character sequences.
+ * All methods delegate to one or more of the underlying character sequences, using relative indexes.
+ * @author Paul Ferraro
+ */
+class CompositeCharSequence implements CharSequence {
+    private final List<CharSequence> sequences;
+
+    CompositeCharSequence(CharSequence... sequences) {
+        this(Arrays.asList(sequences));
+    }
+
+    CompositeCharSequence(List<CharSequence> sequences) {
+        this.sequences = sequences;
+    }
+
+    @Override
+    public int length() {
+        int length = 0;
+        for (CharSequence sequence : this.sequences) {
+            length += sequence.length();
+        }
+        return length;
+    }
+
+    @Override
+    public char charAt(int index) {
+        int relativeIndex = index;
+        for (CharSequence sequence : this.sequences) {
+            if (relativeIndex < sequence.length()) {
+                return sequence.charAt(relativeIndex);
+            }
+            relativeIndex -= sequence.length();
+        }
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+        if ((start < 0) || (start > end) || (end > this.length())) {
+            throw new IndexOutOfBoundsException();
+        }
+        if (start == end) return "";
+        List<CharSequence> result = null;
+        int relativeStart = start;
+        int relativeEnd = end;
+        for (CharSequence sequence : this.sequences) {
+            if ((relativeStart < sequence.length()) && (relativeEnd > 0)) {
+                CharSequence subSequence = sequence.subSequence(Math.max(relativeStart, 0), Math.min(relativeEnd, sequence.length()));
+                if (result == null) {
+                    // If subsequence falls within a single sequence
+                    if ((relativeStart >= 0) && (relativeEnd <= sequence.length())) {
+                        return subSequence;
+                    }
+                    result = new LinkedList<>();
+                }
+                result.add(subSequence);
+            }
+            relativeStart -= sequence.length();
+            relativeEnd -= sequence.length();
+        }
+        return new CompositeCharSequence(result);
+    }
+
+    @Override
+    public String toString() {
+        CharBuffer buffer = CharBuffer.allocate(this.length());
+        for (CharSequence sequence : this.sequences) {
+            buffer.put(CharBuffer.wrap(sequence));
+        }
+        return String.valueOf(buffer.array());
+    }
+}

--- a/web-common/src/main/java/org/jboss/as/web/session/RoutingSupport.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/RoutingSupport.java
@@ -33,7 +33,7 @@ public interface RoutingSupport {
      * @param requestedSessionId the requested session identifier.
      * @return a map entry containing the session ID and routing information as the key and value, respectively.
      */
-    Map.Entry<String, String> parse(String requestedSessionId);
+    Map.Entry<CharSequence, CharSequence> parse(CharSequence requestedSessionId);
 
     /**
      * Formats the specified session identifier and route identifier into a single identifier.
@@ -41,5 +41,5 @@ public interface RoutingSupport {
      * @param route a route identifier.
      * @return a single identifier containing the specified session identifier and routing identifier.
      */
-    String format(String sessionId, String route);
+    CharSequence format(CharSequence sessionId, CharSequence route);
 }

--- a/web-common/src/main/java/org/jboss/as/web/session/SessionIdentifierCodec.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SessionIdentifierCodec.java
@@ -19,7 +19,7 @@ package org.jboss.as.web.session;
 
 /**
  * Encapsulates logic to encode/decode additional information in/from a session identifier.
- * Both the {@link #encode(String)} and {@link #decode(String)} methods should be idempotent.
+ * Both the {@link #encode(CharSequence)} and {@link #decode(CharSequence)} methods should be idempotent.
  * The codec methods should also be symmetrical.  i.e. the result of
  * <code>decode(encode(x))</code> should yield <code>x</code>, just as the result of
  * <code>encode(decode(y))</code> should yield <code>y</code>.
@@ -31,12 +31,12 @@ public interface SessionIdentifierCodec {
      * @param sessionId a session identifier
      * @return an encoded session identifier
      */
-    String encode(String sessionId);
+    CharSequence encode(CharSequence sessionId);
 
     /**
-     * Decodes the specified session identifier encoded via {@link #encode(String)}.
+     * Decodes the specified session identifier encoded via {@link #encode(CharSequence)}.
      * @param encodedSessionId an encoded session identifier
      * @return the decoded session identifier
      */
-    String decode(String encodedSessionId);
+    CharSequence decode(CharSequence encodedSessionId);
 }

--- a/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
@@ -25,6 +25,8 @@ import java.nio.CharBuffer;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map;
 
+import org.wildfly.security.manager.WildFlySecurityManager;
+
 /**
  * Implements logic for parsing/appending routing information from/to a session identifier.
  *
@@ -32,7 +34,7 @@ import java.util.Map;
  */
 public class SimpleRoutingSupport implements RoutingSupport {
 
-    private static final String DELIMITER = ".";
+    private static final String DELIMITER = WildFlySecurityManager.getPropertyPrivileged("jboss.session.route.delimiter", ".");
 
     @Override
     public Map.Entry<CharSequence, CharSequence> parse(CharSequence id) {

--- a/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.web.session;
 
+import java.nio.CharBuffer;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map;
 
@@ -31,34 +32,27 @@ import java.util.Map;
  */
 public class SimpleRoutingSupport implements RoutingSupport {
 
-    public static final String DEFAULT_DELIMITER = ".";
-
-    private final String delimiter;
-
-    public SimpleRoutingSupport() {
-        this(DEFAULT_DELIMITER);
-    }
-
-    public SimpleRoutingSupport(String delimiter) {
-        this.delimiter = delimiter;
-    }
+    private static final String DELIMITER = ".";
 
     @Override
-    public Map.Entry<String, String> parse(String id) {
-        int index = (id != null) ? id.indexOf(this.delimiter) : -1;
-        return (index < 0) ? new SimpleImmutableEntry<String, String>(id, null) : new SimpleImmutableEntry<>(id.substring(0, index), id.substring(index + this.delimiter.length()));
-    }
-
-    @Override
-    public String format(String sessionId, String routeId) {
-        if ((routeId != null) && !routeId.isEmpty()) {
-            StringBuilder sb = new StringBuilder(sessionId.length() + delimiter.length() + routeId.length());
-            sb.append(sessionId);
-            sb.append(this.delimiter);
-            sb.append(routeId);
-            return sb.toString();
-        } else {
-            return sessionId;
+    public Map.Entry<CharSequence, CharSequence> parse(CharSequence id) {
+        if (id != null) {
+            int length = id.length();
+            int delimiterLength = DELIMITER.length();
+            for (int i = 0; i <= length - delimiterLength; ++i) {
+                int routeStart = i + delimiterLength;
+                if (DELIMITER.contentEquals(id.subSequence(i, routeStart))) {
+                    return new SimpleImmutableEntry<>(CharBuffer.wrap(id, 0, i), CharBuffer.wrap(id, routeStart, length));
+                }
+            }
         }
+        return new SimpleImmutableEntry<>(id, null);
+    }
+
+    @Override
+    public CharSequence format(CharSequence sessionId, CharSequence routeId) {
+        if ((routeId == null) || (routeId.length() == 0)) return sessionId;
+
+        return new CompositeCharSequence(sessionId, DELIMITER, routeId);
     }
 }

--- a/web-common/src/main/java/org/jboss/as/web/session/SimpleSessionIdentifierCodec.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SimpleSessionIdentifierCodec.java
@@ -36,12 +36,12 @@ public class SimpleSessionIdentifierCodec implements SessionIdentifierCodec {
     }
 
     @Override
-    public String encode(String sessionId) {
+    public CharSequence encode(CharSequence sessionId) {
         return (this.route != null) ? this.routing.format(sessionId, this.route) : sessionId;
     }
 
     @Override
-    public String decode(String encodedSessionId) {
+    public CharSequence decode(CharSequence encodedSessionId) {
         return (encodedSessionId != null) ? this.routing.parse(encodedSessionId).getKey() : null;
     }
 }

--- a/web-common/src/test/java/org/jboss/as/web/session/CompositeCharSequenceTestCase.java
+++ b/web-common/src/test/java/org/jboss/as/web/session/CompositeCharSequenceTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.web.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link CompositeCharSequence}.
+ * @author Paul Ferraro
+ */
+public class CompositeCharSequenceTestCase {
+    @Test
+    public void test() {
+        CharSequence sequence = new CompositeCharSequence("01", "23", "45");
+        assertEquals(6, sequence.length());
+        assertEquals("012345", sequence.toString());
+
+        for (int i = -1; i < 7; ++i) {
+            try {
+                char result = sequence.charAt(i);
+                if ((i < 0) || (i >= 6)) {
+                    fail(String.format("charAt(%d) returned '%s', but IndexOutOfBoundsException was expected", i, result));
+                }
+                assertEquals('0' + i, result);
+            } catch (IndexOutOfBoundsException e) {
+                if ((i >= 0) && (i < 6)) {
+                    fail(String.format("Unexpected IndexOutOfBoundsException during charAt(%d)", i));
+                }
+            }
+        }
+
+        for (int i = -1; i < 7; ++i) {
+            for (int j = -1; j <= 7; ++j) {
+                try {
+                    CharSequence result = sequence.subSequence(i, j);
+                    if ((i < 0) || (i > j) || (j > 6)) {
+                        fail(String.format("subSequence(%d, %d) returned '%s', but IndexOutOfBoundsException was expected", i, j, result.toString()));
+                    }
+                    StringBuilder expected = new StringBuilder(j - i);
+                    IntStream.range(i, j).forEach(value -> expected.append((char) ('0' + value)));
+                    assertEquals(expected.toString(), result.toString());
+                } catch (IndexOutOfBoundsException e) {
+                    if ((i >= 0) && (j <= 6) && (i <= j)) {
+                        fail(String.format("Unexpected IndexOutOfBoundsException during subSequence(%d, %d)", i, j));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/web-common/src/test/java/org/jboss/as/web/session/SimpleRoutingSupportTestCase.java
+++ b/web-common/src/test/java/org/jboss/as/web/session/SimpleRoutingSupportTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.web.session;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.nio.CharBuffer;
 import java.util.Map;
 
 import org.junit.Test;
@@ -38,24 +39,34 @@ public class SimpleRoutingSupportTestCase {
 
     @Test
     public void parse() {
-        Map.Entry<String, String> result = this.routing.parse("session1.route1");
-        assertEquals("session1", result.getKey());
-        assertEquals("route1", result.getValue());
+        Map.Entry<CharSequence, CharSequence> result = this.routing.parse("session1.route1");
+        assertEquals("session1", result.getKey().toString());
+        assertEquals("route1", result.getValue().toString());
 
         result = this.routing.parse("session2");
-        assertEquals("session2", result.getKey());
+        assertEquals("session2", result.getKey().toString());
         assertNull(result.getValue());
 
         result = this.routing.parse(null);
         assertNull(result.getKey());
         assertNull(result.getValue());
+
+        result = this.routing.parse(CharBuffer.wrap("session1.route1"));
+        assertEquals("session1", result.getKey().toString());
+        assertEquals("route1", result.getValue().toString());
+
+        result = this.routing.parse(new StringBuilder("session1.route1"));
+        assertEquals("session1", result.getKey().toString());
+        assertEquals("route1", result.getValue().toString());
     }
 
     @Test
     public void format() {
-        assertEquals("session1.route1", this.routing.format("session1", "route1"));
-        assertEquals("session2", this.routing.format("session2", ""));
-        assertEquals("session3", this.routing.format("session3", null));
+        assertEquals("session1.route1", this.routing.format("session1", "route1").toString());
+        assertEquals("session2", this.routing.format("session2", "").toString());
+        assertEquals("session3", this.routing.format("session3", null).toString());
+        assertEquals("session1.route1", this.routing.format(CharBuffer.wrap("session1"), CharBuffer.wrap("route1")).toString());
+        assertEquals("session1.route1", this.routing.format(new StringBuilder("session1"), new StringBuilder("route1")).toString());
         assertNull(this.routing.format(null, null));
     }
 }

--- a/web-common/src/test/java/org/jboss/as/web/session/SimpleSessionIdentifierCodecTestCase.java
+++ b/web-common/src/test/java/org/jboss/as/web/session/SimpleSessionIdentifierCodecTestCase.java
@@ -40,7 +40,7 @@ public class SimpleSessionIdentifierCodecTestCase {
         SessionIdentifierCodec codec = new SimpleSessionIdentifierCodec(routing, null);
         String sessionId = "session";
 
-        String result = codec.encode(sessionId);
+        CharSequence result = codec.encode(sessionId);
 
         assertNull(sessionId, null);
 
@@ -66,13 +66,13 @@ public class SimpleSessionIdentifierCodecTestCase {
         String route = "route";
         SessionIdentifierCodec codec = new SimpleSessionIdentifierCodec(routing, route);
 
-        String result = codec.decode(null);
+        CharSequence result = codec.decode(null);
 
         assertNull(result);
 
         String sessionId = "session";
 
-        when(routing.parse(sessionId)).thenReturn(new SimpleImmutableEntry<String, String>(sessionId, null));
+        when(routing.parse(sessionId)).thenReturn(new SimpleImmutableEntry<>(sessionId, null));
 
         result = codec.decode(sessionId);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11626