### PR TITLE
[WFLY-11934] Upgrade wildfly-arquillian from 2.1.1.Final to 2.2.0.Fin…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,7 @@
         <version.org.javassist>3.23.1-GA</version.org.javassist>
         <version.org.jberet>1.3.3.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
-        <version.org.jboss.arquillian.core>1.1.13.Final</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>4.0.16.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
@@ -333,7 +333,7 @@
         <version.org.jboss.security.jboss-negotiation>3.0.5.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->
-        <version.org.jboss.shrinkwrap.descriptors>2.0.0-alpha-10</version.org.jboss.shrinkwrap.descriptors>
+        <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
@@ -375,7 +375,7 @@
         <version.org.picketlink>2.5.5.SP12</version.org.picketlink>
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
         <version.org.wildfly.core>9.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
@@ -6651,6 +6651,17 @@
                 <artifactId>arquillian-junit-container</artifactId>
                 <version>${version.org.jboss.arquillian.core}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Required for the MicroProfile health TCK that is run as part of the testsuite and the TCK brings in an
+                 older version.
+
+                 It also needs to be a runtime dependency because the shared testsuite requires it.
+             -->
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-spi</artifactId>
+                <version>${version.org.jboss.arquillian.core}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…al. This also requires a shrinkwrap and arquillian-core upgrade to stay in sync with what wildfly-arquillian is using.

https://issues.jboss.org/browse/WFLY-11934