### PR TITLE
[WFLY-11612] Test configures two passivation stores per deployment and calls the passivation bean.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DifferentCachePassivationBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DifferentCachePassivationBean.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import org.jboss.ejb3.annotation.Cache;
+
+import javax.ejb.Local;
+import javax.ejb.PostActivate;
+import javax.ejb.PrePassivate;
+import javax.ejb.Remove;
+import javax.ejb.Stateful;
+
+/**
+ * @author Jaikiran Pai
+ */
+@Stateful(passivationCapable = true)
+@Cache("longlife")
+@Local(Bean.class)
+public class DifferentCachePassivationBean implements Bean {
+
+    private boolean prePrePassivateInvoked;
+    private boolean postActivateInvoked;
+
+    @PrePassivate
+    private void beforePassivate() {
+        this.prePrePassivateInvoked = true;
+    }
+
+    @PostActivate
+    private void afterActivate() {
+        this.postActivateInvoked = true;
+    }
+
+    @Override
+    public boolean wasPassivated() {
+        return this.prePrePassivateInvoked;
+    }
+
+    @Override
+    public boolean wasActivated() {
+        return this.postActivateInvoked;
+    }
+
+    @Remove
+    @Override
+    public void close() {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TwoPassivationStoresServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TwoPassivationStoresServerSetupTask.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ * Server setup task for TwoPassivationStoresTestCase. Configures two passivation stores and two EJB caches.
+ *
+ * @author Daniel Cihak
+ */
+public class TwoPassivationStoresServerSetupTask extends SnapshotRestoreSetupTask {
+
+    @Override
+    public void doSetup(ManagementClient managementClient, String s) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+
+        // /subsystem=ejb3/passivation-store=infinispanStore2:add(cache-container=ejb, bean-cache=passivation, max-size=1)
+        ModelNode addPassivationStore = createOpNode("subsystem=ejb3/passivation-store=infinispanStore2", ADD);
+        addPassivationStore.get("cache-container").set("ejb");
+        addPassivationStore.get("bean-cache").set("passivation");
+        addPassivationStore.get("max-size").set("1");
+        operations.add(addPassivationStore);
+
+        // /subsystem=ejb3/cache=infinispanCache2:add(passivation-store=infinispanStore2, aliases=[longlife])
+        ModelNode addCache = createOpNode("subsystem=ejb3/cache=distributable2", ADD);
+        addCache.get("passivation-store").set("infinispanStore2");
+        addCache.get("aliases").get(0).set("longlife");
+        operations.add(addCache);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+
+        //ModelNode passivationStoreAddress = getPassivationStoreAddress();
+        ModelNode passivationStoreAddress = new ModelNode();
+        passivationStoreAddress.add(SUBSYSTEM, "ejb3").add("passivation-store", "infinispan");
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("write-attribute");
+        operation.get(OP_ADDR).set(passivationStoreAddress);
+        operation.get("name").set("max-size");
+        operation.get("value").set(1);
+        managementClient.getControllerClient().execute(operation);
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TwoPassivationStoresTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TwoPassivationStoresTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+
+/**
+ * Test configures two passivation stores per deployment and calls the passivation bean. The call should succeed.
+ * Test for [ WFLY-11612 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(TwoPassivationStoresServerSetupTask.class)
+public class TwoPassivationStoresTestCase {
+
+    private static final String DEPLOYMENT = "DEPLOYMENT";
+
+    @ArquillianResource
+    private InitialContext ctx;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, DEPLOYMENT + ".jar");
+        jar.addClasses(PassivationEnabledBean.class, DifferentCachePassivationBean.class, Bean.class, TwoPassivationStoresServerSetupTask.class);
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        jar.addAsManifestResource(TwoPassivationStoresTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        return jar;
+    }
+
+    @Test
+    public void testTwoPassivationStores() throws Exception {
+        try (Bean bean = (Bean) ctx.lookup("java:module/" + PassivationEnabledBean.class.getSimpleName() + "!" + Bean.class.getName())) {
+            bean.doNothing();
+
+            try (Bean differentCacheBean1 = (Bean) ctx.lookup("java:module/" + DifferentCachePassivationBean.class.getSimpleName() + "!" + Bean.class.getName())) {
+                differentCacheBean1.doNothing();
+
+                // Create a 2nd set of beans, forcing the first set to passivate
+                try (Bean bean2 = (Bean) ctx.lookup("java:module/" + PassivationEnabledBean.class.getSimpleName() + "!" + Bean.class.getName())) {
+                    bean2.doNothing();
+
+                    try (Bean differentCacheBean2 = (Bean) ctx.lookup("java:module/" + DifferentCachePassivationBean.class.getSimpleName() + "!" + Bean.class.getName())) {
+                        differentCacheBean2.doNothing();
+
+                        Assert.assertTrue("(Annotation based) Stateful bean marked as passivation enabled was not passivated", bean.wasPassivated());
+                        Assert.assertTrue("(Annotation based) Stateful bean marked as passivation enabled was not activated", bean.wasActivated());
+
+                        Assert.assertTrue("(Deployment descriptor based) Stateful bean marked as passivation enabled was not passivated", differentCacheBean1.wasPassivated());
+                        Assert.assertTrue("(Deployment descriptor based) Stateful bean marked as passivation enabled was not activated", differentCacheBean1.wasActivated());
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Upstream JIRA issue: https://issues.jboss.org/browse/WFLY-11612

Test configures two passivation stores per deployment and calls the passivation bean. The call should succeed.