### PR TITLE
WFLY-12034 Upgrade jboss-batch-api_1.0_spec from 1.0.1.Final to 1.0.2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
-        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.1.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
+        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.2.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.13.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.2.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>


### PR DESCRIPTION
….Final.  The new release includes a jboss-parent pom upgrade, and was built with secure https maven repositories.

Jira: https://issues.jboss.org/browse/WFLY-12034
Delta: https://github.com/jboss/jboss-batch-api_spec/compare/jboss-batch-api_1.0_spec-1.0.1.Final...jboss-batch-api_1.0_spec-1.0.2.Final
