### PR TITLE
[WFLY-11911] Remove READ_TIMEOUT from channel configuration options

### DIFF
--- a/ejb3/src/main/resources/subsystem-templates/ejb3.xml
+++ b/ejb3/src/main/resources/subsystem-templates/ejb3.xml
@@ -32,7 +32,6 @@
        </timer-service>
        <remote connector-ref="http-remoting-connector" thread-pool-name="default">
            <channel-creation-options>
-               <option name="READ_TIMEOUT" value="${prop.remoting-connector.read.timeout:20}" type="xnio"/>
                <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>
            </channel-creation-options>
        </remote>

--- a/galleon-pack/src/main/resources/feature_groups/ejb3.xml
+++ b/galleon-pack/src/main/resources/feature_groups/ejb3.xml
@@ -42,11 +42,6 @@
             <param name="connector-ref" value="http-remoting-connector"/>
             <param name="thread-pool-name" value="default"/>
             <feature spec="subsystem.ejb3.service.remote.channel-creation-options">
-                <param name="channel-creation-options" value="READ_TIMEOUT"/>
-                <param name="value" value="${prop.remoting-connector.read.timeout:20}"/>
-                <param name="type" value="xnio"/>
-            </feature>
-            <feature spec="subsystem.ejb3.service.remote.channel-creation-options">
                 <param name="channel-creation-options" value="MAX_OUTBOUND_MESSAGES"/>
                 <param name="value" value="1234"/>
                 <param name="type" value="remoting"/>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-11911

READ_TIMEOUT cannot be set as channel option as sample configuration is missleading.

The only configuration options allowed on the channel by the ultimate consumer of the options org.jboss.remoting3.remote.RemoteReadListener are
RemotingOptions.TRANSMIT_WINDOW_SIZE,
RemotingOptions.MAX_OUTBOUND_MESSAGES
RemotingOptions.RECEIVE_WINDOW_SIZE
RemotingOptions.MAX_INBOUND_MESSAGES
RemotingOptions.MAX_OUTBOUND_MESSAGE_SIZE
RemotingOptions.MAX_INBOUND_MESSAGE_SIZE.
