### PR TITLE
[WFLY-11938] Upgrade WildFly Core 9.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.1.1.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>9.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.14.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11938

---


#  Release Notes - WildFly Core - Version 9.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4259'>WFCORE-4259</a>] -         Upgrade WildFly Elytron to 1.9.x
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4378'>WFCORE-4378</a>] -         Upgrade WildFly Elytron to 1.9.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4379'>WFCORE-4379</a>] -         Upgrade WildFly Common to 1.5.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4382'>WFCORE-4382</a>] -         Upgrade Byteman from 4.0.5 to 4.0.6
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4393'>WFCORE-4393</a>] -         Upgrade XNIO to 3.7.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4309'>WFCORE-4309</a>] -         Value validator for &#39;host-context-map&#39; attribute of &#39;server-ssl-sni-context&#39; resource
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4363'>WFCORE-4363</a>] -         Need to disable console error page by console-enabled
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4385'>WFCORE-4385</a>] -         DomainTestSupport and DomainLifecycleUtil should be AutoCloseable
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4390'>WFCORE-4390</a>] -         Introduce COMPONENT_JNDI_DEPENDENCIES attachment key
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4305'>WFCORE-4305</a>] -         CLI, new option to enable properties resolution
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4357'>WFCORE-4357</a>] -         Support new MSC Service API for deployment dependency
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4383'>WFCORE-4383</a>] -         DomainCommandBuilder ignores the specified PC/HC JVM
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4387'>WFCORE-4387</a>] -         Fix typo in remoting descriptions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4388'>WFCORE-4388</a>] -         Subsystem test framework alters order of child resources prior to transformation in presence of override models
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4389'>WFCORE-4389</a>] -         deploy fails in batch when operation is validated
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4380'>WFCORE-4380</a>] -         Remove dependency on separate WildFly Elytron Tool
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4381'>WFCORE-4381</a>] -         Intermittent failures of ReadOnlyModeTestCase.testConfigurationNotUpdated
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4384'>WFCORE-4384</a>] -         Clean up CachedDcDomainTestCase handling of domain lifecycle
</li>
</ul>
                                    