### PR TITLE
[WFLY-11747] Use capabilities in wildfly-connector instead of deprecated service names

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/_private/Capabilities.java
+++ b/connector/src/main/java/org/jboss/as/connector/_private/Capabilities.java
@@ -18,7 +18,9 @@ package org.jboss.as.connector._private;
 
 import javax.sql.DataSource;
 
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.naming.service.NamingService;
 
 /**
  * Capabilities for the connector subsystems.
@@ -41,9 +43,22 @@ public interface Capabilities {
 
     String ELYTRON_SECURITY_DOMAIN_CAPABILITY = "org.wildfly.security.security-domain";
 
+    String RESOURCE_ADAPTER_CAPABILITY_NAME = "org.wildfly.resource-adapter";
+
+    String JCA_NAMING_CAPABILITY_NAME = "org.wildfly.jca.naming";
+
     /**
      * The data-source capability
      */
     RuntimeCapability<Void> DATA_SOURCE_CAPABILITY = RuntimeCapability.Builder.of(DATA_SOURCE_CAPABILITY_NAME, true, DataSource.class)
+            .addRequirements(NamingService.CAPABILITY_NAME, ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME)
+            .build();
+
+    RuntimeCapability<Void> RESOURCE_ADAPTER_CAPABILITY = RuntimeCapability.Builder.of(RESOURCE_ADAPTER_CAPABILITY_NAME, true)
+            .addRequirements(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME, NamingService.CAPABILITY_NAME)
+            .build();
+
+    RuntimeCapability<Void> JCA_NAMING_CAPABILITY = RuntimeCapability.Builder.of(JCA_NAMING_CAPABILITY_NAME)
+            .addRequirements(NamingService.CAPABILITY_NAME)
             .build();
 }

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.deployers.ra;
 
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME;
+
 import org.jboss.as.connector.deployers.ds.processors.DriverProcessor;
 import org.jboss.as.connector.deployers.ds.processors.StructureDriverProcessor;
 import org.jboss.as.connector.deployers.ra.processors.IronJacamarDeploymentParsingProcessor;
@@ -69,7 +71,7 @@ public class RaDeploymentActivator {
         RaRepositoryService raRepositoryService = new RaRepositoryService();
         serviceTarget.addService(ConnectorServices.RA_REPOSITORY_SERVICE, raRepositoryService)
                 .addDependency(ConnectorServices.IRONJACAMAR_MDR, MetadataRepository.class, raRepositoryService.getMdrInjector())
-                .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
+                .addDependency(ConnectorServices.getCachedCapabilityServiceName(TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class,
                         raRepositoryService.getTransactionIntegrationInjector())
                 .install();
 

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RaXmlDeploymentProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RaXmlDeploymentProcessor.java
@@ -23,6 +23,7 @@
 package org.jboss.as.connector.deployers.ra.processors;
 
 import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
+import static org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT;
 
 import org.jboss.as.connector.metadata.xmldescriptors.ConnectorXmlDescriptor;
 import org.jboss.as.connector.services.resourceadapters.deployment.InactiveResourceAdapterDeploymentService;
@@ -31,6 +32,7 @@ import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.connector.util.RaServicesFactory;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.deployment.Attachments;
@@ -72,8 +74,10 @@ public class RaXmlDeploymentProcessor implements DeploymentUnitProcessor {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final ManagementResourceRegistration baseRegistration = deploymentUnit.getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
         final ManagementResourceRegistration registration;
-        final Resource deploymentResource = phaseContext.getDeploymentUnit().getAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE);
+        final Resource deploymentResource = deploymentUnit.getAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE);
         final ConnectorXmlDescriptor connectorXmlDescriptor = deploymentUnit.getAttachment(ConnectorXmlDescriptor.ATTACHMENT_KEY);
+        final CapabilityServiceSupport support = deploymentUnit.getAttachment(CAPABILITY_SERVICE_SUPPORT);
+
         if (connectorXmlDescriptor == null) {
             return; // Skip non ra deployments
         }
@@ -107,7 +111,7 @@ public class RaXmlDeploymentProcessor implements DeploymentUnitProcessor {
                     String rarName = raxml.getArchive();
 
                     if (deploymentUnitName.equals(rarName)) {
-                        RaServicesFactory.createDeploymentService(registration, connectorXmlDescriptor, module, serviceTarget, deploymentUnitName, deploymentUnit.getServiceName(), deploymentUnitName, raxml, deploymentResource, phaseContext.getServiceRegistry());
+                        RaServicesFactory.createDeploymentService(registration, connectorXmlDescriptor, module, serviceTarget, deploymentUnitName, deploymentUnit.getServiceName(), deploymentUnitName, raxml, deploymentResource, phaseContext.getServiceRegistry(), support);
 
                     }
                 }

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectAdminObjectActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectAdminObjectActivatorService.java
@@ -163,7 +163,7 @@ public class DirectAdminObjectActivatorService implements Service<ContextNames.B
                             activator.getManagementRepositoryInjector())
                     .addDependency(ConnectorServices.RESOURCE_ADAPTER_REGISTRY_SERVICE,
                             ResourceAdapterDeploymentRegistry.class, activator.getRegistryInjector())
