### PR TITLE
[WFLY-11733] Remove duplicate dependency log4j.log4j from testsuite/integration/sm…

### DIFF
--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -84,11 +84,6 @@
         </dependency>
         <!-- The following are required at for JAXB on Java 11 -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-databinding-jaxb</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
…oke/pom.xml

The dependency log4j.log4j with scope "test" exists two times in testsuite/integration/smoke/pom.xml. lines 65-69 and 86-90.
This PR removes the second entry.

Linked to https://issues.jboss.org/browse/WFLY-11733.