### PR TITLE
WFLY-12035 Upgrade jberet-core from 1.3.3.Final to 1.3.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         <version.org.infinispan>9.4.11.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>
         <version.org.javassist>3.23.2-GA</version.org.javassist>
-        <version.org.jberet>1.3.3.Final</version.org.jberet>
+        <version.org.jberet>1.3.4.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-12035
jberet-core release delta: https://github.com/jberet/jsr352/compare/1.3.3.Final...1.3.4.Final

The real changes that occurred in jberet-core are:
    upgrade jboss-parent to 34
    upgrade jboss-logging to 3.4.0
    upgrade jboss-batch-api_1.0_spec to 1.0.2 (which was built with secure https maven repository links)
    change to use https for maven repository links in build process
