### PR TITLE
WFLY-11975 Distributed web session metadata payload contains unnecessary nanosecond precision

### DIFF
--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SessionCreationMetaDataEntryExternalizerTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/SessionCreationMetaDataEntryExternalizerTestCase.java
@@ -46,7 +46,8 @@ public class SessionCreationMetaDataEntryExternalizerTestCase {
     }
 
     static void assertEquals(SessionCreationMetaDataEntry<Object> entry1, SessionCreationMetaDataEntry<Object> entry2) {
-        Assert.assertEquals(entry1.getMetaData().getCreationTime(), entry2.getMetaData().getCreationTime());
+        // Compare only to millisecond precision
+        Assert.assertEquals(entry1.getMetaData().getCreationTime().toEpochMilli(), entry2.getMetaData().getCreationTime().toEpochMilli());
         Assert.assertEquals(entry1.getMetaData().getMaxInactiveInterval(), entry2.getMetaData().getMaxInactiveInterval());
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11975