### PR TITLE
[WFLY-11869] JSF Session / View Beans @Destroy not invoked after GC

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBean.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.SessionScoped;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+
+@ManagedBean
+@SessionScoped
+public class CountBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @ManagedProperty("#{initBean}")
+    private InitBean initBean;
+
+    private static final Logger LOG = Logger.getLogger(CountBean.class.getName());
+
+    private int count;
+
+    @PostConstruct
+    public void init() {
+        LOG.info("CountBean#Initializing counter with @PostConstruct ...");
+        count = initBean.getInit();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        LOG.info("Destroyed CountBean");
+        TestResultsBean.setPreDestroySessionScoped(true);
+    }
+
+    public String invalidateGC() {
+
+        LOG.info("Running Garbage Collect and Invalidating Session");
+
+        System.gc();
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = facesContext.getExternalContext();
+        externalContext.invalidateSession();
+
+        return "";
+    }
+
+    public void setInitBean(InitBean initBean) {
+        this.initBean = initBean;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBeanViewScoped.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBeanViewScoped.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import java.io.Serializable;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.ManagedProperty;
+import javax.faces.bean.ViewScoped;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
+
+@ManagedBean
+@ViewScoped
+public class CountBeanViewScoped implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @ManagedProperty("#{initBeanViewScoped}")
+    private InitBeanViewScoped initBeanViewScoped;
+
+    private static final Logger LOG = Logger.getLogger(CountBeanViewScoped.class.getName());
+
+    private int count;
+
+    @PostConstruct
+    public void init() {
+        LOG.info("CountBeanViewScoped#Initializing counter with @PostConstruct ...");
+        count = initBeanViewScoped.getInit();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        LOG.info("Destroyed View Scoped CountBean");
+        TestResultsBean.setPreDestroyViewScoped(true);
+    }
+
+    public String invalidateGC() {
+
+        LOG.info("Running View Scoped Garbage Collect, invalidate session so view will be destroyed");
+        System.gc();
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = facesContext.getExternalContext();
+        externalContext.invalidateSession();
+
+        return "";
+    }
+
+    public void setInitBeanViewScoped(InitBeanViewScoped initBean) {
+        this.initBeanViewScoped = initBean;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/GCPreDestroyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/GCPreDestroyTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the predestroy is invoked after a call to system.gc on a short lived bean
+ *
+ * @author tmiyar
+ *
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class GCPreDestroyTestCase {
+    @ArquillianResource
+    private URL url;
+
+    private final Pattern viewStatePattern = Pattern.compile("id=\".*javax.faces.ViewState.*\" value=\"([^\"]*)\"");
+
+    @Deployment(testable = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "jsfpredestroy.war");
+        war.addPackage(GCPreDestroyTestCase.class.getPackage());
+        war.addAsWebResource(GCPreDestroyTestCase.class.getPackage(), "sessionscoped.xhtml", "sessionscoped.xhtml");
+        war.addAsWebResource(GCPreDestroyTestCase.class.getPackage(), "viewscoped.xhtml", "viewscoped.xhtml");
+        war.addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    public void preDestroyCalled(String jsf) throws Exception {
+        String responseString;
+        DefaultHttpClient client = new DefaultHttpClient();
+
+        try {
+            // Create and execute a GET request
+            String jsfViewState = null;
+            String requestUrl = url.toString();
+            HttpGet getRequest = new HttpGet(requestUrl + jsf);
+
+            HttpResponse response = client.execute(getRequest);
+            try {
+                responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+
+                // Get the JSF view state
+                Matcher jsfViewMatcher = viewStatePattern.matcher(responseString);
+                if (jsfViewMatcher.find()) {
+                    jsfViewState = jsfViewMatcher.group(1);
+                }
+
+                assertTrue("PreDestroy initial value must be false", responseString.contains("IsPreDestroy:false"));
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            // Create and execute a POST request
+            HttpPost post = new HttpPost(requestUrl + jsf);
+
+            List<NameValuePair> list = new ArrayList<NameValuePair>();
+            list.add(new BasicNameValuePair("javax.faces.ViewState", jsfViewState));
+            list.add(new BasicNameValuePair("gcForm", "gcForm"));
+            list.add(new BasicNameValuePair("gcForm:gcButton", "gc"));
+
+            post.setEntity(new StringEntity(URLEncodedUtils.format(list, "UTF-8"), ContentType.APPLICATION_FORM_URLENCODED));
+            response = client.execute(post);
+
+            try {
+                responseString = IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+        } finally {
+            HttpClientUtils.closeQuietly(client);
+        }
+
+        assertTrue("PreDestroy should have been invoked", responseString.contains("IsPreDestroy:true"));
+    }
+
+    @Test
+    public void testPreDestroyCalledSessionScoped() throws Exception {
+        preDestroyCalled("sessionscoped.jsf");
+    }
+
+    @Test
+    public void testPreDestroyCalledViewScoped() throws Exception {
+        preDestroyCalled("viewscoped.jsf");
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/InitBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/InitBean.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import java.io.Serializable;
+
+import javax.faces.bean.SessionScoped;
+import javax.faces.bean.ManagedBean;
+
+@ManagedBean
+@SessionScoped
+public class InitBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int init;
+
+    public InitBean() {
+        init = 1;
+    }
+
+    public int getInit() {
+        return init;
+    }
+
+    public void setInit(int init) {
+        this.init = init;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/InitBeanViewScoped.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/InitBeanViewScoped.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import java.io.Serializable;
+
+import javax.faces.bean.ViewScoped;
+import javax.faces.bean.ManagedBean;
+
+@ManagedBean
+@ViewScoped
+public class InitBeanViewScoped implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int init;
+
+    public InitBeanViewScoped() {
+        init = 1;
+    }
+
+    public int getInit() {
+        return init;
+    }
+
+    public void setInit(int init) {
+        this.init = init;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/TestResultsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/TestResultsBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jsf.managedbean.gc;
+
+import javax.faces.bean.ApplicationScoped;
+import javax.faces.bean.ManagedBean;
+
+@ManagedBean(name = "testResultsBean", eager = true)
+@ApplicationScoped
+public class TestResultsBean {
+
+    private static boolean preDestroySessionScoped = false;
+    private static boolean preDestroyViewScoped = false;
+
+    public static boolean isPreDestroySessionScoped() {
+        return preDestroySessionScoped;
+    }
+
+    public static void setPreDestroySessionScoped(boolean preDestroy) {
+        TestResultsBean.preDestroySessionScoped = preDestroy;
+    }
+
+    public static boolean isPreDestroyViewScoped() {
+        return preDestroyViewScoped;
+    }
+
+    public static void setPreDestroyViewScoped(boolean preDestroy) {
+        TestResultsBean.preDestroyViewScoped = preDestroy;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/sessionscoped.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/sessionscoped.xhtml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>        
+        <title></title>          
+    </h:head>
+    <h:body>
+        <p>Current value: #{countBean.count}</p>
+        <p>IsPreDestroy:#{testResultsBean.isPreDestroySessionScoped()}</p>
+        <hr/>
+        <h4>Garbage Collect and Invalidate :</h4>
+        <h:form id="gcForm">
+            <h:commandButton id="gcButton" value="gc" action="#{countBean.invalidateGC()}">
+            </h:commandButton>
+        </h:form>
+        <hr/>
+    </h:body>
+</html>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/viewscoped.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/viewscoped.xhtml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>        
+        <title></title>          
+    </h:head>
+    <h:body>
+        <p>Current value: #{countBeanViewScoped.count}</p>
+        <p>IsPreDestroy:#{testResultsBean.isPreDestroyViewScoped()}</p>
+        <hr/>
+        <h4>Garbage Collect and Invalidate :</h4>
+        <h:form id="gcForm">
+            <h:commandButton id="gcButton" value="gc" action="#{countBeanViewScoped.invalidateGC()}">
+            </h:commandButton>
+        </h:form>
+        <hr/>
+    </h:body>
+</html>
+

--- a/web-common/src/main/java/org/jboss/as/web/common/WebInjectionContainer.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/WebInjectionContainer.java
@@ -48,7 +48,7 @@ public class WebInjectionContainer {
         this.instanceMap = new ConcurrentReferenceHashMap<Object, ManagedReference>
                 (256, ConcurrentReferenceHashMap.DEFAULT_LOAD_FACTOR,
                         Runtime.getRuntime().availableProcessors(), ConcurrentReferenceHashMap.ReferenceType.STRONG,
-                        ConcurrentReferenceHashMap.ReferenceType.WEAK, EnumSet.of(ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS));
+                        ConcurrentReferenceHashMap.ReferenceType.STRONG, EnumSet.of(ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS));
     }
 
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11869

View and Session scoped beans skip PreDestroy method if a gc was performed before the bean is destroyed. 
