### PR TITLE
[WFLY-11352] WildFly registers multiple distinct drivers for current MySQL driver jar - rework

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceWrongDsClassTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceWrongDsClassTestCase.java
@@ -35,6 +35,8 @@ import java.util.List;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.integration.management.util.ModelUtil;
@@ -59,9 +61,116 @@ public class DatasourceWrongDsClassTestCase extends JcaMgmtBase {
     @Deployment(name = DEPLOYMENT)
     public static JavaArchive jdbcArchive() throws Exception {
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, DEPLOYMENT + ".jar");
-        ja.addClasses(DummyDataSource.class, DummyXADataSource.class, TestDriver.class);
-        ja.addAsServiceProviderAndClasses(Driver.class, TestDriver.class);
+        ja.addClasses(DummyDataSource.class, DummyXADataSource.class, TestDriver.class, TestDriver2.class);
+        ja.addAsServiceProviderAndClasses(Driver.class, TestDriver.class, TestDriver2.class);
         return ja;
+    }
+
+    @Test
+    public void testJdbcDrivers() throws Exception {
+        String driverName = DEPLOYMENT + ".jar";
+        ModelNode address = new ModelNode().add(SUBSYSTEM, "datasources");
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("get-installed-driver");
+        operation.get(OP_ADDR).set(address);
+        operation.get("driver-name").set(driverName);
+
+        ModelNode result = executeOperation(operation).asList().get(0);
+        Assert.assertEquals(driverName, result.get("driver-name").asString());
+        Assert.assertEquals(driverName, result.get("deployment-name").asString());
+        Assert.assertEquals(TestDriver.class.getName(), result.get("driver-class-name").asString());
+        Assert.assertEquals(1, result.get("driver-major-version").asInt());
+        Assert.assertEquals(0, result.get("driver-minor-version").asInt());
+        Assert.assertFalse(result.get("jdbc-compliant").asBoolean());
+
+        String driver1FQCN = driverName + "_" + TestDriver.class.getName() + "_1_0";
+        operation.get("driver-name").set(driver1FQCN);
+        result = executeOperation(operation).asList().get(0);
+        Assert.assertEquals(driver1FQCN, result.get("driver-name").asString());
+        Assert.assertEquals(driver1FQCN, result.get("deployment-name").asString());
+        Assert.assertEquals(TestDriver.class.getName(), result.get("driver-class-name").asString());
+        Assert.assertEquals(1, result.get("driver-major-version").asInt());
+        Assert.assertEquals(0, result.get("driver-minor-version").asInt());
+        Assert.assertFalse(result.get("jdbc-compliant").asBoolean());
+
+        String driver2FQCN = driverName + "_" + TestDriver2.class.getName() + "_1_1";
+        operation.get("driver-name").set(driver2FQCN);
+        result = executeOperation(operation).asList().get(0);
+        Assert.assertEquals(driver2FQCN, result.get("driver-name").asString());
+        Assert.assertEquals(driver2FQCN, result.get("deployment-name").asString());
+        Assert.assertEquals(TestDriver2.class.getName(), result.get("driver-class-name").asString());
+        Assert.assertEquals(1, result.get("driver-major-version").asInt());
+        Assert.assertEquals(1, result.get("driver-minor-version").asInt());
+        Assert.assertTrue(result.get("jdbc-compliant").asBoolean());
+
+    }
+
+    private ModelNode getDatasourceAddress(Datasource datasource) {
+        ModelNode address = new ModelNode()
+            .add(SUBSYSTEM, "datasources")
+            .add("data-source", datasource.getName());
+        address.protect();
+        return address;
+    }
+
+    private ModelNode getAddDatasourceOperation(Datasource datasource) {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(OP_ADDR).set(getDatasourceAddress(datasource));
+        operation.get("jndi-name").set(datasource.getJndiName());
+        operation.get("driver-name").set(datasource.getDriverName());
+        operation.get("enabled").set(datasource.getEnabled());
+        operation.get("connection-url").set(datasource.getConnectionUrl());
+        return operation;
+    }
+
+    private ModelNode getRemoveDatasourceOperation(Datasource ds) {
+        ModelNode removeOperation = Operations.createRemoveOperation(getDatasourceAddress(ds));
+        removeOperation.get(ModelDescriptionConstants.OPERATION_HEADERS).get("allow-resource-service-restart")
+                .set(true);
+        return removeOperation;
+    }
+
+    @Test
+    public void testDSWithMutipleDrivers() throws Exception {
+        String driverName = DEPLOYMENT + ".jar";
+        String driver1FQCN = driverName + "_" + TestDriver.class.getName() + "_1_0";
+        String driver2FQCN = driverName + "_" + TestDriver2.class.getName() + "_1_1";
+
+        Datasource ds1 = Datasource.Builder("test-ds1").connectionUrl("foo").driverName(driverName).enabled(true)
+            .jndiName("java:jboss/datasources/test-ds1")
+            .build();
+        ModelNode addDS1Operation = getAddDatasourceOperation(ds1);
+        try {
+            ModelNode addDSResult = getManagementClient().getControllerClient().execute(addDS1Operation);
+            Assert.assertEquals("success", addDSResult.get("outcome").asString());
+        } finally {
+            ModelNode removeDSOperation = getRemoveDatasourceOperation(ds1);
+            executeOperation(removeDSOperation);
+        }
+
+        Datasource ds1FQCN = Datasource.Builder("test-ds1FQCN").connectionUrl("foo").driverName(driver1FQCN).enabled(true)
+                .jndiName("java:jboss/datasources/test-ds1FQCN").build();
+        ModelNode addDS1FQCNOperation = getAddDatasourceOperation(ds1FQCN);
+        try {
+            ModelNode addDSResult = getManagementClient().getControllerClient().execute(addDS1FQCNOperation);
+            Assert.assertEquals("success", addDSResult.get("outcome").asString());
+        } finally {
+            ModelNode removeDSOperation = getRemoveDatasourceOperation(ds1FQCN);
+            executeOperation(removeDSOperation);
+        }
+
+        Datasource ds2FQCN = Datasource.Builder("test-ds2FQCN").connectionUrl("foo").driverName(driver2FQCN)
+                .enabled(true).jndiName("java:jboss/datasources/test-ds2FQCN").build();
+        ModelNode addDS2FQCNOperation = getAddDatasourceOperation(ds2FQCN);
+        try {
+            ModelNode addDSResult = getManagementClient().getControllerClient().execute(addDS2FQCNOperation);
+            Assert.assertEquals("success", addDSResult.get("outcome").asString());
+        } finally {
+            ModelNode removeDSOperation = getRemoveDatasourceOperation(ds2FQCN);
+            executeOperation(removeDSOperation);
+        }
+
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/TestDriver2.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Test JDBC driver
+ */
+public class TestDriver2 implements Driver {
+  /**
+   * {@inheritDoc}
+   */
+  public Connection connect(String url, Properties info) throws SQLException {
+    return null;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean acceptsURL(String url) throws SQLException {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    Driver driver = DriverManager.getDriver(url);
+    return driver.getPropertyInfo(url, info);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public int getMajorVersion() {
+    return 1;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public int getMinorVersion() {
+    return 1;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public boolean jdbcCompliant() {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    throw new SQLFeatureNotSupportedException();
+  }
+}


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-11352

This is rework for WFLY-11352, because it caused a regression in case of multiple drivers defined in the JDBC driver.

The proposed fix is trying to start an extra DriverService with DeploymentUnit name as the driver-name for the first one as well if there are more than one Driver classes defined in META-INF/services/java.sql.Driver, so that both following command can work:

> /subsystem=datasources:get-installed-driver(driver-name=mysql-connector-java-5.1.46.jar)
> /subsystem=datasources:get-installed-driver(driver-name=mysql-connector-java-5.1.46.jar_com.mysql.jdbc.Driver_5_1)

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
