### PR TITLE
[WFLY-11711] Prepare HostExcludesTestCase for the following product host exclusion

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HostExcludesTestCase.java
@@ -204,6 +204,13 @@ public class HostExcludesTestCase extends BuildConfigurationTestBase {
                 "org.wildfly.extension.core-management",
                 "org.wildfly.extension.discovery",
                 "org.wildfly.extension.elytron"
+        )),
+        EAP72("EAP72", EAP71, Arrays.asList(
+                "org.wildfly.extension.datasources-agroal",
+                "org.wildfly.extension.microprofile.opentracing-smallrye",
+                "org.wildfly.extension.microprofile.health-smallrye",
+                "org.wildfly.extension.microprofile.config-smallrye",
+                "org.wildfly.extension.ee-security"
         ));
 
         private final String name;


### PR DESCRIPTION
Added to the test the list of expected extensions used by EAP72. It will allow asserting the host exclusions on the product branches.

Jira issue: https://issues.jboss.org/browse/WFLY-11711