### PR TITLE
[WFLY-11710] Expose metrics from runtime resources

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsRegistrationService.java
@@ -30,6 +30,8 @@ import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMe
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -42,8 +44,10 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.Services;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -54,6 +58,7 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
     private final Resource rootResource;
     private final Supplier<ModelControllerClientFactory> modelControllerClientFactory;
     private final Supplier<Executor> managementExecutor;
+    private Supplier<ExecutorService> executorService;
     private List<String> exposedSubsystems;
     private String globalPrefix;
     private MetricCollector metricCollector;
@@ -70,22 +75,50 @@ public class MetricsRegistrationService implements Service<MetricsRegistrationSe
         Supplier<ModelControllerClientFactory> modelControllerClientFactory = serviceBuilder.requires(context.getCapabilityServiceName(CLIENT_FACTORY_CAPABILITY, ModelControllerClientFactory.class));
         Supplier<Executor> managementExecutor = serviceBuilder.requires(context.getCapabilityServiceName(MANAGEMENT_EXECUTOR, Executor.class));
         serviceBuilder.requires(CONFIG_PROVIDER);
-        MetricsRegistrationService service = new MetricsRegistrationService(rootResourceRegistration, rootResource, modelControllerClientFactory, managementExecutor, exposedSubsystems, prefix);
+        Supplier<ExecutorService> executorService = Services.requireServerExecutor(serviceBuilder);
+        MetricsRegistrationService service = new MetricsRegistrationService(rootResourceRegistration, rootResource, modelControllerClientFactory, managementExecutor, executorService, exposedSubsystems, prefix);
         serviceBuilder.setInstance(service)
                 .install();
     }
 
-    public MetricsRegistrationService(ImmutableManagementResourceRegistration rootResourceRegistration, Resource rootResource, Supplier<ModelControllerClientFactory> modelControllerClientFactory, Supplier<Executor> managementExecutor, List<String> exposedSubsystems, String globalPrefix) {
+    public MetricsRegistrationService(ImmutableManagementResourceRegistration rootResourceRegistration, Resource rootResource, Supplier<ModelControllerClientFactory> modelControllerClientFactory, Supplier<Executor> managementExecutor, Supplier<ExecutorService> executorService, List<String> exposedSubsystems, String globalPrefix) {
         this.rootResourceRegistration = rootResourceRegistration;
         this.rootResource = rootResource;
         this.modelControllerClientFactory = modelControllerClientFactory;
         this.managementExecutor = managementExecutor;
+        this.executorService = executorService;
         this.exposedSubsystems = exposedSubsystems;
         this.globalPrefix = globalPrefix;
     }
 
     @Override
     public void start(StartContext context) throws StartException {
+        final Runnable task = new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    doStart(context);
+                } catch (StartException e) {
+                    context.failed(e);
+                }
+            }
+        };
+        try {
+            executorService.get().submit(task);
+        } catch (RejectedExecutionException e) {
+            task.run();
+        } finally {
+            context.complete();
+        }
+
+    }
+
+    private void doStart(StartContext context) throws StartException {
+        final ServiceContainer serviceContainer = context.getController().getServiceContainer();
+        try {
+            serviceContainer.awaitStability();
+        } catch (InterruptedException e) {
+        }
         jmxRegistrar = new JmxRegistrar();
         try {
             jmxRegistrar.init();

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -67,8 +67,8 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
         List<String> exposedSubsystems = MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS.unwrap(context, model);
         String prefix = MicroProfileMetricsSubsystemDefinition.PREFIX.resolveModelAttribute(context, model).asStringOrNull();
 
-        MetricsRegistrationService.install(context, exposedSubsystems, prefix);
         MetricsContextService.install(context, securityEnabled);
+        MetricsRegistrationService.install(context, exposedSubsystems, prefix);
 
         MicroProfileMetricsLogger.LOGGER.activatingSubsystem();
     }


### PR DESCRIPTION
* Install the MetricsRegistrationService at VERIFY stage (instead of
  RUNTIME) so that any resources created during  RUNTIME (such as
  datasources statistics) will be registered in WildFly management tree.

JIRA: https://issues.jboss.org/browse/WFLY-11710
