### PR TITLE
[WFLY-11944] Some clustering test cases do not close JNDI context between tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -36,9 +36,9 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 
 /**
  * @author Ondrej Chaloupka
@@ -49,8 +49,8 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends AbstractCl
     protected static final String MODULE_NAME = RemoteEJBClientStatefulFailoverTestBase.class.getSimpleName();
     protected static final String MODULE_NAME_SINGLE = MODULE_NAME + "-single";
 
-    protected static EJBDirectory singletonDirectory;
-    protected static EJBDirectory directory;
+    protected EJBDirectory singletonDirectory;
+    protected EJBDirectory directory;
 
     protected static Archive<?> createDeploymentSingleton() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_SINGLE + ".jar");
@@ -69,14 +69,14 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends AbstractCl
         undeploy(TWO_DEPLOYMENT_HELPERS);
     }
 
-    @BeforeClass
-    public static void beforeClass() throws NamingException {
+    @Before
+    public void beforeTest() throws NamingException {
         directory = new RemoteEJBDirectory(MODULE_NAME);
         singletonDirectory = new RemoteEJBDirectory(MODULE_NAME_SINGLE);
     }
 
-    @AfterClass
-    public static void destroy() throws Exception {
+    @After
+    public void afterTest() throws Exception {
         directory.close();
         singletonDirectory.close();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/passivation/ClusterPassivationTestBase.java
@@ -39,9 +39,9 @@ import org.jboss.as.test.clustering.ejb.EJBDirectory;
 import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.logging.Logger;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 
 /**
  * Base class for passivation tests on EJB2 beans.
@@ -52,15 +52,15 @@ public abstract class ClusterPassivationTestBase {
     private static Logger log = Logger.getLogger(ClusterPassivationTestBase.class);
     public static final String MODULE_NAME = ClusterPassivationTestBase.class.getSimpleName();
 
-    protected static EJBDirectory directory;
+    protected EJBDirectory directory;
 
-    @BeforeClass
-    public static void beforeClass() throws NamingException {
+    @Before
+    public void beforeTest() throws NamingException {
         directory = new RemoteEJBDirectory(MODULE_NAME);
     }
 
-    @AfterClass
-    public static void destroy() throws Exception {
+    @After
+    public void afterTest() throws Exception {
         directory.close();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -49,8 +49,9 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -64,8 +65,6 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class RemoteStatelessFailoverTestCase {
     private static final Logger log = Logger.getLogger(RemoteStatelessFailoverTestCase.class);
-    private static EJBDirectory directoryAnnotation;
-    private static EJBDirectory directoryDD;
 
     private static final String MODULE_NAME = RemoteStatelessFailoverTestCase.class.getSimpleName();
     private static final String MODULE_NAME_DD = MODULE_NAME + "dd";
@@ -74,11 +73,11 @@ public class RemoteStatelessFailoverTestCase {
     private static final Map<String, Boolean> started = new HashMap<String, Boolean>();
     private static final Map<String, List<String>> container2deployment = new HashMap<String, List<String>>();
 
+    private EJBDirectory directoryAnnotation;
+    private EJBDirectory directoryDD;
+
     @BeforeClass
     public static void init() throws NamingException {
-        directoryAnnotation = new RemoteEJBDirectory(MODULE_NAME);
-        directoryDD = new RemoteEJBDirectory(MODULE_NAME_DD);
-
         deployed.put(DEPLOYMENT_1, false);
         deployed.put(DEPLOYMENT_2, false);
         deployed.put(DEPLOYMENT_HELPER_1, false);
@@ -96,8 +95,15 @@ public class RemoteStatelessFailoverTestCase {
         container2deployment.put(NODE_2, deployments2);
     }
 
-    @AfterClass
-    public static void destroy() throws Exception {
+
+    @Before
+    public void beforeTest() throws Exception {
+        directoryAnnotation = new RemoteEJBDirectory(MODULE_NAME);
+        directoryDD = new RemoteEJBDirectory(MODULE_NAME_DD);
+    }
+
+    @After
+    public void afterTest() throws Exception {
         directoryAnnotation.close();
         directoryDD.close();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ejb/RemoteEJBDirectory.java
@@ -29,6 +29,12 @@ import javax.naming.NamingException;
 
 /**
  * {@link EJBDirectory} that uses remote JNDI.
+ *
+ * NOTE:
+ * if you hold a static reference to this class, it causes any JNDI lookups across different tests to use the same discovered node registry (DNR).
+ * This can cause server starts and stops in one test to contaminate other tests and produce incorrect results.
+ * It is adviseable to use one instance per test by defining a @Before and @After method to create and dispose of the instance on a per test basis.
+ *
  * @author Paul Ferraro
  */
 public class RemoteEJBDirectory extends NamingEJBDirectory {


### PR DESCRIPTION
This PR adjusts the use of RemoteEJBDirectory for a few clustering test cases, making it non-static as opposed to static. Static use is not advised as it negatively affects EJB client invocation.

The JIRA issue: https://issues.jboss.org/browse/WFLY-11944

