### PR TITLE
[WFLY-11876]: Upgrade Artemis to 2.7.0

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -152,7 +152,7 @@
         <copy-artifact artifact="org.jboss.seam.integration:jboss-seam-int-jbossas" to-location="modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/jboss-seam-int-jbossas.jar"/>
         <copy-artifact artifact="org.wildfly:wildfly-client-all" to-location="bin/client/jboss-client.jar"/>
         <copy-artifact artifact="org.wildfly.core:wildfly-cli::client" to-location="bin/client/jboss-cli-client.jar"/>
-        <copy-artifact artifact="org.apache.activemq:artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/journal/main" extract="true" >
+        <copy-artifact artifact="org.apache.activemq:activemq-artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/journal/main" extract="true" >
             <filter pattern="lib/*" include="true" />
             <filter pattern="*" include="false"/>
         </copy-artifact>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1823,7 +1823,13 @@
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-native</artifactId>
+            <artifactId>activemq-artemis-native</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -872,7 +872,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>artemis-native</artifactId>
+      <artifactId>activemq-artemis-native</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -27,7 +27,7 @@
         <resource-root path="lib"/>
         <artifact name="${org.apache.activemq:artemis-commons}"/>
         <artifact name="${org.apache.activemq:artemis-journal}"/>
-        <artifact name="${org.apache.activemq:artemis-native}"/>
+        <artifact name="${org.apache.activemq:activemq-artemis-native}"/>
     </resources>
 
     <dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -35,10 +35,6 @@
         <module name="com.google.guava"/>
         <module name="javax.api"/>
         <module name="org.apache.commons.beanutils" />
-        <!-- the journal module depends on org.apache.activemq.artemis so that
-             Artemis's ClassLoadingUtil (from artemis-commons.jar) can load classes
-              from the org.apache.activemq.artemis module) -->
-        <module name="org.apache.activemq.artemis" />
         <module name="org.jboss.logging"/>
         <module name="io.netty"/>
         <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -47,6 +47,7 @@
         <module name="org.apache.activemq.artemis.journal" export="true"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.logmanager"/>
         <module name="io.netty"/>
         <module name="org.jgroups"/>
         <module name="javax.resource.api"/>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -2323,8 +2323,14 @@
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-native</artifactId>
+            <artifactId>activemq-artemis-native</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/galleon-pack/src/main/resources/packages/org.apache.activemq.artemis.journal/pm/wildfly/tasks.xml
+++ b/galleon-pack/src/main/resources/packages/org.apache.activemq.artemis.journal/pm/wildfly/tasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
-    <copy-artifact artifact="org.apache.activemq:artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/journal/main" extract="true" >
+    <copy-artifact artifact="org.apache.activemq:activemq-artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/journal/main" extract="true" >
         <filter pattern="lib/*" include="true" />
         <filter pattern="*" include="false"/>
     </copy-artifact>

--- a/legacy/messaging/pom.xml
+++ b/legacy/messaging/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
-			<type>pom</type>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAttributesTestCase.java
@@ -38,6 +38,7 @@ public class PooledConnectionFactoryAttributesTestCase extends AttributesTestBas
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("cacheDestinations");
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("ignoreJTA");
         UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("enable1xPrefixes");
+        UNSUPPORTED_ACTIVEMQ_RA_PROPERTIES.add("useTopologyForLoadBalancing");
 
         KNOWN_ATTRIBUTES = new TreeSet<String>();
         // these are supported but it is not found by JavaBeans introspector because of the type

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,8 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.6.3.jbossorg-00014</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.8.0</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis.native>1.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.2.7</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.2.3</version.org.apache.cxf.xjcplugins>
@@ -285,7 +286,7 @@
         <version.org.apache.myfaces.core>2.3.1</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
-        <version.org.apache.qpid.proton>0.27.3</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.31.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.2</version.org.apache.santuario>
         <version.org.apache.thrift>0.11.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>
@@ -1922,12 +1923,16 @@
 
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-native</artifactId>
-                <version>${version.org.apache.activemq.artemis}</version>
+                <artifactId>activemq-artemis-native</artifactId>
+                <version>${version.org.apache.activemq.artemis.native}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1991,6 +1996,10 @@
                         <groupId>org.apache.geronimo.specs</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-configuration2</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -2002,6 +2011,10 @@
                     <exclusion>
                         <groupId>org.apache.geronimo.specs</groupId>
                         <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <version.org.apache.myfaces.core>2.3.1</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
-        <version.org.apache.qpid.proton>0.31.0</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.32.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.2</version.org.apache.santuario>
         <version.org.apache.thrift>0.11.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
@@ -67,7 +67,7 @@ public class SecurityTestCase {
             fail("must not allow to create a session with bad authentication");
         } catch (ActiveMQException e) {
             assertEquals(ActiveMQExceptionType.SECURITY_EXCEPTION, e.getType());
-            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ119031"));
+            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ229031"));
         } finally {
             if (sf != null) {
                 sf.close();
@@ -83,7 +83,7 @@ public class SecurityTestCase {
             fail("must not allow to create a session without any authentication");
         } catch (ActiveMQException e) {
             assertEquals(ActiveMQExceptionType.SECURITY_EXCEPTION, e.getType());
-            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ119031"));
+            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ229031"));
         } finally {
             if (sf != null) {
                 sf.close();
@@ -99,7 +99,7 @@ public class SecurityTestCase {
             fail("must not allow to create a session with the default cluster user credentials");
         } catch (ActiveMQException e) {
             assertEquals(ActiveMQExceptionType.CLUSTER_SECURITY_EXCEPTION, e.getType());
-            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ119099"));
+            assertTrue(e.getMessage(), e.getMessage().startsWith("AMQ229099"));
         } finally {
             if (sf != null) {
                 sf.close();
@@ -156,7 +156,7 @@ public class SecurityTestCase {
         } catch (ActiveMQException e) {
             assertEquals(ActiveMQExceptionType.SECURITY_EXCEPTION, e.getType());
             // Code of exception has changed in Artemis 2.x
-            assertTrue(e.getMessage().startsWith("AMQ119213"));
+            assertTrue(e.getMessage().startsWith("AMQ229213"));
             assertTrue(e.getMessage().contains("CREATE_DURABLE_QUEUE"));
         } finally {
             if (session != null) {


### PR DESCRIPTION
* Updating to Apache Artemis 2.8.0
* Taking new Artemis native packaging into account
* Taking advantage of ARTEMIS-2163.
* Aligning qpid j-proton version with Artemis

Jira: https://issues.jboss.org/browse/WFLY-11876
        https://issues.jboss.org/browse/WFLY-11727