### PR TITLE
[WFLY-11881] Upgrade WildFly Core 9.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>8.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.13.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11881

---



# Release Notes - WildFly Core - Version 9.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4372'>WFCORE-4372</a>] -         Upgrade CLI to use aesh 2.0
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4339'>WFCORE-4339</a>] -         The layers testsuite should use thin servers
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4346'>WFCORE-4346</a>] -         ChildFirstClassLoader and LegacyKernelServicesInitializer should allow exclusion of resources from the paren
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4316'>WFCORE-4316</a>] -         Spaces are not supported in a header value
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4327'>WFCORE-4327</a>] -         Switched order of method arguments - ModuleLoadService
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4329'>WFCORE-4329</a>] -         The launcher API may incorrectly assume the JVM is a non-modular JVM
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4354'>WFCORE-4354</a>] -         secure-management layer doesn&#39;t secure direct http access
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4366'>WFCORE-4366</a>] -         Exclude org.apache.commons:commons-lang3 from the elytron-tool
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4373'>WFCORE-4373</a>] -         org.jboss.log4j.logmanager module requires java.sql module
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4374'>WFCORE-4374</a>] -         security-manager minimum-set for MBeanServerPermission createMBeanServer not working but permissions.xml does
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4342'>WFCORE-4342</a>] -         Bump the Elytron subsystem version.
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4352'>WFCORE-4352</a>] -         When on JDK 12, disable tests that hang due to https://bugs.openjdk.java.net/browse/JDK-8219658
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4370'>WFCORE-4370</a>] -         Add maven.repo.local property to the surefire settings for standalone tests
</li>
</ul>
                                    