### PR TITLE
[WFLY-11941] Add the org.wildfly.event.logger module to the NOT_USED …

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -49,7 +49,9 @@ public class LayersTestCase {
         "javax.activation.api",
         // No patching modules in layers
         "org.jboss.as.patching",
-        "org.jboss.as.patching.cli"
+        "org.jboss.as.patching.cli",
+        // Not currently used internally
+        "org.wildfly.event.logger"
     };
     // Packages that are not referenced from the module graph but needed.
     // This is the expected set of un-referenced modules found when scanning


### PR DESCRIPTION
…array. This module will be introduced via WFCORE-4355.

https://issues.jboss.org/browse/WFLY-11941

This may be a bit premature as https://github.com/wildfly/wildfly-core/pull/3700 has not been approved. However it needs to be merged before https://github.com/wildfly/wildfly-core/pull/3700 is merged.