### PR TITLE
[WFLY-11918] Revert "[WFLY-11679] Remove org.jboss.metadata module"

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
@@ -32,8 +32,7 @@
         <module name="org.jboss.as.ee"/>
 
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.metadata.common"/>
-        <module name="org.jboss.metadata.web"/>
+        <module name="org.jboss.metadata"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.wildfly.security.elytron"/>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,30 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.clustering.singleton">
+<module xmlns="urn:jboss:module:1.5" name="org.jboss.metadata">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <resources>
-        <artifact name="${org.wildfly:wildfly-clustering-singleton-extension}"/>
-    </resources>
-
     <dependencies>
-        <module name="javax.api"/>
-        <module name="org.jboss.as.clustering.common"/>
-        <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.network"/>
-        <module name="org.jboss.as.server"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.metadata"/>
-        <module name="org.jboss.msc"/>
-        <module name="org.jboss.staxmapper"/>
-        <module name="org.jboss.vfs"/>
-        <module name="org.wildfly.clustering.api"/>
-        <module name="org.wildfly.clustering.service"/>
-        <module name="org.wildfly.clustering.singleton"/>
-        <module name="org.wildfly.clustering.spi"/>
+        <module name="org.jboss.metadata.appclient" optional="true" export="true"/>
+        <module name="org.jboss.metadata.common" optional="true" export="true"/>
+        <module name="org.jboss.metadata.ear" optional="true" export="true"/>
+        <module name="org.jboss.metadata.ejb" optional="true" export="true"/>
+        <module name="org.jboss.metadata.web" optional="true" export="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
- Keycloak adapters are still using this module, so we cannot remove it until removing the dependency on keycloak.

This reverts commit ed983a7ef6f5e27d3afca33c197553b492e32b0d.

Jira issue: https://issues.jboss.org/browse/WFLY-11918