### PR TITLE
[WFLY-11692] Upgrade WilfFly Core 8.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>8.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11692

---


## Release Notes - WildFly Core - Version 8.0.0.Beta5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4315'>WFCORE-4315</a>] -         Upgrade the wildfly-maven-plugin to 1.2.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4317'>WFCORE-4317</a>] -         Upgrade jboss-logmanager from 2.1.5.Final to 2.1.7.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4318'>WFCORE-4318</a>] -         Upgrade jboss-classfilewriter from 1.2.3.Final to 1.2.4.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4311'>WFCORE-4311</a>] -         Testing of layer execution
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1427'>WFCORE-1427</a>] -         Provide ability to suspend and resume the set of servers managed by a specific host controller
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4251'>WFCORE-4251</a>] -         Provide ability to list modules which are on deployment&#39;s classpath
</li>
</ul>
                
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3997'>WFCORE-3997</a>] -         Add HostExcludeResourceDefinition.KnownRelease items for EAP 7.2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4089'>WFCORE-4089</a>] -         Update subsystem and core-model tests to use EAP 7.2.0 rather than WF14
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4321'>WFCORE-4321</a>] -         Upgrade target XML namespace for Galleon packages from 1.0 to 2.0
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4322'>WFCORE-4322</a>] -         Bump the kernel management API version to 10.0.0
</li>
</ul>
                                    