-                    .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
+                    .addDependency(ConnectorServices.getCachedCapabilityServiceName(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class,
                             activator.getTxIntegrationInjector())
                     .addDependency(ConnectorServices.CONNECTOR_CONFIG_SERVICE,
                             JcaSubsystemConfiguration.class, activator.getConfigInjector())
@@ -177,8 +177,8 @@ public class DirectAdminObjectActivatorService implements Service<ContextNames.B
                     */
                     .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class,
                             activator.getCcmInjector());
-            adminObjectServiceBuilder.requires(NamingService.SERVICE_NAME);
-            adminObjectServiceBuilder.requires(ConnectorServices.getLocalTransactionProviderServiceName());
+            adminObjectServiceBuilder.requires(ConnectorServices.getCachedCapabilityServiceName(NamingService.CAPABILITY_NAME));
+            adminObjectServiceBuilder.requires(ConnectorServices.getCachedCapabilityServiceName(ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY));
             adminObjectServiceBuilder.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
             adminObjectServiceBuilder.setInitialMode(ServiceController.Mode.ACTIVE).install();
         } catch (Exception e) {

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
@@ -244,10 +244,10 @@ public class DirectConnectionFactoryActivatorService implements org.jboss.msc.se
                             JcaSubsystemConfiguration.class, activator.getConfigInjector())
                     .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class,
                             activator.getCcmInjector())
-                    .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
+                    .addDependency(ConnectorServices.getCachedCapabilityServiceName(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class,
                             activator.getTxIntegrationInjector());
-            connectionFactoryServiceBuilder.requires(NamingService.SERVICE_NAME);
-            connectionFactoryServiceBuilder.requires(ConnectorServices.getLocalTransactionProviderServiceName());
+            connectionFactoryServiceBuilder.requires(ConnectorServices.getCachedCapabilityServiceName(NamingService.CAPABILITY_NAME));
+            connectionFactoryServiceBuilder.requires(ConnectorServices.getCachedCapabilityServiceName(ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY));
             connectionFactoryServiceBuilder.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"));
 
             if (ActivationSecurityUtil.isLegacySecurityRequired(security)) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -57,6 +57,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
@@ -147,6 +148,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         // expression in the model can be resolved to a correct value.
         @SuppressWarnings("unused")
         final boolean statsEnabled = STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
+        final CapabilityServiceSupport support = context.getCapabilityServiceSupport();
 
         final ServiceTarget serviceTarget = context.getServiceTarget();
 
@@ -182,9 +184,10 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
          dataSourceServiceBuilder.requires(ConnectorServices.IDLE_REMOVER_SERVICE);
          dataSourceServiceBuilder.requires(ConnectorServices.CONNECTION_VALIDATOR_SERVICE);
          dataSourceServiceBuilder.addDependency(ConnectorServices.IRONJACAMAR_MDR, MetadataRepository.class, dataSourceService.getMdrInjector());
-         dataSourceServiceBuilder.requires(NamingService.SERVICE_NAME);
+         dataSourceServiceBuilder.requires(support.getCapabilityServiceName(NamingService.CAPABILITY_NAME));
+
         if (jta) {
-            dataSourceServiceBuilder.addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class, dataSourceService.getTransactionIntegrationInjector());
+            dataSourceServiceBuilder.addDependency(support.getCapabilityServiceName(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class, dataSourceService.getTransactionIntegrationInjector());
             dataSourceServiceBuilder.addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class, dataSourceService.getCcmInjector());
             dataSourceServiceBuilder.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append(DEFAULT_NAME));
             dataSourceServiceBuilder.addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class, dataSourceService.getRaRepositoryInjector());

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/CachedConnectionManagerAdd.java
@@ -132,7 +132,7 @@ public class CachedConnectionManagerAdd extends AbstractBoottimeAddStepHandler {
         CachedConnectionManagerService ccmService = new CachedConnectionManagerService(debug, error, ignoreUnknownConnections);
         serviceTarget
                 .addService(ConnectorServices.CCM_SERVICE, ccmService)
-                .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
+                .addDependency(context.getCapabilityServiceSupport().getCapabilityServiceName(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class,
                         ccmService.getTransactionIntegrationInjector())
                 .install();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -25,6 +25,7 @@ package org.jboss.as.connector.subsystems.jca;
 
 import static org.jboss.as.connector.subsystems.jca.JcaSubsystemRootDefinition.TRANSACTION_INTEGRATION_CAPABILITY;
 import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME;
 import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY;
 import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 
@@ -38,6 +39,8 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.txn.integration.JBossContextXATerminator;
@@ -87,6 +90,12 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .addAliases(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE)
                 .install();
+
+        // Cache the some capability service names for use by our runtime services
+        final CapabilityServiceSupport support = context.getCapabilityServiceSupport();
+        ConnectorServices.registerCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, support.getCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY));
+        ConnectorServices.registerCapabilityServiceName(NamingService.CAPABILITY_NAME, support.getCapabilityServiceName(NamingService.CAPABILITY_NAME));
+        ConnectorServices.registerCapabilityServiceName(TRANSACTION_INTEGRATION_CAPABILITY_NAME, support.getCapabilityServiceName(TRANSACTION_INTEGRATION_CAPABILITY_NAME));
 
         final JcaSubsystemConfiguration config = new JcaSubsystemConfiguration();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -22,7 +22,10 @@
 
 package org.jboss.as.connector.subsystems.jca;
 
