### PR TITLE
@Ignore intermittently failing EJBClientXidTransactionTestCase.testSe…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
@@ -54,6 +54,7 @@ import org.jboss.tm.XAResourceRecoveryRegistry;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.transaction.client.ContextTransactionManager;
@@ -286,6 +287,7 @@ public class EJBClientXidTransactionTestCase {
      *
      * @throws Exception
      */
+    @Ignore("WFLY-11670")
     @Test
     public void testServerSuspension() throws Exception {
         final StatelessEJBLocator<org.jboss.as.test.integration.ejb.remote.client.api.tx.CMTRemote> cmtRemoteBeanLocator = new StatelessEJBLocator<org.jboss.as.test.integration.ejb.remote.client.api.tx.CMTRemote>(


### PR DESCRIPTION
…rverSuspension()

Ignores intermittently failing test discussed in https://issues.jboss.org/browse/WFLY-11670.