### PR TITLE
WFLY-9951 Remotable exception caused by non-remotable Infinispan Cach…

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
@@ -190,8 +190,15 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     }
 
     @Override
-    public boolean isRemotable(Throwable throwable) {
-        return !(throwable instanceof CacheException);
+    public boolean isRemotable(final Throwable throwable) {
+        Throwable subject = throwable;
+        while (subject != null) {
+            if (subject instanceof CacheException) {
+                return false;
+            }
+            subject = subject.getCause();
+        }
+        return true;
     }
 
     @Override

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/ClientExceptionRemoteEJBTestCase.java
@@ -47,7 +47,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Test for WFLY-5788.
+ * Test for WFLY-5788 and WFLY-9951.
+ *
  * @author Radoslav Husar
  */
 @RunWith(Arquillian.class)

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/InfinispanExceptionThrowingIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/InfinispanExceptionThrowingIncrementorBean.java
@@ -25,13 +25,15 @@ package org.jboss.as.test.clustering.cluster.ejb.remote.bean;
 import javax.ejb.Remote;
 import javax.ejb.Stateful;
 
-import org.infinispan.statetransfer.OutdatedTopologyException;
+import org.infinispan.commons.CacheException;
+import org.infinispan.util.concurrent.TimeoutException;
 
 /**
- * Implementation of {@link Incrementor} which always throws a {@link RuntimeException}: an Infinispan's {@link OutdatedTopologyException}.
+ * Implementation of {@link Incrementor} which always throws a standard remotable (known to a client classloader) exception
+ * which is caused by an Infinispan {@link RuntimeException} {@link CacheException} {@link TimeoutException} which the client
+ * typically cannot load the class for.
  *
  * @author Radoslav Husar
- * @version January 2016
  */
 @Stateful
 @Remote(Incrementor.class)
@@ -39,6 +41,6 @@ public class InfinispanExceptionThrowingIncrementorBean implements Incrementor {
 
     @Override
     public Result<Integer> increment() {
-        throw new OutdatedTopologyException("Remote values are missing because of a topology change");
+        throw new IllegalStateException("standard remotable exception that is caused by non-remotable infinispan CacheException", new TimeoutException("the non-remotable infinispan cause"));
     }
 }


### PR DESCRIPTION
…eException cannot be sent to the client

Jira
https://issues.jboss.org/browse/WFLY-9951