### PR TITLE
[WFLY-11690] Upgrade XML namespace for Galleon packages from 1.0 to 2.0

### DIFF
--- a/galleon-pack/src/main/resources/packages/bin.common/package.xml
+++ b/galleon-pack/src/main/resources/packages/bin.common/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="bin.common">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="bin.common">
     <dependencies>
         <origin name="org.wildfly.core:wildfly-core-galleon-pack">
             <package name="bin.common"/>

--- a/galleon-pack/src/main/resources/packages/docs.examples.configs/package.xml
+++ b/galleon-pack/src/main/resources/packages/docs.examples.configs/package.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" ?>
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="docs.examples.configs"/>
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="docs.examples.configs"/>

--- a/galleon-pack/src/main/resources/packages/docs.licenses.merge/package.xml
+++ b/galleon-pack/src/main/resources/packages/docs.licenses.merge/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="docs.licenses.merge">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="docs.licenses.merge">
     <dependencies>
     <!--
         <origin name="org.wildfly.core:wildfly-core-galleon-pack">

--- a/galleon-pack/src/main/resources/packages/ejb-appclient/package.xml
+++ b/galleon-pack/src/main/resources/packages/ejb-appclient/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="ejb-appclient">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="ejb-appclient">
     <dependencies>
         <package name="appclient"/>
         <package name="bin.appclient"/>

--- a/galleon-pack/src/main/resources/packages/misc.common/package.xml
+++ b/galleon-pack/src/main/resources/packages/misc.common/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.common">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.common">
     <dependencies>
         <origin name="org.wildfly:wildfly-servlet-galleon-pack">
             <package name="misc.common"/>

--- a/galleon-pack/src/main/resources/packages/misc.domain/package.xml
+++ b/galleon-pack/src/main/resources/packages/misc.domain/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.domain">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.domain">
     <dependencies>
         <origin name="org.wildfly:wildfly-servlet-galleon-pack">
             <package name="misc.domain"/>

--- a/galleon-pack/src/main/resources/packages/misc.standalone/package.xml
+++ b/galleon-pack/src/main/resources/packages/misc.standalone/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.standalone">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.standalone">
     <dependencies>
         <origin name="org.wildfly:wildfly-servlet-galleon-pack">
             <package name="misc.standalone"/>

--- a/galleon-pack/src/main/resources/packages/product.conf/package.xml
+++ b/galleon-pack/src/main/resources/packages/product.conf/package.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="product.conf">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="product.conf">
 </package-spec>

--- a/galleon-pack/src/main/resources/packages/vaulttools/package.xml
+++ b/galleon-pack/src/main/resources/packages/vaulttools/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="vaulttools">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="vaulttools">
     <dependencies>
         <package name="org.jboss.as.vault-tool"/>
         <origin name="org.wildfly.core:wildfly-core-galleon-pack">

--- a/galleon-pack/src/main/resources/packages/wstools/package.xml
+++ b/galleon-pack/src/main/resources/packages/wstools/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="wstools">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="wstools">
     <dependencies>
         <package name="bin.wstools"/>
         <package name="org.jboss.ws.tools.wsconsume"/>

--- a/servlet-galleon-pack/src/main/resources/packages/docs.licenses.merge/package.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/docs.licenses.merge/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="docs.licenses.merge">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="docs.licenses.merge">
     <dependencies>
         <package name="docs.licenses"/>
     </dependencies>

--- a/servlet-galleon-pack/src/main/resources/packages/misc.common/package.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/misc.common/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.common">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.common">
     <dependencies>
         <package name="LICENSE.txt"/>
         <package name="README.txt"/>

--- a/servlet-galleon-pack/src/main/resources/packages/misc.domain/package.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/misc.domain/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.domain">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.domain">
     <dependencies>
         <origin name="org.wildfly.core:wildfly-core-galleon-pack">
             <package name="misc.domain"/>

--- a/servlet-galleon-pack/src/main/resources/packages/misc.standalone/package.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/misc.standalone/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="misc.standalone">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="misc.standalone">
     <dependencies>
         <origin name="org.wildfly.core:wildfly-core-galleon-pack">
             <package name="misc.standalone"/>

--- a/servlet-galleon-pack/src/main/resources/packages/product.conf/package.xml
+++ b/servlet-galleon-pack/src/main/resources/packages/product.conf/package.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" ?>
 
-<package-spec xmlns="urn:jboss:galleon:package:1.0" name="product.conf">
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="product.conf">
 </package-spec>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11690