### PR TITLE
WFLY-11752 testsuite/integration/elytron uses directly a jboss.dist d…

### DIFF
--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -47,8 +47,10 @@
 
     <properties>
         <wildfly.instance.name>wildfly</wildfly.instance.name>
-        <jboss.dist>${basedir}/target/${wildfly.instance.name}</jboss.dist>
-        <wildfly.dir>${jboss.dist}</wildfly.dir>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
 
         <enforcer.skip>true</enforcer.skip>
     </properties>
@@ -130,7 +132,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-batch-jberet</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
     </dependencies>
 
     <build>
@@ -143,93 +145,6 @@
             </testResource>
         </testResources>
         <plugins>
-            <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>server-provisioning</id>
-                        <goals>
-                            <goal>provision</goal>
-                        </goals>
-                        <phase>generate-test-resources</phase>
-                        <configuration>
-                            <install-dir>${project.build.directory}/${wildfly.instance.name}</install-dir>
-                            <record-state>false</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>true</offline>
-                            <feature-packs>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>org.wildfly.core</groupId>
-                                    <artifactId>wildfly-core-galleon-pack</artifactId>
-                                    <version>${version.org.wildfly.core}</version>
-                                </feature-pack>
-                                <feature-pack>
-                                    <transitive>true</transitive>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
-                                    <version>${project.version}</version>
-                                </feature-pack>
-                                <feature-pack>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>wildfly-galleon-pack</artifactId>
-                                    <version>${project.version}</version>
-                                    <excluded-packages>
-                                        <name>product.conf</name>
-                                        <name>docs</name>
-                                        <name>docs.licenses.merge</name>
-                                    </excluded-packages>
-                                    <inherit-configs>false</inherit-configs>
-                                    <included-configs>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                        </config>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone-full.xml</name>
-                                        </config>
-                                    </included-configs>
-                                </feature-pack>
-                            </feature-packs>
-                            <plugin-options>
-                                <jboss-maven-dist/>
-                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>${version.resources.plugin}</version>
-                <executions combine.self="override">
-                    <execution>
-                        <id>ts.config-as.copy-mgmt-users</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>ts.copy-wildfly</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>ts.copy-elytron.config</id>
-                        <phase>process-test-resources</phase>
-                        <inherited>false</inherited>
-                        <configuration combine.self="override">
-                            <outputDirectory>${wildfly.dir}/standalone/configuration</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>src/test/config</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Use keytool plugin to create JCEKS keystore for Elytron Credential Store related testing -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -282,6 +197,7 @@
                     <systemPropertyVariables>
                         <jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
                         <jboss.inst>${wildfly.dir}</jboss.inst>
+                        <module.path>${wildfly.dir}/modules</module.path>
                         <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} -Djboss.bind.address=${node0} -Djboss.bind.address.management=${node0} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.other} ${jvm.args.timeouts} ${extra.server.jvm.args}</server.jvm.args>
                         <node0>${node0}</node0>
                     </systemPropertyVariables>
@@ -291,6 +207,140 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>server-jboss-dist-profile</id>
+            <activation>
+                <property>
+                    <name>jboss.dist</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions combine.children="append">
+                            <!-- Copy the AS modules into current_submodule/target/wildfly/modules. -->
+                            <!-- JASPI tests create new modules. -->
+                            <execution>
+                                <id>copy-wildfly-modules</id>
+                                <inherited>true</inherited>
+                                <phase>generate-test-resources</phase>
+                                <goals><goal>copy-resources</goal></goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly/modules</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>${jboss.dist}/modules</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>server-provisioning-profile</id>
+            <activation>
+                <property>
+                    <name>!jboss.dist</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jboss.galleon</groupId>
+                        <artifactId>galleon-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>server-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>generate-test-resources</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/${wildfly.instance.name}</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <transitive>true</transitive>
+                                            <groupId>org.wildfly.core</groupId>
+                                            <artifactId>wildfly-core-galleon-pack</artifactId>
+                                            <version>${version.org.wildfly.core}</version>
+                                        </feature-pack>
+                                        <feature-pack>
+                                            <transitive>true</transitive>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                        </feature-pack>
+                                        <feature-pack>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                            <excluded-packages>
+                                                <name>product.conf</name>
+                                                <name>docs</name>
+                                                <name>docs.licenses.merge</name>
+                                            </excluded-packages>
+                                            <inherit-configs>false</inherit-configs>
+                                            <included-configs>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone.xml</name>
+                                                </config>
+                                                <config>
+                                                    <model>standalone</model>
+                                                    <name>standalone-full.xml</name>
+                                                </config>
+                                            </included-configs>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                    </plugin-options>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>${version.resources.plugin}</version>
+                        <executions combine.self="override">
+                            <execution>
+                                <id>ts.config-as.copy-mgmt-users</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>ts.copy-wildfly</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>ts.copy-elytron.config</id>
+                                <phase>process-test-resources</phase>
+                                <inherited>false</inherited>
+                                <configuration combine.self="override">
+                                    <outputDirectory>${wildfly.dir}/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/test/config</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>adjust-server-config</id>
             <activation>


### PR DESCRIPTION
…ir when set instead of its copy in the target dir

https://issues.jboss.org/browse/WFLY-11752

When the jboss.dist property is set for the mvn command, the testsuite/integration/elytron project uses directly a server distribution in the jboss.dist directory instead of its copy in the target/wildfly directory, and the distribution is customized with the modify-elytron-config.cli script.
As a result, when running the test suite in the elytron mode (-Delytron), the next testing module (compat) fails.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ x ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ x ] Pull Request contains link to the JIRA issue(s)
- [ x ] Pull Request contains description of the issue(s)
- [ x ] Pull Request does not include fixes for issues other than the main ticket
- [ x ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.