### PR TITLE
[WFLY-11813] Test for empty username for Elytron's FormAuthenticationMechanism

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/FormMechTestBase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/FormMechTestBase.java
@@ -22,45 +22,178 @@
 
 package org.wildfly.test.integration.elytron.http;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.arquillian.api.ServerSetup;
-import org.jboss.as.test.integration.security.common.Utils;
-import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
-import org.jboss.as.test.integration.web.sso.LogoutServlet;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.runner.RunWith;
-import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.Header;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+
+import static org.apache.http.HttpStatus.SC_FORBIDDEN;
+import static org.apache.http.HttpStatus.SC_MOVED_TEMPORARILY;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.jboss.as.test.integration.security.common.servlets.SimpleServlet.RESPONSE_BODY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * Test of FORM HTTP mechanism.
  *
  * @author Jan Kalina
  */
-@RunWith(Arquillian.class)
-@RunAsClient
-@ServerSetup({ FormMechTestBase.ServerSetup.class })
-public class FormMechTestBase extends FormMechTestCase {
+abstract class FormMechTestBase extends AbstractMechTestBase {
 
-    @Deployment(testable = false)
-    public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class, NAME + ".war")
-                .addClasses(SimpleServlet.class)
-                .addClasses(LogoutServlet.class)
-                .addAsWebInfResource(Utils.getJBossWebXmlAsset(APP_DOMAIN), "jboss-web.xml")
-                .addAsWebResource(new StringAsset(LOGIN_PAGE_CONTENT), "login.html")
-                .addAsWebResource(new StringAsset(ERROR_PAGE_CONTENT), "error.html")
-                .addAsWebInfResource(FormMechTestCase.class.getPackage(), NAME + "-web.xml", "web.xml");
+    protected static final String NAME = FormMechTestCase.class.getSimpleName();
+    protected static final String LOGIN_PAGE_CONTENT = "LOGINPAGE";
+    protected static final String ERROR_PAGE_CONTENT = "ERRORPAGE";
+
+    @Test
+    @Override
+    public void testUnauthorized() throws Exception {
+        HttpGet request = new HttpGet(new URI(url.toExternalForm() + "role1"));
+        HttpClientContext context = HttpClientContext.create();
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            try (CloseableHttpResponse response = httpClient.execute(request, context)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
+        }
     }
 
-    static class ServerSetup extends AbstractMechTestBase.ServerSetup {
-        @Override protected MechanismConfiguration getMechanismConfiguration() {
-            return MechanismConfiguration.builder()
-                    .withMechanismName("FORM")
-                    .build();
+    @Test
+    public void testLoginPage() throws Exception {
+        HttpGet request = new HttpGet(new URI(url.toExternalForm() + "login.html"));
+        HttpClientContext context = HttpClientContext.create();
+
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            try (CloseableHttpResponse response = httpClient.execute(request, context)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
         }
+    }
+
+    @Test
+    public void testCorrectWorkflow() throws Exception {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
+            // unauthorized - login form should be shown
+            HttpGet request1 = new HttpGet(new URI(url.toExternalForm() + "role1"));
+            try (CloseableHttpResponse response = httpClient.execute(request1)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
+
+            // logging-in
+            HttpPost request2 = createLoginRequest( "user1",  "password1");
+            try (CloseableHttpResponse response = httpClient.execute(request2)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                Header[] locations = response.getHeaders("Location");
+                assertEquals("Unexpected status code in HTTP response.", SC_MOVED_TEMPORARILY, statusCode);
+                assertEquals("Missing redirect in HTTP response.", 1, locations.length);
+                assertEquals("Unexpected redirect in HTTP response.", url.toExternalForm() + "role1", locations[0].getValue());
+            }
+
+            // should be logged now
+            HttpGet request3 = new HttpGet(new URI(url.toExternalForm() + "role1"));
+            try (CloseableHttpResponse response = httpClient.execute(request3)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", RESPONSE_BODY, EntityUtils.toString(response.getEntity()));
+            }
+
+            // but no role2
+            HttpGet request4 = new HttpGet(new URI(url.toExternalForm() + "role2"));
+            try (CloseableHttpResponse response = httpClient.execute(request4)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_FORBIDDEN, statusCode);
+                assertNotEquals("Unexpected content of HTTP response.", RESPONSE_BODY, EntityUtils.toString(response.getEntity()));
+            }
+
+            // try to log-out
+            HttpGet request5 = new HttpGet(new URI(url.toExternalForm() + "logout"));
+            try (CloseableHttpResponse response = httpClient.execute(request5)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                Header[] locations = response.getHeaders("Location");
+                assertEquals("Unexpected status code in HTTP response.", SC_MOVED_TEMPORARILY, statusCode);
+                assertEquals("Missing redirect in HTTP response.", 1, locations.length);
+                assertEquals("Unexpected redirect in HTTP response.", url.toExternalForm() + "index.html", locations[0].getValue());
+            }
+
+            // should be logged-out again
+            HttpGet request6 = new HttpGet(new URI(url.toExternalForm() + "role1"));
+            try (CloseableHttpResponse response = httpClient.execute(request6)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidPrincipal() throws Exception {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
+            HttpPost request = createLoginRequest("user1wrong",  "password1");
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidCredential() throws Exception {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
+            HttpPost request = createLoginRequest("user1",  "password1wrong");
+            try (CloseableHttpResponse response = httpClient.execute(request)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
+            }
+        }
+    }
+
+    @Test
+    public void testEmptyUsername() throws Exception {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
+            HttpPost emptyUsernameRequest = createLoginRequest("", "non-empty-password");
+            try (CloseableHttpResponse response = httpClient.execute(emptyUsernameRequest)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT,
+                    EntityUtils.toString(response.getEntity()));
+            }
+            HttpPost emptyUsernameAndPasswordLoginRequest = createLoginRequest("", "");
+            try (CloseableHttpResponse response = httpClient.execute(emptyUsernameAndPasswordLoginRequest)) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
+                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT,
+                    EntityUtils.toString(response.getEntity()));
+            }
+        }
+    }
+
+    protected HttpPost createLoginRequest(String username, String password)
+        throws Exception {
+        HttpPost request = new HttpPost(new URI(url.toExternalForm() + "j_security_check"));
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("j_username", username));
+        params.add(new BasicNameValuePair("j_password", password));
+        request.setEntity(new UrlEncodedFormEntity(params));
+        return request;
     }
 }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/FormMechTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/FormMechTestCase.java
