### PR TITLE
[WFLY-11727]: QPid Proton-J version is lagging behind.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <version.org.apache.myfaces.core>2.3.1</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
-        <version.org.apache.qpid.proton>0.27.3</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.32.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.2</version.org.apache.santuario>
         <version.org.apache.thrift>0.11.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>


### PR DESCRIPTION
* Updating the version from 0.27.3 to 0.32.0 which matches the one used by Artemis.

Jira: https://issues.jboss.org/browse/WFLY-11727