### PR TITLE
[WFLY-11710] Expose metrics from runtime resources

### DIFF
--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -41,15 +41,15 @@ import org.jboss.msc.service.ServiceName;
  */
 public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDefinition {
 
-    static final String METRICS_REGISTRATION_CAPABILITY = "org.wildlfy.extension.microprofile.metrics.wildfly-registrar";
+    static final String METRICS_COLLECTOR_CAPABILITY = "org.wildlfy.extension.microprofile.metrics.wildfly-collector";
 
     static final String CLIENT_FACTORY_CAPABILITY ="org.wildfly.management.model-controller-client-factory";
     static final String MANAGEMENT_EXECUTOR ="org.wildfly.management.executor";
-    static final RuntimeCapability<Void> METRICS_REGISTRATION_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(METRICS_REGISTRATION_CAPABILITY, MetricsRegistrationService.class)
+    static final RuntimeCapability<Void> METRICS_COLLECTOR_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(METRICS_COLLECTOR_CAPABILITY, MetricsCollectorService.class)
             .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR)
             .build();
 
-    public static final ServiceName WILDFLY_REGISTRATION_SERVICE = METRICS_REGISTRATION_RUNTIME_CAPABILITY.getCapabilityServiceName();
+    public static final ServiceName WILDFLY_COLLECTOR_SERVICE = METRICS_COLLECTOR_RUNTIME_CAPABILITY.getCapabilityServiceName();
 
     static final String HTTP_EXTENSIBILITY_CAPABILITY = "org.wildfly.management.http.extensible";
     static final RuntimeCapability<Void> HTTP_CONTEXT_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.microprofile.metrics.http-context", MetricsContextService.class)
@@ -82,7 +82,7 @@ public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDe
                 MicroProfileMetricsExtension.getResourceDescriptionResolver(MicroProfileMetricsExtension.SUBSYSTEM_NAME))
                 .setAddHandler(MicroProfileMetricsSubsystemAdd.INSTANCE)
                 .setRemoveHandler(new ServiceRemoveStepHandler(MicroProfileMetricsSubsystemAdd.INSTANCE))
-                .setCapabilities(METRICS_REGISTRATION_RUNTIME_CAPABILITY, HTTP_CONTEXT_CAPABILITY));
+                .setCapabilities(METRICS_COLLECTOR_RUNTIME_CAPABILITY, HTTP_CONTEXT_CAPABILITY));
     }
 
     @Override

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DependencyProcessor.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DependencyProcessor.java
@@ -43,7 +43,7 @@ public class DependencyProcessor implements DeploymentUnitProcessor {
 
         addModuleDependencies(deploymentUnit);
 
-        phaseContext.addDeploymentDependency(MicroProfileMetricsSubsystemDefinition.WILDFLY_REGISTRATION_SERVICE, DeploymentMetricProcessor.METRICS_REGISTRATION);
+        phaseContext.addDeploymentDependency(MicroProfileMetricsSubsystemDefinition.WILDFLY_COLLECTOR_SERVICE, DeploymentMetricProcessor.METRICS_COLLECTOR);
     }
 
     @Override

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricProcessor.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/deployment/DeploymentMetricProcessor.java
@@ -29,11 +29,11 @@ import org.jboss.as.server.deployment.DeploymentModelUtils;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-import org.wildfly.extension.microprofile.metrics.MetricsRegistrationService;
+import org.wildfly.extension.microprofile.metrics.MetricCollector;
 
 public class DeploymentMetricProcessor implements DeploymentUnitProcessor {
 
-    static final AttachmentKey<MetricsRegistrationService> METRICS_REGISTRATION = AttachmentKey.create(MetricsRegistrationService.class);
+    static final AttachmentKey<MetricCollector> METRICS_COLLECTOR = AttachmentKey.create(MetricCollector.class);
 
     private Resource rootResource;
     private ManagementResourceRegistration managementResourceRegistration;


### PR DESCRIPTION
* Install the MetricsCollectorService at RUNTIME stage
  but delay the actual collection of metrics from the WildFly resource
  at VERIFY stage so that any resources created during  RUNTIME (such as
  datasources statistics) will be registered in WildFly management tree.

JIRA: https://issues.jboss.org/browse/WFLY-11710