@@ -22,162 +22,46 @@
 
 package org.wildfly.test.integration.elytron.http;
 
-import static org.apache.http.HttpStatus.SC_FORBIDDEN;
-import static org.apache.http.HttpStatus.SC_MOVED_TEMPORARILY;
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.jboss.as.test.integration.security.common.servlets.SimpleServlet.RESPONSE_BODY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.http.Header;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.util.EntityUtils;
-import org.junit.Test;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.integration.web.sso.LogoutServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
 
 /**
  * Test of FORM HTTP mechanism.
  *
  * @author Jan Kalina
  */
-abstract class FormMechTestCase extends AbstractMechTestBase {
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ FormMechTestCase.ServerSetup.class })
+public class FormMechTestCase extends FormMechTestBase {
 
-    protected static final String NAME = FormMechTestCase.class.getSimpleName();
-    protected static final String LOGIN_PAGE_CONTENT = "LOGINPAGE";
-    protected static final String ERROR_PAGE_CONTENT = "ERRORPAGE";
-
-    @Test
-    @Override
-    public void testUnauthorized() throws Exception {
-        HttpGet request = new HttpGet(new URI(url.toExternalForm() + "role1"));
-        HttpClientContext context = HttpClientContext.create();
-
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            try (CloseableHttpResponse response = httpClient.execute(request, context)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
+    static class ServerSetup extends AbstractMechTestBase.ServerSetup {
+        @Override protected MechanismConfiguration getMechanismConfiguration() {
+            return MechanismConfiguration.builder()
+                .withMechanismName("FORM")
+                .build();
         }
     }
 
-    @Test
-    public void testLoginPage() throws Exception {
-        HttpGet request = new HttpGet(new URI(url.toExternalForm() + "login.html"));
-        HttpClientContext context = HttpClientContext.create();
-
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            try (CloseableHttpResponse response = httpClient.execute(request, context)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
-        }
-    }
-
-    @Test
-    public void testCorrectWorkflow() throws Exception {
-        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
-            // unauthorized - login form should be shown
-            HttpGet request1 = new HttpGet(new URI(url.toExternalForm() + "role1"));
-            try (CloseableHttpResponse response = httpClient.execute(request1)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
-
-            // logging-in
-            HttpPost request2 = new HttpPost(new URI(url.toExternalForm() + "j_security_check"));
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair("j_username", "user1"));
-            params.add(new BasicNameValuePair("j_password", "password1"));
-            request2.setEntity(new UrlEncodedFormEntity(params));
-            try (CloseableHttpResponse response = httpClient.execute(request2)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                Header[] locations = response.getHeaders("Location");
-                assertEquals("Unexpected status code in HTTP response.", SC_MOVED_TEMPORARILY, statusCode);
-                assertEquals("Missing redirect in HTTP response.", 1, locations.length);
-                assertEquals("Unexpected redirect in HTTP response.", url.toExternalForm() + "role1", locations[0].getValue());
-            }
-
-            // should be logged now
-            HttpGet request3 = new HttpGet(new URI(url.toExternalForm() + "role1"));
-            try (CloseableHttpResponse response = httpClient.execute(request3)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", RESPONSE_BODY, EntityUtils.toString(response.getEntity()));
-            }
-
-            // but no role2
-            HttpGet request4 = new HttpGet(new URI(url.toExternalForm() + "role2"));
-            try (CloseableHttpResponse response = httpClient.execute(request4)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_FORBIDDEN, statusCode);
-                assertNotEquals("Unexpected content of HTTP response.", RESPONSE_BODY, EntityUtils.toString(response.getEntity()));
-            }
-
-            // try to log-out
-            HttpGet request5 = new HttpGet(new URI(url.toExternalForm() + "logout"));
-            try (CloseableHttpResponse response = httpClient.execute(request5)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                Header[] locations = response.getHeaders("Location");
-                assertEquals("Unexpected status code in HTTP response.", SC_MOVED_TEMPORARILY, statusCode);
-                assertEquals("Missing redirect in HTTP response.", 1, locations.length);
-                assertEquals("Unexpected redirect in HTTP response.", url.toExternalForm() + "index.html", locations[0].getValue());
-            }
-
-            // should be logged-out again
-            HttpGet request6 = new HttpGet(new URI(url.toExternalForm() + "role1"));
-            try (CloseableHttpResponse response = httpClient.execute(request6)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", LOGIN_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
-        }
-    }
-
-    @Test
-    public void testInvalidPrincipal() throws Exception {
-        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
-            HttpPost request = new HttpPost(new URI(url.toExternalForm() + "j_security_check"));
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair("j_username", "user1wrong"));
-            params.add(new BasicNameValuePair("j_password", "password1"));
-            request.setEntity(new UrlEncodedFormEntity(params));
-            try (CloseableHttpResponse response = httpClient.execute(request)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
-        }
-    }
-
-    @Test
-    public void testInvalidCredential() throws Exception {
-        try (CloseableHttpClient httpClient = HttpClientBuilder.create().disableRedirectHandling().build()) {
-            HttpPost request = new HttpPost(new URI(url.toExternalForm() + "j_security_check"));
-            List<NameValuePair> params = new ArrayList<NameValuePair>();
-            params.add(new BasicNameValuePair("j_username", "user1"));
-            params.add(new BasicNameValuePair("j_password", "password1wrong"));
-            request.setEntity(new UrlEncodedFormEntity(params));
-            try (CloseableHttpResponse response = httpClient.execute(request)) {
-                int statusCode = response.getStatusLine().getStatusCode();
-                assertEquals("Unexpected status code in HTTP response.", SC_OK, statusCode);
-                assertEquals("Unexpected content of HTTP response.", ERROR_PAGE_CONTENT, EntityUtils.toString(response.getEntity()));
-            }
-        }
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class, NAME + ".war")
+            .addClasses(SimpleServlet.class)
+            .addClasses(LogoutServlet.class)
+            .addAsWebInfResource(Utils.getJBossWebXmlAsset(APP_DOMAIN), "jboss-web.xml")
+            .addAsWebResource(new StringAsset(LOGIN_PAGE_CONTENT), "login.html")
+            .addAsWebResource(new StringAsset(ERROR_PAGE_CONTENT), "error.html")
+            .addAsWebInfResource(FormMechTestCase.class.getPackage(), NAME + "-web.xml", "web.xml");
     }
 
 }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/MinimalFormMechTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/MinimalFormMechTestCase.java
