### PR TITLE
[WFLY-11993] Prefer HTTPS over plain-text HTTP in default welcome-con…

### DIFF
--- a/servlet-feature-pack/src/main/resources/content/welcome-content/index.html
+++ b/servlet-feature-pack/src/main/resources/content/welcome-content/index.html
@@ -21,13 +21,13 @@
 
         <h3>Your WildFly instance is running.</h3>
 
-        <p><a href="http://docs.wildfly.org">Documentation</a> | <a href="http://github.com/wildfly/quickstart">Quickstarts</a> | <a href="/console">Administration
+        <p><a href="https://docs.wildfly.org">Documentation</a> | <a href="https://github.com/wildfly/quickstart">Quickstarts</a> | <a href="/console">Administration
             Console</a> </p>
 
-        <p><a href="http://wildfly.org">WildFly Project</a> |
+        <p><a href="https://wildfly.org">WildFly Project</a> |
             <a href="https://community.jboss.org/en/wildfly">User Forum</a> |
             <a href="https://issues.jboss.org/browse/WFLY">Report an issue</a></p>
-        <p class="logos"><a href="http://jboss.org"><img src="jbosscommunity_logo_hori_white.png" alt="JBoss and JBoss Community" width=
+        <p class="logos"><a href="https://www.jboss.org"><img src="jbosscommunity_logo_hori_white.png" alt="JBoss and JBoss Community" width=
                 "195" height="37" border="0"></a></p>
 
         <p class="note">To replace this page simply deploy your own war with / as its context path.<br />

--- a/servlet-feature-pack/src/main/resources/content/welcome-content/index_noconsole.html
+++ b/servlet-feature-pack/src/main/resources/content/welcome-content/index_noconsole.html
@@ -21,13 +21,13 @@
         
         <h3>Your WildFly instance is running.</h3>
 
-        <p><a href="http://docs.wildfly.org">Documentation</a> | <a href="http://github.com/wildfly/quickstart">Quickstarts</a></p>
+        <p><a href="https://docs.wildfly.org">Documentation</a> | <a href="https://github.com/wildfly/quickstart">Quickstarts</a></p>
 
-        <p><a href="http://wildfly.org/">WildFly AS Project</a> |
+        <p><a href="https://wildfly.org/">WildFly AS Project</a> |
             <a href="https://community.jboss.org/en/wildfly">User Forum</a> |
             <a href="https://issues.jboss.org/browse/WFLY">Report an issue</a></p>
 
-        <p class="logos"><a href="http://jboss.org"><img src="jbosscommunity_logo_hori_white.png" alt="JBoss and JBoss Community" width=
+        <p class="logos"><a href="https://www.jboss.org"><img src="jbosscommunity_logo_hori_white.png" alt="JBoss and JBoss Community" width=
                 "195" height="37" border="0"></a></p>
 
         <p class="note">To replace this page simply deploy your own war with / as its context path.<br />


### PR DESCRIPTION
…tent

We probably want to prefer HTTPS over simple HTTP when redirecting users
to external links or resources in our default welcome-content stuff.

Upstream jira: https://issues.jboss.org/browse/WFLY-11993

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.