### PR TITLE
WFLY-11636 WeldClassFileInfo should account for meta-annotations.

### DIFF
--- a/weld/common/src/main/java/org/jboss/as/weld/util/Reflections.java
+++ b/weld/common/src/main/java/org/jboss/as/weld/util/Reflections.java
@@ -111,7 +111,7 @@ public class Reflections {
         return false;
     }
 
-    private static boolean containsAnnotations(Annotation[] annotations, Class<? extends Annotation> requiredAnnotation) {
+    public static boolean containsAnnotations(Annotation[] annotations, Class<? extends Annotation> requiredAnnotation) {
         return containsAnnotation(annotations, requiredAnnotation, true);
     }
 


### PR DESCRIPTION
JIRA - https://issues.jboss.org/browse/WFLY-11636

There is no test attached because the test is a part of Weld PR(https://github.com/weld/core/pull/1892) where this originated. We need similar test for SE, embedded container and WFLY all of which we can cover on Weld side.