@@ -44,17 +44,17 @@ import org.wildfly.test.security.common.elytron.MechanismConfiguration;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ MinimalFormMechTestCase.ServerSetup.class })
-public class MinimalFormMechTestCase extends FormMechTestCase {
+public class MinimalFormMechTestCase extends FormMechTestBase {
 
     @Deployment(testable = false)
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class, NAME + ".war")
-                .addClasses(SimpleServlet.class)
-                .addClasses(LogoutServlet.class)
-                .addAsWebInfResource(Utils.getJBossWebXmlAsset(APP_DOMAIN), "jboss-web.xml")
-                .addAsWebResource(new StringAsset(LOGIN_PAGE_CONTENT), "login.html")
-                .addAsWebResource(new StringAsset(ERROR_PAGE_CONTENT), "error.html")
-                .addAsWebInfResource(FormMechTestCase.class.getPackage(), NAME + "-web.xml", "web.xml");
+            .addClasses(SimpleServlet.class)
+            .addClasses(LogoutServlet.class)
+            .addAsWebInfResource(Utils.getJBossWebXmlAsset(APP_DOMAIN), "jboss-web.xml")
+            .addAsWebResource(new StringAsset(LOGIN_PAGE_CONTENT), "login.html")
+            .addAsWebResource(new StringAsset(ERROR_PAGE_CONTENT), "error.html")
+            .addAsWebInfResource(FormMechTestCase.class.getPackage(), NAME + "-web.xml", "web.xml");
     }
 
     static class ServerSetup extends AbstractMechTestBase.ServerSetup {

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/SilentBasicMechTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/http/SilentBasicMechTestCase.java
@@ -59,7 +59,7 @@ import org.wildfly.test.security.common.elytron.MechanismConfiguration;
 @RunWith(Arquillian.class)
 @RunAsClient
 @ServerSetup({ SilentBasicMechTestCase.ServerSetup.class})
-public class SilentBasicMechTestCase extends FormMechTestCase {
+public class SilentBasicMechTestCase extends FormMechTestBase {
 
     private static final String FORBIDDEN_CONTENT = "Forbidden";
     private static final String NAME = SilentBasicMechTestCase.class.getSimpleName();


### PR DESCRIPTION
`FormMechTestCase#testEmptyUsername()` could be added to `FormMechTestBase`, however I'm not sure if it is within desired scope of other test classes extending `FormMechTestBase`