### PR TITLE
[WFLY-11921] Fix JaCoCo profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <!-- use older version of checkstyle as otherwise lots of checks fail -->
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
-        <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
+        <version.jacoco.plugin>0.8.2</version.jacoco.plugin>
         <version.org.jboss.galleon>3.0.1.Final</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
@@ -7348,257 +7348,31 @@
                                                     <include name="**/target/jacoco.exec"></include>
                                                 </fileset>
                                             </executiondata>
-                                            <structure name="AS 7 project">
+                                            <structure name="WildFly project">
                                                 <classfiles>
                                                     <fileset dir="${jboss.dist}/modules">
                                                         <include name="**/*.jar"></include>
                                                         <!-- Excludes solve "Can't add different class with same name: ..." -->
-                                                        <!-- We have 2.x in main. -->
-                                                        <exclude name="com/sun/jsf-impl/1.*/**/*"></exclude>
-                                                        <!--  Wildfly-3383 - com/sun/codemodel vs. /1.0/com/sun/codemodel -->
-                                                        <exclude name="com/sun/xml/**/*"></exclude>
-                                                        <exclude name="javax/faces/api/1.2/**/*"></exclude>
-                                                        <!-- Wildfly-3390 -->
-                                                        <exclude name="org/apache/commons/beanutils/**/*"></exclude>
-                                                        <!-- others -->
-                                                        <exclude name="**/jipijapa-hibernate4-3/**/*"></exclude>
-                                                        <exclude name="**/hornetq-core-client*"></exclude>
-                                                        <exclude name="**/jboss-marshalling*"></exclude>
-                                                        <!-- Wildfly-3389 -->
+                                                        <exclude name="**/jaxb-jxc*.jar"></exclude>
+                                                        <exclude name="**/jaxb-xjc*.jar"></exclude>
+                                                        <exclude name="**/openjdk-orb*.jar"></exclude>
+                                                        <exclude name="**/jboss-marshalling*.jar"></exclude>
+                                                        <exclude name="**/hornetq-core-client*.jar"></exclude>
+                                                        <exclude name="**/jipijapa-hibernate4-3*.jar"></exclude>
+                                                        <exclude name="**/jipijapa-hibernate5*.jar"></exclude>
+                                                        <exclude name="**/infinispan-commons*.jar"></exclude>
+                                                        <exclude name="**/jboss-logmanager*.jar"></exclude>
+                                                        <exclude name="**/wildfly-common*.jar"></exclude>
+                                                        <exclude name="**/wildfly-elytron*.jar"></exclude>
+                                                        <exclude name="**/jaxb*.jar"></exclude>
+                                                        <exclude name="**/jaxb*.jar"></exclude>
+                                                        <exclude name="**/jaxb*.jar"></exclude>
                                                     </fileset>
                                                 </classfiles>
                                                 <sourcefiles encoding="UTF-8">
-                                                    <!--
-                                                         for i in $(find . -path './*/src/main/java' | sort); do
-                                                             DIR=`echo $i | sed 's|./||'`;
-                                                             echo "<fileset dir=\"$DIR\"><include name=\"**/*.java\"></include></fileset>";
-                                                         done
-                                                    -->
-                                                    <fileset dir="appclient/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="batch-jberet/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="bean-validation/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/common/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/ee/infinispan/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/ee/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/ejb/infinispan/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/ejb/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/infinispan/extension/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/infinispan/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/jgroups/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/jgroups/extension/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/jgroups/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/marshalling/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/marshalling/infinispan/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/marshalling/jboss/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/marshalling/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/server/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/service/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/singleton/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/singleton/extension/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/web/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/web/infinispan/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/web/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="clustering/web/undertow/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="connector/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="ee/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="ejb3/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="iiop-openjdk/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jaxrs/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jdr/jboss-as-jdr/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/eclipselink/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/hibernate4_1/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/hibernate4_3/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/hibernate5/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/openjpa/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jpa/subsystem/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jsf/injection/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jsf/subsystem/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="jsr77/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/cmp/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/configadmin/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/jacorb/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/jaxr/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/messaging/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="legacy/web/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="mail/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="messaging-activemq/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="mod_cluster/extension/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="mod_cluster/undertow/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="naming/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="picketlink/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="pojo/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="rts/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="sar/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="security/api/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="security/subsystem/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="system-jmx/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="testsuite/shared/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="transactions/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="undertow/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="web-common/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="webservices/server-integration/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/bean-validation/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/common/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/ejb/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/jpa/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/spi/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/subsystem/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/transactions/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="weld/webservices/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
-                                                    <fileset dir="xts/src/main/java">
-                                                        <include name="**/*.java"></include>
-                                                    </fileset>
+                                                    <dirset dir="${basedir}">
+                                                        <include name="**/src/main/java"/>
+                                                    </dirset>
                                                 </sourcefiles>
                                             </structure>
                                             <html destdir="${basedir}/target/coverage-report/html"></html>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11921 - Fix JaCoCo profile

 - make JaCoCo profile work again
 - update JaCoCo version
 - avoid listing all the modules

0.8.3 can't be used due to regression with module-info.class
There is still the pain with excludes to avoid "Can't add different class with same name: ..." errors

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
