### PR TITLE
Fix for WFLY-11774, Rename microprofile layer to be observability

### DIFF
--- a/galleon-pack/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
@@ -5,7 +5,7 @@
         <layer name="jaxrs" optional="true"/>
         <layer name="jms-activemq" optional="true"/>
         <layer name="jpa" optional="true"/>
-        <layer name="microprofile" optional="true"/>
+        <layer name="observability" optional="true"/>
         <layer name="resource-adapters" optional="true"/>
     </dependencies>
 </layer-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
         <layer name="web-server"/>
         <layer name="management"/>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -693,13 +693,13 @@
                         </configuration>
                     </execution>
                      <execution>
-                        <id>microprofile-provisioning</id>
+                        <id>observability-provisioning</id>
                         <goals>
                             <goal>provision</goal>
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${layers.install.dir}/microprofile</install-dir>
+                            <install-dir>${layers.install.dir}/observability</install-dir>
                             <record-state>false</record-state>
                             <log-time>${galleon.log.time}</log-time>
                             <plugin-options>
@@ -733,7 +733,7 @@
                                     <model>standalone</model>
                                     <name>standalone.xml</name>
                                     <layers>
-                                        <layer>microprofile</layer>
+                                        <layer>observability</layer>
                                     </layers>
                                 </config>
                             </configurations>
@@ -928,7 +928,7 @@
                                         <layer>jaxrs</layer>
                                         <layer>jms-activemq</layer>
                                         <layer>jpa</layer>
-                                        <layer>microprofile</layer>
+                                        <layer>observability</layer>
                                         <layer>resource-adapters</layer>
                                         <layer>undertow</layer>
                                         <layer>vault</layer>


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFLY-11774.