### PR TITLE
[WFLY-11768] Upgrade libthrift from 0.11.0 to 0.12.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
         <version.org.apache.qpid.proton>0.27.3</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.2</version.org.apache.santuario>
-        <version.org.apache.thrift>0.11.0</version.org.apache.thrift>
+        <version.org.apache.thrift>0.12.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>
         <version.org.apache.ws.security>2.2.2</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11768

This requires approval from @jmesnil or @jpkrohling. For this reason I've placed a hold on the PR.