### PR TITLE
[WFLY-11827] Broken validation for pooled-connection-factory's transaction attribute

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -590,10 +590,10 @@ public interface ConnectionFactoryAttributes {
                                     return new ModelNode(CommonAttributes.LOCAL);
                                 case CommonAttributes.NONE:
                                     return new ModelNode(CommonAttributes.NONE);
+                                case CommonAttributes.XA:
+                                    return new ModelNode(CommonAttributes.XA);
                                 default:
-                                    if (newValue.asString() != CommonAttributes.XA) {
-                                        MessagingLogger.ROOT_LOGGER.invalidTransactionNameValue(newValue.asString(), "transaction", Arrays.asList(CommonAttributes.LOCAL, CommonAttributes.NONE, CommonAttributes.XA));
-                                    }
+                                    MessagingLogger.ROOT_LOGGER.invalidTransactionNameValue(newValue.asString(), "transaction", Arrays.asList(CommonAttributes.LOCAL, CommonAttributes.NONE, CommonAttributes.XA));
                                     return new ModelNode(CommonAttributes.XA);
                             }
                         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11827 Broken validation for pooled-connection-factory's transaction attribute. 

The issue was introduced by https://issues.jboss.org/browse/WFLY-11617 Validation not working for pooled-connection-factory's transaction attribute.

Starting Wildfly with full profile gives now a WARN log, although the value for the transaction attribute is valid.