### PR TITLE
[WFLY-11678] Reset EE concurrency managed threads to use a null TCCL …

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/handle/ClassLoaderContextHandleFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/handle/ClassLoaderContextHandleFactory.java
@@ -79,9 +79,8 @@ public class ClassLoaderContextHandleFactory implements ContextHandleFactory {
 
         @Override
         public ResetContextHandle setup() throws IllegalStateException {
-            final ClassLoaderResetContextHandle resetContextHandle = new ClassLoaderResetContextHandle(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
-            return resetContextHandle;
+            return ClassLoaderResetContextHandle.INSTANCE;
         }
 
         @Override
@@ -101,16 +100,11 @@ public class ClassLoaderContextHandleFactory implements ContextHandleFactory {
     }
 
     private static class ClassLoaderResetContextHandle implements ResetContextHandle {
-
-        private final ClassLoader previous;
-
-        private ClassLoaderResetContextHandle(ClassLoader previous) {
-            this.previous = previous;
-        }
+        static final ClassLoaderResetContextHandle INSTANCE = new ClassLoaderResetContextHandle();
 
         @Override
         public void reset() {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(previous);
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged((ClassLoader) null);
         }
 
         @Override


### PR DESCRIPTION
…after execution is finished.

https://issues.jboss.org/browse/WFLY-11678

My only concern here is if this is if the class loader looks like it will be set to `null` before the `TransactionSetupProvider.afterProxyMethod()` method is invoked. I'm not sure if that will be an issue or not.

@mmusgrov Will [this](https://github.com/wildfly/wildfly/blob/d28f05ff7dd1e317d3377ecce30c0f63549b1e9a/transactions/src/main/java/org/jboss/as/txn/ee/concurrency/TransactionSetupProviderImpl.java#L62-L71) if the TCCL is set to `null`?

```
    public void afterProxyMethod(TransactionHandle transactionHandle, String transactionExecutionProperty) {
        final Transaction transaction = ((TransactionHandleImpl) transactionHandle).getTransaction();
        if (transaction != null) {
            try {
                transactionManager.resume(transaction);
            } catch (Throwable e) {
                TransactionLogger.ROOT_LOGGER.debug("failed to resume transaction",e);
            }
        }
    }
```