### PR TITLE
WFLY-11991 Applications that extend certain Hibernate classes should be updated to use type SharedSessionContractImplementor instead of SessionImplementor

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
@@ -711,7 +711,7 @@ Hibernate51CompatibilityTransformer transformed application classes in 'deployme
 
 |Hibernate51CompatibilityTransformer.disableAmbiguousChanges| disable transformation of org.hibernate.Query.setFirstResult(int) + org.hibernate.Query.setMaxResults(int), since these methods are in both Hibernate ORM 5.1.x + 5.3.x|false
 
-|Hibernate51CompatibilityTransformer.showTransformedClassFolder| specifies the folder name to create bytecode level description of applications run through the transformer.  If the transformer actually makes a change to your application, a (boolean) class variable will be added "$_org_jboss_as_hibernate_Hibernate51CompatibilityTransformer_transformed_$", that ensures that the application is only transformed once|disabled
+|Hibernate51CompatibilityTransformer.showTransformedClassFolder| specifies the folder name to create bytecode level description of applications run through the transformer.  The specified folder must already exist.  If the transformer actually makes a change to your application, a (boolean) class variable will be added "$_org_jboss_as_hibernate_Hibernate51CompatibilityTransformer_transformed_$", that ensures that the application is only transformed once|disabled
 | 
 ----
 ----

--- a/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
+++ b/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
@@ -18,6 +18,7 @@
 
 package org.jboss.as.hibernate;
 
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
@@ -74,15 +75,27 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
 
     @Override
     public byte[] transform(final ClassLoader loader, final String className, final Class<?> classBeingRedefined, final ProtectionDomain protectionDomain, final byte[] classfileBuffer) {
+
+        // ignore these non-application classes
+        if(className.startsWith("org/jboss/arquillian") ||
+           className.startsWith("org/jboss/as/arquillian") ||
+           className.startsWith("org/junit") ||
+           className.startsWith("org/jboss/shrinkwrap")) {
+            logger.debugf("Hibernate51CompatibilityTransformer ignoring class '%s' from '%s'", className, getModuleName(loader));
+            return null;
+        }
         logger.debugf("Hibernate51CompatibilityTransformer transforming deployment class '%s' from '%s'", className, getModuleName(loader));
 
         final Set<String> parentClassesAndInterfaces = new HashSet<>();
+
         collectClassesAndInterfaces(parentClassesAndInterfaces, loader, className);
         logger.tracef("Class %s extends or implements %s", className, parentClassesAndInterfaces);
 
+        final boolean rewriteSessionImplementor = parentExpectsSharedSessionContractImplementor(parentClassesAndInterfaces);
+
         final TransformedState transformedState = new TransformedState();
         final ClassReader classReader = new ClassReader(classfileBuffer);
-        final ClassWriter classWriter = new ClassWriter(classReader, 0);
+        final ClassWriter classWriter = new ClassWriter(classReader, COMPUTE_FRAMES);
         ClassVisitor traceClassVisitor = classWriter;
         PrintWriter tracePrintWriter = null;
         try {
@@ -128,203 +141,15 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
                 public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
 
                     // Handle changing SessionImplementor parameter to SharedSessionContractImplementor
-                    boolean rewriteSessionImplementor = false;
                     final String descOrig = desc;
 
                     logger.tracef("method %s, description %s, signature %s", name, desc, signature);
-                    if (parentClassesAndInterfaces.contains("org/hibernate/usertype/UserType")) {
-                        if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;[Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeSet") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
 
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/usertype/CompositeUserType")) {
-                        if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;[Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeSet") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("assemble") &&
-                                "(Ljava/io/Serializable;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("disassemble") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/io/Serializable;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("replace") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/usertype/UserCollectionType")) {
-                        if (name.equals("instantiate") &&
-                                "(Lorg/hibernate/engine/spi/SessionImplementor;Lorg/hibernate/persister/collection/CollectionPersister;)Lorg/hibernate/collection/spi/PersistentCollection;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("replaceElements") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;Lorg/hibernate/persister/collection/CollectionPersister;Ljava/lang/Object;Ljava/util/Map;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("wrap") &&
-                                "(Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Lorg/hibernate/collection/spi/PersistentCollection;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/usertype/UserVersionType")) {
-                        if (name.equals("seed") &&
-                                "(Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("next") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/Type")) {
-                        if (name.equals("assemble") &&
-                                "(Ljava/io/Serializable;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("disassemble") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/io/Serializable;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("beforeAssemble") &&
-                                "(Ljava/io/Serializable;Lorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("hydrate") &&
-                                "(Ljava/sql/ResultSet;[Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("isDirty") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;)Z".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("isDirty") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;[ZLorg/hibernate/engine/spi/SessionImplementor;)Z".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("isModified") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;[ZLorg/hibernate/engine/spi/SessionImplementor;)Z".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;[Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeSet") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;I[ZLorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeSet") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("replace") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;Ljava/util/Map;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("replace") &&
-                                "(Ljava/lang/Object;Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;Ljava/util/Map;Lorg/hibernate/type/ForeignKeyDirection;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("resolve") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("resolve") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;Ljava/lang/Boolean;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("semiResolve") &&
-                                "(Ljava/lang/Object;Lorg/hibernate/engine/spi/SessionImplementor;Ljava/lang/Object;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/SingleColumnType")) {
-                        if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("get") &&
-                                "(Ljava/sql/ResultSet;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("set") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/AbstractStandardBasicType")) {
-                        if (name.equals("get") &&
-                                "(Ljava/sql/ResultSet;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("nullSafeGet") &&
-                                "(Ljava/sql/ResultSet;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)Ljava/lang/Object;".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("set") &&
-                                "(Ljava/sql/PreparedStatement;Ljava/lang/Object;ILorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/ProcedureParameterExtractionAware")) {
-                        if (name.equals("extract")
-                                && (desc.startsWith(
-                                "(Ljava/sql/CallableStatement;ILorg/hibernate/engine/spi/SessionImplementor;)")
-                                || desc.startsWith(
-                                "(Ljava/sql/CallableStatement;[Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)"))) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/ProcedureParameterNamedBinder")) {
-                        if (name.equals("nullSafeSet") &&
-                                "(Ljava/sql/CallableStatement;Ljava/lang/Object;Ljava/lang/String;Lorg/hibernate/engine/spi/SessionImplementor;)V".equals(desc)) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/type/VersionType")) {
-                        if (name.equals("seed") &&
-                                desc.startsWith("(Lorg/hibernate/engine/spi/SessionImplementor;)")) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("next") &&
-                                desc.contains("Lorg/hibernate/engine/spi/SessionImplementor;")) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (parentClassesAndInterfaces.contains("org/hibernate/collection/spi/PersistentCollection")) {
-                        if (name.equals("unsetSession") &&
-                                desc.equals("(Lorg/hibernate/engine/spi/SessionImplementor;)Z")) {
-                            desc = replaceSessionImplementor(desc);
-                        } else if (name.equals("setCurrentSession") &&
-                                desc.equals("(Lorg/hibernate/engine/spi/SessionImplementor;)Z")) {
-                            desc = replaceSessionImplementor(desc);
-                        }
-
-                        rewriteSessionImplementor = true;
-                    }
-
-                    if (rewriteSessionImplementor && name.equals("<init>")) {
-                        // update constructor methods to use SharedSessionContractImplementor instead of SessionImplementor
+                    // If application class has certain checked Hibernate ORM classes as super class,
+                    // replace method parameters of type 'SessionImplementor', to instead use type 'SharedSessionContractImplementor'.
+                    if (rewriteSessionImplementor && desc.contains("org/hibernate/engine/spi/SessionImplementor")) {
                         desc = replaceSessionImplementor(desc);
                     }
-
                     if (descOrig != desc) {  // if we are changing from type SessionImplementor to SharedSessionContractImplementor
                         // mark the class as transformed
                         transformedState.setClassTransformed(true);
@@ -334,7 +159,7 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
                 }
             }, 0);
             if (!transformedState.transformationsMade()) {
-                // no change was actually made, indicate so by returning null
+                // no change was made, indicate so by returning null
                 return null;
             }
             return classWriter.toByteArray();
@@ -360,10 +185,25 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
                 "Lorg/hibernate/engine/spi/SharedSessionContractImplementor;");
     }
 
