### PR TITLE
[WFLY-11672] @ApplicationScoped does not work when used with @ServerEndpoint

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -83,6 +83,11 @@
             </exclusions>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Required for Java 11 -->
         <dependency>
             <groupId>javax.activation</groupId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/ChatWebsocketResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/ChatWebsocketResource.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.weld.deployment;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.PathParam;
+import javax.websocket.server.ServerEndpoint;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 3/26/19.
+ */
+@ServerEndpoint("/chat/{username}")
+@ApplicationScoped
+public class ChatWebsocketResource {
+
+    Map<String, Session> sessions = new ConcurrentHashMap<>();
+
+    @OnOpen
+    public void onOpen(Session session, @PathParam("username") String username) {
+        sessions.put(username, session);
+        broadcast("User " + username + " joined");
+    }
+
+    @OnClose
+    public void onClose(Session session, @PathParam("username") String username) {
+        sessions.remove(username);
+        broadcast("User " + username + " left");
+    }
+
+    @OnError
+    public void onError(Session session, @PathParam("username") String username, Throwable throwable) {
+        sessions.remove(username);
+        broadcast("User " + username + " left on error: " + throwable);
+    }
+
+    @OnMessage
+    public void onMessage(String message, @PathParam("username") String username) {
+        broadcast(">> " + username + ": " + message);
+    }
+
+    private void broadcast(String message) {
+        sessions.values().forEach(s -> {
+            s.getAsyncRemote().sendObject(message, result -> {
+                if (result.getException() != null) {
+                    System.out.println("Unable to send message: " + result.getException());
+                }
+            });
+        });
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/WebsocketApplicationScopedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/WebsocketApplicationScopedTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.weld.deployment;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 3/26/19.
+ */
+@RunWith(Arquillian.class)
+public class WebsocketApplicationScopedTestCase {
+    private static final String CLIENT_STANDALONE = "standalone";
+    private static final HashMap<String, LinkedBlockingDeque<String>> queues = new HashMap<>();
+
+    @Deployment(testable = false, name = CLIENT_STANDALONE)
+    public static WebArchive createThinDeployment() {
+        return ShrinkWrap.create(WebArchive.class, CLIENT_STANDALONE + ".war")
+                .addClasses(ChatWebsocketResource.class)
+                .addAsManifestResource(new StringAsset("io.undertow.websockets.jsr.UndertowContainerProvider"),
+                        "services/javax.websocket.ContainerProvider");
+    }
+
+    @Test
+    @OperateOnDeployment(CLIENT_STANDALONE)
+    @RunAsClient
+    public void testClientStandalone(@ArquillianResource URL webapp) throws Exception {
+        URI uriUser1 = createUri(webapp,"/chat/user1");
+        URI uriUser2 = createUri(webapp,"/chat/user2");
+
+        try (Session session = ContainerProvider.getWebSocketContainer().connectToServer(Client.class, uriUser1)) {
+            //Wait until the client is initialized e.q. the OnOpen is executed
+            Thread.sleep(10);
+            Assert.assertTrue(queues.size() > 0);
+
+            //Check if the user1 is connected
+            Assert.assertEquals("CONNECT", queues.get(session.getId()).poll(10, TimeUnit.SECONDS));
+            Assert.assertEquals("User user1 joined", queues.get(session.getId()).poll(10, TimeUnit.SECONDS));
+            session.getAsyncRemote().sendText("hello world");
+            Assert.assertEquals(">> user1: hello world", queues.get(session.getId()).poll(10, TimeUnit.SECONDS));
+
+            try (Session sessioUser2 = ContainerProvider.getWebSocketContainer().connectToServer(Client.class, uriUser2)) {
+                //Wait until the client is initialized e.q. the OnOpen is executed
+                Thread.sleep(10);
+                Assert.assertTrue(queues.size() > 1);
+
+                //Assert that the sessioUser2 got the messages
+                Assert.assertEquals("CONNECT", queues.get(sessioUser2.getId()).poll(10, TimeUnit.SECONDS));
+                Assert.assertEquals("User user2 joined", queues.get(sessioUser2.getId()).poll(10, TimeUnit.SECONDS));
+                sessioUser2.getAsyncRemote().sendText("hello world");
+                Assert.assertEquals(">> user2: hello world", queues.get(sessioUser2.getId()).poll(10, TimeUnit.SECONDS));
+
+                //Assert that the user1's session got user2's messages
+                Assert.assertEquals("User user2 joined", queues.get(session.getId()).poll(10, TimeUnit.SECONDS));
+                Assert.assertEquals(">> user2: hello world", queues.get(session.getId()).poll(10, TimeUnit.SECONDS));
+            }
+        }
+    }
+
+    private URI createUri(URL webapp, String path) throws URISyntaxException {
+        return new URI("ws", "", TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getHttpPort(), webapp.getPath() + path, "", "");
+    }
+
+    @ClientEndpoint
+    public static class Client {
+
+        @OnOpen
+        public void open(Session session) {
+            queues.put(session.getId(), new LinkedBlockingDeque<>());
+            queues.get(session.getId()).add("CONNECT");
+        }
+
+        @OnMessage
+        void message(Session session, String msg) {
+            queues.get(session.getId()).add(msg);
+        }
+
+    }
+
+}
+
+
+

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/WeldClassIntrospector.java
@@ -30,6 +30,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.weld.bean.builtin.BeanManagerProxy;
+import org.jboss.weld.injection.producer.BasicInjectionTarget;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 /**
@@ -71,7 +72,15 @@ public class WeldClassIntrospector implements EEClassIntrospector, Service {
             @Override
             public ManagedReference getReference() {
                 final CreationalContext context = beanManager.createCreationalContext(null);
-                final Object instance = injectionTarget.produce(context);
+
+                Object instance;
+                BasicInjectionTarget target = injectionTarget instanceof BasicInjectionTarget ? (BasicInjectionTarget) injectionTarget: null;
+                if(target != null && target.getBean() != null) {
+                    instance = beanManager.getReference(target.getBean(), target.getAnnotatedType().getBaseType(), context);
+                } else {
+                    instance = injectionTarget.produce(context);
+                }
+
                 injectionTarget.inject(instance, context);
                 injectionTarget.postConstruct(instance);
                 return new WeldManagedReference(injectionTarget, context, instance);


### PR DESCRIPTION
Wildfly issue: https://issues.jboss.org/browse/WFLY-11672

This fixes injection of bean which has combination of @ApplicationScoped and @ServerEndpoint annotations.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted