### PR TITLE
[WFLY-11734] Weld subsystem throws NPE deploying an application if transactions subsystem is missing

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/WeldBootstrapService.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/WeldBootstrapService.java
@@ -124,7 +124,7 @@ public class WeldBootstrapService implements Service {
         // set up injected services
         addWeldService(SecurityServices.class, securityServicesSupplier.get());
 
-        TransactionServices transactionServices = weldTransactionServicesSupplier.get();
+        TransactionServices transactionServices = weldTransactionServicesSupplier != null ? weldTransactionServicesSupplier.get() : null;
         if (transactionServices != null) {
             addWeldService(TransactionServices.class, transactionServices);
         }


### PR DESCRIPTION
Avoid NPE if the supplier is null, which means TransactionServices is not available.

Jira issue: https://issues.jboss.org/browse/WFLY-11734