+import static org.jboss.as.connector._private.Capabilities.JCA_NAMING_CAPABILITY;
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME;
 import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
+import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY;
 import static org.jboss.as.connector.util.ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
@@ -39,8 +42,10 @@ import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
     protected static final PathElement PATH_SUBSYSTEM = PathElement.pathElement(SUBSYSTEM, JcaExtension.SUBSYSTEM_NAME);
 
-    static final RuntimeCapability<Void> TRANSACTION_INTEGRATION_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jca.transaction-integration", TransactionIntegration.class)
-            .addRequirements(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY)
+    static final RuntimeCapability<Void> TRANSACTION_INTEGRATION_CAPABILITY = RuntimeCapability.Builder.of(TRANSACTION_INTEGRATION_CAPABILITY_NAME, TransactionIntegration.class)
+            .addRequirements(LOCAL_TRANSACTION_PROVIDER_CAPABILITY,
+                    TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY,
+                    TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY)
             .build();
 
     private final boolean registerRuntimeOnly;
@@ -50,6 +55,7 @@ public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
         super(new Parameters(PATH_SUBSYSTEM, JcaExtension.getResourceDescriptionResolver())
                 .setAddHandler(JcaSubsystemAdd.INSTANCE)
                 .setRemoveHandler(JcaSubSystemRemove.INSTANCE)
+                .setCapabilities(JCA_NAMING_CAPABILITY)
                 .setCapabilities(TRANSACTION_INTEGRATION_CAPABILITY)
         );
         this.registerRuntimeOnly = registerRuntimeOnly;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
