### PR TITLE
[WFLY-11985] Upgrade Commons Codec to 1.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <version.com.sun.xml.fastinfoset>1.2.13</version.com.sun.xml.fastinfoset>
         <version.commons-beanutils>1.9.3</version.commons-beanutils>
         <version.commons-cli>1.3.1</version.commons-cli>
-        <version.commons-codec>1.10</version.commons-codec>
+        <version.commons-codec>1.11</version.commons-codec>
         <version.commons-collections>3.2.2</version.commons-collections>
         <version.commons-digester>1.8.1</version.commons-digester>
         <version.commons-lang3>3.8</version.commons-lang3>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11985

Upgrading Commons Codec to 1.11

Release notes: https://commons.apache.org/proper/commons-codec/changes-report.html#a1.11
Source diff:  https://github.com/apache/commons-codec/compare/1.10...commons-codec-1.11
The pom only has test dependencies, so this should not drive a requirement for upgrading other dependents.