### PR TITLE
[WFLY-11976] Upgrading WildFly-Naming-Client to 1.0.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
         <version.org.wildfly.core>9.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.14.Final</version.org.wildfly.http-client>
-        <version.org.wildfly.naming-client>1.0.9.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.3.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>


### PR DESCRIPTION
This component upgrade brings in the following fix:
 * [WFNC-54] jboss-naming-client.properties not being used
