### PR TITLE
WFLY-12006 EJB3 IIOP attributes enable-by-default and use-qualified-name should be required

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPAdd.java
@@ -47,8 +47,8 @@ public class EJB3IIOPAdd extends AbstractBoottimeAddStepHandler {
 
     @Override
     protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final Boolean enableByDefault = EJB3IIOPResourceDefinition.ENABLE_BY_DEFAULT.resolveModelAttribute(context, model).asBoolean();
-        final Boolean useQualifiedName = EJB3IIOPResourceDefinition.USE_QUALIFIED_NAME.resolveModelAttribute(context, model).asBoolean();
+        final boolean enableByDefault = EJB3IIOPResourceDefinition.ENABLE_BY_DEFAULT.resolveModelAttribute(context, model).asBoolean();
+        final boolean useQualifiedName = EJB3IIOPResourceDefinition.USE_QUALIFIED_NAME.resolveModelAttribute(context, model).asBoolean();
         final IIOPSettingsService settingsService = new IIOPSettingsService(enableByDefault, useQualifiedName);
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
@@ -54,15 +54,17 @@ public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
 
 
     static final SimpleAttributeDefinition USE_QUALIFIED_NAME =
-            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.USE_QUALIFIED_NAME, ModelType.BOOLEAN, true)
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.USE_QUALIFIED_NAME, ModelType.BOOLEAN)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setRequired(true)
                     .build();
 
     static final SimpleAttributeDefinition ENABLE_BY_DEFAULT =
-            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.ENABLE_BY_DEFAULT, ModelType.BOOLEAN, true)
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.ENABLE_BY_DEFAULT, ModelType.BOOLEAN)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setRequired(true)
                     .build();
 
     private static final Map<String, AttributeDefinition> ATTRIBUTES;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingEjbReceiverChannelCreationOptionResource.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingEjbReceiverChannelCreationOptionResource.java
@@ -54,7 +54,7 @@ class RemotingEjbReceiverChannelCreationOptionResource extends SimpleResourceDef
      * Attribute definition of the channel creation option "type"
      */
     static final SimpleAttributeDefinition CHANNEL_CREATION_OPTION_TYPE = new SimpleAttributeDefinitionBuilder(
-            EJB3SubsystemModel.TYPE, ModelType.STRING, true).setRequired(true)
+            EJB3SubsystemModel.TYPE, ModelType.STRING).setRequired(true)
             .setValidator(AllowedChannelOptionTypesValidator.INSTANCE).build();
 
     public static final Map<String, AttributeDefinition> ATTRIBUTES;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingEjbReceiverDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingEjbReceiverDefinition.java
@@ -45,7 +45,7 @@ import org.jboss.dmr.ModelType;
 public class RemotingEjbReceiverDefinition extends SimpleResourceDefinition {
 
     public static final SimpleAttributeDefinition OUTBOUND_CONNECTION_REF = new SimpleAttributeDefinitionBuilder(
-            EJB3SubsystemModel.OUTBOUND_CONNECTION_REF, ModelType.STRING, true).setRequired(true).setAllowExpression(true)
+            EJB3SubsystemModel.OUTBOUND_CONNECTION_REF, ModelType.STRING).setRequired(true).setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition CONNECT_TIMEOUT = new SimpleAttributeDefinitionBuilder(

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandlerHost.java
@@ -84,7 +84,7 @@ public class ReverseProxyHandlerHost extends PersistentResourceDefinition {
                         .setDynamicNameMapper(DynamicNameMappers.PARENT)
                         .build();
 
-    public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder("outbound-socket-binding", ModelType.STRING, true)
+    public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder("outbound-socket-binding", ModelType.STRING)
             .setRequired(true)
             .setValidator(new StringLengthValidator(1, false))
             .setAllowExpression(true)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12006

Update attributes enable-by-default and use-qualified-name to required.
Because enable-by-default and use-qualified-name must be required during parsing at https://github.com/wildfly/wildfly/blob/16.0.0.Final/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java#L227