### PR TITLE
[WFLY-11784] IIOP: make sure caches are cleared before module is removed

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemAdd.java
@@ -59,6 +59,7 @@ import org.omg.PortableServer.LifespanPolicyValue;
 import org.omg.PortableServer.POA;
 import org.wildfly.iiop.openjdk.csiv2.CSIV2IORToSocketInfo;
 import org.wildfly.iiop.openjdk.csiv2.ElytronSASClientInterceptor;
+import org.wildfly.iiop.openjdk.deployment.IIOPClearCachesProcessor;
 import org.wildfly.iiop.openjdk.deployment.IIOPDependencyProcessor;
 import org.wildfly.iiop.openjdk.deployment.IIOPMarkerProcessor;
 import org.wildfly.iiop.openjdk.logging.IIOPLogger;
@@ -149,6 +150,8 @@ public class IIOPSubsystemAdd extends AbstractBoottimeAddStepHandler {
                         Phase.DEPENDENCIES_IIOP_OPENJDK, new IIOPDependencyProcessor());
                 processorTarget.addDeploymentProcessor(IIOPExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_IIOP_OPENJDK,
                         new IIOPMarkerProcessor());
+                processorTarget.addDeploymentProcessor(IIOPExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_IIOP_CLEAR_CACHES,
+                        new IIOPClearCachesProcessor());
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/deployment/IIOPClearCachesProcessor.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/deployment/IIOPClearCachesProcessor.java
@@ -1,8 +1,8 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2010, Red Hat Inc., and individual contributors as indicated
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
  * This is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as
@@ -19,28 +19,38 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.iiop.openjdk.deployment;
 
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
-
+import org.jboss.modules.Module;
+import org.wildfly.iiop.openjdk.rmi.ExceptionAnalysis;
+import org.wildfly.iiop.openjdk.rmi.InterfaceAnalysis;
+import org.wildfly.iiop.openjdk.rmi.ValueAnalysis;
 
 /**
- * Processor responsible for marking a deployment as using IIOP
- *
- * @author Stuart Douglas
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
  */
-public class IIOPMarkerProcessor implements DeploymentUnitProcessor{
+
+public class IIOPClearCachesProcessor implements DeploymentUnitProcessor {
+
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
-        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        //for now we mark all subsystems as using IIOP if the IIOP subsystem is installed
-        IIOPDeploymentMarker.mark(deploymentUnit);
     }
 
     @Override
     public void undeploy(final DeploymentUnit context) {
+        //clear data from the relevant caches
+        Module module = context.getAttachment(Attachments.MODULE);
+        if(module == null) {
+            return;
+        }
+        ExceptionAnalysis.clearCache(module.getClassLoader());
+        InterfaceAnalysis.clearCache(module.getClassLoader());
+        ValueAnalysis.clearCache(module.getClassLoader());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11784
https://issues.jboss.org/browse/JBEAP-16564
https://issues.jboss.org/browse/JBEAP-16465

Clearing the caches was scheduled after Attachment.MODULE was removed hence it never took place. This fix moves the cleaning to INSTALL phase which solves this problem.

This fix can only be merged after wildfly-core with changes https://github.com/wildfly/wildfly-core/pull/3695 is released.

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.