### PR TITLE
WFLY-11870 Do not process resource annotations on abstract classes or …

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/AbstractReferencingBeanA.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/AbstractReferencingBeanA.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import javax.ejb.EJB;
+
+public abstract class AbstractReferencingBeanA {
+
+    @EJB
+    private ReferencedBeanInterface referencedBean;
+
+    public String relayHello() {
+        return referencedBean.sayHello();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencedBean.java
@@ -1,0 +1,11 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class ReferencedBean implements ReferencedBeanInterface {
+    @Override
+    public String sayHello() {
+        return "Hello!";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencedBeanInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencedBeanInterface.java
@@ -1,0 +1,5 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+public interface ReferencedBeanInterface {
+    String sayHello();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingBeanBInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingBeanBInterface.java
@@ -1,0 +1,10 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import javax.ejb.EJB;
+
+public interface ReferencingBeanBInterface {
+
+    @EJB
+    ReferencedBeanInterface refencedBean = null;
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingClassA.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingClassA.java
@@ -1,0 +1,4 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+public class ReferencingClassA extends AbstractReferencingBeanA {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingClassB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingClassB.java
@@ -1,0 +1,4 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+public class ReferencingClassB implements ReferencingBeanBInterface {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingComponentA.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingComponentA.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class ReferencingComponentA extends AbstractReferencingBeanA {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingComponentB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ReferencingComponentB.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class ReferencingComponentB implements ReferencingBeanBInterface {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ResourceAnnotationsProcessingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/annotationprocessing/ResourceAnnotationsProcessingTestCase.java
@@ -1,0 +1,128 @@
+package org.jboss.as.test.integration.ejb.annotationprocessing;
+
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ResourceAnnotationsProcessingTestCase {
+
+    private static final String ABSTRACT_REFERENCING_INTERFACE_WITHOUT_IMPL = "abstract-referencing-interface-without-impl";
+    private static final String INTERFACE_REFERENCING_INTERFACE_WITHOUT_IMPL = "interface-referencing-interface-without-impl";
+    private static final String EJBS_REFERENCING_INTERFACE_WITH_IMPL = "ejbs-referencing-interface-with-impl";
+    private static final String EJBS_REFERENCING_INTERFACE_WITHOUT_IMPL = "ejbs-referencing-interface-without-impl";
+    private static final String CLASSES_REFERENCING_INTERFACE_WITH_IMPL = "classes-referencing-interface-with-impl";
+    private static final String CLASSES_REFERENCING_INTERFACE_WITHOUT_IMPL = "classes-referencing-interface-without-impl";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(name = ABSTRACT_REFERENCING_INTERFACE_WITHOUT_IMPL, managed = false)
+    public static WebArchive createDeployment1() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                ABSTRACT_REFERENCING_INTERFACE_WITHOUT_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(AbstractReferencingBeanA.class);
+        return war;
+    }
+
+    @Deployment(name = INTERFACE_REFERENCING_INTERFACE_WITHOUT_IMPL, managed = false)
+    public static WebArchive createDeployment2() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                INTERFACE_REFERENCING_INTERFACE_WITHOUT_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(ReferencingBeanBInterface.class);
+        return war;
+    }
+
+    @Deployment(name = EJBS_REFERENCING_INTERFACE_WITH_IMPL, managed = false)
+    public static WebArchive createDeployment3() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                EJBS_REFERENCING_INTERFACE_WITH_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(ReferencedBean.class);
+        war.addClass(AbstractReferencingBeanA.class);
+        war.addClass(ReferencingComponentA.class);
+        war.addClass(ReferencingBeanBInterface.class);
+        war.addClass(ReferencingComponentB.class);
+        return war;
+    }
+
+    @Deployment(name = EJBS_REFERENCING_INTERFACE_WITHOUT_IMPL, managed = false)
+    public static WebArchive createDeployment4() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                EJBS_REFERENCING_INTERFACE_WITHOUT_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(AbstractReferencingBeanA.class);
+        war.addClass(ReferencingComponentA.class);
+        war.addClass(ReferencingBeanBInterface.class);
+        war.addClass(ReferencingComponentB.class);
+        return war;
+    }
+
+    @Deployment(name = CLASSES_REFERENCING_INTERFACE_WITH_IMPL, managed = false)
+    public static WebArchive createDeployment5() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                CLASSES_REFERENCING_INTERFACE_WITH_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(ReferencedBean.class);
+        war.addClass(AbstractReferencingBeanA.class);
+        war.addClass(ReferencingClassA.class);
+        war.addClass(ReferencingBeanBInterface.class);
+        war.addClass(ReferencingClassB.class);
+        return war;
+    }
+
+    @Deployment(name = CLASSES_REFERENCING_INTERFACE_WITHOUT_IMPL, managed = false)
+    public static WebArchive createDeployment6() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class,
+                CLASSES_REFERENCING_INTERFACE_WITHOUT_IMPL + ".war");
+        war.addClass(ReferencedBeanInterface.class);
+        war.addClass(AbstractReferencingBeanA.class);
+        war.addClass(ReferencingClassA.class);
+        war.addClass(ReferencingBeanBInterface.class);
+        war.addClass(ReferencingClassB.class);
+        return war;
+    }
+
+    @Test
+    public void testAbstractReferencingInterfaceWithoutImpl() {
+        tryDeployment(ABSTRACT_REFERENCING_INTERFACE_WITHOUT_IMPL);
+    }
+
+    @Test
+    public void testInterfaceReferencingInterfaceWithoutImpl() {
+        tryDeployment(INTERFACE_REFERENCING_INTERFACE_WITHOUT_IMPL);
+    }
+
+    @Test
+    public void testEjbsReferencingInterfaceWithImpl() {
+        tryDeployment(EJBS_REFERENCING_INTERFACE_WITH_IMPL);
+    }
+
+    @Test(expected = DeploymentException.class)
+    public void testEjbsReferencingInterfaceWithoutImpl() {
+        tryDeployment(EJBS_REFERENCING_INTERFACE_WITHOUT_IMPL);
+    }
+
+    @Test
+    public void testClassesReferencingInterfaceWithImpl() {
+        tryDeployment(CLASSES_REFERENCING_INTERFACE_WITH_IMPL);
+    }
+
+    @Test(expected = DeploymentException.class)
+    public void testClassesReferencingInterfaceWithoutImpl() {
+        tryDeployment(CLASSES_REFERENCING_INTERFACE_WITHOUT_IMPL);
+    }
+
+    private void tryDeployment(String name) {
+        deployer.deploy(name);
+        deployer.undeploy(name);
+    }
+}


### PR DESCRIPTION
…interfaces that do not have concrete subclasses

Issue: https://issues.jboss.org/browse/WFLY-11870
Downstream issue: https://issues.jboss.org/browse/JBEAP-16576
Related to: https://github.com/wildfly/wildfly/pull/11203

This issue comes from a customer case, they are unable to deploy an application to EAP 7.2, which was deployable on EAP 7.1.

The point is that their deployment contains *abstract* class with @EJB annotated field referencing an interface:

```
public abstract class AbstractReferencingBean { // doesn't have concrete subclass
    @EJB
    private ReferencedBeanInterface referencedBean; // doesn't have implementing class
}
```

Neither the referencing abstract class nor the referenced interface have concrete subclasses in this deployment, so theoretically they should be ignored? The deployment fails because a binding processor can't find any bean that would satisfy this injection point.

In the PR, I'm trying to prevent the resource annotations from being processed if an annotated class is an abstract class or an interface and there's no concrete subclass in the deployment.

