### PR TITLE
Ignore frequently failing MicroProfileMetricsDifferentFormatsValueTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsDifferentFormatsValueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsDifferentFormatsValueTestCase.java
@@ -56,6 +56,7 @@ import org.wildfly.test.integration.microprofile.metrics.TestApplication;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@org.junit.Ignore("https://issues.jboss.org/browse/WFLY-11855")
 public class MicroProfileMetricsDifferentFormatsValueTestCase {
 
     /**


### PR DESCRIPTION
Test issue: https://issues.jboss.org/browse/WFLY-11855