### PR TITLE
[WFLY-11769] do not identity wrap runnable when creating shared manag…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ElytronManagedThreadFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ElytronManagedThreadFactory.java
@@ -20,13 +20,12 @@
  * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.ee.concurrent.service;
+package org.jboss.as.ee.concurrent;
 
 import org.glassfish.enterprise.concurrent.AbstractManagedThread;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.glassfish.enterprise.concurrent.spi.ContextHandle;
-import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -41,51 +40,25 @@ import java.security.PrivilegedAction;
  */
 public class ElytronManagedThreadFactory extends ManagedThreadFactoryImpl {
 
-    private static final ClassLoader CLASSLOADER = ElytronManagedThreadFactory.class.getClassLoader();
-
     public ElytronManagedThreadFactory(String name, ContextServiceImpl contextService, int priority) {
         super(name, contextService, priority);
     }
 
-    protected AbstractManagedThread createThread(final Runnable r, final ContextHandle contextHandleForSetup) {
-        boolean checking = WildFlySecurityManager.isChecking();
-        SecurityDomain domain = checking ?
-                AccessController.doPrivileged((PrivilegedAction<SecurityDomain>) SecurityDomain::getCurrent) :
-                SecurityDomain.getCurrent();
-        SecurityIdentity identity = domain == null ? null : domain.getCurrentSecurityIdentity();
-        final ClassLoader tccl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-        try {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(CLASSLOADER);
-            if (checking) {
-                return AccessController.doPrivileged((PrivilegedAction<ElytronManagedThread>)
-                        () -> new ElytronManagedThread(r, contextHandleForSetup, identity)
-                );
-            } else {
-                return new ElytronManagedThread(r, contextHandleForSetup, identity);
-            }
-        } finally {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(tccl);
+    protected AbstractManagedThread createThread(Runnable r, final ContextHandle contextHandleForSetup) {
+        if (contextHandleForSetup != null) {
+            // app thread, do identity wrap
+            r = SecurityIdentityUtils.doIdentityWrap(r);
         }
+        final AbstractManagedThread t = super.createThread(r, contextHandleForSetup);
+        // reset thread classloader to prevent leaks
+        if (!WildFlySecurityManager.isChecking()) {
+            t.setContextClassLoader(null);
+        } else {
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                t.setContextClassLoader(null);
+                return null;
+            });
+        }
+        return t;
     }
-
-    public class ElytronManagedThread extends ManagedThread {
-
-        final SecurityIdentity securityIdentity;
-
-        ElytronManagedThread(Runnable target, ContextHandle contextHandleForSetup, SecurityIdentity securityIdentity) {
-            super(target, contextHandleForSetup);
-            this.securityIdentity = securityIdentity;
-        }
-
-        @Override
-        public void run() {
-            if (securityIdentity != null) {
-                securityIdentity.runAs(super::run);
-            } else {
-                super.run();
-            }
-        }
-
-    }
-
 }

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorServiceService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorServiceService.java
@@ -26,6 +26,7 @@ import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedExecutorServiceAdapter;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.jboss.as.ee.concurrent.ElytronManagedThreadFactory;
 import org.jboss.as.ee.concurrent.ManagedExecutorServiceImpl;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedScheduledExecutorServiceService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedScheduledExecutorServiceService.java
@@ -26,6 +26,7 @@ import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedScheduledExecutorServiceAdapter;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.jboss.as.ee.concurrent.ElytronManagedThreadFactory;
 import org.jboss.as.ee.concurrent.ManagedScheduledExecutorServiceImpl;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedThreadFactoryService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedThreadFactoryService.java
@@ -24,6 +24,7 @@ package org.jboss.as.ee.concurrent.service;
 
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
+import org.jboss.as.ee.concurrent.ElytronManagedThreadFactory;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.StartContext;


### PR DESCRIPTION
…ed threads

Issue: https://issues.jboss.org/browse/WFLY-11769

Regarding this solution, wrapping the runnable instead of the thread seems better and safer to me, (exit() cleans thread -> runnable ref), and we should only do it when setup context handle is not null, which is when it's creation of a thread for an app. If handle is null then it's an executor factory and for such app shared threads the task wrapping done in executor should be used instead (and that's already being done). 

Please note that I am also going back here for the class loader leak solution, adopting the set CL as null (after creation) practice common everywhere in server code.