### PR TITLE
[WFLY-12041] Upgrade WildFly Core 9.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>9.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12041

---


## Release Notes - WildFly Core - Version 9.0.0.Beta4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4421'>WFCORE-4421</a>] -         Upgrade JBoss Remoting from 5.0.8 to 5.0.9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4422'>WFCORE-4422</a>] -         Upgrade to galleon 4.0
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4432'>WFCORE-4432</a>] -         Upgrade JBoss Marshalling from 2.0.6.Final to 2.0.7.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4433'>WFCORE-4433</a>] -         Update wildfly-discovery-client to 1.2.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4443'>WFCORE-4443</a>] -         Upgrade WildFly Elytron to 1.9.0.CR4
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4444'>WFCORE-4444</a>] -         Upgrade Elytron Web to 1.5.0.CR2
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4406'>WFCORE-4406</a>] -         Core Galleon feature-pack pom.xml should define deps as provided
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3298'>WFCORE-3298</a>] -         EnumValidator should avoid trying to modify protected nodes
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4436'>WFCORE-4436</a>] -         NPE with the CLI embedded server when in admin-only mode
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4438'>WFCORE-4438</a>] -         No welcome page in WildFly 17
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4442'>WFCORE-4442</a>] -         Migrate UndertowHttpManagementService &amp; HttpShutdownService to use new MSC service builder API
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4448'>WFCORE-4448</a>] -         Deprecate unused MultistepUtil methods
</li>
</ul>
                                    