### PR TITLE
Fix for WFLY-11797, org.hibernate.envers not provisioned with jpa layer

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPADefinition.java
@@ -102,6 +102,8 @@ public class JPADefinition extends SimpleResourceDefinition {
         resourceRegistration.registerAdditionalRuntimePackages(
                 // Only if annotation is in use.
                 RuntimePackageDependency.optional("org.hibernate.search.orm"),
-                RuntimePackageDependency.required("org.hibernate"));
+                RuntimePackageDependency.required("org.hibernate"),
+                // An alias to org.hibernate module.
+                RuntimePackageDependency.optional("org.hibernate.envers"));
     }
 }


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFLY-11797
Expose  "org.hibernate.envers" as an optional runtime Galleon package.