@@ -117,6 +117,7 @@ import org.jboss.as.connector.util.RaServicesFactory;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.UninterruptibleCountDownLatch;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.annotation.ResourceRootIndexer;
@@ -376,6 +377,7 @@ public class RaOperationUtil {
     public static void activate(OperationContext context, String raName, String archiveName) throws OperationFailedException {
         ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController<?> inactiveRaController = registry.getService(ConnectorServices.INACTIVE_RESOURCE_ADAPTER_SERVICE.append(archiveName));
+        final CapabilityServiceSupport support = context.getCapabilityServiceSupport();
 
         if (inactiveRaController == null) {
 
@@ -390,7 +392,7 @@ public class RaOperationUtil {
         final ServiceController<?> RaxmlController = registry.getService(ServiceName.of(ConnectorServices.RA_SERVICE, raName));
         Activation raxml = (Activation) RaxmlController.getValue();
         RaServicesFactory.createDeploymentService(inactive.getRegistration(), inactive.getConnectorXmlDescriptor(), inactive.getModule(), inactive.getServiceTarget(),
-                archiveName, inactive.getDeploymentUnitServiceName(), inactive.getDeployment(), raxml, inactive.getResource(), registry);
+                archiveName, inactive.getDeploymentUnitServiceName(), inactive.getDeployment(), raxml, inactive.getResource(), registry, support);
     }
 
     public static ServiceName installRaServices(OperationContext context, String name, ModifiableResourceAdapter resourceAdapter, final List<ServiceController<?>> newControllers) {
@@ -464,6 +466,7 @@ public class RaOperationUtil {
         final boolean resolveProperties = true;
         final ServiceTarget serviceTarget = context.getServiceTarget();
         final String moduleName;
+        final CapabilityServiceSupport support = context.getCapabilityServiceSupport();
 
 
         //load module
@@ -519,7 +522,7 @@ public class RaOperationUtil {
                 final ServiceName deployerServiceName = ConnectorServices.RESOURCE_ADAPTER_DEPLOYER_SERVICE_PREFIX.append(connectorXmlDescriptor.getDeploymentName());
                 final ServiceController<?> deployerService = context.getServiceRegistry(true).getService(deployerServiceName);
                 if (deployerService == null) {
-                    ServiceBuilder builder = ParsedRaDeploymentProcessor.process(connectorXmlDescriptor, ironJacamarXmlDescriptor, module.getClassLoader(), serviceTarget, annotationIndexes, RAR_MODULE.append(name), null, null);
+                    ServiceBuilder builder = ParsedRaDeploymentProcessor.process(connectorXmlDescriptor, ironJacamarXmlDescriptor, module.getClassLoader(), serviceTarget, annotationIndexes, RAR_MODULE.append(name), null, null, support);
                     builder.requires(raServiceName);
                     newControllers.add(builder.setInitialMode(ServiceController.Mode.ACTIVE).install());
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaRemove.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import java.util.LinkedList;
 import java.util.List;
 
+import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.OperationContext;
@@ -80,6 +81,7 @@ public class RaRemove implements OperationStepHandler {
 
 
         context.removeResource(PathAddress.EMPTY_ADDRESS);
+        context.deregisterCapability(Capabilities.RESOURCE_ADAPTER_CAPABILITY.getDynamicName(context.getCurrentAddress()));
 
         if (context.isDefaultRequiresRuntime()) {
             context.addStep(new OperationStepHandler() {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterResourceDefinition.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.connector.subsystems.resourceadapters;
 
+import static org.jboss.as.connector._private.Capabilities.RESOURCE_ADAPTER_CAPABILITY;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RESOURCEADAPTER_NAME;
 
 import java.util.List;
@@ -49,17 +50,27 @@ public class ResourceAdapterResourceDefinition extends SimpleResourceDefinition 
 
     // The ManagedConnectionPool implementation used by default by versions < 4.0.0 (WildFly 10)
 
-
     private final boolean readOnly;
     private final boolean runtimeOnlyRegistrationValid;
     private final List<AccessConstraintDefinition> accessConstraints;
 
     public ResourceAdapterResourceDefinition(boolean readOnly, boolean runtimeOnlyRegistrationValid) {
-        super(PathElement.pathElement(RESOURCEADAPTER_NAME), RESOLVER, readOnly ? null : RaAdd.INSTANCE, readOnly ? null : RaRemove.INSTANCE);
+        super(getParameters(readOnly));
         this.readOnly = readOnly;
         this.runtimeOnlyRegistrationValid = runtimeOnlyRegistrationValid;
         ApplicationTypeConfig atc = new ApplicationTypeConfig(ResourceAdaptersExtension.SUBSYSTEM_NAME, RESOURCEADAPTER_NAME);
         accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
+    }
+
+    private static Parameters getParameters(boolean readOnly) {
+        Parameters parameters = new Parameters(PathElement.pathElement(RESOURCEADAPTER_NAME), RESOLVER);
+        if (!readOnly) {
+            parameters.setAddHandler(RaAdd.INSTANCE)
+                    .setRemoveHandler(RaRemove.INSTANCE)
+                    .setCapabilities(RESOURCE_ADAPTER_CAPABILITY);
+        }
+
+        return parameters;
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubSystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubSystemAdd.java
@@ -24,7 +24,6 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ARCHIVE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RESOURCEADAPTER_NAME;
-import static org.jboss.as.connector.util.ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY;
 
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.connector.util.CopyOnWriteArrayListMultiMap;
@@ -56,9 +55,6 @@ class ResourceAdaptersSubsystemAdd extends AbstractAddStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-
-        // Cache the TransactionManager service name for use by our runtime services
-        ConnectorServices.registerCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, context.getCapabilityServiceName(LOCAL_TRANSACTION_PROVIDER_CAPABILITY, null));
 
         final Resource subsystemResource = context.readResourceFromRoot(PathAddress.pathAddress(ResourceAdaptersExtension.SUBSYSTEM_PATH));
         ResourceAdaptersSubsystemService service = new ResourceAdaptersSubsystemService();

--- a/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/ConnectorServices.java
@@ -277,9 +277,14 @@ public class ConnectorServices {
      */
     public static final String TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY = "org.wildfly.transactions.xa-resource-recovery-registry";
 
-    public static ServiceName getLocalTransactionProviderServiceName() {
+    public static ServiceName getCachedCapabilityServiceName(String capabilityName) {
         synchronized (capabilityServiceNames) {
-            return capabilityServiceNames.get(LOCAL_TRANSACTION_PROVIDER_CAPABILITY);
+            return capabilityServiceNames.get(capabilityName);
         }
     }
+
+    /**
+     * The capability name for the JCA transaction integration TransactionIntegration.
+     */
+    public static final String TRANSACTION_INTEGRATION_CAPABILITY_NAME = "org.wildfly.jca.transaction-integration";
 }

--- a/connector/src/main/java/org/jboss/as/connector/util/RaServicesFactory.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/RaServicesFactory.java
@@ -34,6 +34,7 @@ import org.jboss.as.connector.services.mdr.AS7MetadataRepository;
 import org.jboss.as.connector.services.resourceadapters.deployment.ResourceAdapterXmlDeploymentService;
 import org.jboss.as.connector.services.resourceadapters.deployment.registry.ResourceAdapterDeploymentRegistry;
 import org.jboss.as.connector.subsystems.jca.JcaSubsystemConfiguration;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -56,7 +57,7 @@ public class RaServicesFactory {
 
     public static void createDeploymentService(final ManagementResourceRegistration registration, ConnectorXmlDescriptor connectorXmlDescriptor, Module module,
                                                ServiceTarget serviceTarget, final String deploymentUnitName, ServiceName deploymentUnitServiceName, String deployment,
-                                               Activation raxml, final Resource deploymentResource, final ServiceRegistry serviceRegistry) {
+                                               Activation raxml, final Resource deploymentResource, final ServiceRegistry serviceRegistry, final CapabilityServiceSupport support) {
         // Create the service
 
         ServiceName serviceName = ConnectorServices.getDeploymentServiceName(deploymentUnitName,raxml);
@@ -77,14 +78,14 @@ public class RaServicesFactory {
                         service.getManagementRepositoryInjector())
                 .addDependency(ConnectorServices.RESOURCE_ADAPTER_REGISTRY_SERVICE,
                         ResourceAdapterDeploymentRegistry.class, service.getRegistryInjector())
-                .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
+                .addDependency(support.getCapabilityServiceName(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME), TransactionIntegration.class,
                         service.getTxIntegrationInjector())
                 .addDependency(ConnectorServices.CONNECTOR_CONFIG_SERVICE, JcaSubsystemConfiguration.class,
                         service.getConfigInjector())
                 .addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class, service.getCcmInjector());
         builder.requires(ConnectorServices.IDLE_REMOVER_SERVICE);
         builder.requires(ConnectorServices.CONNECTION_VALIDATOR_SERVICE);
-        builder.requires(NamingService.SERVICE_NAME);
+        builder.requires(support.getCapabilityServiceName(NamingService.CAPABILITY_NAME));
         builder.requires(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append(bootStrapCtxName));
         builder.requires(ConnectorServices.RESOURCE_ADAPTER_DEPLOYER_SERVICE_PREFIX.append(connectorXmlDescriptor.getDeploymentName()));
 

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.logging.ConnectorLogger;
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.security.CredentialReference;
@@ -42,6 +43,7 @@ import org.jboss.as.model.test.FailedOperationTransformationConfig.AttributesPat
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
+import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -104,10 +106,12 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
     protected AdditionalInitialization createAdditionalInitialization() {
         // Create a AdditionalInitialization.MANAGEMENT variant that has all the external
         // capabilities used by the various configs used in this test class
-        return AdditionalInitialization.withCapabilities(
+        return AdditionalInitialization.MANAGEMENT.withCapabilities(
                 Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY + ".DsAuthCtxt",
                 Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY + ".CredentialAuthCtxt",
-                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".test-store"
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".test-store",
+                NamingService.CAPABILITY_NAME,
+                ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME
         );
     }
 
@@ -183,7 +187,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
      */
     private void testTransformer(String subsystemXml, ModelTestControllerVersion controllerVersion, final ModelVersion modelVersion) throws Exception {
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         KernelServices mainServices = initialKernelServices(builder, controllerVersion, modelVersion);
         List<ModelNode> ops = builder.parseXmlResource(subsystemXml);
         PathAddress subsystemAddress = PathAddress.pathAddress(DataSourcesSubsystemRootDefinition.PATH_SUBSYSTEM);
@@ -239,7 +243,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
     private void testTransformerEAP7FullConfiguration(String subsystemXml) throws Exception {
         ModelTestControllerVersion eap7ControllerVersion = ModelTestControllerVersion.EAP_7_0_0;
         ModelVersion eap7ModelVersion = ModelVersion.create(4, 0, 0);
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         KernelServices mainServices = initialKernelServices(builder, eap7ControllerVersion, eap7ModelVersion);
         List<ModelNode> ops = builder.parseXmlResource(subsystemXml);
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, eap7ModelVersion, ops, FailedOperationTransformationConfig.NO_FAILURES);
@@ -254,7 +258,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
         //Use the non-runtime version of the extension which will happen on the HC
         ModelTestControllerVersion eap7ControllerVersion = ModelTestControllerVersion.EAP_7_0_0;
         ModelVersion eap7ModelVersion = ModelVersion.create(4, 0, 0);
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         KernelServices mainServices = initialKernelServices(builder, eap7ControllerVersion, eap7ModelVersion);
         List<ModelNode> ops = builder.parseXmlResource(subsystemXml);
         PathAddress subsystemAddress = PathAddress.pathAddress(DataSourcesSubsystemRootDefinition.PATH_SUBSYSTEM);

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -88,6 +88,7 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
                 ClusteringDefaultRequirement.COMMAND_DISPATCHER_FACTORY.getName(),
                 ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY,
                 ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY,
+                ConnectorServices.TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY,
                 "org.wildfly.threads.thread-factory.string");
     }
 

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
+import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -52,6 +53,7 @@ import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
+import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -289,7 +291,7 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
      */
     private void testRejectingTransformer7ElytronEnabled(String subsystemXml, ModelTestControllerVersion controllerVersion, ModelVersion modelVersion) throws Exception {
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         //.setSubsystemXmlResource(subsystemXml);
         String artifactId = ":wildfly-connector:";
         String ironJacamarVersion = "1.3.3.Final-redhat-1";
@@ -412,7 +414,9 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
 
 
     protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.MANAGEMENT;
+        return AdditionalInitialization.MANAGEMENT
+                .withCapabilities(ConnectorServices.TRANSACTION_INTEGRATION_CAPABILITY_NAME,
+                        NamingService.CAPABILITY_NAME);
     }
 
     //TODO: remove this special method as soon as RA will have a unique name in DMR marshalled in xml

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -179,9 +179,11 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
         serverState = readAttribute(new ModelNode(), "server-state");
         Assert.assertEquals("reload-required", serverState.asString());
 
-        // check that runtime was updated
-        Assert.assertEquals(4, poolConfiguration.getMinSize());
-        Assert.assertEquals(10, poolConfiguration.getMaxSize());
+        ModelNode result = readAttribute(CONNECTION_ADDRESS, Constants.MIN_POOL_SIZE.getName());
+        Assert.assertEquals(4, result.asInt());
+
+        result = readAttribute(CONNECTION_ADDRESS, Constants.MAX_POOL_SIZE.getName());
+        Assert.assertEquals(10, result.asInt());
     }
 
     static class ResourceAdapterCapacityPoliciesServerSetupTask extends JcaMgmtServerSetupTask {


### PR DESCRIPTION
This issue removes the uses of deprecated service names in favor of its capabilities. Additionally, it adds required capabilities for some connector subsystems. This patch will help Galleon to ensure that the provisioned server is correct.

Jira issue: https://issues.jboss.org/browse/WFLY-11747

cc: @maeste 