### PR TITLE
[WFLY-11851]: Adding a system property to define the default routing type of core queues.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueAdd.java
@@ -27,6 +27,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.DURABLE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.FILTER;
+import static org.wildfly.extension.messaging.activemq.QueueDefinition.DEFAULT_ROUTING_TYPE;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -48,6 +49,8 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 
 import static org.wildfly.extension.messaging.activemq.QueueDefinition.ROUTING_TYPE;
+
+import java.util.Locale;
 
 /**
  * Core queue add update.
@@ -103,7 +106,12 @@ public class QueueAdd extends AbstractAddStepHandler {
     private static CoreQueueConfiguration createCoreQueueConfiguration(final OperationContext context, String name, ModelNode model) throws OperationFailedException {
         final String queueAddress = QueueDefinition.ADDRESS.resolveModelAttribute(context, model).asString();
         final String filter = FILTER.resolveModelAttribute(context, model).asStringOrNull();
-        final String routing = ROUTING_TYPE.resolveModelAttribute(context, model).asString();
+        final String routing;
+        if(DEFAULT_ROUTING_TYPE != null && ! model.hasDefined(ROUTING_TYPE.getName())) {
+            routing = RoutingType.valueOf(DEFAULT_ROUTING_TYPE.toUpperCase(Locale.ENGLISH)).toString();
+        } else {
+            routing = ROUTING_TYPE.resolveModelAttribute(context, model).asString();
+        }
         final boolean durable = DURABLE.resolveModelAttribute(context, model).asBoolean();
 
         return new CoreQueueConfiguration()

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueDefinition.java
@@ -22,10 +22,14 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static java.lang.System.getProperty;
+import static java.lang.System.getSecurityManager;
+import static java.security.AccessController.doPrivileged;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.dmr.ModelType.LONG;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.RUNTIME_QUEUE;
 
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -54,6 +58,9 @@ import org.jboss.dmr.ModelType;
  * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
  */
 public class QueueDefinition extends PersistentResourceDefinition {
+
+    private static final String DEFAULT_ROUTING_TYPE_PROPERTY = "org.wildfly.messaging.core.queue.default.routing-type";
+    public static final String DEFAULT_ROUTING_TYPE = getSecurityManager() == null ? getProperty(DEFAULT_ROUTING_TYPE_PROPERTY) : doPrivileged((PrivilegedAction<String>) () -> getProperty(DEFAULT_ROUTING_TYPE_PROPERTY));
 
     public static final SimpleAttributeDefinition ADDRESS = create("queue-address", ModelType.STRING)
             .setXmlName(CommonAttributes.ADDRESS)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
@@ -67,7 +67,7 @@ class QueueService implements Service<Void> {
                 final SimpleString address = new SimpleString(queueConfiguration.getAddress());
                 final SimpleString filterString = SimpleString.toSimpleString(queueConfiguration.getFilterString());
                 server.createQueue(address,
-                        server.getAddressSettingsRepository().getMatch(address == null ? resourceName.toString() : address.toString()).getDefaultQueueRoutingType(),
+                        queueConfiguration.getRoutingType(),
                         resourceName,
                         filterString,
                         queueConfiguration.isDurable(),


### PR DESCRIPTION
Adding 'org.wildfly.messaging.core.queue.default.routing-type' so that we can define the default routing type of core queues.

Jira: https://issues.jboss.org/browse/WFLY-11851
       https://issues.jboss.org/browse/JBEAP-16556