### PR TITLE
WFLY-12000 Upgrade Weld to 3.1.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.0.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>3.1.1.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>3.1.Final</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.2.2.Final</version.org.jboss.ws.common>


### PR DESCRIPTION
JIRA - https://issues.jboss.org/browse/WFLY-12000
Release notes - http://weld.cdi-spec.org/news/2019/05/07/weld-311Final/

This release only bumps the core version, no API/SPI changes were made on Weld side.