### PR TITLE
[WFLY-11670] Remove @ignore annotation from EJBClientXidTransactionTe…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/tx/EJBClientXidTransactionTestCase.java
@@ -54,7 +54,6 @@ import org.jboss.tm.XAResourceRecoveryRegistry;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.transaction.client.ContextTransactionManager;
@@ -287,7 +286,6 @@ public class EJBClientXidTransactionTestCase {
      *
      * @throws Exception
      */
-    @Ignore("WFLY-11670")
     @Test
     public void testServerSuspension() throws Exception {
         final StatelessEJBLocator<org.jboss.as.test.integration.ejb.remote.client.api.tx.CMTRemote> cmtRemoteBeanLocator = new StatelessEJBLocator<org.jboss.as.test.integration.ejb.remote.client.api.tx.CMTRemote>(


### PR DESCRIPTION
…stCase.testServerSuspension test case which was failing intermitently

The test was initially ignored, since we got the wildly-transaction-client component upgrade to 1.1.3.Final, we are now able to remove the ignore annotation.

Jira issue: https://issues.jboss.org/browse/WFLY-11670