### PR TITLE
WFLY-11874 Remove unneeded dependencies from Hibernate ORM module (vfs + asm)

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -44,11 +44,9 @@
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
         <module name="org.hibernate.commons-annotations"/>
         <module name="org.hibernate.jipijapa-hibernate5-3" services="import"/>
         <module name="org.infinispan.hibernate-cache" services="import" optional="true"/>
         <module name="net.bytebuddy"/>
-        <module name="asm.asm"/>
     </dependencies>
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11874

The target of this work was removing the unneeded dependency on asm.asm module but also noticed that VFS is not used by Hibernate ORM 5.3.