### PR TITLE
[WFLY-11741]: Upgrade Jboss Metadata to 13.0.0.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,7 +323,7 @@
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.metadata>12.0.0.Final</version.org.jboss.metadata>
+        <version.org.jboss.metadata>13.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.4.0.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.9.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.2.Final</version.org.jboss.openjdk-orb>


### PR DESCRIPTION
* Upgrading JBoss Metadata to deprecate ReplicationConfig.

Jira: https://issues.jboss.org/browse/WFLY-11741