### PR TITLE
Revert "[WFLY-11710] Expose metrics from runtime resources"

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -67,8 +67,8 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
         List<String> exposedSubsystems = MicroProfileMetricsSubsystemDefinition.EXPOSED_SUBSYSTEMS.unwrap(context, model);
         String prefix = MicroProfileMetricsSubsystemDefinition.PREFIX.resolveModelAttribute(context, model).asStringOrNull();
 
-        MetricsContextService.install(context, securityEnabled);
         MetricsRegistrationService.install(context, exposedSubsystems, prefix);
+        MetricsContextService.install(context, securityEnabled);
 
         MicroProfileMetricsLogger.LOGGER.activatingSubsystem();
     }


### PR DESCRIPTION
This reverts commit 8c4904dcbe3053d099c36442336a6d91024e7c48.

The MSC approach here is missing context.asynchronous(), leading to WFLY-11760. But if that is added, boot hangs.