### PR TITLE
[WFLY-11966] Capability requirements declared twice in JCA root resource definition

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -55,8 +55,7 @@ public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
         super(new Parameters(PATH_SUBSYSTEM, JcaExtension.getResourceDescriptionResolver())
                 .setAddHandler(JcaSubsystemAdd.INSTANCE)
                 .setRemoveHandler(JcaSubSystemRemove.INSTANCE)
-                .setCapabilities(JCA_NAMING_CAPABILITY)
-                .setCapabilities(TRANSACTION_INTEGRATION_CAPABILITY)
+                .setCapabilities(JCA_NAMING_CAPABILITY, TRANSACTION_INTEGRATION_CAPABILITY)
         );
         this.registerRuntimeOnly = registerRuntimeOnly;
     }

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemTestCase.java
@@ -40,6 +40,7 @@ import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
+import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -89,6 +90,7 @@ public class JcaSubsystemTestCase extends AbstractSubsystemBaseTest {
                 ConnectorServices.LOCAL_TRANSACTION_PROVIDER_CAPABILITY,
                 ConnectorServices.TRANSACTION_XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY,
                 ConnectorServices.TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY,
+                NamingService.CAPABILITY_NAME,
                 "org.wildfly.threads.thread-factory.string");
     }
 


### PR DESCRIPTION
- JCA_NAMING_CAPABILITY is being overwritten by TRANSACTION_INTEGRATION_CAPABILITY , so naming requirement is lost.

Jira issue: https://issues.jboss.org/browse/WFLY-11966