### PR TITLE
[WFLY-11677] Upgrade WildFly Core 8.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>8.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11677

---


### Release Notes - WildFly Core - Version 8.0.0.Beta4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4304'>WFCORE-4304</a>] -         Upgrade Galleon to 3.0.1.CR2 and WFGP to 3.0.1.CR3
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4307'>WFCORE-4307</a>] -         Upgrade WildFly Elytron to 1.8.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4308'>WFCORE-4308</a>] -         Upgrade WildFly Elytron Tool to 1.6.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4310'>WFCORE-4310</a>] -         Upgrade Remoting JMX to 3.0.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4058'>WFCORE-4058</a>] -         Automatic detection of file based KeyStore types.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4297'>WFCORE-4297</a>] -         Add constant to Phase for jaxrs
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1478'>WFCORE-1478</a>] -         DefaultOperationRequestAddress.appendPath loses Node.name
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1698'>WFCORE-1698</a>] -         CLI shutdown command completion shouldn&#39;t propose headers 
</li>
</ul>
                                            