### PR TITLE
WFLY-11946/WFLY-10340 Remove unneeded dependencies from OpenJPA module

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
@@ -515,10 +515,10 @@ version="1.0"> +
 [[migrating-from-openjpa]]
 == Migrating from OpenJPA
 
-You need to copy the OpenJPA jars (e.g. openjpa-all.jar serp.jar) into
+You need to copy the OpenJPA jar (e.g. openjpa-all.jar) into
 the WildFly modules/org/apache/openjpa/main folder and update
 modules/org/apache/openjpa/main/module.xml to include the same jar file
-names that you copied in. This will help you get your application that
+name that you copied in. This will help you get your application that
 depends on OpenJPA, to deploy on WildFly.
 
 [source,java,options="nowrap"]
@@ -531,22 +531,17 @@ depends on OpenJPA, to deploy on WildFly.
               <exclude path="javax/**" />
            </filter>
         </resource-root>
-        <resource-root path="serp.jar"/>
     </resources>
  
     <dependencies>
-        <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="javax.xml.bind.api"/>
-        <module name="org.apache.commons.collections"/>
-        <module name="org.apache.commons.lang"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
         <module name="org.jboss.jandex"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
@@ -33,18 +33,14 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
         <module name="javax.xml.bind.api"/>
-        <module name="org.apache.commons.collections"/>
-        <module name="org.apache.commons.lang"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
         <module name="org.jboss.jandex"/>
     </dependencies>
 </module>

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/openjpa/OpenJPASharedModuleProviderTestCase.java
@@ -33,7 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import javax.naming.InitialContext;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,7 +43,6 @@ import org.junit.runner.RunWith;
  * @author Antti Laisi
  */
 @RunWith(Arquillian.class)
-@Ignore("WFLY-10340")
 public class OpenJPASharedModuleProviderTestCase {
 
     private static final String ARCHIVE_NAME = "openjpa_module_test";

--- a/testsuite/compat/src/test/scripts/build-jars.xml
+++ b/testsuite/compat/src/test/scripts/build-jars.xml
@@ -87,18 +87,14 @@
 &lt;/resources&gt;
 
 &lt;dependencies&gt;
-&lt;module name="javax.api"/&gt;
 &lt;module name="javax.annotation.api"/&gt;
 &lt;module name="javax.enterprise.api"/&gt;
 &lt;module name="javax.persistence.api"/&gt;
 &lt;module name="javax.transaction.api"/&gt;
 &lt;module name="javax.validation.api"/&gt;
 &lt;module name="javax.xml.bind.api"/&gt;
-&lt;module name="org.apache.commons.collections"/&gt;
-&lt;module name="org.apache.commons.lang"/&gt;
 &lt;module name="org.jboss.as.jpa.spi"/&gt;
 &lt;module name="org.jboss.logging"/&gt;
-&lt;module name="org.jboss.vfs"/&gt;
 &lt;module name="org.jboss.jandex"/&gt;
 &lt;/dependencies&gt;
 &lt;/module&gt;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10340 (Enable OpenJPA integration tests for Java 10)
https://issues.jboss.org/browse/WFLY-11946 (Remove unneeded dependencies from OpenJPA module)

As per http://openjpa.apache.org/build-and-runtime-dependencies.html, we don't need the org.apache.commons.lang dependency, as openjpa-all.jar includes that and other dependencies.  

Also updated doc accordingly (current doc is at https://docs.wildfly.org/16/Developer_Guide.html#migrating-from-openjpa).  
