### PR TITLE
WFLY-11866 Exception can not be passed-by-reference

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloBean.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.remote.byreference;
+
+
+import java.util.logging.Logger;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class HelloBean implements HelloRemote {
+
+    private Logger log = Logger.getLogger(this.getClass().getSimpleName().toString());
+
+    public TransferReturnValue hello ( TransferParameter param ) throws RemoteByReferenceException {
+        log.info("hello("+ param +") = Hello " + param );
+
+        if(param == null)
+            throw new RemoteByReferenceException("Param was null");
+
+        return new TransferReturnValue ( "Hello " + param );
+    }
+
+    @Override
+    public SerializableObject helloSerializable(SerializableObject param) throws RemoteByReferenceException {
+        log.info("helloserializable("+ param +") = Hello " + param );
+
+        if(param == null)
+            throw new RemoteByReferenceException("Param was null");
+        param.setValue("Bye");
+
+        return param;
+    }
+
+    @Override
+    public NonSerializableObject helloNonSerializable(NonSerializableObject param) throws RemoteByReferenceException {
+        log.info("helloserializable("+ param +") = Hello " + param );
+
+        if(param == null)
+            throw new RemoteByReferenceException("Param was null");
+        param.setValue("Bye");
+
+        return param;
+    }
+
+    @Override
+    public SerializableObject helloNonSerializableToSerializable(NonSerializableObject param)
+            throws RemoteByReferenceException {
+        log.info("helloserializable("+ param +") = Hello " + param );
+
+        if(param == null)
+            throw new RemoteByReferenceException("Param was null");
+        param.setValue("Bye");
+
+        return new SerializableObject(param.getValue());
+    }
+
+    @Override
+    public NonSerializableObject helloSerializableToNonSerializable(SerializableObject param)
+            throws RemoteByReferenceException {
+        log.info("helloserializable("+ param +") = Hello " + param );
+
+        if(param == null)
+            throw new RemoteByReferenceException("Param was null");
+        param.setValue("Bye");
+
+        return new NonSerializableObject(param.getValue());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloRemote.java
@@ -23,18 +23,17 @@
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
 import javax.ejb.Remote;
-import javax.ejb.Stateless;
 
-/**
- * @author Jaikiran Pai
- */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+@Remote
+public interface HelloRemote {
+    public TransferReturnValue hello ( TransferParameter param ) throws RemoteByReferenceException;
 
+    public SerializableObject helloSerializable ( SerializableObject param ) throws RemoteByReferenceException;
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
-    }
+    public NonSerializableObject helloNonSerializable(NonSerializableObject param) throws RemoteByReferenceException;
+
+    public SerializableObject helloNonSerializableToSerializable(NonSerializableObject param) throws RemoteByReferenceException;
+
+    public NonSerializableObject helloSerializableToNonSerializable(SerializableObject param) throws RemoteByReferenceException;
 }
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/NonSerializableObject.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/NonSerializableObject.java
@@ -22,19 +22,26 @@
 
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
-import javax.ejb.Remote;
-import javax.ejb.Stateless;
+public class NonSerializableObject {
 
-/**
- * @author Jaikiran Pai
- */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+    private String value;
 
+    public NonSerializableObject() {
+    }
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
+    public NonSerializableObject(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/RemoteByReferenceException.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/RemoteByReferenceException.java
@@ -22,19 +22,18 @@
 
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
-import javax.ejb.Remote;
-import javax.ejb.Stateless;
+public class RemoteByReferenceException extends Exception {
 
-/**
- * @author Jaikiran Pai
- */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+    private NonSerializableObject nonSerializableObject;
 
+    public RemoteByReferenceException() {
+        super();
+        nonSerializableObject = new NonSerializableObject("null");
+    }
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
+    public RemoteByReferenceException(String msg) {
+        super(msg);
+        nonSerializableObject = new NonSerializableObject(msg);
     }
 }
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/RemoteInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/RemoteInterface.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2012, Red Hat, Inc., and individual contributors
+ * Copyright 2019, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/SerializableObject.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/SerializableObject.java
@@ -22,19 +22,28 @@
 
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
-import javax.ejb.Remote;
-import javax.ejb.Stateless;
+import java.io.Serializable;
 
-/**
- * @author Jaikiran Pai
- */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+public class SerializableObject implements Serializable {
 
+    private String value;
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
+    public SerializableObject() {
+    }
+
+    public SerializableObject(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/TransferParameter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/TransferParameter.java
@@ -22,19 +22,29 @@
 
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
-import javax.ejb.Remote;
-import javax.ejb.Stateless;
-
 /**
- * @author Jaikiran Pai
+ * A class that does not implement serializable used in pass-by-reference
  */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+public class TransferParameter {
 
+    private String value;
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
+    public TransferParameter() {
+    }
+
+    public TransferParameter( String value ) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue ( String value ) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
     }
 }
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/TransferReturnValue.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/TransferReturnValue.java
@@ -22,19 +22,28 @@
 
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
-import javax.ejb.Remote;
-import javax.ejb.Stateless;
-
 /**
- * @author Jaikiran Pai
+ * A return value class that does not implement serializable
  */
-@Stateless
-@Remote(RemoteInterface.class)
-public class StatelessRemoteBean implements RemoteInterface {
+public class TransferReturnValue {
 
+    private String value;
 
-    @Override
-    public void modifyFirstElementOfArray(String[] array, String newValue) {
-        array[0] = newValue;
+    public TransferReturnValue() {
+    }
+
+    public TransferReturnValue( String value ) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    public void setValue ( String value ) {
+        this.value = value;
+    }
+
+    public String getString() {
+        return value;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11866 is a regression of WFLY-2949.

Exceptions are not passed-by-reference if enabled, this cause issues if the Exception is not marked as Serializable.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.