### PR TITLE
[WFLY-9954] Fixing too many services and dependencies created for EJBs issue

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleInitialProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleInitialProcessor.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.ee.component.deployers;
 
+import java.util.HashMap;
+
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -31,6 +33,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public final class EEModuleInitialProcessor implements DeploymentUnitProcessor {
 
@@ -60,6 +63,7 @@ public final class EEModuleInitialProcessor implements DeploymentUnitProcessor {
             appName = null;
         }
         deploymentUnit.putAttachment(Attachments.EE_MODULE_DESCRIPTION, new EEModuleDescription(appName, moduleName, earApplicationName, appClient));
+        deploymentUnit.putAttachment(org.jboss.as.server.deployment.Attachments.COMPONENT_JNDI_DEPENDENCIES, new HashMap<>());
     }
 
     public void undeploy(final DeploymentUnit context) {

--- a/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/naming/InApplicationClientBindingProcessor.java
@@ -21,6 +21,10 @@
  */
 package org.jboss.as.ee.naming;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.ComponentNamingMode;
@@ -43,6 +47,7 @@ import org.jboss.msc.value.Values;
  * Processor responsible for binding java:comp/InAppClientContainer
  *
  * @author Stuart Douglas
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class InApplicationClientBindingProcessor implements DeploymentUnitProcessor {
 
@@ -85,7 +90,12 @@ public class InApplicationClientBindingProcessor implements DeploymentUnitProces
         serviceTarget.addService(inAppClientServiceName, inAppClientContainerService)
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, inAppClientContainerService.getNamingStoreInjector())
             .install();
-        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES, inAppClientServiceName);
+        final Map<ServiceName, Set<ServiceName>> jndiComponentDependencies = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.COMPONENT_JNDI_DEPENDENCIES);
+        Set<ServiceName> jndiDependencies = jndiComponentDependencies.get(contextServiceName);
+        if (jndiDependencies == null) {
+            jndiComponentDependencies.put(contextServiceName, jndiDependencies = new HashSet<>());
+        }
+        jndiDependencies.add(inAppClientServiceName);
     }
 
 

--- a/ee/src/main/java/org/jboss/as/ee/naming/InstanceNameBindingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/naming/InstanceNameBindingProcessor.java
@@ -21,6 +21,10 @@
  */
 package org.jboss.as.ee.naming;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.ComponentNamingMode;
@@ -47,6 +51,7 @@ import org.jboss.msc.service.ServiceTarget;
  * Processor responsible for binding java:comp/InstanceName
  *
  * @author Stuart Douglas
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class InstanceNameBindingProcessor implements DeploymentUnitProcessor {
 
@@ -110,10 +115,13 @@ public class InstanceNameBindingProcessor implements DeploymentUnitProcessor {
                 }
             })
             .install();
-        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES, instanceNameServiceName);
-
+        final Map<ServiceName, Set<ServiceName>> jndiComponentDependencies = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.COMPONENT_JNDI_DEPENDENCIES);
+        Set<ServiceName> jndiDependencies = jndiComponentDependencies.get(contextServiceName);
+        if (jndiDependencies == null) {
+            jndiComponentDependencies.put(contextServiceName, jndiDependencies = new HashSet<>());
+        }
+        jndiDependencies.add(instanceNameServiceName);
     }
-
 
     @Override
     public void undeploy(DeploymentUnit context) {

--- a/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/deployment/TransactionJndiBindingProcessor.java
@@ -21,6 +21,10 @@
  */
 package org.jboss.as.txn.deployment;
 
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
@@ -52,6 +56,7 @@ import org.jboss.msc.service.ServiceTarget;
  * regardless of the presence of the {@link javax.annotation.Resource} annotation.
  *
  * @author Stuart Douglas
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor {
     @Override
@@ -96,7 +101,12 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
                     new ManagedReferenceInjector<UserTransaction>(userTransactionBindingService.getManagedObjectInjector()))
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, userTransactionBindingService.getNamingStoreInjector())
             .install();
-        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES,userTransactionServiceName);
+        final Map<ServiceName, Set<ServiceName>> jndiComponentDependencies = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.COMPONENT_JNDI_DEPENDENCIES);
+        Set<ServiceName> jndiDependencies = jndiComponentDependencies.get(contextServiceName);
+        if (jndiDependencies == null) {
+            jndiComponentDependencies.put(contextServiceName, jndiDependencies = new HashSet<>());
+        }
+        jndiDependencies.add(userTransactionServiceName);
 
         final ServiceName transactionSynchronizationRegistryName = contextServiceName.append("TransactionSynchronizationRegistry");
         BinderService transactionSyncBinderService = new BinderService("TransactionSynchronizationRegistry");
@@ -105,7 +115,7 @@ public class TransactionJndiBindingProcessor implements DeploymentUnitProcessor 
                     new ManagedReferenceInjector<TransactionSynchronizationRegistry>(transactionSyncBinderService.getManagedObjectInjector()))
             .addDependency(contextServiceName, ServiceBasedNamingStore.class, transactionSyncBinderService.getNamingStoreInjector())
             .install();
-        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES,transactionSynchronizationRegistryName);
+        jndiDependencies.add(transactionSynchronizationRegistryName);
     }
 
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-9954

Moving component related JNDI dependencies from o.j.a.s.d.Attachments.JNDI_DEPENDENCIES
 to  o.j.a.s.d.Attachments.COMPONENT_JNDI_DEPENDENCIES attachment.
Before this fix JNDI_DEPENDENCY_SERVICE had too many dependencies.
With this fix applied JNDI_DEPENDENCY_SERVICE will now depend on
JNDI_AGGREGATION_SERVICES and these aggregation services
will reference COMPONENT_JNDI_DEPENDENCIES that were referenced
by JNDI_DEPENDENCY_SERVICE before. In other words we are decreasing
JNDI_DEPENDENCY_SERVICE dependencies count and reorganizing (simplifying)
its dependency tree.