### PR TITLE
WFLY-11906 Managed Executor Task Fails with CDI if created from Batch…

### DIFF
--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentService.java
@@ -225,7 +225,7 @@ public class BatchEnvironmentService implements Service<SecurityAwareBatchEnviro
             final ClassLoaderContextHandle classLoaderContextHandle = (tccl == null ? new ClassLoaderContextHandle(classLoader) : new ClassLoaderContextHandle(tccl));
             // Class loader handle must be first so the TCCL is set before the other handles execute
             return new ContextHandle.ChainedContextHandle(classLoaderContextHandle, new NamespaceContextHandle(),
-                    new SecurityContextHandle(), artifactFactory.createContextHandle());
+                    new SecurityContextHandle(), artifactFactory.createContextHandle(), new ConcurrentContextHandle());
         }
     }
 }

--- a/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/ConcurrentContextHandle.java
+++ b/batch-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/ConcurrentContextHandle.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import org.jboss.as.ee.concurrent.ConcurrentContext;
+
+/**
+ * A handle to propagate EE concurrency context to batch thread.
+ */
+class ConcurrentContextHandle implements ContextHandle {
+    private final ConcurrentContext concurrentContext;
+
+    ConcurrentContextHandle() {
+        this.concurrentContext = ConcurrentContext.current();
+    }
+
+    @Override
+    public Handle setup() {
+        ConcurrentContext.pushCurrent(concurrentContext);
+
+        return new Handle() {
+            @Override
+            public void tearDown() {
+                ConcurrentContext.popCurrent();
+            }
+        };
+    }
+}


### PR DESCRIPTION
…let.
Need to propagate EE concurrency context to batch thread to support EE concurrency operations from batch artifacts.
Jira issue: https://issues.jboss.org/browse/WFLY-11906