### PR TITLE
Ignore LayersTestCase until we can get it working with thin servers. …

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -20,12 +20,15 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
 import static org.jboss.as.test.layers.LayersTest.recursiveDelete;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  *
  * @author jdenise@redhat.com
  */
+@Ignore("WFLY-11715")
 public class LayersTestCase {
     // Packages that are provisioned but not used (not injected nor referenced).
     // This is the expected set of not provisioned modules when all layers are provisioned.


### PR DESCRIPTION
…With fat servers the disk space budget is too high for CI

Ignore the test until #12073 can be merged.