### PR TITLE
WFLY-12008 WFLY-11875 - Upgrade Hibernate ORM to 5.3.10.Final; upgrade Javassist to 3.23.2-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,14 +310,14 @@
         <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
-        <version.org.hibernate>5.3.9.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.10.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.5.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.16.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>9.4.11.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>
-        <version.org.javassist>3.23.1-GA</version.org.javassist>
+        <version.org.javassist>3.23.2-GA</version.org.javassist>
         <version.org.jberet>1.3.3.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12008
https://issues.jboss.org/browse/JBEAP-16457

https://issues.jboss.org/browse/WFLY-11875
https://issues.jboss.org/browse/JBEAP-16139
