### PR TITLE
WFLY-11715, The layers testsuite should use thin servers, un-ignore the layers test

### DIFF
--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -965,6 +965,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
+                        <!-- maven.local.repo is set in parent pom.xml, system property surefire.system.args -->
                         <servlet.layers.install.root>${servlet.layers.install.dir}</servlet.layers.install.root>
                         <layers.install.root>${layers.install.dir}</layers.install.root>
                         <jbossas.version>${project.parent.version}</jbossas.version>

--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -21,14 +21,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import static org.jboss.as.test.layers.LayersTest.recursiveDelete;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  *
  * @author jdenise@redhat.com
  */
-@Ignore("WFLY-11715")
 public class LayersTestCase {
     // Packages that are provisioned but not used (not injected nor referenced).
     // This is the expected set of not provisioned modules when all layers are provisioned.


### PR DESCRIPTION
This is the last step of : https://issues.jboss.org/browse/WFLY-11715
Un-ignoring the layers test.