### PR TITLE
[WFLY-11570][WFLY-11687][WFLY-11607] component upgrades to fix remote transaction propagation issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.13.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.14.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.2.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.1.Final</version.org.jboss.genericjms>

--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,7 @@
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.1.2.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>1.1.3.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.1</version.sun.jaxb>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/InnerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/InnerBean.java
@@ -32,7 +32,7 @@ import javax.inject.Inject;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 
-import org.jboss.as.test.integration.transactions.TestLastResource;
+import org.jboss.as.test.integration.transactions.spi.TestLastResource;
 import org.jboss.as.test.integration.transactions.TestXAResource;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TxTestUtil;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/fail/TransactionFirstPhaseErrorTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.as.test.integration.transactions.TransactionTestLookupUtil;
 import org.jboss.as.test.integration.transactions.TxTestUtil;
+import org.jboss.as.test.integration.transactions.spi.TestLastResource;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -64,6 +65,7 @@ public class TransactionFirstPhaseErrorTestCase {
     public static Archive<?> createDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test-txn-one-phase.jar")
         .addPackage(TxTestUtil.class.getPackage())
+        .addPackage(TestLastResource.class.getPackage())
         .addClasses(InnerBean.class, OuterBean.class)
         .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jboss-transaction-spi \n"), "MANIFEST.MF")
         // grant necessary permissions for -Dsecurity.manager

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/ActivationPropertyTimeoutMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/ActivationPropertyTimeoutMDB.java
@@ -72,6 +72,10 @@ public class ActivationPropertyTimeoutMDB implements MessageListener {
                     + " and bean does not know where to reply to");
             }
 
+            // should timeout txn - this timeout waiting has to be greater than 1 s
+            // (see transactionTimeout activation config property)
+            TxTestUtil.waitForTimeout(tm);
+
             TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
 
             try (
@@ -82,9 +86,6 @@ public class ActivationPropertyTimeoutMDB implements MessageListener {
                     .send(replyTo, REPLY_PREFIX + ((TextMessage) message).getText());
             }
 
-            // would timeout txn - this timeout waiting has to be greater than 1 s
-            // (see transactionTimeout activation config property)
-            TxTestUtil.waitForTimeout(tm);
         } catch (Exception e) {
             throw new RuntimeException("onMessage method execution failed", e);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/DefaultTimeoutMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/DefaultTimeoutMDB.java
@@ -78,6 +78,10 @@ public class DefaultTimeoutMDB implements MessageListener {
                     + " and bean does not know where to reply to");
             }
 
+            // should timeout txn - this timeout waiting has to be greater than 1 s
+            // (see transaction timeout default setup task)
+            TxTestUtil.waitForTimeout(tm);
+
             TxTestUtil.enlistTestXAResource(tm.getTransaction(), checker);
 
             try (JMSContext context = factory.createContext()) {
@@ -85,9 +89,6 @@ public class DefaultTimeoutMDB implements MessageListener {
                     .setJMSCorrelationID(message.getJMSMessageID())
                     .send(replyTo, REPLY_PREFIX + ((TextMessage) message).getText());
             }
-
-            // waiting up to 2.5 sec - expecting transaction timeout to happen
-            TxTestUtil.waitForTimeout(tm);
         } catch (Exception e) {
             throw new RuntimeException("onMessage method execution failed", e);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/mdb/timeout/MessageDrivenDefaultTimeoutTestCase.java
@@ -88,9 +88,8 @@ public class MessageDrivenDefaultTimeoutTestCase {
     public void defaultTimeout() throws Exception {
         String text = "default timeout";
         Queue q = MessageDrivenTimeoutTestCase.sendMessage(text, TransactionTimeoutQueueSetupTask.DEFAULT_TIMEOUT_JNDI_NAME, initCtx);
-        Assert.assertNull("No message should be received as mdb timeouted", MessageDrivenTimeoutTestCase.receiveMessage(q, initCtx));
+        Assert.assertNull("No message should be received as mdb timeouted", MessageDrivenTimeoutTestCase.receiveMessage(q, initCtx, false));
 
         Assert.assertEquals("Expecting no commmit happened as default timeout was hit", 0, checker.getCommitted());
-        Assert.assertTrue("Expecting a rollback happened as default timeout was hit", checker.getRolledback() > 0);
     }
 }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatefulBean.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatefulBean.java
@@ -82,8 +82,7 @@ public class StatefulBean implements SessionSynchronization {
     @TransactionTimeout(value = 1)
     public void testTimeout() throws SystemException, RemoteException {
         log.trace("Method stateful #testTimeout called");
-        Transaction txn;
-        txn = tm.getTransaction();
+        Transaction txn = tm.getTransaction();
 
         TxTestUtil.enlistTestXAResource(txn, checker);
         TxTestUtil.enlistTestXAResource(txn, checker);

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatelessBean.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/timeout/StatelessBean.java
@@ -70,6 +70,8 @@ public class StatelessBean {
         Transaction txn;
         txn = tm.getTransaction();
 
+        TxTestUtil.addSynchronization(txn, checker);
+
         TxTestUtil.enlistTestXAResource(txn, checker);
         TxTestUtil.enlistTestXAResource(txn, checker);
     }
@@ -80,7 +82,8 @@ public class StatelessBean {
         Transaction txn;
         txn = tm.getTransaction();
 
-        TxTestUtil.enlistTestXAResource(txn, checker);
+        TxTestUtil.addSynchronization(txn, checker);
+
         TxTestUtil.enlistTestXAResource(txn, checker);
 
         try {
@@ -89,6 +92,8 @@ public class StatelessBean {
             Thread.currentThread().interrupt();
             throw new RemoteException("Interupted during waiting for transaction timeout", ie);
         }
+
+        TxTestUtil.enlistTestXAResource(txn, checker);
     }
 
     public void touch() {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/TxTestUtil.java
@@ -40,7 +40,7 @@ import org.junit.Assert;
  * @author Ondra Chaloupka <ochaloup@redhat.com>
  */
 public final class TxTestUtil {
-    private static final int timeoutWaitTime_ms = 2500;
+    public static final int timeoutWaitTime_ms = 2500;
 
     private TxTestUtil() {
         // no instance here

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/spi/TestLastResource.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/transactions/spi/TestLastResource.java
@@ -20,8 +20,10 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.integration.transactions;
+package org.jboss.as.test.integration.transactions.spi;
 
+import org.jboss.as.test.integration.transactions.TestXAResource;
+import org.jboss.as.test.integration.transactions.TransactionCheckerSingleton;
 import org.jboss.tm.LastResource;
 
 /**


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11687
~~https://issues.jboss.org/browse/WFLY-11684~~
https://issues.jboss.org/browse/WFLY-11570
https://issues.jboss.org/browse/WFLY-11607

project issue: https://issues.jboss.org/browse/JBEAP-16089

The fix for the transaction timeout propagation error was done in two components (jboss ejb client and the wfly transaction client). That's why the component upgrades.
The reason of the changes in the integration testsuite is the different handling of timeouted transaction in wftc as it was so far. For more details please check the discussion at https://issues.jboss.org/browse/WFTC-54?focusedCommentId=13677791#comment-13677791