### PR TITLE
[WFLY-6684]: JMS Bridge should display statistics about messages that have been processed.

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Messaging.adoc
@@ -558,6 +558,27 @@ CLI:
 }
 ----
 
+[[jms-bridge-statistics]]
+=== Statistics of a JMS Bridge
+
+Currently two statistics are available on a JMS bridge: the number of processed messages and the number of aborted/rolled back messages.
+Those are available with the following command :
+
+[source, ruby]
+----
+/subsystem=messaging/jms-bridge=myBridge:read-attribute(name=message-count)
+{
+    "outcome" => "success",
+    "result" => 0L
+}
+
+/subsystem=messaging/jms-bridge=myBridge:read-attribute(name=aborted-message-count)
+{
+    "outcome" => "success",
+    "result" => 0L
+}
+----
+
 == Component Reference
 
 The messaging-activemq subsystem is provided by the Artemis project. For

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -52,7 +52,6 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.dmr.ModelNode;
@@ -202,7 +201,11 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .build();
     public static final SimpleAttributeDefinition STARTED = create(CommonAttributes.STARTED, BOOLEAN)
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .setStorageRuntime()
+            .build();
+
+     public static final SimpleAttributeDefinition ABORTED_MESSAGE_COUNT = create("aborted-message-count", LONG)
+            .setStorageRuntime()
             .build();
 
     public static final AttributeDefinition[] ATTRIBUTES = {
@@ -232,6 +235,10 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             STARTED, CommonAttributes.PAUSED
     };
 
+    public static final AttributeDefinition[] METRICS = {
+            CommonAttributes.MESSAGE_COUNT, ABORTED_MESSAGE_COUNT
+    };
+
     public static final String[] OPERATIONS = {
             ModelDescriptionConstants.START, ModelDescriptionConstants.STOP,
             PAUSE, RESUME
@@ -259,6 +266,9 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
         }
         for (AttributeDefinition attr : READONLY_ATTRIBUTES) {
             registry.registerReadOnlyAttribute(attr, JMSBridgeHandler.INSTANCE);
+        }
+        for (AttributeDefinition attr : METRICS) {
+            registry.registerMetric(attr, JMSBridgeHandler.READ_ONLY_INSTANCE);
         }
     }
 

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -509,6 +509,7 @@ http-connector=Used by a remote client to define how it connects to a server ove
 http-listener=The Undertow's http-listener that handles HTTP upgrade requests.
 in-vm-acceptor=Defines a way in which in-VM connections can be made to the ActiveMQ server.
 in-vm-connector=Used by an in-VM client to define how it connects to a server.
+jms-bridge.aborted-message-count=The number of messages aborted/rolled back.
 jms-bridge.add-messageID-in-header=If true, then the original message's message ID will be appended in the message sent to the destination in the header AMQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
 jms-bridge.add=Add a new JMS bridge.
 jms-bridge.client-id=The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
@@ -516,6 +517,7 @@ jms-bridge.failure-retry-interval=The amount of time in milliseconds to wait bet
 jms-bridge.max-batch-size=The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
 jms-bridge.max-batch-time=The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
 jms-bridge.max-retries=The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+jms-bridge.message-count=The number of messages successfully committed.
 jms-bridge.module=The name of AS7 module containing the resources required to lookup source and target JMS resources.
 jms-bridge.pause=Pause the JMS bridge.
 jms-bridge.paused=Whether the JMS bridge is paused.


### PR DESCRIPTION
Displaying 2 new statistics on JMSBridge:
 - number of processed messages
 - number of aborted messages

Jira: https://issues.jboss.org/browse/WFLY-6684
JBEAP: https://issues.jboss.org/browse/JBEAP-16579

This PR depends on https://github.com/wildfly/wildfly/pull/12178