### PR TITLE
WFLY-9477: avoid registering ROOT.war as default web module more than…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -87,7 +87,10 @@ class HostAdd extends AbstractAddStepHandler {
         final int defaultResponseCode = HostDefinition.DEFAULT_RESPONSE_CODE.resolveModelAttribute(context, model).asInt();
         final boolean enableConsoleRedirect = !HostDefinition.DISABLE_CONSOLE_REDIRECT.resolveModelAttribute(context, model).asBoolean();
         final boolean queueRequestsOnStart = HostDefinition.QUEUE_REQUESTS_ON_START.resolveModelAttribute(context, model).asBoolean();
-        DefaultDeploymentMappingProvider.instance().addMapping(defaultWebModule, serverName, name);
+
+        if (!defaultWebModule.equals(HostDefinition.DEFAULT_WEB_MODULE_DEFAULT) || DefaultDeploymentMappingProvider.instance().getMapping(HostDefinition.DEFAULT_WEB_MODULE_DEFAULT) == null) {
+            DefaultDeploymentMappingProvider.instance().addMapping(defaultWebModule, serverName, name);
+        }
 
         final ServiceName virtualHostServiceName = HostDefinition.HOST_CAPABILITY.fromBaseCapability(address).getCapabilityServiceName();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -50,6 +50,8 @@ import org.wildfly.extension.undertow.filters.FilterRefDefinition;
  */
 class HostDefinition extends PersistentResourceDefinition {
 
+    public static final String DEFAULT_WEB_MODULE_DEFAULT = "ROOT.war";
+
     static final RuntimeCapability<Void> HOST_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HOST, true, Host.class)
             .addRequirements(Capabilities.CAPABILITY_UNDERTOW)
             //addDynamicRequirements(Capabilities.CAPABILITY_SERVER) -- has no function so don't use it
@@ -68,7 +70,7 @@ class HostDefinition extends PersistentResourceDefinition {
     static final SimpleAttributeDefinition DEFAULT_WEB_MODULE = new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_WEB_MODULE, ModelType.STRING, true)
             .setRestartAllServices()
             .setValidator(new StringLengthValidator(1, true, false))
-            .setDefaultValue(new ModelNode("ROOT.war"))
+            .setDefaultValue(new ModelNode(DEFAULT_WEB_MODULE_DEFAULT))
             .build();
 
     static final SimpleAttributeDefinition DEFAULT_RESPONSE_CODE = new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_RESPONSE_CODE, ModelType.INT, true)


### PR DESCRIPTION
… once

Issue: [WFLY-9477](https://issues.jboss.org/browse/WFLY-9477)

`default-web-module` is an optional attribute with default value "ROOT.war" but because the module names have to be unique per server it essentially becomes required. Since you can control which host to deploy to in other ways the simplest solution would be to remove the default value. However some users may depend on the default value so I propose to register "ROOT.war" once and then ignore it if it's used by other hosts.