### PR TITLE
[WFLY-11775] Upgrade WildFly Core 8.0.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,7 +378,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>8.0.0.CR1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11775

---



## Release Notes - WildFly Core - Version 8.0.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4334'>WFCORE-4334</a>] -         Upgrade to Galleon and WFGP 3.0.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4340'>WFCORE-4340</a>] -         Upgrade jboss-invocation from 1.5.1.Final to 1.5.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4341'>WFCORE-4341</a>] -         Upgrade Undertow to 2.0.19.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4343'>WFCORE-4343</a>] -         Upgrade WildFly Elytron to 1.8.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4344'>WFCORE-4344</a>] -         Upgrade Elytron Web to 1.4.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4345'>WFCORE-4345</a>] -         Upgrade WildFly Elytron Tool to 1.6.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4347'>WFCORE-4347</a>] -         Update Maven Plugins to 2.0.0.Final
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4298'>WFCORE-4298</a>] -         Multi-release jar resource loading in VFSResourceLoader doesn&#39;t take into account the Multi-Release manifest attribute value
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4326'>WFCORE-4326</a>] -         Follow up on WFCORE-3826 to add mechanism override support to the native connector.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4330'>WFCORE-4330</a>] -         Subsystem test framework does not work with model overrides
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4331'>WFCORE-4331</a>] -         Rotating file handlers don&#39;t allow a .zip or .gz suffix for compressing rotated files
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4335'>WFCORE-4335</a>] -         null file is created in bin directory when starting standalone.bat
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4348'>WFCORE-4348</a>] -         Shell scripts tests are intermittently failing on Windows CI runs
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4349'>WFCORE-4349</a>] -         PowerShell script tests should run with an unrestricted execution policy
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4351'>WFCORE-4351</a>] -         Fixed Value used in error message instead of effective environment value 
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4328'>WFCORE-4328</a>] -         Add EAP 7.2 host exclusion enum type in wildfly config xsd
</li>
</ul>
                                    