### PR TITLE
[WFLY-11751] Error in JBoss Management Console when clicking on the deployed subsystem jaxrs/rest-resource

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsScanningProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsScanningProcessor.java
@@ -33,14 +33,10 @@ import java.util.Set;
 
 import javax.ws.rs.core.Application;
 
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.jaxrs.DeploymentRestResourcesDefintion;
 import org.jboss.as.jaxrs.JaxrsAnnotations;
-import org.jboss.as.jaxrs.JaxrsExtension;
 import org.jboss.as.jaxrs.logging.JaxrsLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
-import org.jboss.as.server.deployment.DeploymentResourceSupport;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
@@ -118,22 +114,8 @@ public class JaxrsScanningProcessor implements DeploymentUnitProcessor {
                 }
             }
             deploymentUnit.putAttachment(JaxrsAttachments.RESTEASY_DEPLOYMENT_DATA, resteasyDeploymentData);
-            List<String> rootRestClasses = new ArrayList<>(resteasyDeploymentData.getScannedResourceClasses());
-            Collections.sort(rootRestClasses);
-            for(String cls: rootRestClasses) {
-                addManagement(deploymentUnit, cls);
-            }
         } catch (ModuleLoadException e) {
             throw new DeploymentUnitProcessingException(e);
-        }
-    }
-
-    private void addManagement(DeploymentUnit deploymentUnit, String componentClass) {
-        try {
-            final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
-            deploymentResourceSupport.getDeploymentSubModel(JaxrsExtension.SUBSYSTEM_NAME, PathElement.pathElement(DeploymentRestResourcesDefintion.REST_RESOURCE_NAME, componentClass));
-        } catch (Exception e) {
-            JaxrsLogger.JAXRS_LOGGER.failedToRegisterManagementViewForRESTResources(componentClass, e);
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/packaging/ear/EarApplicationRESTInEJBIsolatedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/packaging/ear/EarApplicationRESTInEJBIsolatedTestCase.java
@@ -1,0 +1,200 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jaxrs.packaging.ear;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+/**
+ * Use Case: 2 ejb modules, 2 web modules, isolated via jboss-deployment-structure.xml.
+ *
+ * REST Endpoints are defined in ejb module.
+ * Application is defined in web module.
+ *
+ * web1 depends on ejb1 only, web2 can access ejb1 and ejb2
+ *
+ * @author Lin Gao
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EarApplicationRESTInEJBIsolatedTestCase {
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jaxrsapp-isolated.ear");
+        ear.addAsManifestResource(new StringAsset(
+                "<jboss-deployment-structure>"
+                    + "    <ear-subdeployments-isolated>true</ear-subdeployments-isolated>"
+                    + "    <sub-deployment name=\"web1.war\">"
+                    + "        <dependencies>"
+                    + "            <module name=\"deployment.jaxrsapp-isolated.ear.ejb1.jar\" />"
+                    + "        </dependencies>"
+                    + "    </sub-deployment>"
+                    + "    <sub-deployment name=\"web2.war\">"
+                    + "        <dependencies>"
+                    + "            <module name=\"deployment.jaxrsapp-isolated.ear.ejb1.jar\" />"
+                    + "            <module name=\"deployment.jaxrsapp-isolated.ear.ejb2.jar\" />"
+                    + "        </dependencies>"
+                    + "    </sub-deployment>"
+                    + "</jboss-deployment-structure>"),
+                "jboss-deployment-structure.xml");
+
+        JavaArchive ejb1 = ShrinkWrap.create(JavaArchive.class, "ejb1.jar");
+        ejb1.addPackage(HttpRequest.class.getPackage());
+        ejb1.addClasses(EarApplicationRESTInEJBIsolatedTestCase.class, HelloWorldResource.class);
+        ear.addAsModule(ejb1);
+
+        JavaArchive ejb2 = ShrinkWrap.create(JavaArchive.class, "ejb2.jar");
+        ejb2.addPackage(HttpRequest.class.getPackage());
+        ejb2.addClasses(EarApplicationRESTInEJBIsolatedTestCase.class, HelloRestResource.class);
+        ear.addAsModule(ejb2);
+
+        // define a REST inside the WAR ?
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "web1.war");
+        war1.addClasses(HelloWorldPathApplication.class);
+        war1.addAsWebInfResource(WebXml.get(""), "web.xml");
+        ear.addAsModule(war1);
+
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "web2.war");
+        war2.addAsWebInfResource(WebXml.get("<servlet-mapping>\n" +
+                "        <servlet-name>javax.ws.rs.core.Application</servlet-name>\n" +
+                "        <url-pattern>/api/*</url-pattern>\n" +
+                "    </servlet-mapping>\n" +
+                    "\n"), "web.xml");
+        ear.addAsModule(war2);
+
+        return ear;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    private String performCall(String urlPattern) throws Exception {
+        return HttpRequest.get(url + urlPattern, 10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testJaxRs() throws Exception {
+        String result = performCall("/web1/hellopath/helloworld");
+        assertEquals("Hello World!", result);
+
+        result = performCall("/web2/api/helloworld");
+        assertEquals("Hello World!", result);
+
+        result = performCall("/web2/api/hellorest");
+        assertEquals("Hello Rest", result);
+
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void testRESTNotAvailable() throws Exception {
+        performCall("/web1/hellopath/hellorest");
+    }
+
+    @Test
+    public void testReadRestResources() throws Exception {
+        testRestReadHelloWorldResource("web1", "hellopath");
+        testRestReadHelloWorldResource("web2", "api");
+
+        testRestReadHelloRestResourceOnWeb1();
+        testRestReadHelloRestResourceOnWeb2();
+    }
+
+    // HelloWorldResource is visible to web1 and web2
+    private void testRestReadHelloWorldResource(String web, String appPath) throws Exception {
+        ModelNode addr = new ModelNode().add("deployment", "jaxrsapp-isolated.ear").add("subdeployment", web + ".war")
+                .add("subsystem", "jaxrs").add("rest-resource", HelloWorldResource.class.getName());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("read-resource");
+        operation.get(OP_ADDR).set(addr);
+        operation.get("include-runtime").set(true);
+
+        ModelNode result = managementClient.getControllerClient().execute(operation).get("result");
+        assertEquals(HelloWorldResource.class.getName(), result.get("resource-class").asString());
+        ModelNode restResPath = result.get("rest-resource-paths").asList().get(0);
+        assertEquals("helloworld", restResPath.get("resource-path").asString());
+        assertEquals("java.lang.String " + HelloWorldResource.class.getName() + ".getMessage()",
+                restResPath.get("java-method").asString());
+        assertEquals("GET /" + web + "/" + appPath + "/helloworld", restResPath.get("resource-methods").asList().get(0).asString());
+
+    }
+
+    // HelloRestResource is not visible to web1
+    private void testRestReadHelloRestResourceOnWeb1() throws Exception {
+        ModelNode addr = new ModelNode().add("deployment", "jaxrsapp-isolated.ear").add("subdeployment", "web1.war")
+                .add("subsystem", "jaxrs").add("rest-resource", HelloRestResource.class.getName());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("read-resource");
+        operation.get(OP_ADDR).set(addr);
+        operation.get("include-runtime").set(true);
+        ModelNode result = managementClient.getControllerClient().execute(operation);
+        assertEquals("failed", result.get("outcome").asString());
+        String failureDescription = result.get("failure-description").asString();
+        assertTrue(failureDescription.contains("WFLYCTL0216"));
+        assertTrue(failureDescription.contains("org.jboss.as.test.integration.jaxrs.packaging.ear.HelloRestResource"));
+        assertTrue(failureDescription.contains("not found"));
+    }
+
+    // HelloRestResource is visible to web2
+    private void testRestReadHelloRestResourceOnWeb2() throws Exception {
+        ModelNode addr = new ModelNode().add("deployment", "jaxrsapp-isolated.ear").add("subdeployment", "web2.war")
+                .add("subsystem", "jaxrs").add("rest-resource", HelloRestResource.class.getName());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("read-resource");
+        operation.get(OP_ADDR).set(addr);
+        operation.get("include-runtime").set(true);
+        ModelNode result = managementClient.getControllerClient().execute(operation).get("result");
+        assertEquals(HelloRestResource.class.getName(), result.get("resource-class").asString());
+        ModelNode restResPath = result.get("rest-resource-paths").asList().get(0);
+        assertEquals("hellorest", restResPath.get("resource-path").asString());
+        assertEquals("java.lang.String " + HelloRestResource.class.getName() + ".getMessage()",
+                restResPath.get("java-method").asString());
+        assertEquals("GET /web2/api/hellorest", restResPath.get("resource-methods").asList().get(0).asString());
+
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/packaging/ear/HelloRestResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxrs/packaging/ear/HelloRestResource.java
@@ -1,0 +1,18 @@
+package org.jboss.as.test.integration.jaxrs.packaging.ear;
+
+import javax.ejb.Stateless;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("hellorest")
+@Stateless
+public class HelloRestResource {
+
+  @GET
+  @Produces({ "text/plain" })
+  public String getMessage() {
+    return "Hello Rest";
+  }
+
+}


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11751

Changes in the PR:
- Move the code of adding management model from `POST_MODULE(JaxrsScanningProcessor.java)` to `INSTALL(JaxrsIntegrationProcessor.java)`


~~Recording scanned rest resource classes into a set as an DeploymentUnit's Attachment so that they can be used for adding the management resources under jaxrs subsystem.~~
~~A new attachment is used instead of using the existed `ADDITIONAL_RESTEASY_DEPLOYMENT_DATA`  because if the scanned resource classes are EJBs as well, they will be removed from `ResteasyDeploymentData`~~


- In case of EAR deployment, even the REST endpoints are defined in the ejb module, they can only be read out under the war sub-deployment.
   -  Using `/deployment=test.ear/subdeployment=web.war/subsystem=jaxrs/rest-resource=xx:read-resource(include-runtime)`

- In case of multiple wars inside one ear deployment, the `reset-resource` of one war will only display the  resource classes which are accessible to the war.

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted