### PR TITLE
[WFLY-11896] Improve ability of mixed-domain testsuite to deal with different JVMs

### DIFF
--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -199,8 +199,28 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <jboss.test.host.slave.jvmhome>${java8.home}</jboss.test.host.slave.jvmhome>
-                                <jboss.test.host.slave.controller.jvmhome>${java8.home}</jboss.test.host.slave.controller.jvmhome>
+                                <jboss.test.legacy.host.java8.home>${java8.home}</jboss.test.legacy.host.java8.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>legacy-slave-java11-home</id>
+            <activation>
+                <jdk>[12,)</jdk>
+                <property>
+                    <name>java11.home</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jboss.test.legacy.host.java11.home>${java11.home}</jboss.test.legacy.host.java11.home>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
@@ -87,9 +87,6 @@ public class DomainAdjuster {
 
         final DomainAdjuster adjuster;
         switch (asVersion) {
-            case EAP_6_2_0:
-            case EAP_6_3_0:
-                throw new UnsupportedOperationException();
             case EAP_6_4_0:
                 adjuster = new DomainAdjuster640();
                 break;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
@@ -47,9 +47,6 @@ public class LegacyConfigAdjuster {
 
         final LegacyConfigAdjuster adjuster;
         switch (asVersion) {
-            case EAP_6_2_0:
-            case EAP_6_3_0:
-                throw new UnsupportedOperationException();
             case EAP_6_4_0:
                 adjuster = new LegacyConfigAdjuster640();
                 break;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
@@ -68,7 +68,7 @@ public class MixedDomainTestSuite {
             return getSupport(testClass, Profile.FULL_HA, false);
     }
 
-protected static MixedDomainTestSupport getSupport(Class<?> testClass,  boolean withMasterServers) {
+    protected static MixedDomainTestSupport getSupport(Class<?> testClass,  boolean withMasterServers) {
             return getSupport(testClass, Profile.FULL_HA, withMasterServers);
     }
 
@@ -79,6 +79,7 @@ protected static MixedDomainTestSupport getSupport(Class<?> testClass,  boolean 
         }
         return support;
     }
+
     /**
      * Call this from a @BeforeClass method
      *
@@ -91,6 +92,7 @@ protected static MixedDomainTestSupport getSupport(Class<?> testClass,  boolean 
     protected static MixedDomainTestSupport getSupport(Class<?> testClass, String masterConfig, boolean adjustDomain, boolean legacyConfig, boolean withMasterServers) {
         return getSupport(testClass, masterConfig, null, Profile.FULL_HA, adjustDomain, legacyConfig, withMasterServers);
     }
+
     /**
      * Call this from a @BeforeClass method
      *
@@ -147,7 +149,8 @@ protected static MixedDomainTestSupport getSupport(Class<?> testClass,  boolean 
                     testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version);
                 }
             } catch (Exception e) {
-                throw new RuntimeException(e);
+                MixedDomainTestSuite.version = null;
+                throw (e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e));
             }
             try {
                 //Start the the domain with adjustments to domain.xml

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -116,9 +116,7 @@ public abstract class SimpleMixedDomainTest  {
 
     @Test
     public void test00002_Versioning() throws Exception {
-        if (version == Version.AsVersion.EAP_6_2_0
-                || version == Version.AsVersion.EAP_7_0_0) {
-            //6.2.0 (https://issues.jboss.org/browse/WFLY-3228) and
+        if (version == Version.AsVersion.EAP_7_0_0) {
             //7.0.0 (https://issues.jboss.org/browse/WFCORE-401)
             // have the slave report back its own version, rather than the one from the DC,
             //which is what should happen
@@ -226,10 +224,6 @@ public abstract class SimpleMixedDomainTest  {
      */
     @Test
     public void test00011_ExampleDSConnection() throws Exception{
-        if (version == Version.AsVersion.EAP_6_2_0) {
-            // see: https://issues.jboss.org/browse/WFLY-7792
-            return;
-        }
         PathAddress exampleDSAddress = PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"),
                 PathElement.pathElement(RUNNING_SERVER, "server-one"), PathElement.pathElement(SUBSYSTEM, "datasources"),
                 PathElement.pathElement("data-source", "ExampleDS"));

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -41,8 +41,6 @@ public @interface Version {
     String EAP = "jboss-eap-";
 
     enum AsVersion {
-        EAP_6_2_0(EAP, 6, 2, 0),
-        EAP_6_3_0(EAP, 6, 3, 0),
         EAP_6_4_0(EAP, 6, 4, 0),
         EAP_7_0_0(EAP, 7, 0, 0),
         EAP_7_1_0(EAP, 7, 1, 0),
@@ -86,7 +84,7 @@ public @interface Version {
         }
 
         public boolean isEAP6Version() {
-            return (this == EAP_6_2_0 || this == EAP_6_3_0 || this == EAP_6_4_0);
+            return (this == EAP_6_4_0);
         }
 
         public int getMajor() {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -21,6 +21,8 @@
 */
 package org.jboss.as.test.integration.domain.mixed;
 
+import org.junit.Assume;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -41,10 +43,10 @@ public @interface Version {
     String EAP = "jboss-eap-";
 
     enum AsVersion {
-        EAP_6_4_0(EAP, 6, 4, 0),
-        EAP_7_0_0(EAP, 7, 0, 0),
-        EAP_7_1_0(EAP, 7, 1, 0),
-        EAP_7_2_0(EAP, 7, 2, 0),
+        EAP_6_4_0(EAP, 6, 4, 0, 8, 8),
+        EAP_7_0_0(EAP, 7, 0, 0, 8, 8),
+        EAP_7_1_0(EAP, 7, 1, 0, 8, 8),
+        EAP_7_2_0(EAP, 7, 2, 0, 11, 8),
         ;
 
 
@@ -53,14 +55,18 @@ public @interface Version {
         private final int major;
         private final int minor;
         private final int micro;
+        private final int maxVM;
+        private final int minVM;
         final String version;
 
-        AsVersion(String basename, int major, int minor, int micro){
+        AsVersion(String basename, int major, int minor, int micro, int maxVM, int minVM){
             this.basename = basename;
             this.major = major;
             this.minor = minor;
             this.micro = micro;
             this.version = major + "." + minor + "." + micro;
+            this.maxVM = maxVM;
+            this.minVM = minVM;
         }
 
         public String getBaseName() {
@@ -97,6 +103,34 @@ public @interface Version {
 
         public int getMicro() {
             return micro;
+        }
+
+        /**
+         * Gets the maximum Java version under which a legacy host can properly
+         * execute tests.
+         */
+        public int getMaxVMVersion() {
+            return maxVM;
+        }
+
+        /**
+         * Gets the minimum Java version under which a legacy host can properly
+         * execute tests.
+         */
+        public int getMinVMVersion() {
+            return minVM;
+        }
+
+        /**
+         * Checks whether the current VM version exceeds the maximum version under which a legacy host can properly
+         * execute tests. The check is disabled if system property "jboss.test.host.slave.jvmhome" is set.
+         */
+        public void assumeMaxVM() {
+            if (System.getProperty("jboss.test.host.slave.jvmhome") == null) {
+                String javaSpecVersion = System.getProperty("java.specification.version");
+                int vm = "1.8".equals(javaSpecVersion) ? 8 : Integer.parseInt(javaSpecVersion);
+                Assume.assumeFalse(vm > maxVM);
+            }
         }
 
         int compare(int major, int minor) {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/ElytronOnlyMaster640TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/ElytronOnlyMaster640TestSuite.java
@@ -36,6 +36,7 @@ public class ElytronOnlyMaster640TestSuite extends ElytronOnlyMasterTestSuite {
 
     @BeforeClass
     public static void initializeDomain() {
+        Version.AsVersion.EAP_6_4_0.assumeMaxVM();
         ElytronOnlyMasterTestSuite.getSupport(ElytronOnlyMaster640TestSuite.class);
     }
 }


### PR DESCRIPTION
MERGERS: If this is ok, please let me merge it. I want to make some CI config changes associated with that, and merging this will be my reminder to do those.

MixedDomainTestSupport will trigger caller (i.e a TestSuite) being ignored if the version under test can't handle the JVMs on offer.
    
Test jobs can be configured with different java home paths for different JVMs. If this is done MixedDomainTestSupport will try and use an appropriate one for the legacy host.

https://issues.jboss.org/browse/WFLY-11896

Also: Remove unneeded mixed domain Version enums