### PR TITLE
[WFLY-11979] Stop using jboss fork of glassfish el impl; move to v3.0.2

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -60,7 +60,7 @@
             <!-- Needed for Hibernate Validator since it asserts the existence of javax.el during bootstrap in the
                   default configuration-->
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el-impl</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
@@ -54,7 +54,7 @@
         <module name="javax.xml.bind.api" export="true"/>
         <module name="javax.xml.soap.api" export="true"/>
         <module name="javax.xml.ws.api" export="true"/>
-        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
 
         <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
              Prior to WFLY-5922 they were exported by javax.ejb.api. -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
@@ -30,7 +30,7 @@
         <module name="javax.servlet.jsp.api" export="true"/>
         <module name="javax.servlet.jstl.api" export="true"/>
         <module name="javax.validation.api" export="true"/>
-        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.api"/>
         <module name="javax.websocket.api"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -33,7 +33,7 @@
     <module name="javax.persistence.api"/>
     <module name="javax.validation.api"/>
     <module name="javax.xml.bind.api"/>
-    <module name="org.glassfish.javax.el"/>
+    <module name="org.glassfish.jakarta.el"/>
     <module name="org.jboss.logging"/>
     <module name="org.jboss.weld.core"/>
     <module name="org.jboss.weld.spi"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -75,7 +75,7 @@
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.common"/>
-        <module name="org.glassfish.javax.el"/>
+        <module name="org.glassfish.jakarta.el"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -54,7 +54,7 @@
         <module name="javax.servlet.jsp.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
-        <module name="org.glassfish.javax.el" />
+        <module name="org.glassfish.jakarta.el" />
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -45,7 +45,7 @@
         <module name="javax.servlet.api"/>
         <module name="javax.transaction.api"/>
         <module name="javax.validation.api"/>
-        <module name="org.glassfish.javax.el" />
+        <module name="org.glassfish.jakarta.el" />
         <module name="org.jboss.classfilewriter"/>
         <module name="org.jboss.weld.api" export="true"/>
         <module name="org.jboss.weld.spi" export="true"/>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
@@ -29,7 +29,7 @@
         <module name="javax.servlet.jsp.api" export="true"/>
         <module name="javax.servlet.jstl.api" export="true"/>
         <module name="javax.validation.api" export="true"/>
-        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.api"/>
 
         <!-- extra dependencies for MyFaces 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <version.org.eclipse.microprofile.rest.client.api>1.0.1</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
-        <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
+        <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
         <version.org.hibernate>5.3.9.Final</version.org.hibernate>
@@ -3979,14 +3979,8 @@
             <!-- EL3 RI implementation -->
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el-impl</artifactId>
-                <version>${version.org.glassfish.javax.el}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.glassfish</groupId>
-                        <artifactId>javax.el-api</artifactId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.org.glassfish.jakarta.el}</version>
             </dependency>
 
             <!-- JSR-236 RI -->

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -150,7 +150,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el-impl</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -161,11 +161,11 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
-      <artifactId>javax.el-impl</artifactId>
+      <artifactId>jakarta.el</artifactId>
       <licenses>
         <license>
-          <name>Common Development and Distribution License 1.1</name>
-          <url>https://javaee.github.io/glassfish/LICENSE</url>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-2.0</url>
           <distribution>repo</distribution>
         </license>
         <license>

--- a/servlet-feature-pack/src/main/resources/content/docs/licenses/eclipse public license 2.0.txt
+++ b/servlet-feature-pack/src/main/resources/content/docs/licenses/eclipse public license 2.0.txt
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -24,7 +24,7 @@
 
 <module xmlns="urn:jboss:module:1.8" name="javax.enterprise.api">
     <dependencies>
-        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
         <module name="javax.inject.api" export="true"/>
         <module name="javax.interceptor.api" export="true"/>
 

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.5" name="javax.servlet.jsp.api">
     <dependencies>
         <module name="javax.servlet.api" export="true"/>
-        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="org.glassfish.jakarta.el" export="true"/>
     </dependencies>
 
     <resources>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/el/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/el/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,21 +22,24 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="javax.faces.api:${jsf-impl-name}-${jsf-version}">
-    <dependencies>
-        <module name="com.sun.jsf-impl:${jsf-impl-name}-${jsf-version}"/>
-        <module name="javax.enterprise.api" export="true"/>
-        <module name="javax.servlet.api" export="true"/>
-        <module name="javax.servlet.jsp.api" export="true"/>
-        <module name="javax.servlet.jstl.api" export="true"/>
-        <module name="javax.validation.api" export="true"/>
-        <module name="org.glassfish.jakarta.el" export="true"/>
-        <module name="javax.api"/>
-        <module name="javax.websocket.api"/>
-    </dependencies>
+<module xmlns="urn:jboss:module:1.5" name="org.glassfish.jakarta.el">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
-        <resource-root path="${jsf-api-name}-${jsf-version}.jar"/>
+        <artifact name="${org.glassfish:jakarta.el}">
+            <filter>
+                <!-- This artifact packages both the API and the impl in the same jar,
+                     but we want to use our own API jar (see javax.el.api module).
+                     So suppress the API packages. -->
+                <exclude path="javax/*"/>
+            </filter>
+        </artifact>
     </resources>
+    <dependencies>
+            <module name="javax.api"/>
+            <module name="javax.el.api" services="import" export="true"/>
+    </dependencies>
 </module>
-

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
@@ -21,18 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.el">
-
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
-    <resources>
-        <artifact name="${org.glassfish:javax.el-impl}"/>
-    </resources>
-    <dependencies>
-            <module name="javax.api"/>
-            <module name="javax.el.api" services="import" export="true"/>
-    </dependencies>
-</module>
+<module-alias xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.el" target-name="org.glassfish.jakarta.el"/>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -152,7 +152,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el-impl</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11979

@psakar Please note that this brings in a new license --EPL 2.0.