### PR TITLE
[WFLY-11856] EJB: testcase for creating InitialContext based on syste…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -240,4 +240,28 @@ public class RemoteNamingEjbTestCase {
             Thread.currentThread().setContextClassLoader(current);
         }
     }
+
+    @Test
+    public void testSystemPropertyConfig() throws Exception {
+        System.setProperty("java.naming.factory.initial","org.wildfly.naming.client.WildFlyInitialContextFactory");
+
+        final Properties env = new Properties();
+        env.put(Context.PROVIDER_URL, managementClient.getRemoteEjbURL().toString());
+        env.put("jboss.naming.client.ejb.context", true);
+        env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
+
+        final InitialContext ctx = new InitialContext(env);
+        final ClassLoader current = Thread.currentThread().getContextClassLoader();
+
+        try {
+            Thread.currentThread().setContextClassLoader(Remote.class.getClassLoader());
+
+            Remote remote = (Remote) ctx.lookup(ARCHIVE_NAME + "/" + Bean.class.getSimpleName() + "!" + Remote.class.getName());
+            assertNotNull(remote);
+            assertEquals("Echo: test", remote.echo("test"));
+        } finally {
+            ctx.close();
+            Thread.currentThread().setContextClassLoader(current);
+        }
+    }
 }


### PR DESCRIPTION
…m property

https://issues.jboss.org/browse/WFLY-11856

The issue was fixed in EAP7.1.3+. Adding the test to make sure that this behavior is present and consisent with docs https://github.com/wildfly/wildfly-naming-client#usage.

This should be ported to 7.1.x as well.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.