### PR TITLE
[WFLY-11811] explicitly passing txn default timeout to TxControl during server startup

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
@@ -24,6 +24,7 @@ package org.jboss.as.txn.service;
 
 import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
+import com.arjuna.ats.arjuna.coordinator.TxControl;
 import com.arjuna.ats.arjuna.tools.osb.mbean.ObjStoreBrowser;
 import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.orbportability.internal.utils.PostInitLoader;
@@ -86,6 +87,8 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
         coordinatorEnvironmentBean.setEnableStatistics(coordinatorEnableStatistics);
         coordinatorEnvironmentBean.setDefaultTimeout(coordinatorDefaultTimeout);
         coordinatorEnvironmentBean.setTransactionStatusManagerEnable(transactionStatusManagerEnable);
+
+        TxControl.setDefaultTimeout(coordinatorDefaultTimeout);
 
         // Object Store Browser bean
         Map<String, String> objStoreBrowserTypes = new HashMap<String, String>();

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -521,6 +521,8 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
             throws OperationFailedException {
             int timeout = resolvedValue.asInt();
 
+            // TxControl allow timeout to be set to 0 with meaning of no timeout at all
+            arjPropertyManager.getCoordinatorEnvironmentBean().setDefaultTimeout(timeout);
             TxControl.setDefaultTimeout(timeout);
             if (timeout == 0) {
                 ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
@@ -536,6 +538,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                                              final String attributeName, final ModelNode valueToRestore,
                                              final ModelNode valueToRevert, final Void handback)
             throws OperationFailedException {
+            arjPropertyManager.getCoordinatorEnvironmentBean().setDefaultTimeout(valueToRestore.asInt());
             TxControl.setDefaultTimeout(valueToRestore.asInt());
             ContextTransactionManager.setGlobalDefaultTransactionTimeout(valueToRestore.asInt());
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11811

Ensuring the {{TxControl.setDefaultTimeout(...)}} is called during the server startup.

@zhfeng , @tomjenkinson : can you please review?