### PR TITLE
WFLY-11891 Add tests that enable JPA entity class bytecode enhancement

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/multiplepersistenceunittest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/multiplepersistenceunittest/persistence.xml
@@ -5,6 +5,9 @@
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="PersistenceUnitName" value="pu1"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="pu2">
@@ -13,6 +16,9 @@
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="PersistenceUnitName" value="pu2"/>
             <property name="wildfly.jpa.default-unit" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/entitylistener/persistence.xml
@@ -4,6 +4,9 @@
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/persistence.xml
@@ -4,6 +4,9 @@
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/envers/persistence.xml
@@ -28,6 +28,9 @@
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="org.hibernate.envers.audit_strategy" value="org.hibernate.envers.strategy.ValidityAuditStrategy"/>
             <property name="org.hibernate.envers.revision_type_field_name" value="REVTYPE_CUSTOM"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/management/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/hibernate/management/persistence.xml
@@ -30,6 +30,9 @@
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
             <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/persistence.xml
@@ -10,6 +10,10 @@
             <property name="hibernate.cache.use_second_level_cache" value="true"/>
             <property name="hibernate.cache.use_query_cache" value="true"/>
             <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
+
             <!-- Hibernate 5.2+ (see https://hibernate.atlassian.net/browse/HHH-10877 +
                  https://hibernate.atlassian.net/browse/HHH-12665) no longer defaults
                  to allowing a DML operation outside of a started transaction.
@@ -28,6 +32,10 @@
             <property name="hibernate.cache.use_second_level_cache" value="true"/>
             <property name="hibernate.cache.use_query_cache" value="true"/>
             <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
+
             <!-- Hibernate 5.2+ (see https://hibernate.atlassian.net/browse/HHH-10877 +
                  https://hibernate.atlassian.net/browse/HHH-12665) no longer defaults
                  to allowing a DML operation outside of a started transaction.
@@ -46,6 +54,10 @@
             <property name="hibernate.cache.use_second_level_cache" value="false"/>
             <property name="hibernate.cache.use_query_cache" value="false"/>
             <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
+
             <!-- Hibernate 5.2+ (see https://hibernate.atlassian.net/browse/HHH-10877 +
                  https://hibernate.atlassian.net/browse/HHH-12665) no longer defaults
                  to allowing a DML operation outside of a started transaction.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/persistence.xml
@@ -29,6 +29,9 @@
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
             <property name="jboss.as.jpa.deferdetach" value="true"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="mypc">
@@ -37,6 +40,9 @@
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
     <persistence-unit name="unsynchronized">
@@ -45,6 +51,9 @@
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
+            <property name="hibernate.enhancer.enableDirtyTracking" value="true"/>
+            <property name="hibernate.enhancer.enableLazyInitialization" value="true"/>
+            <property name="hibernate.enhancer.enableAssociationManagement" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11891

I expect these to fail, as they fail locally.