+    private boolean parentExpectsSharedSessionContractImplementor(Set parentClassesAndInterfaces) {
+        return (parentClassesAndInterfaces.contains("org/hibernate/usertype/UserType")
+                || parentClassesAndInterfaces.contains("org/hibernate/usertype/CompositeUserType")
+                || parentClassesAndInterfaces.contains("org/hibernate/usertype/UserCollectionType")
+                || parentClassesAndInterfaces.contains("org/hibernate/usertype/UserVersionType")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/Type")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/SingleColumnType")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/AbstractStandardBasicType")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/ProcedureParameterExtractionAware")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/ProcedureParameterNamedBinder")
+                || parentClassesAndInterfaces.contains("org/hibernate/type/VersionType")
+                || parentClassesAndInterfaces.contains("org/hibernate/collection/spi/PersistentCollection"));
+    }
+
     private void collectClassesAndInterfaces(Set<String> classesAndInterfaces, ClassLoader classLoader, String className) {
         if (className == null || "java/lang/Object".equals(className)) {
             return;
         }
+
 
         try (InputStream is = classLoader.getResourceAsStream(className.replace('.', '/') + ".class")) {
             ClassReader classReader = new ClassReader(is);
@@ -392,7 +232,7 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
 
             }, 0);
         } catch (IOException e) {
-            logger.warn("Unable to open class file %1$s", className, e);
+            logger.debugf("Unable to open class file %s, due to exception %s", className, e);
         }
     }
 
@@ -407,5 +247,6 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
         }
         return major;
     }
+
 }
 

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StateType.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StateType.java
@@ -58,6 +58,10 @@ public class StateType implements UserType {
     }
 
     public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
+        return internalNullSafeGet(rs, names, session, owner);
+    }
+
+    private Object internalNullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
         internalSessionImplementorUsingMethod(session);
         session.isTransactionInProgress();
         int result = rs.getInt( names[0] );

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.java
@@ -56,7 +56,7 @@ public class VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase
         ear.addAsModule(war);
 
         ear.addAsManifestResource(VerifyHibernate51CompatibilityJDSEnabledTransformerTestCase.class.getPackage(),
-                "jboss-deployment-structure.xml","jboss-deployment-structure.xml");
+                "jboss-deployment-structure.xml", "jboss-deployment-structure.xml");
         return ear;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11991
https://issues.jboss.org/browse/JBEAP-16745

App application classes that extend certain listed Hibernate classes, will be transformed from using type org.hibernate.engine.spi.SessionImplementor to instead use type org.hibernate.engine.spi.SharedSessionContractImplementor.  

All method calls in these identified application classes will also be updated to switch from using type org.hibernate.engine.spi.SessionImplementor to instead use type org.hibernate.engine.spi.SharedSessionContractImplementor. 

These changes will cover the case where the application contains code that must be changed to use SharedSessionContractImplementor instead of SessionImplementor.
