### PR TITLE
[WFLY-11637] Upgrade WildFly Core 8.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>8.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11637

---


## Release Notes - WildFly Core - Version 8.0.0.Beta3
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4268'>WFCORE-4268</a>] -         Upgrade FasterXML Jackson from 2.9.5 to 2.9.8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4277'>WFCORE-4277</a>] -         Upgrade CLI to aesh 1.11 and readline 1.14
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4279'>WFCORE-4279</a>] -         Upgrade WildFly Elytron to 1.8.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4280'>WFCORE-4280</a>] -         Undertow upgrade from 2.0.15.Final to 2.0.17.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4281'>WFCORE-4281</a>] -         Upgrade threads to 2.3.3
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4284'>WFCORE-4284</a>] -         Upgrade Elytron Web to 1.4.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4285'>WFCORE-4285</a>] -         Upgrade JBoss Modules to 1.9.0
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4286'>WFCORE-4286</a>] -         Upgrade to galleon 3.0.1.CR1 and galleon-plugin 3.0.1.CR2
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4207'>WFCORE-4207</a>] -         Add capabilities in the Thread subsystem resource definitions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4238'>WFCORE-4238</a>] -         Distinguish type of WildFly metrics
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4273'>WFCORE-4273</a>] -         Layers for core-galleon-pack
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4228'>WFCORE-4228</a>] -         Add methods to the management API to get Capability Runtime API as an Optional object
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4266'>WFCORE-4266</a>] -         Classes for newer versions are not loaded from Multi-Release-JARs in WARs
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4269'>WFCORE-4269</a>] -         Multiple &lt;socket&gt; elements inside an http-interface parsed wrongly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4274'>WFCORE-4274</a>] -         SuspendResumeTestCase fails sometimes
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4275'>WFCORE-4275</a>] -         SuspendOnSoftKillTestCase fails sometimes
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4271'>WFCORE-4271</a>] -         Exclude Servlet 3.1 transitive dependency from JACC API dependency
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4276'>WFCORE-4276</a>] -         Audit and if possible eliminate overrides of SimpleResourceDefinition.registerCapabilities
</li>
</ul>
                                    