### PR TITLE
[WFLY-11031] Introduce a console-access-log for web access logging

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Undertow.adoc
@@ -249,6 +249,52 @@ be matched
 serve up requests that do not match anything.
 |=======================================================================
 
+==== Console Access Logging
+
+Each host allows for access logging to the console which writes structured data in JSON format. This only writes to
+`stdout` and is a single line of JSON structured data.
+
+The `attributes` management model attribute is used to determine which exchange attributes should be logged. This is
+similar to the `pattern` used for traditional access logging. The main difference being since the data is structured
+the ability to use defined keys is essential.
+
+A `metadata` attribute also exists which allows extra metadata to be added to the output. The value of the attribute is
+a set of arbitrary key/value pairs. The values can include management model expressions, which must be resolvable when
+the console access log service is started. The value is resolved once per start or reload of the server.
+
+
+===== CLI Examples
+
+.add-console-access-logging.cli
+----
+/subsystem=undertow/server=default-server/host=default-host/setting=console-access-log:add
+----
+
+.complex-add-console-access-logging.cli
+----
+/subsystem=undertow/server=default-server/host=default-host/setting=console-access-log:add(metadata={"@version"="1", "qualifiedHostName"=${jboss.qualified.host.name:unknown}}, attributes={bytes-sent={}, date-time={key="@timestamp", date-format="yyyy-MM-dd'T'HH:mm:ssSSS"}, remote-host={}, request-line={}, response-header={key-prefix="responseHeader", names=["Content-Type"]}, response-code={}, remote-user={}})
+----
+
+[source,json]
+----
+{
+    "eventSource":"web-access",
+    "hostName":"default-host",
+    "@version":"1",
+    "qualifiedHostName":"localhost.localdomain",
+    "bytesSent":1504,
+    "@timestamp":"2019-05-02T11:57:37123",
+    "remoteHost":"127.0.0.1",
+    "remoteUser":null,
+    "requestLine":"GET / HTTP/2.0",
+    "responseCode":200,
+    "responseHeaderContent-Type":"text/html"
+}
+----
+
+NOTE: The above JSON is formatted only for readability. The output will be on a single line.
+
+
 [[servlet-container-configuration]]
 == Servlet container configuration
 

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -76,6 +76,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-event-logger</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
             <exclusions>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -556,6 +556,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.wildfly.core</groupId>
+      <artifactId>wildfly-event-logger</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v2.1 or later</name>
+          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.wildfly.wildfly-http-client</groupId>
       <artifactId>wildfly-http-client-common</artifactId>
       <licenses>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -88,5 +88,9 @@
         <module name="org.jboss.xnio"/>
         <module name="org.jboss.xnio.nio" services="import"/>
         <module name="org.wildfly.http-client.common"/>
+        <!-- Only needed if using access logging -->
+        <module name="javax.json.api" optional="true"/>
+        <module name="org.wildfly.event.logger" optional="true"/>
+        <module name="org.wildfly.common" optional="true"/>
     </dependencies>
 </module>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -79,6 +79,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-event-logger</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
             <exclusions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/ConsoleAccessLogTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/ConsoleAccessLogTestCase.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.web.access.log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(ConsoleAccessLogTestCase.ConsoleAccessLogSetupTask.class)
+public class ConsoleAccessLogTestCase {
+
+    private static final ModelNode CONSOLE_ACCESS_LOG_ADDRESS = Operations.createAddress("subsystem", "undertow",
+            "server", "default-server", "host", "default-host", "setting", "console-access-log");
+    private static final String[] ATTRIBUTE_NAMES = {
+            "authentication-type",
+            "bytes-sent",
+            "date-time",
+            "host-and-port",
+            "local-ip",
+            "local-port",
+            "local-server-name",
+            "query-string",
+            "relative-path",
+            "remote-host",
+            "remote-ip",
+            "remote-user",
+            "request-line",
+            "request-method",
+            "request-path",
+            "request-protocol",
+            "request-scheme",
+            "request-url",
+            "resolved-path",
+            "response-code",
+            "response-reason-phrase",
+            "response-time",
+            "secure-exchange",
+            "ssl-cipher",
+            "ssl-client-cert",
+            "ssl-session-id",
+            "stored-response",
+            "thread-name",
+            "transport-protocol",
+    };
+
+    @ArquillianResource
+    private ManagementClient client;
+    @ArquillianResource
+    private URL url;
+    private Stdout stdout;
+    private PrintStream currentStdout;
+
+    @Deployment
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "simple-war.war")
+                .addClass(SimpleServlet.class);
+    }
+
+    @Before
+    @SuppressWarnings("UseOfSystemOutOrSystemErr")
+    public void setup() {
+        // Capture the current stdout to be replaced then replace stdout
+        currentStdout = System.out;
+        stdout = new Stdout(currentStdout);
+        System.setOut(new PrintStream(stdout));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        // Replaced with the captured stdout
+        System.setOut(currentStdout);
+        executeOperation(client.getControllerClient(), Operations.createRemoveOperation(CONSOLE_ACCESS_LOG_ADDRESS), false);
+    }
+
+    @Test
+    public void testDefaults() throws Exception {
+        executeOperation(client.getControllerClient(), Operations.createAddOperation(CONSOLE_ACCESS_LOG_ADDRESS));
+        sendRequest();
+        final Collection<JsonObject> lines = findLines();
+        Assert.assertFalse("Did not find eventSource in " + stdout.toString(), lines.isEmpty());
+        for (JsonObject jsonObject : lines) {
+            Assert.assertEquals("web-access", jsonObject.getString("eventSource"));
+            Assert.assertEquals("default-host", jsonObject.getString("hostName"));
+            Assert.assertEquals(HttpStatus.SC_OK, jsonObject.getInt("responseCode"));
+        }
+    }
+
+    @Test
+    public void testPredicate() throws Exception {
+        final ModelNode op = Operations.createAddOperation(CONSOLE_ACCESS_LOG_ADDRESS);
+        op.get("predicate").set(false);
+        executeOperation(client.getControllerClient(), op);
+        sendRequest();
+        final Collection<JsonObject> lines = findLines();
+        Assert.assertTrue("Expected no eventSource in " + stdout.toString(), lines.isEmpty());
+    }
+
+    @Test
+    public void testAllAttributes() throws Exception {
+        final ModelNode op = Operations.createAddOperation(CONSOLE_ACCESS_LOG_ADDRESS);
+        final ModelNode attributes = op.get("attributes");
+        for (String name : ATTRIBUTE_NAMES) {
+            attributes.get(name).setEmptyObject();
+        }
+        // Attributes with required parameters
+        attributes.get("path-parameter").setEmptyObject().get("names").add("testPathParameter");
+        attributes.get("predicate").setEmptyObject().get("names").add("testPredicate");
+        attributes.get("query-parameter").setEmptyObject().get("names").add("testQueryParameter");
+        attributes.get("request-header").setEmptyObject().get("names").add("User-Agent");
+        attributes.get("response-header").setEmptyObject().get("names").add("Content-Type");
+
+        executeOperation(client.getControllerClient(), op);
+        sendRequest();
+        final Collection<JsonObject> lines = findLines();
+        Assert.assertFalse("Did not find eventSource in " + stdout.toString(), lines.isEmpty());
+        for (JsonObject jsonObject : lines) {
+            // First assert all keys are there
+            for (String name : ATTRIBUTE_NAMES) {
+                Assert.assertNotNull("Missing key " + name, jsonObject.get(translateToKey(name)));
+            }
+            Assert.assertNotNull("Missing key testPathParameter", jsonObject.get("testPathParameter"));
+            Assert.assertNotNull("Missing key testPredicate", jsonObject.get("testPredicate"));
+            Assert.assertNotNull("Missing key testQueryParameter", jsonObject.get("testQueryParameter"));
+            Assert.assertNotNull("Missing key User-Agent", jsonObject.get("User-Agent"));
+            Assert.assertNotNull("Missing key Content-Type", jsonObject.get("Content-Type"));
+
+            // Assert known values
+            Assert.assertEquals("web-access", jsonObject.getString("eventSource"));
+            Assert.assertEquals("default-host", jsonObject.getString("hostName"));
+            Assert.assertEquals("GET", jsonObject.getString("requestMethod"));
+            Assert.assertEquals(url.getProtocol(), jsonObject.getString("requestScheme"));
+            Assert.assertEquals("/simple-war/simple", jsonObject.getString("requestUrl"));
+            Assert.assertEquals("/simple-war", jsonObject.getString("resolvedPath"));
+            Assert.assertEquals(HttpStatus.SC_OK, jsonObject.getInt("responseCode"));
+            Assert.assertEquals(url.getPort(), jsonObject.getInt("localPort"));
+            Assert.assertEquals("/simple", jsonObject.getString("relativePath"));
+            Assert.assertEquals("OK", jsonObject.getString("responseReasonPhrase"));
+            Assert.assertTrue(jsonObject.getString("Content-Type").startsWith("application/json"));
+        }
+    }
+
+    @Test
+    public void testKeyOverrides() throws Exception {
+        final ModelNode op = Operations.createAddOperation(CONSOLE_ACCESS_LOG_ADDRESS);
+        final ModelNode attributes = op.get("attributes");
+        final Collection<String> keys = new ArrayList<>();
+        for (String name : ATTRIBUTE_NAMES) {
+            final String key = reformatKeyOverride(name);
+            keys.add(key);
+            attributes.get(name).setEmptyObject().get("key").set(key);
+        }
+
+        executeOperation(client.getControllerClient(), op);
+        sendRequest();
+        final Collection<JsonObject> lines = findLines();
+        Assert.assertFalse("Did not find eventSource in " + stdout.toString(), lines.isEmpty());
+        for (JsonObject jsonObject : lines) {
+            // First assert all keys are there
+            for (String key : keys) {
+                Assert.assertNotNull("Missing key " + key, jsonObject.get(translateToKey(key)));
+            }
+        }
+    }
+
+    @Test
+    public void testOverrides() throws Exception {
+        final String dateFormat = "yyyy-MM-dd'T'HH:mm:ssSSS";
+        final ModelNode op = Operations.createAddOperation(CONSOLE_ACCESS_LOG_ADDRESS);
+        op.get("include-host-name").set(false);
+        op.get("metadata").add("@version", "1");
+        final ModelNode attributes = op.get("attributes");
+        final ModelNode dateTime = attributes.get("date-time").setEmptyObject();
+        dateTime.get("date-format").set(dateFormat);
+        dateTime.get("key").set("@timestamp");
+        dateTime.get("time-zone").set("GMT");
+
+        attributes.get("local-port").setEmptyObject().get("key").set("port");
+        attributes.get("response-code").setEmptyObject().get("key").set("http_response_code");
+
+        final ModelNode responseHeader = attributes.get("response-header").setEmptyObject();
+        responseHeader.get("key-prefix").set("response_header_");
+        final ModelNode names = responseHeader.get("names").setEmptyList();
+        names.add("Content-Type");
+        names.add("Content-Encoding");
+
+        attributes.get("request-method").setEmptyObject().get("key").set("request_method");
+        attributes.get("request-scheme").setEmptyObject().get("key").set("request_scheme");
+        attributes.get("request-url").setEmptyObject().get("key").set("request_url");
+
+        final ModelNode queryString = attributes.get("query-string").setEmptyObject();
+        queryString.get("key").set("query_string");
+        queryString.get("include-question-mark").set(true);
+
+        executeOperation(client.getControllerClient(), op);
+
+        sendRequest(new BasicNameValuePair("testParam", "testValue"));
+        final Collection<JsonObject> lines = findLines();
+        Assert.assertFalse("Did not find eventSource in " + stdout.toString(), lines.isEmpty());
+        for (JsonObject jsonObject : lines) {
+            Assert.assertEquals("web-access", jsonObject.getString("eventSource"));
+            Assert.assertNull("include-host-name attribute was set to false and should not be included in the output.", jsonObject.get("hostName"));
+            Assert.assertEquals("Expected @version to be 1", "1", jsonObject.getString("@version"));
+            final String timestamp = jsonObject.getString("@timestamp");
+            try {
+                DateTimeFormatter.ofPattern(dateFormat).parse(timestamp);
+            } catch (DateTimeParseException e) {
+                Assert.fail(String.format("Failed to parse date %s with pattern %s: %s", timestamp, dateFormat, e.getMessage()));
+            }
+            Assert.assertEquals("?testParam=testValue", jsonObject.getString("query_string"));
+            Assert.assertEquals("GET", jsonObject.getString("request_method"));
+            Assert.assertEquals(url.getProtocol(), jsonObject.getString("request_scheme"));
+            Assert.assertEquals("/simple-war/simple", jsonObject.getString("request_url"));
+            Assert.assertEquals(HttpStatus.SC_OK, jsonObject.getInt("http_response_code"));
+            Assert.assertEquals(url.getPort(), jsonObject.getInt("port"));
+            Assert.assertTrue(jsonObject.getString("response_header_Content-Type").startsWith("application/json"));
+            Assert.assertNotNull(jsonObject.get("response_header_Content-Encoding"));
+        }
+    }
+
+    private void sendRequest(final NameValuePair... params) throws IOException, URISyntaxException {
+        final URI uri = new URI(url.toString() + "simple");
+        final URIBuilder builder = new URIBuilder(uri);
+        if (params != null && params.length > 0) {
+            builder.setParameters(params);
+        }
+
+        final HttpGet request = new HttpGet(builder.build());
+        try (
+                CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+                CloseableHttpResponse response = httpClient.execute(request)
+        ) {
+            Assert.assertEquals("Failed to access " + uri, HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    private Collection<JsonObject> findLines() throws InterruptedException {
+        // Note this could be a potential spot for a race in the test validation. The console-access-log is
+        // asynchronous so we need to wait to ensure it's fully written to the console.
+        TimeUnit.SECONDS.sleep(TimeoutUtil.adjust(1));
+        final Collection<JsonObject> result = new ArrayList<>();
+        final String[] lines = stdout.toString().split(System.lineSeparator());
+
+        for (String line : lines) {
+            if (!line.isEmpty()) {
+                try (JsonReader reader = Json.createReader(new StringReader(line))) {
+                    final JsonObject jsonObject = reader.readObject();
+                    if (jsonObject.get("eventSource") != null) {
+                        result.add(jsonObject);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
+        return executeOperation(client, op, true);
+    }
+
+    private static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op, final boolean failOnError) throws IOException {
+        return executeOperation(client, Operation.Factory.create(op), failOnError);
+    }
+
+    private static ModelNode executeOperation(final ModelControllerClient client, final Operation op, final boolean failOnError) throws IOException {
+        final ModelNode result = client.execute(op);
+        if (failOnError && !Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(String.format("Failed to execute operation: %s%n%s", op, Operations.getFailureDescription(result).asString()));
+        }
+        return Operations.readResult(result);
+    }
+
+    private static String translateToKey(final String attributeName) {
+        final StringBuilder result = new StringBuilder(attributeName.length());
+        boolean toUpper = false;
+        for (char c : attributeName.toCharArray()) {
+            if (c == '-') {
+                toUpper = true;
+            } else {
+                if (toUpper) {
+                    result.append(Character.toUpperCase(c));
+                    toUpper = false;
+                } else {
+                    result.append(c);
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    private static String reformatKeyOverride(final String key) {
+        return key.replace('-', '_');
+    }
+
+    public static class ConsoleAccessLogSetupTask implements ServerSetupTask {
+        private final ModelNode formatterAddress = Operations.createAddress("subsystem", "logging", "json-formatter", "json");
+        private final ModelNode consoleHandlerAddress = Operations.createAddress("subsystem", "logging", "console-handler", "CONSOLE");
+
+        private ModelNode currentFormatter;
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String s) throws Exception {
+            final ModelControllerClient client = managementClient.getControllerClient();
+
+            // Get the current console handler formatter name
+            currentFormatter = executeOperation(client, Operations.createReadAttributeOperation(consoleHandlerAddress, "named-formatter"));
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create()
+                    .addStep(Operations.createAddOperation(formatterAddress))
+                    // Change the current formatter just in case a message is logged so the line will still be valid JSON
+                    .addStep(Operations.createWriteAttributeOperation(consoleHandlerAddress, "named-formatter", "json"));
+            executeOperation(client, builder.build(), true);
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String s) throws Exception {
+            final ModelControllerClient client = managementClient.getControllerClient();
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // Reset the named-formatter on the console
+            if (currentFormatter != null) {
+                builder.addStep(Operations.createWriteAttributeOperation(consoleHandlerAddress, "named-formatter", currentFormatter));
+            } else {
+                builder.addStep(Operations.createUndefineAttributeOperation(consoleHandlerAddress, "named-formatter"));
+            }
+            builder.addStep(Operations.createRemoveOperation(formatterAddress));
+            executeOperation(client, builder.build(), true);
+        }
+    }
+
+    private static class Stdout extends ByteArrayOutputStream {
+
+        private final OutputStream dftStdout;
+
+        private Stdout(final OutputStream dftStdout) {
+            this.dftStdout = dftStdout;
+        }
+
+        @Override
+        public synchronized void write(final int b) {
+            super.write(b);
+            try {
+                dftStdout.write(b);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public synchronized void write(final byte[] b, final int off, final int len) {
+            super.write(b, off, len);
+            try {
+                dftStdout.write(b, off, len);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void write(final byte[] b) throws IOException {
+            super.write(b);
+            dftStdout.write(b);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            dftStdout.flush();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/access/log/SimpleServlet.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.web.access.log;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WebServlet("simple")
+public class SimpleServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        final PrintWriter writer = response.getWriter();
+        response.setContentType(MediaType.APPLICATION_JSON);
+        try (JsonGenerator generator = Json.createGenerator(writer)) {
+            generator.writeStartObject();
+
+            generator.writeStartObject("parameters");
+
+            request.getParameterMap().forEach((key, values) -> {
+                if (values == null) {
+                    generator.writeNull(key);
+                } else if (values.length > 1) {
+                    generator.writeStartArray(key);
+                    for (String value : values) {
+                        generator.write(value);
+                    }
+                    generator.writeEnd();
+                } else {
+                    final String value = values[0];
+                    if (value == null) {
+                        generator.writeNull(key);
+                    } else {
+                        generator.write(key, value);
+                    }
+                }
+            });
+
+            generator.writeEnd(); // end parameters
+
+            generator.writeEnd(); // end main
+        }
+    }
+}

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -64,6 +64,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-event-logger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-io</artifactId>
         </dependency>
         <dependency>
@@ -115,6 +119,12 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Required implementation for the org.wildfly.core:event-logger which is initialized in the subsystem tests -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AccessLogAttribute.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AccessLogAttribute.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import io.undertow.attribute.ExchangeAttribute;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class AccessLogAttribute implements Comparable<AccessLogAttribute> {
+    private final String key;
+    private final ExchangeAttribute exchangeAttribute;
+    private final Function<String, Object> valueConverter;
+
+    private AccessLogAttribute(final String key, final ExchangeAttribute exchangeAttribute, final Function<String, Object> valueConverter) {
+        this.key = key;
+        this.exchangeAttribute = exchangeAttribute;
+        this.valueConverter = valueConverter;
+    }
+
+    /**
+     * Creates a new attribute.
+     *
+     * @param key               the key for the attribute
+     * @param exchangeAttribute the exchange attribute which resolves the value
+     *
+     * @return the new attribute
+     */
+    static AccessLogAttribute of(final String key, final ExchangeAttribute exchangeAttribute) {
+        return new AccessLogAttribute(key, exchangeAttribute, null);
+    }
+
+
+    /**
+     * Creates a new attribute.
+     *
+     * @param key               the key for the attribute
+     * @param exchangeAttribute the exchange attribute which resolves the value
+     * @param valueConverter    the converter used to convert the
+     *                          {@linkplain ExchangeAttribute#readAttribute(HttpServerExchange) string} into a different
+     *                          type
+     *
+     * @return the new attribute
+     */
+    static AccessLogAttribute of(final String key, final ExchangeAttribute exchangeAttribute, final Function<String, Object> valueConverter) {
+        return new AccessLogAttribute(key, exchangeAttribute, valueConverter);
+    }
+
+    /**
+     * Returns the key used for the structured log output.
+     *
+     * @return the key
+     */
+    String getKey() {
+        return key;
+    }
+
+    /**
+     * Resolves the value for the attribute.
+     *
+     * @param exchange the exchange to resolve the value from
+     *
+     * @return the value of the attribute
+     */
+    Object resolveAttribute(final HttpServerExchange exchange) {
+        if (valueConverter == null) {
+            return exchangeAttribute.readAttribute(exchange);
+        }
+        return valueConverter.apply(exchangeAttribute.readAttribute(exchange));
+    }
+
+    @Override
+    public int compareTo(final AccessLogAttribute o) {
+        return key.compareTo(o.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof AccessLogAttribute)) {
+            return false;
+        }
+        final AccessLogAttribute other = (AccessLogAttribute) obj;
+        return key.equals(other.key);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{key=" + key + ", exchangeAttribute=" + exchangeAttribute +
+                ", valueConverter=" + valueConverter + "}";
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
@@ -36,6 +36,7 @@ public final class Capabilities {
     public static final String CAPABILITY_HOST_SSO = "org.wildfly.undertow.host.sso";
     public static final String CAPABILITY_LOCATION = "org.wildfly.undertow.host.location";
     public static final String CAPABILITY_ACCESS_LOG = "org.wildfly.undertow.host.access-log";
+    public static final String CAPABILITY_CONSOLE_ACCESS_LOG = "org.wildfly.undertow.host.console-access-log";
     public static final String CAPABILITY_HANDLER = "org.wildfly.extension.undertow.handler";
     public static final String CAPABILITY_MOD_CLUSTER_FILTER = "org.wildfly.undertow.mod_cluster-filter";
     public static final String CAPABILITY_SERVLET_CONTAINER = "org.wildfly.undertow.servlet-container";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ConsoleAccessLogDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ConsoleAccessLogDefinition.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.undertow;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import io.undertow.predicate.Predicate;
+import io.undertow.predicate.Predicates;
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.PropertiesAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.DynamicNameMappers;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.xnio.XnioWorker;
+
+/**
+ * The resource definition for the {@code setting=console-access-log} resource.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ConsoleAccessLogDefinition extends PersistentResourceDefinition {
+    private static final RuntimeCapability<Void> CONSOLE_ACCESS_LOG_CAPABILITY = RuntimeCapability.Builder.of(
+            Capabilities.CAPABILITY_CONSOLE_ACCESS_LOG, true, EventLoggerService.class)
+            .setDynamicNameMapper(DynamicNameMappers.GRAND_PARENT)
+            .build();
+
+    static final SimpleAttributeDefinition INCLUDE_HOST_NAME = SimpleAttributeDefinitionBuilder.create("include-host-name", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(true))
+            .setRestartAllServices()
+            .build();
+
+    static final PropertiesAttributeDefinition METADATA = new PropertiesAttributeDefinition.Builder("metadata", true)
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
+
+    static final Collection<AttributeDefinition> ATTRIBUTES = Arrays.asList(
+            ExchangeAttributeDefinitions.ATTRIBUTES,
+            INCLUDE_HOST_NAME,
+            AccessLogDefinition.WORKER,
+            AccessLogDefinition.PREDICATE,
+            METADATA
+    );
+    static final ConsoleAccessLogDefinition INSTANCE = new ConsoleAccessLogDefinition();
+
+
+    private ConsoleAccessLogDefinition() {
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(Constants.SETTING, "console-access-log"),
+                UndertowExtension.getResolver("console-access-log"))
+                .setAddHandler(AddHandler.INSTANCE)
+                .setRemoveHandler(RemoveHandler.INSTANCE)
+                .addCapabilities(CONSOLE_ACCESS_LOG_CAPABILITY)
+        );
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return ATTRIBUTES;
+    }
+
+    private static class AddHandler extends AbstractAddStepHandler {
+        static final AddHandler INSTANCE = new AddHandler();
+
+        private AddHandler() {
+            super(ATTRIBUTES);
+        }
+
+        @Override
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            final PathAddress address = context.getCurrentAddress();
+            final PathAddress hostAddress = address.getParent();
+            final PathAddress serverAddress = hostAddress.getParent();
+
+            final String worker = AccessLogDefinition.WORKER.resolveModelAttribute(context, model).asString();
+            final ModelNode properties = METADATA.resolveModelAttribute(context, model);
+            final Map<String, Object> metadata = new LinkedHashMap<>();
+            if (properties.isDefined()) {
+                for (Property property : properties.asPropertyList()) {
+                    metadata.put(property.getName(), property.getValue().asString());
+                }
+            }
+
+            Predicate predicate = null;
+            final ModelNode predicateNode = AccessLogDefinition.PREDICATE.resolveModelAttribute(context, model);
+            if (predicateNode.isDefined()) {
+                predicate = Predicates.parse(predicateNode.asString(), getClass().getClassLoader());
+            }
+
+            final boolean includeHostName = INCLUDE_HOST_NAME.resolveModelAttribute(context, model).asBoolean();
+
+            final String serverName = serverAddress.getLastElement().getValue();
+            final String hostName = hostAddress.getLastElement().getValue();
+
+            final ServiceBuilder<?> serviceBuilder = context.getServiceTarget()
+                    .addService(CONSOLE_ACCESS_LOG_CAPABILITY.getCapabilityServiceName(address));
+
+            final Supplier<Host> hostSupplier = serviceBuilder.requires(
+                    context.getCapabilityServiceName(Capabilities.CAPABILITY_HOST, Host.class, serverName, hostName));
+            final Supplier<XnioWorker> workerSupplier = serviceBuilder.requires(
+                    context.getCapabilityServiceName(Capabilities.REF_IO_WORKER, XnioWorker.class, worker));
+
+            // Get the list of attributes to log
+            final Collection<AccessLogAttribute> attributes = parseAttributes(context, model);
+
+            final EventLoggerService service = new EventLoggerService(attributes, predicate, metadata, includeHostName, hostSupplier,
+                    workerSupplier);
+            serviceBuilder.setInstance(service)
+                    .setInitialMode(ServiceController.Mode.ACTIVE)
+                    .install();
+        }
+
+        private Collection<AccessLogAttribute> parseAttributes(final OperationContext context, final ModelNode model) throws OperationFailedException {
+            final Collection<AccessLogAttribute> attributes = new ArrayList<>();
+            final ModelNode attributesModel = ExchangeAttributeDefinitions.ATTRIBUTES.resolveModelAttribute(context, model);
+            for (AttributeDefinition valueType : ExchangeAttributeDefinitions.ATTRIBUTES.getValueTypes()) {
+                attributes.addAll(ExchangeAttributeDefinitions.resolveAccessLogAttribute(valueType, context, attributesModel));
+            }
+            return attributes;
+        }
+    }
+
+    private static class RemoveHandler extends AbstractRemoveStepHandler {
+
+        static final RemoveHandler INSTANCE = new RemoveHandler();
+
+        @Override
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            final PathAddress address = context.getCurrentAddress();
+            context.removeService(CONSOLE_ACCESS_LOG_CAPABILITY.getCapabilityServiceName(address));
+        }
+
+        @Override
+        protected void recoverServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            AddHandler.INSTANCE.performRuntime(context, operation, model);
+        }
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/EventLoggerHttpHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/EventLoggerHttpHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import io.undertow.predicate.Predicate;
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.wildfly.event.logger.EventLogger;
+
+/**
+ * An HTTP handler that writes exchange attributes to an event logger.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class EventLoggerHttpHandler implements HttpHandler {
+
+    private final HttpHandler next;
+    private final ExchangeCompletionListener exchangeCompletionListener = new AccessLogCompletionListener();
+    private final Predicate predicate;
+    private final Collection<AccessLogAttribute> attributes;
+    private final EventLogger eventLogger;
+
+    /**
+     * Creates a new instance of the HTTP handler.
+     *
+     * @param next        the next handler in the chain to invoke to invoke after this handler executes
+     * @param predicate   the predicate used to determine if this handler should execute
+     * @param attributes  the attributes which should be logged
+     * @param eventLogger the event logger
+     */
+    EventLoggerHttpHandler(final HttpHandler next, final Predicate predicate,
+                           final Collection<AccessLogAttribute> attributes, final EventLogger eventLogger) {
+        this.next = next;
+        this.predicate = predicate;
+        this.attributes = attributes;
+        this.eventLogger = eventLogger;
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        exchange.addExchangeCompleteListener(exchangeCompletionListener);
+        next.handleRequest(exchange);
+    }
+
+    private class AccessLogCompletionListener implements ExchangeCompletionListener {
+        @Override
+        public void exchangeEvent(final HttpServerExchange exchange, final NextListener nextListener) {
+            try {
+                if (predicate == null || predicate.resolve(exchange)) {
+                    final Map<String, Object> data = new LinkedHashMap<>();
+                    for (AccessLogAttribute attribute : attributes) {
+                        data.put(attribute.getKey(), attribute.resolveAttribute(exchange));
+                    }
+                    eventLogger.log(data);
+                }
+            } finally {
+                nextListener.proceed();
+            }
+        }
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/EventLoggerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/EventLoggerService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.undertow.predicate.Predicate;
+import io.undertow.predicate.Predicates;
+import io.undertow.server.HttpHandler;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.event.logger.EventLogger;
+import org.wildfly.event.logger.JsonEventFormatter;
+import org.wildfly.event.logger.StdoutEventWriter;
+import org.wildfly.extension.undertow.logging.UndertowLogger;
+import org.xnio.XnioWorker;
+
+/**
+ * A service which creates an asynchronous {@linkplain EventLogger event logger} which writes to {@code stdout} in JSON
+ * structured format.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class EventLoggerService implements Service {
+    private final Set<AccessLogAttribute> attributes;
+    private final boolean includeHostName;
+    private final Map<String, Object> metadata;
+    private final Predicate predicate;
+    private final Supplier<Host> host;
+    private final Supplier<XnioWorker> worker;
+
+    /**
+     * Creates a new service.
+     *
+     * @param predicate       the predicate that determines if the request should be logged
+     * @param metadata        a map of metadata to be prepended to the structured output
+     * @param includeHostName {@code true} to include the host name in the structured JSON output
+     * @param host            the host service supplier
+     * @param worker          the worker service supplier for the
+     *                        {@linkplain EventLogger#createAsyncLogger(String, Executor) async logger}
+     */
+    EventLoggerService(final Collection<AccessLogAttribute> attributes, final Predicate predicate, final Map<String, Object> metadata,
+                       final boolean includeHostName, final Supplier<Host> host, final Supplier<XnioWorker> worker) {
+        this.attributes = new CopyOnWriteArraySet<>(attributes);
+        this.predicate = predicate == null ? Predicates.truePredicate() : predicate;
+        this.metadata = metadata;
+        this.includeHostName = includeHostName;
+        this.host = host;
+        this.worker = worker;
+    }
+
+    @Override
+    @SuppressWarnings("Convert2Lambda")
+    public void start(final StartContext context) throws StartException {
+        final Host host = this.host.get();
+        // Create the JSON event formatter
+        final JsonEventFormatter.Builder formatterBuilder = JsonEventFormatter.builder()
+                .setIncludeTimestamp(false);
+        if (includeHostName) {
+            formatterBuilder.addMetaData("hostName", host.getName());
+        }
+        if (metadata != null && !metadata.isEmpty()) {
+            formatterBuilder.addMetaData(metadata);
+        }
+        final JsonEventFormatter formatter = formatterBuilder.build();
+        final EventLogger eventLogger = EventLogger.createAsyncLogger("web-access",
+                StdoutEventWriter.of(formatter), worker.get());
+        UndertowLogger.ROOT_LOGGER.debugf("Adding console-access-log for host %s", host.getName());
+        host.setAccessLogHandler(new Function<HttpHandler, HttpHandler>() {
+            @Override
+            public HttpHandler apply(final HttpHandler httpHandler) {
+                return new EventLoggerHttpHandler(httpHandler, predicate, attributes, eventLogger);
+            }
+        });
+    }
+
+    @Override
+    public void stop(final StopContext context) {
+        final Host host = this.host.get();
+        UndertowLogger.ROOT_LOGGER.debugf("Removing console-access-log for host %s", host.getName());
+        host.setAccessLogHandler(null);
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ExchangeAttributeDefinitions.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ExchangeAttributeDefinitions.java
@@ -1,0 +1,708 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import io.undertow.attribute.AuthenticationTypeExchangeAttribute;
+import io.undertow.attribute.BytesSentAttribute;
+import io.undertow.attribute.DateTimeAttribute;
+import io.undertow.attribute.ExchangeAttribute;
+import io.undertow.attribute.HostAndPortAttribute;
+import io.undertow.attribute.LocalIPAttribute;
+import io.undertow.attribute.LocalPortAttribute;
+import io.undertow.attribute.LocalServerNameAttribute;
+import io.undertow.attribute.PathParameterAttribute;
+import io.undertow.attribute.PredicateContextAttribute;
+import io.undertow.attribute.QueryParameterAttribute;
+import io.undertow.attribute.QueryStringAttribute;
+import io.undertow.attribute.RelativePathAttribute;
+import io.undertow.attribute.RemoteHostAttribute;
+import io.undertow.attribute.RemoteIPAttribute;
+import io.undertow.attribute.RemoteObfuscatedIPAttribute;
+import io.undertow.attribute.RemoteUserAttribute;
+import io.undertow.attribute.RequestHeaderAttribute;
+import io.undertow.attribute.RequestLineAttribute;
+import io.undertow.attribute.RequestMethodAttribute;
+import io.undertow.attribute.RequestPathAttribute;
+import io.undertow.attribute.RequestProtocolAttribute;
+import io.undertow.attribute.RequestSchemeAttribute;
+import io.undertow.attribute.RequestURLAttribute;
+import io.undertow.attribute.ResolvedPathAttribute;
+import io.undertow.attribute.ResponseCodeAttribute;
+import io.undertow.attribute.ResponseHeaderAttribute;
+import io.undertow.attribute.ResponseReasonPhraseAttribute;
+import io.undertow.attribute.ResponseTimeAttribute;
+import io.undertow.attribute.SecureExchangeAttribute;
+import io.undertow.attribute.SslCipherAttribute;
+import io.undertow.attribute.SslClientCertAttribute;
+import io.undertow.attribute.SslSessionIdAttribute;
+import io.undertow.attribute.StoredResponse;
+import io.undertow.attribute.ThreadNameAttribute;
+import io.undertow.attribute.TransportProtocolAttribute;
+import io.undertow.util.HttpString;
+import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.wildfly.common.function.ExceptionBiFunction;
+import org.wildfly.extension.undertow.logging.UndertowLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
+class ExchangeAttributeDefinitions {
+
+    private static final String KEY_NAME = "key";
+    private static final SimpleAttributeDefinitionBuilder KEY_BUILDER = SimpleAttributeDefinitionBuilder.create(KEY_NAME, ModelType.STRING, true);
+
+    private static final Map<AttributeDefinition, ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>> ATTRIBUTE_RESOLVERS =
+            new HashMap<>();
+
+    private static final SimpleAttributeDefinitionBuilder KEY_PREFIX_BUILDER = SimpleAttributeDefinitionBuilder.create("key-prefix", ModelType.STRING, true);
+    private static final StringListAttributeDefinition NAMES = StringListAttributeDefinition.Builder.of("names")
+            .setAllowExpression(true)
+            .setAttributeMarshaller(new AttributeMarshaller.AttributeElementMarshaller() {
+
+                @Override
+                public void marshallAsElement(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
+                    assert attribute instanceof StringListAttributeDefinition;
+                    try {
+                        final List<String> list = ((StringListAttributeDefinition) attribute).unwrap(ExpressionResolver.SIMPLE, resourceModel);
+                        if (list.isEmpty()) {
+                            return;
+                        }
+                        if (resourceModel.hasDefined(attribute.getName())) {
+                            for (ModelNode value : resourceModel.get(attribute.getName()).asList()) {
+                                writer.writeStartElement(attribute.getXmlName());
+                                writer.writeAttribute(VALUE, value.asString());
+                                writer.writeEndElement();
+                            }
+                        }
+
+                    } catch (OperationFailedException e) {
+                        throw new XMLStreamException(e);
+                    }
+                }
+            })
+            .setAttributeParser(new AttributeParser() {
+                @Override
+                public boolean isParseAsElement() {
+                    return true;
+                }
+
+                @Override
+                public void parseElement(final AttributeDefinition attribute, final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+                    ParseUtils.requireSingleAttribute(reader, VALUE);
+                    final String value = reader.getAttributeValue(0);
+                    operation.get(attribute.getName()).add(value);
+                    ParseUtils.requireNoContent(reader);
+                }
+            })
+            .setRequired(true)
+            .setXmlName("name")
+            .build();
+
+    private static final SimpleAttributeDefinition AUTHENTICATION_TYPE_KEY = createKey("authenticationType");
+    private static final ObjectTypeAttributeDefinition AUTHENTICATION_TYPE = create(
+            ObjectTypeAttributeDefinition.create("authentication-type", AUTHENTICATION_TYPE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(AUTHENTICATION_TYPE_KEY, context, model, AuthenticationTypeExchangeAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition BYTES_SENT_KEY = createKey("bytesSent");
+    private static final ObjectTypeAttributeDefinition BYTES_SENT = create(
+            ObjectTypeAttributeDefinition.create("bytes-sent", BYTES_SENT_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(BYTES_SENT_KEY, context, model,
+                            new BytesSentAttribute(false), new Function<String, Object>() {
+                                @Override
+                                public Object apply(final String s) {
+                                    return Long.valueOf(s);
+                                }
+                            });
+                }
+            });
+
+    private static final SimpleAttributeDefinition DATE_TIME_KEY = createKey("dateTime");
+    private static final SimpleAttributeDefinition DATE_FORMAT = SimpleAttributeDefinitionBuilder.create("date-format", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setValidator(new ModelTypeValidator(ModelType.STRING, true, true) {
+                @Override
+                public void validateParameter(final String parameterName, final ModelNode value) throws OperationFailedException {
+                    super.validateParameter(parameterName, value);
+                    try {
+                        new SimpleDateFormat(value.asString());
+                    } catch (IllegalArgumentException ignore) {
+                        throw UndertowLogger.ROOT_LOGGER.invalidDateTimeFormatterPattern(value.asString());
+                    }
+                }
+            })
+            .build();
+    private static final SimpleAttributeDefinition TIME_ZONE = SimpleAttributeDefinitionBuilder.create("time-zone", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setValidator(new ModelTypeValidator(ModelType.STRING, true, true) {
+                private final List<String> zoneIds = Arrays.asList(TimeZone.getAvailableIDs());
+                @Override
+                public void validateParameter(final String parameterName, final ModelNode value) throws OperationFailedException {
+                    super.validateParameter(parameterName, value);
+                    if (!zoneIds.contains(value.asString())) {
+                        throw UndertowLogger.ROOT_LOGGER.invalidTimeZoneId(value.asString());
+                    }
+                }
+            })
+            .build();
+    private static final ObjectTypeAttributeDefinition DATE_TIME = create(
+            ObjectTypeAttributeDefinition.create("date-time", DATE_TIME_KEY, DATE_FORMAT, TIME_ZONE),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final ExchangeAttribute exchangeAttribute;
+                    if (model.hasDefined(DATE_FORMAT.getName())) {
+                        String timeZone = null;
+                        if (model.hasDefined(TIME_ZONE.getName())) {
+                            timeZone = TIME_ZONE.resolveModelAttribute(context, model).asString();
+                        }
+                        exchangeAttribute = new DateTimeAttribute(DATE_FORMAT.resolveModelAttribute(context, model).asString(), timeZone);
+                    } else {
+                        exchangeAttribute = DateTimeAttribute.INSTANCE;
+                    }
+                    return createSingleton(DATE_TIME_KEY, context, model, exchangeAttribute);
+                }
+            });
+
+    private static final SimpleAttributeDefinition HOST_AND_PORT_KEY = createKey("hostAndPort");
+    private static final ObjectTypeAttributeDefinition HOST_AND_PORT = create(
+            ObjectTypeAttributeDefinition.create("host-and-port", HOST_AND_PORT_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(HOST_AND_PORT_KEY, context, model, HostAndPortAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition LOCAL_IP_KEY = createKey("localIp");
+    private static final ObjectTypeAttributeDefinition LOCAL_IP = create(
+            ObjectTypeAttributeDefinition.create("local-ip", LOCAL_IP_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(LOCAL_IP_KEY, context, model, LocalIPAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition LOCAL_PORT_KEY = createKey("localPort");
+    private static final ObjectTypeAttributeDefinition LOCAL_PORT = create(
+            ObjectTypeAttributeDefinition.create("local-port", LOCAL_PORT_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(LOCAL_PORT_KEY, context, model, LocalPortAttribute.INSTANCE, new Function<String, Object>() {
+                        @Override
+                        public Object apply(final String s) {
+                            return Integer.valueOf(s);
+                        }
+                    });
+                }
+            });
+
+    private static final SimpleAttributeDefinition LOCAL_SERVER_NAME_KEY = createKey("localServerName");
+    private static final ObjectTypeAttributeDefinition LOCAL_SERVER_NAME = create(
+            ObjectTypeAttributeDefinition.create("local-server-name", LOCAL_SERVER_NAME_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(LOCAL_SERVER_NAME_KEY, context, model, LocalServerNameAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition PATH_PARAMETER_KEY_PREFIX = KEY_PREFIX_BUILDER.build();
+    private static final ObjectTypeAttributeDefinition PATH_PARAMETER = create(ObjectTypeAttributeDefinition.Builder.of("path-parameter",
+            PATH_PARAMETER_KEY_PREFIX, NAMES),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final Collection<AccessLogAttribute> result = new ArrayList<>(5);
+                    for (ModelNode m : NAMES.resolveModelAttribute(context, model).asList()) {
+                        final String name = m.asString();
+                        final String keyName = resolveKeyName(PATH_PARAMETER_KEY_PREFIX.resolveModelAttribute(context, model), name);
+                        result.add(AccessLogAttribute.of(keyName, new PathParameterAttribute(name)));
+                    }
+                    return result;
+                }
+            });
+
+    private static final SimpleAttributeDefinition PREDICATE_KEY_PREFIX = KEY_PREFIX_BUILDER.build();
+    private static final ObjectTypeAttributeDefinition PREDICATE = create(ObjectTypeAttributeDefinition.Builder.of("predicate",
+            PREDICATE_KEY_PREFIX, NAMES),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final Collection<AccessLogAttribute> result = new ArrayList<>(5);
+                    for (ModelNode m : NAMES.resolveModelAttribute(context, model).asList()) {
+                        final String predicateName = m.asString();
+                        final String keyName = resolveKeyName(PREDICATE_KEY_PREFIX.resolveModelAttribute(context, model), predicateName);
+                        result.add(AccessLogAttribute.of(keyName, new PredicateContextAttribute(predicateName)));
+                    }
+                    return result;
+                }
+            });
+
+    private static final SimpleAttributeDefinition QUERY_PARAMETER_KEY_PREFIX = KEY_PREFIX_BUILDER.build();
+    private static final ObjectTypeAttributeDefinition QUERY_PARAMETER = create(ObjectTypeAttributeDefinition.Builder.of("query-parameter",
+            QUERY_PARAMETER_KEY_PREFIX, NAMES),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final Collection<AccessLogAttribute> result = new ArrayList<>(5);
+                    for (ModelNode m : NAMES.resolveModelAttribute(context, model).asList()) {
+                        final String paramName = m.asString();
+                        final String keyName = resolveKeyName(QUERY_PARAMETER_KEY_PREFIX.resolveModelAttribute(context, model), paramName);
+                        result.add(AccessLogAttribute.of(keyName, new QueryParameterAttribute(paramName)));
+                    }
+                    return result;
+                }
+            });
+
+    private static final SimpleAttributeDefinition QUERY_STRING_KEY = createKey("queryString");
+    private static final SimpleAttributeDefinition INCLUDE_QUESTION_MARK = SimpleAttributeDefinitionBuilder
+            .create("include-question-mark", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    private static final ObjectTypeAttributeDefinition QUERY_STRING = create(
+            ObjectTypeAttributeDefinition.create("query-string", QUERY_STRING_KEY, INCLUDE_QUESTION_MARK),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    if (INCLUDE_QUESTION_MARK.resolveModelAttribute(context, model).asBoolean()) {
+                        return createSingleton(QUERY_STRING_KEY, context, model, QueryStringAttribute.INSTANCE);
+                    }
+                    return createSingleton(QUERY_STRING_KEY, context, model, QueryStringAttribute.BARE_INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition RELATIVE_PATH_KEY = createKey("relativePath");
+    private static final ObjectTypeAttributeDefinition RELATIVE_PATH = create(
+            ObjectTypeAttributeDefinition.create("relative-path", RELATIVE_PATH_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(RELATIVE_PATH_KEY, context, model, RelativePathAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REMOTE_HOST_KEY = createKey("remoteHost");
+    private static final ObjectTypeAttributeDefinition REMOTE_HOST = create(
+            ObjectTypeAttributeDefinition.create("remote-host", REMOTE_HOST_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REMOTE_HOST_KEY, context, model, RemoteHostAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REMOTE_IP_KEY = createKey("remoteIp");
+    private static final SimpleAttributeDefinition OBFUSCATED = SimpleAttributeDefinitionBuilder.create("obfuscated", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    private static final ObjectTypeAttributeDefinition REMOTE_IP = create(
+            ObjectTypeAttributeDefinition.create("remote-ip", REMOTE_IP_KEY, OBFUSCATED),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    if (OBFUSCATED.resolveModelAttribute(context, model).asBoolean()) {
+                        return createSingleton(REMOTE_IP_KEY, context, model, RemoteObfuscatedIPAttribute.INSTANCE);
+                    }
+                    return createSingleton(REMOTE_IP_KEY, context, model, RemoteIPAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REMOTE_USER_KEY = createKey("remoteUser");
+    private static final ObjectTypeAttributeDefinition REMOTE_USER = create(
+            ObjectTypeAttributeDefinition.create("remote-user", REMOTE_USER_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REMOTE_USER_KEY, context, model, RemoteUserAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_HEADER_KEY_PREFIX = KEY_PREFIX_BUILDER.build();
+    private static final ObjectTypeAttributeDefinition REQUEST_HEADER = create(ObjectTypeAttributeDefinition.Builder.of("request-header",
+            REQUEST_HEADER_KEY_PREFIX, NAMES),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final Collection<AccessLogAttribute> result = new ArrayList<>(5);
+                    for (ModelNode m : NAMES.resolveModelAttribute(context, model).asList()) {
+                        final String name = m.asString();
+                        final String keyName = resolveKeyName(REQUEST_HEADER_KEY_PREFIX.resolveModelAttribute(context, model), name);
+                        result.add(AccessLogAttribute.of(keyName, new RequestHeaderAttribute(HttpString.tryFromString(name))));
+                    }
+                    return result;
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_LINE_KEY = createKey("requestLine");
+    private static final ObjectTypeAttributeDefinition REQUEST_LINE = create(
+            ObjectTypeAttributeDefinition.create("request-line", REQUEST_LINE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_LINE_KEY, context, model, RequestLineAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_METHOD_KEY = createKey("requestMethod");
+    private static final ObjectTypeAttributeDefinition REQUEST_METHOD = create(
+            ObjectTypeAttributeDefinition.create("request-method", REQUEST_METHOD_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_METHOD_KEY, context, model, RequestMethodAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_PATH_KEY = createKey("requestPath");
+    private static final ObjectTypeAttributeDefinition REQUEST_PATH = create(
+            ObjectTypeAttributeDefinition.create("request-path", REQUEST_PATH_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_PATH_KEY, context, model, RequestPathAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_PROTOCOL_KEY = createKey("requestProtocol");
+    private static final ObjectTypeAttributeDefinition REQUEST_PROTOCOL = create(
+            ObjectTypeAttributeDefinition.create("request-protocol", REQUEST_PROTOCOL_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_PROTOCOL_KEY, context, model, RequestProtocolAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_SCHEME_KEY = createKey("requestScheme");
+    private static final ObjectTypeAttributeDefinition REQUEST_SCHEME = create(
+            ObjectTypeAttributeDefinition.create("request-scheme", REQUEST_SCHEME_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_SCHEME_KEY, context, model, RequestSchemeAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition REQUEST_URL_KEY = createKey("requestUrl");
+    private static final ObjectTypeAttributeDefinition REQUEST_URL = create(
+            ObjectTypeAttributeDefinition.create("request-url", REQUEST_URL_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(REQUEST_URL_KEY, context, model, RequestURLAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition RESOLVED_PATH_KEY = createKey("resolvedPath");
+    private static final ObjectTypeAttributeDefinition RESOLVED_PATH = create(
+            ObjectTypeAttributeDefinition.create("resolved-path", RESOLVED_PATH_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(RESOLVED_PATH_KEY, context, model, ResolvedPathAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition RESPONSE_CODE_KEY = createKey("responseCode");
+    private static final ObjectTypeAttributeDefinition RESPONSE_CODE = create(
+            ObjectTypeAttributeDefinition.create("response-code", RESPONSE_CODE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(RESPONSE_CODE_KEY, context, model, ResponseCodeAttribute.INSTANCE, new Function<String, Object>() {
+                        @Override
+                        public Object apply(final String s) {
+                            return Integer.valueOf(s);
+                        }
+                    });
+                }
+            });
+
+    private static final SimpleAttributeDefinition RESPONSE_HEADER_KEY_PREFIX = KEY_PREFIX_BUILDER.build();
+    private static final ObjectTypeAttributeDefinition RESPONSE_HEADER = create(ObjectTypeAttributeDefinition.Builder.of("response-header",
+            RESPONSE_HEADER_KEY_PREFIX, NAMES),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    final Collection<AccessLogAttribute> result = new ArrayList<>(5);
+                    for (ModelNode m : NAMES.resolveModelAttribute(context, model).asList()) {
+                        final String name = m.asString();
+                        final String keyName = resolveKeyName(RESPONSE_HEADER_KEY_PREFIX.resolveModelAttribute(context, model), name);
+                        result.add(AccessLogAttribute.of(keyName, new ResponseHeaderAttribute(HttpString.tryFromString(name))));
+                    }
+                    return result;
+                }
+            });
+
+    private static final SimpleAttributeDefinition RESPONSE_REASON_PHRASE_KEY = createKey("responseReasonPhrase");
+    private static final ObjectTypeAttributeDefinition RESPONSE_REASON_PHRASE = create(
+            ObjectTypeAttributeDefinition.create("response-reason-phrase", RESPONSE_REASON_PHRASE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(RESPONSE_REASON_PHRASE_KEY, context, model, ResponseReasonPhraseAttribute.INSTANCE);
+                }
+            });
+
+
+    private static final SimpleAttributeDefinition RESPONSE_TIME_KEY = createKey("responseTime");
+    private static final SimpleAttributeDefinition TIME_UNIT = new SimpleAttributeDefinitionBuilder("time-unit", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(TimeUnit.MILLISECONDS.name()))
+            .setValidator(EnumValidator.create(TimeUnit.class, TimeUnit.SECONDS, TimeUnit.NANOSECONDS, TimeUnit.MILLISECONDS, TimeUnit.MICROSECONDS))
+            .build();
+    private static final ObjectTypeAttributeDefinition RESPONSE_TIME = create(
+            ObjectTypeAttributeDefinition.create("response-time", RESPONSE_TIME_KEY, TIME_UNIT),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(RESPONSE_TIME_KEY, context, model,
+                            new ResponseTimeAttribute(TimeUnit.valueOf(TIME_UNIT.resolveModelAttribute(context, model).asString())),
+                            new Function<String, Object>() {
+                                @Override
+                                public Object apply(final String s) {
+                                    if (s == null) {
+                                        return null;
+                                    }
+                                    return Long.valueOf(s);
+                                }
+                            });
+                }
+            });
+
+    private static final SimpleAttributeDefinition SECURE_EXCHANGE_KEY = createKey("secureExchange");
+    private static final ObjectTypeAttributeDefinition SECURE_EXCHANGE = create(
+            ObjectTypeAttributeDefinition.create("secure-exchange", SECURE_EXCHANGE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                @SuppressWarnings("Anonymous2MethodRef")
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(SECURE_EXCHANGE_KEY, context, model, SecureExchangeAttribute.INSTANCE,
+                            new Function<String, Object>() {
+                                @Override
+                                public Object apply(final String s) {
+                                    return Boolean.valueOf(s);
+                                }
+                            });
+                }
+            });
+
+    private static final SimpleAttributeDefinition SSL_CIPHER_KEY = createKey("sslCipher");
+    private static final ObjectTypeAttributeDefinition SSL_CIPHER = create(
+            ObjectTypeAttributeDefinition.create("ssl-cipher", SSL_CIPHER_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(SSL_CIPHER_KEY, context, model, SslCipherAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition SSL_CLIENT_CERT_KEY = createKey("sslClientCert");
+    private static final ObjectTypeAttributeDefinition SSL_CLIENT_CERT = create(
+            ObjectTypeAttributeDefinition.create("ssl-client-cert", SSL_CLIENT_CERT_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(SSL_CLIENT_CERT_KEY, context, model, SslClientCertAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition SSL_SESSION_ID_KEY = createKey("sslSessionId");
+    private static final ObjectTypeAttributeDefinition SSL_SESSION_ID = create(
+            ObjectTypeAttributeDefinition.create("ssl-session-id", SSL_SESSION_ID_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(SSL_SESSION_ID_KEY, context, model, SslSessionIdAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition STORED_RESPONSE_KEY = createKey("storedResponse");
+    private static final ObjectTypeAttributeDefinition STORED_RESPONSE = create(
+            ObjectTypeAttributeDefinition.create("stored-response", STORED_RESPONSE_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(STORED_RESPONSE_KEY, context, model, StoredResponse.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition THREAD_NAME_KEY = createKey("threadName");
+    private static final ObjectTypeAttributeDefinition THREAD_NAME = create(
+            ObjectTypeAttributeDefinition.create("thread-name", THREAD_NAME_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(THREAD_NAME_KEY, context, model, ThreadNameAttribute.INSTANCE);
+                }
+            });
+
+    private static final SimpleAttributeDefinition TRANSPORT_PROTOCOL_KEY = createKey("transportProtocol");
+    private static final ObjectTypeAttributeDefinition TRANSPORT_PROTOCOL = create(
+            ObjectTypeAttributeDefinition.create("transport-protocol", TRANSPORT_PROTOCOL_KEY),
+            new ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException>() {
+                @Override
+                public Collection<AccessLogAttribute> apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
+                    return createSingleton(TRANSPORT_PROTOCOL_KEY, context, model, TransportProtocolAttribute.INSTANCE);
+                }
+            });
+
+    static final ObjectTypeAttributeDefinition ATTRIBUTES = ObjectTypeAttributeDefinition.create("attributes",
+            AUTHENTICATION_TYPE,
+            BYTES_SENT,
+            DATE_TIME,
+            HOST_AND_PORT,
+            LOCAL_IP,
+            LOCAL_PORT,
+            LOCAL_SERVER_NAME,
+            PATH_PARAMETER,
+            PREDICATE,
+            QUERY_PARAMETER,
+            QUERY_STRING,
+            RELATIVE_PATH,
+            REMOTE_HOST,
+            REMOTE_IP,
+            REMOTE_USER,
+            REQUEST_HEADER,
+            REQUEST_LINE,
+            REQUEST_METHOD,
+            REQUEST_PATH,
+            REQUEST_PROTOCOL,
+            REQUEST_SCHEME,
+            REQUEST_URL,
+            RESOLVED_PATH,
+            RESPONSE_CODE,
+            RESPONSE_HEADER,
+            RESPONSE_REASON_PHRASE,
+            RESPONSE_TIME,
+            SECURE_EXCHANGE,
+            SSL_CIPHER,
+            SSL_CLIENT_CERT,
+            SSL_SESSION_ID,
+            STORED_RESPONSE,
+            THREAD_NAME,
+            TRANSPORT_PROTOCOL
+    )
+            .setDefaultValue(createDefaultAttribute())
+            .setRestartAllServices()
+            .build();
+
+    static Collection<AccessLogAttribute> resolveAccessLogAttribute(final AttributeDefinition attribute,
+                                                                    final OperationContext context,
+                                                                    final ModelNode model) throws OperationFailedException {
+        final ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException> attributeResolver =
+                ATTRIBUTE_RESOLVERS.get(attribute);
+        assert attributeResolver != null;
+        if (model.hasDefined(attribute.getName())) {
+            return attributeResolver.apply(context, model.get(attribute.getName()));
+        }
+        return Collections.emptyList();
+    }
+
+    private static Collection<AccessLogAttribute> createSingleton(final AttributeDefinition keyAttribute,
+                                                                  final OperationContext context, final ModelNode model,
+                                                                  final ExchangeAttribute exchangeAttribute) throws OperationFailedException {
+        return Collections.singletonList(AccessLogAttribute.of(keyAttribute.resolveModelAttribute(context, model).asString(),
+                exchangeAttribute));
+    }
+
+    @SuppressWarnings({"SameParameterValue"})
+    private static Collection<AccessLogAttribute> createSingleton(final AttributeDefinition keyAttribute,
+                                                                  final OperationContext context, final ModelNode model,
+                                                                  final ExchangeAttribute exchangeAttribute,
+                                                                  final Function<String, Object> valueConverter) throws OperationFailedException {
+        return Collections.singletonList(AccessLogAttribute.of(keyAttribute.resolveModelAttribute(context, model).asString(),
+                exchangeAttribute, valueConverter));
+    }
+
+    private static SimpleAttributeDefinition createKey(final String dftValue) {
+        return KEY_BUILDER.setDefaultValue(new ModelNode(dftValue)).build();
+    }
+
+    private static ModelNode createDefaultAttribute() {
+        final ModelNode result = new ModelNode().setEmptyObject();
+        result.get(REMOTE_HOST.getName()).setEmptyObject();
+        result.get(REMOTE_USER.getName()).setEmptyObject();
+        result.get(DATE_TIME.getName()).setEmptyObject();
+        result.get(REQUEST_LINE.getName()).setEmptyObject();
+        result.get(RESPONSE_CODE.getName()).setEmptyObject();
+        result.get(BYTES_SENT.getName()).setEmptyObject();
+        return result;
+    }
+
+    private static <R extends AttributeDefinition, B extends AbstractAttributeDefinitionBuilder<B, R>> R create(final B builder,
+                                                                                                                final ExceptionBiFunction<OperationContext, ModelNode, Collection<AccessLogAttribute>, OperationFailedException> attributeResolver) {
+        final R result = builder.setRequired(false).build();
+        ATTRIBUTE_RESOLVERS.put(result, attributeResolver);
+        return result;
+    }
+
+    private static String resolveKeyName(final ModelNode prefix, final String name) {
+        final StringBuilder result = new StringBuilder();
+        if (prefix.isDefined()) {
+            result.append(prefix.asString());
+        }
+        result.append(name);
+        return result.toString();
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -95,6 +95,7 @@ class HostDefinition extends PersistentResourceDefinition {
     private static final List<? extends PersistentResourceDefinition> CHILDREN = Collections.unmodifiableList(Arrays.asList(
             LocationDefinition.INSTANCE,
             AccessLogDefinition.INSTANCE,
+            ConsoleAccessLogDefinition.INSTANCE,
             FilterRefDefinition.INSTANCE,
             HttpInvokerDefinition.INSTANCE,
             new HostSingleSignOnDefinition()

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
@@ -43,12 +43,13 @@ enum Namespace {
     UNDERTOW_5_0("urn:jboss:domain:undertow:5.0"),
     UNDERTOW_6_0("urn:jboss:domain:undertow:6.0"),
     UNDERTOW_7_0("urn:jboss:domain:undertow:7.0"),
-    UNDERTOW_8_0("urn:jboss:domain:undertow:8.0");
+    UNDERTOW_8_0("urn:jboss:domain:undertow:8.0"),
+    UNDERTOW_9_0("urn:jboss:domain:undertow:9.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = UNDERTOW_8_0;
+    public static final Namespace CURRENT = UNDERTOW_9_0;
 
     private final String name;
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
@@ -79,7 +79,7 @@ public class UndertowExtension implements Extension {
     static final AccessConstraintDefinition LISTENER_CONSTRAINT = new SensitiveTargetAccessConstraintDefinition(
                     new SensitivityClassification(SUBSYSTEM_NAME, "web-connector", false, false, false));
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(8, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(9, 0, 0);
 
 
     public static StandardResourceDescriptionResolver getResolver(final String... keyPrefix) {
@@ -103,6 +103,7 @@ public class UndertowExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_6_0.getUriString(), UndertowSubsystemParser_6_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_7_0.getUriString(), UndertowSubsystemParser_7_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_8_0.getUriString(), UndertowSubsystemParser_8_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_9_0.getUriString(), UndertowSubsystemParser_9_0::new);
     }
 
     @Override
@@ -115,7 +116,7 @@ public class UndertowExtension implements Extension {
         deployments.registerSubModel(DeploymentServletDefinition.INSTANCE);
         deployments.registerSubModel(DeploymentWebSocketDefinition.INSTANCE);
 
-        subsystem.registerXMLElementWriter(UndertowSubsystemParser_8_0::new);
+        subsystem.registerXMLElementWriter(UndertowSubsystemParser_9_0::new);
     }
 
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_9_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_9_0.java
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.as.controller.operations.common.Util;
+import org.wildfly.extension.undertow.filters.CustomFilterDefinition;
+import org.wildfly.extension.undertow.filters.ErrorPageDefinition;
+import org.wildfly.extension.undertow.filters.ExpressionFilterDefinition;
+import org.wildfly.extension.undertow.filters.FilterDefinitions;
+import org.wildfly.extension.undertow.filters.FilterRefDefinition;
+import org.wildfly.extension.undertow.filters.GzipFilter;
+import org.wildfly.extension.undertow.filters.ModClusterDefinition;
+import org.wildfly.extension.undertow.filters.RequestLimitHandler;
+import org.wildfly.extension.undertow.filters.ResponseHeaderFilter;
+import org.wildfly.extension.undertow.filters.RewriteFilterDefinition;
+import org.wildfly.extension.undertow.handlers.FileHandler;
+import org.wildfly.extension.undertow.handlers.HandlerDefinitions;
+import org.wildfly.extension.undertow.handlers.ReverseProxyHandler;
+import org.wildfly.extension.undertow.handlers.ReverseProxyHandlerHost;
+
+/**
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
+ */
+public class UndertowSubsystemParser_9_0 extends PersistentResourceXMLParser {
+    private final PersistentResourceXMLDescription xmlDescription;
+
+    UndertowSubsystemParser_9_0() {
+        xmlDescription = builder(UndertowRootDefinition.INSTANCE.getPathElement(), Namespace.UNDERTOW_9_0.getUriString())
+                .addAttributes(
+                        UndertowRootDefinition.DEFAULT_SERVER,
+                        UndertowRootDefinition.DEFAULT_VIRTUAL_HOST,
+                        UndertowRootDefinition.DEFAULT_SERVLET_CONTAINER,
+                        UndertowRootDefinition.INSTANCE_ID,
+                        UndertowRootDefinition.DEFAULT_SECURITY_DOMAIN,
+                        UndertowRootDefinition.STATISTICS_ENABLED)
+                .addChild(
+                        builder(ByteBufferPoolDefinition.INSTANCE.getPathElement())
+                                .addAttributes(ByteBufferPoolDefinition.DIRECT, ByteBufferPoolDefinition.BUFFER_SIZE, ByteBufferPoolDefinition.MAX_POOL_SIZE, ByteBufferPoolDefinition.THREAD_LOCAL_CACHE_SIZE, ByteBufferPoolDefinition.LEAK_DETECTION_PERCENT)
+                )
+                .addChild(
+                        builder(BufferCacheDefinition.INSTANCE.getPathElement())
+                                .addAttributes(BufferCacheDefinition.BUFFER_SIZE, BufferCacheDefinition.BUFFERS_PER_REGION, BufferCacheDefinition.MAX_REGIONS)
+                )
+                .addChild(builder(ServerDefinition.INSTANCE.getPathElement())
+                                .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
+                                .addChild(
+                                        listenerBuilder(AjpListenerResourceDefinition.INSTANCE)
+                                                // xsd ajp-listener-type
+                                                .addAttributes(AjpListenerResourceDefinition.SCHEME,
+                                                        ListenerResourceDefinition.REDIRECT_SOCKET,
+                                                        AjpListenerResourceDefinition.MAX_AJP_PACKET_SIZE)
+                                )
+                                .addChild(
+                                        listenerBuilder(HttpListenerResourceDefinition.INSTANCE)
+                                                // xsd http-listener-type
+                                                .addAttributes(
+                                                        HttpListenerResourceDefinition.CERTIFICATE_FORWARDING,
+                                                        ListenerResourceDefinition.REDIRECT_SOCKET,
+                                                        HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING,
+                                                        HttpListenerResourceDefinition.ENABLE_HTTP2,
+                                                        HttpListenerResourceDefinition.HTTP2_ENABLE_PUSH,
+                                                        HttpListenerResourceDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_FRAME_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                                        HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11,
+                                                        HttpListenerResourceDefinition.PROXY_PROTOCOL)
+                                ).addChild(
+                                        listenerBuilder(HttpsListenerResourceDefinition.INSTANCE)
+                                                // xsd https-listener-type
+                                                .setMarshallDefaultValues(true)
+                                                .addAttributes(
+                                                        HttpsListenerResourceDefinition.SSL_CONTEXT,
+                                                        HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING,
+                                                        HttpListenerResourceDefinition.CERTIFICATE_FORWARDING,
+                                                        HttpsListenerResourceDefinition.SECURITY_REALM,
+                                                        HttpsListenerResourceDefinition.VERIFY_CLIENT,
+                                                        HttpsListenerResourceDefinition.ENABLED_CIPHER_SUITES,
+                                                        HttpsListenerResourceDefinition.ENABLED_PROTOCOLS,
+                                                        HttpsListenerResourceDefinition.ENABLE_HTTP2,
+                                                        HttpsListenerResourceDefinition.ENABLE_SPDY,
+                                                        HttpsListenerResourceDefinition.SSL_SESSION_CACHE_SIZE,
+                                                        HttpsListenerResourceDefinition.SSL_SESSION_TIMEOUT,
+                                                        HttpListenerResourceDefinition.HTTP2_ENABLE_PUSH,
+                                                        HttpListenerResourceDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_FRAME_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                                        HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11,
+                                                        HttpListenerResourceDefinition.PROXY_PROTOCOL)
+                                ).addChild(
+                                        builder(HostDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(HostDefinition.ALIAS,
+                                                        HostDefinition.DEFAULT_WEB_MODULE,
+                                                        HostDefinition.DEFAULT_RESPONSE_CODE,
+                                                        HostDefinition.DISABLE_CONSOLE_REDIRECT,
+                                                        HostDefinition.QUEUE_REQUESTS_ON_START)
+                                                .addChild(
+                                                        builder(LocationDefinition.INSTANCE.getPathElement())
+                                                                .addAttributes(LocationDefinition.HANDLER)
+                                                                .addChild(filterRefBuilder())
+                                                ).addChild(
+                                                builder(AccessLogDefinition.INSTANCE.getPathElement())
+                                                        .addAttributes(
+                                                                AccessLogDefinition.PATTERN,
+                                                                AccessLogDefinition.WORKER,
+                                                                AccessLogDefinition.DIRECTORY,
+                                                                AccessLogDefinition.RELATIVE_TO,
+                                                                AccessLogDefinition.PREFIX,
+                                                                AccessLogDefinition.SUFFIX,
+                                                                AccessLogDefinition.ROTATE,
+                                                                AccessLogDefinition.USE_SERVER_LOG,
+                                                                AccessLogDefinition.EXTENDED,
+                                                                AccessLogDefinition.PREDICATE)
+                                        ).addChild(filterRefBuilder())
+                                                .addChild(
+                                                    builder(UndertowExtension.PATH_SSO)
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.DOMAIN.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.PATH.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.HTTP_ONLY.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.SECURE.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.COOKIE_NAME.getDefinition())
+                                        ).addChild(builder(HttpInvokerDefinition.INSTANCE.getPathElement())
+                                            .addAttributes(HttpInvokerDefinition.PATH, HttpInvokerDefinition.HTTP_AUTHENTICATION_FACTORY, HttpInvokerDefinition.SECURITY_REALM))
+                                        )
+                )
+                .addChild(
+                        builder(ServletContainerDefinition.INSTANCE.getPathElement())
+                                .addAttribute(ServletContainerDefinition.ALLOW_NON_STANDARD_WRAPPERS)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_BUFFER_CACHE)
+                                .addAttribute(ServletContainerDefinition.STACK_TRACE_ON_ERROR)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_ENCODING)
+                                .addAttribute(ServletContainerDefinition.USE_LISTENER_ENCODING)
+                                .addAttribute(ServletContainerDefinition.IGNORE_FLUSH)
+                                .addAttribute(ServletContainerDefinition.EAGER_FILTER_INIT)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_SESSION_TIMEOUT)
+                                .addAttribute(ServletContainerDefinition.DISABLE_CACHING_FOR_SECURED_PAGES)
+                                .addAttribute(ServletContainerDefinition.DIRECTORY_LISTING)
+                                .addAttribute(ServletContainerDefinition.PROACTIVE_AUTHENTICATION)
+                                .addAttribute(ServletContainerDefinition.SESSION_ID_LENGTH)
+                                .addAttribute(ServletContainerDefinition.MAX_SESSIONS)
+                                .addAttribute(ServletContainerDefinition.DISABLE_FILE_WATCH_SERVICE)
+                                .addAttribute(ServletContainerDefinition.DISABLE_SESSION_ID_REUSE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_METADATA_SIZE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_MAX_FILE_SIZE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_TIME_TO_LIVE)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_COOKIE_VERSION)
+                                .addChild(
+                                        builder(JspDefinition.INSTANCE.getPathElement())
+                                                .setXmlElementName(Constants.JSP_CONFIG)
+                                                .addAttributes(
+                                                        JspDefinition.DISABLED,
+                                                        JspDefinition.DEVELOPMENT,
+                                                        JspDefinition.KEEP_GENERATED,
+                                                        JspDefinition.TRIM_SPACES,
+                                                        JspDefinition.TAG_POOLING,
+                                                        JspDefinition.MAPPED_FILE,
+                                                        JspDefinition.CHECK_INTERVAL,
+                                                        JspDefinition.MODIFICATION_TEST_INTERVAL,
+                                                        JspDefinition.RECOMPILE_ON_FAIL,
+                                                        JspDefinition.SMAP,
+                                                        JspDefinition.DUMP_SMAP,
+                                                        JspDefinition.GENERATE_STRINGS_AS_CHAR_ARRAYS,
+                                                        JspDefinition.ERROR_ON_USE_BEAN_INVALID_CLASS_ATTRIBUTE,
+                                                        JspDefinition.SCRATCH_DIR,
+                                                        JspDefinition.SOURCE_VM,
+                                                        JspDefinition.TARGET_VM,
+                                                        JspDefinition.JAVA_ENCODING,
+                                                        JspDefinition.X_POWERED_BY,
+                                                        JspDefinition.DISPLAY_SOURCE_FRAGMENT,
+                                                        JspDefinition.OPTIMIZE_SCRIPTLETS)
+                                )
+                                .addChild(
+                                        builder(SessionCookieDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        SessionCookieDefinition.NAME,
+                                                        SessionCookieDefinition.DOMAIN,
+                                                        SessionCookieDefinition.COMMENT,
+                                                        SessionCookieDefinition.HTTP_ONLY,
+                                                        SessionCookieDefinition.SECURE,
+                                                        SessionCookieDefinition.MAX_AGE
+                                                )
+                                )
+                                .addChild(
+                                        builder(PersistentSessionsDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PersistentSessionsDefinition.PATH,
+                                                        PersistentSessionsDefinition.RELATIVE_TO
+                                                )
+                                )
+                                .addChild(
+                                        builder(WebsocketsDefinition.INSTANCE.getPathElement())
+                                                .setMarshallDefaultValues(true)
+                                                .addAttributes(
+                                                        WebsocketsDefinition.WORKER,
+                                                        WebsocketsDefinition.BUFFER_POOL,
+                                                        WebsocketsDefinition.DISPATCH_TO_WORKER,
+                                                        WebsocketsDefinition.PER_MESSAGE_DEFLATE,
+                                                        WebsocketsDefinition.DEFLATER_LEVEL
+                                                )
+                                )
+                                .addChild(builder(MimeMappingDefinition.INSTANCE.getPathElement())
+                                        .setXmlWrapperElement("mime-mappings")
+                                        .addAttributes(
+                                                MimeMappingDefinition.VALUE
+                                        ))
+                                .addChild(builder(WelcomeFileDefinition.INSTANCE.getPathElement()).setXmlWrapperElement("welcome-files"))
+                                .addChild(builder(CrawlerSessionManagementDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(CrawlerSessionManagementDefinition.USER_AGENTS, CrawlerSessionManagementDefinition.SESSION_TIMEOUT))
+                )
+                .addChild(
+                        builder(HandlerDefinitions.INSTANCE.getPathElement())
+                                .setXmlElementName(Constants.HANDLERS)
+                                .setNoAddOperation(true)
+                                .addChild(
+                                        builder(FileHandler.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        FileHandler.PATH,
+                                                        FileHandler.CACHE_BUFFER_SIZE,
+                                                        FileHandler.CACHE_BUFFERS,
+                                                        FileHandler.DIRECTORY_LISTING,
+                                                        FileHandler.FOLLOW_SYMLINK,
+                                                        FileHandler.SAFE_SYMLINK_PATHS,
+                                                        FileHandler.CASE_SENSITIVE
+                                                )
+                                )
+                                .addChild(
+                                        builder(ReverseProxyHandler.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        ReverseProxyHandler.CONNECTIONS_PER_THREAD,
+                                                        ReverseProxyHandler.SESSION_COOKIE_NAMES,
+                                                        ReverseProxyHandler.PROBLEM_SERVER_RETRY,
+                                                        ReverseProxyHandler.MAX_REQUEST_TIME,
+                                                        ReverseProxyHandler.REQUEST_QUEUE_SIZE,
+                                                        ReverseProxyHandler.CACHED_CONNECTIONS_PER_THREAD,
+                                                        ReverseProxyHandler.CONNECTION_IDLE_TIMEOUT,
+                                                        ReverseProxyHandler.MAX_RETRIES)
+                                                .addChild(builder(ReverseProxyHandlerHost.INSTANCE.getPathElement())
+                                                        .setXmlElementName(Constants.HOST)
+                                                        .addAttributes(
+                                                                ReverseProxyHandlerHost.OUTBOUND_SOCKET_BINDING,
+                                                                ReverseProxyHandlerHost.SCHEME,
+                                                                ReverseProxyHandlerHost.PATH,
+                                                                ReverseProxyHandlerHost.INSTANCE_ID,
+                                                                ReverseProxyHandlerHost.SSL_CONTEXT,
+                                                                ReverseProxyHandlerHost.SECURITY_REALM,
+                                                                ReverseProxyHandlerHost.ENABLE_HTTP2))
+                                )
+
+
+                )
+                .addChild(
+                        builder(FilterDefinitions.INSTANCE.getPathElement())
+                                .setXmlElementName(Constants.FILTERS)
+                                .setNoAddOperation(true)
+                                .addChild(
+                                        builder(RequestLimitHandler.INSTANCE.getPathElement())
+                                                .addAttributes(RequestLimitHandler.MAX_CONCURRENT_REQUESTS, RequestLimitHandler.QUEUE_SIZE)
+                                ).addChild(
+                                builder(ResponseHeaderFilter.INSTANCE.getPathElement())
+                                        .addAttributes(ResponseHeaderFilter.NAME, ResponseHeaderFilter.VALUE)
+                        ).addChild(
+                                builder(GzipFilter.INSTANCE.getPathElement())
+                        ).addChild(
+                                builder(ErrorPageDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(ErrorPageDefinition.CODE, ErrorPageDefinition.PATH)
+                        ).addChild(
+                                builder(ModClusterDefinition.INSTANCE.getPathElement())
+                                .addAttributes(ModClusterDefinition.MANAGEMENT_SOCKET_BINDING,
+                                        ModClusterDefinition.ADVERTISE_SOCKET_BINDING,
+                                        ModClusterDefinition.SECURITY_KEY,
+                                        ModClusterDefinition.ADVERTISE_PROTOCOL,
+                                        ModClusterDefinition.ADVERTISE_PATH,
+                                        ModClusterDefinition.ADVERTISE_FREQUENCY,
+                                        ModClusterDefinition.FAILOVER_STRATEGY,
+                                        ModClusterDefinition.HEALTH_CHECK_INTERVAL,
+                                        ModClusterDefinition.BROKEN_NODE_TIMEOUT,
+                                        ModClusterDefinition.WORKER,
+                                        ModClusterDefinition.MAX_REQUEST_TIME,
+                                        ModClusterDefinition.MANAGEMENT_ACCESS_PREDICATE,
+                                        ModClusterDefinition.CONNECTIONS_PER_THREAD,
+                                        ModClusterDefinition.CACHED_CONNECTIONS_PER_THREAD,
+                                        ModClusterDefinition.CONNECTION_IDLE_TIMEOUT,
+                                        ModClusterDefinition.REQUEST_QUEUE_SIZE,
+                                        ModClusterDefinition.SSL_CONTEXT,
+                                        ModClusterDefinition.SECURITY_REALM,
+                                        ModClusterDefinition.USE_ALIAS,
+                                        ModClusterDefinition.ENABLE_HTTP2,
+                                        ModClusterDefinition.MAX_AJP_PACKET_SIZE,
+                                        ModClusterDefinition.HTTP2_ENABLE_PUSH,
+                                        ModClusterDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                        ModClusterDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                        ModClusterDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                        ModClusterDefinition.HTTP2_MAX_FRAME_SIZE,
+                                        ModClusterDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                        ModClusterDefinition.MAX_RETRIES)
+                        ).addChild(
+                                builder(CustomFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(CustomFilterDefinition.CLASS_NAME, CustomFilterDefinition.MODULE, CustomFilterDefinition.PARAMETERS)
+                                        .setXmlElementName("filter")
+                        ).addChild(
+                                builder(ExpressionFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(ExpressionFilterDefinition.EXPRESSION, ExpressionFilterDefinition.MODULE)
+                        ).addChild(
+                                builder(RewriteFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(RewriteFilterDefinition.TARGET, RewriteFilterDefinition.REDIRECT)
+                        )
+
+                )
+                .addChild(
+                        builder(ApplicationSecurityDomainDefinition.INSTANCE.getPathElement())
+                            .setXmlWrapperElement(Constants.APPLICATION_SECURITY_DOMAINS)
+                            .addAttribute(ApplicationSecurityDomainDefinition.HTTP_AUTHENTICATION_FACTORY)
+                            .addAttribute(ApplicationSecurityDomainDefinition.OVERRIDE_DEPLOYMENT_CONFIG)
+                            .addAttribute(ApplicationSecurityDomainDefinition.SECURITY_DOMAIN)
+                            .addAttribute(ApplicationSecurityDomainDefinition.ENABLE_JACC)
+                            .addAttribute(ApplicationSecurityDomainDefinition.ENABLE_JASPI)
+                            .addAttribute(ApplicationSecurityDomainDefinition.INTEGRATED_JASPI)
+                            .addChild(builder(UndertowExtension.PATH_SSO)
+                                    .addAttribute(SingleSignOnDefinition.Attribute.DOMAIN.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.PATH.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.HTTP_ONLY.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.SECURE.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.COOKIE_NAME.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.KEY_STORE.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.KEY_ALIAS.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.SSL_CONTEXT.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.CREDENTIAL.getDefinition(), AttributeParser.OBJECT_PARSER, AttributeMarshaller.ATTRIBUTE_OBJECT)
+                            )
+                )
+                 //here to make sure we always add filters & handlers path to mgmt model
+                .setAdditionalOperationsGenerator((address, addOperation, operations) -> {
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_FILTERS)));
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_HANDLERS)));
+                })
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+                return xmlDescription;
+        }
+
+    /** Registers attributes common across listener types */
+    private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder listenerBuilder(PersistentResourceDefinition resource) {
+        return builder(resource.getPathElement())
+                // xsd socket-optionsType
+                .addAttributes(
+                        ListenerResourceDefinition.RECEIVE_BUFFER,
+                        ListenerResourceDefinition.SEND_BUFFER,
+                        ListenerResourceDefinition.BACKLOG,
+                        ListenerResourceDefinition.KEEP_ALIVE,
+                        ListenerResourceDefinition.READ_TIMEOUT,
+                        ListenerResourceDefinition.WRITE_TIMEOUT,
+                        ListenerResourceDefinition.MAX_CONNECTIONS)
+                // xsd listener-type
+                .addAttributes(
+                        ListenerResourceDefinition.SOCKET_BINDING,
+                        ListenerResourceDefinition.WORKER,
+                        ListenerResourceDefinition.BUFFER_POOL,
+                        ListenerResourceDefinition.ENABLED,
+                        ListenerResourceDefinition.RESOLVE_PEER_ADDRESS,
+                        ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                        ListenerResourceDefinition.BUFFER_PIPELINED_DATA,
+                        ListenerResourceDefinition.MAX_HEADER_SIZE,
+                        ListenerResourceDefinition.MAX_PARAMETERS,
+                        ListenerResourceDefinition.MAX_HEADERS,
+                        ListenerResourceDefinition.MAX_COOKIES,
+                        ListenerResourceDefinition.ALLOW_ENCODED_SLASH,
+                        ListenerResourceDefinition.DECODE_URL,
+                        ListenerResourceDefinition.URL_CHARSET,
+                        ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE,
+                        ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE,
+                        ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                        ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE,
+                        ListenerResourceDefinition.NO_REQUEST_TIMEOUT,
+                        ListenerResourceDefinition.REQUEST_PARSE_TIMEOUT,
+                        ListenerResourceDefinition.DISALLOWED_METHODS,
+                        ListenerResourceDefinition.SECURE,
+                        ListenerResourceDefinition.RFC6265_COOKIE_VALIDATION,
+                        ListenerResourceDefinition.ALLOW_UNESCAPED_CHARACTERS_IN_URL);
+    }
+
+    private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder filterRefBuilder() {
+        return builder(FilterRefDefinition.INSTANCE.getPathElement())
+                .addAttributes(FilterRefDefinition.PREDICATE, FilterRefDefinition.PRIORITY);
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_9_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_9_0.java
@@ -135,6 +135,16 @@ public class UndertowSubsystemParser_9_0 extends PersistentResourceXMLParser {
                                                                 AccessLogDefinition.USE_SERVER_LOG,
                                                                 AccessLogDefinition.EXTENDED,
                                                                 AccessLogDefinition.PREDICATE)
+                                        ).addChild(
+                                                builder(ConsoleAccessLogDefinition.INSTANCE.getPathElement())
+                                                    .addAttributes(
+                                                            ExchangeAttributeDefinitions.ATTRIBUTES,
+                                                            ConsoleAccessLogDefinition.INCLUDE_HOST_NAME,
+                                                            AccessLogDefinition.PATTERN,
+                                                            AccessLogDefinition.WORKER,
+                                                            ConsoleAccessLogDefinition.METADATA,
+                                                            AccessLogDefinition.PREDICATE
+                                                    )
                                         ).addChild(filterRefBuilder())
                                                 .addChild(
                                                     builder(UndertowExtension.PATH_SSO)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
@@ -22,9 +22,9 @@
 
 package org.wildfly.extension.undertow;
 
-import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.SECURITY_DOMAIN;
 import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.ENABLE_JASPI;
 import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.INTEGRATED_JASPI;
+import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.SECURITY_DOMAIN;
 import static org.wildfly.extension.undertow.Constants.ENABLE_HTTP2;
 import static org.wildfly.extension.undertow.HostDefinition.QUEUE_REQUESTS_ON_START;
 import static org.wildfly.extension.undertow.HttpListenerResourceDefinition.CERTIFICATE_FORWARDING;
@@ -78,6 +78,7 @@ public class UndertowTransformers implements ExtensionTransformerRegistration {
     private static ModelVersion MODEL_VERSION_EAP7_0_0 = ModelVersion.create(3, 1, 0);
     private static ModelVersion MODEL_VERSION_EAP7_1_0 = ModelVersion.create(4, 0, 0);
     private static ModelVersion MODEL_VERSION_EAP7_2_0 = ModelVersion.create(7, 0, 0);
+    private static final ModelVersion MODEL_VERSION_WILDFLY_16 = ModelVersion.create(8, 0, 0);
 
     @Override
     public String getSubsystemName() {
@@ -89,11 +90,19 @@ public class UndertowTransformers implements ExtensionTransformerRegistration {
 
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemRegistration.getCurrentSubsystemVersion());
 
-        registerTransformers_EAP_7_2_0(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), MODEL_VERSION_EAP7_2_0));
+        registerTransformersWildFly16(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), MODEL_VERSION_WILDFLY_16));
+        registerTransformers_EAP_7_2_0(chainedBuilder.createBuilder(MODEL_VERSION_WILDFLY_16, MODEL_VERSION_EAP7_2_0));
         registerTransformers_EAP_7_1_0(chainedBuilder.createBuilder(MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0));
         registerTransformers_EAP_7_0_0(chainedBuilder.createBuilder(MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0));
 
-        chainedBuilder.buildAndRegister(subsystemRegistration, new ModelVersion[]{MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0});
+        chainedBuilder.buildAndRegister(subsystemRegistration, new ModelVersion[]{MODEL_VERSION_WILDFLY_16, MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0});
+    }
+
+    private static void registerTransformersWildFly16(ResourceTransformationDescriptionBuilder subsystemBuilder) {
+        subsystemBuilder
+                .addChildResource(UndertowExtension.SERVER_PATH)
+                .addChildResource(UndertowExtension.HOST_PATH)
+                .rejectChildResource(ConsoleAccessLogDefinition.INSTANCE.getPathElement());
     }
 
     private static void registerTransformers_EAP_7_2_0(ResourceTransformationDescriptionBuilder subsystemBuilder) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -410,4 +410,10 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 101, value = "Duplicate servlet mapping %s found")
     void duplicateServletMapping(String mapping);
+
+    @Message(id = 102, value = "The pattern %s is not a valid date pattern.")
+    OperationFailedException invalidDateTimeFormatterPattern(String pattern);
+
+    @Message(id = 103, value = "The time zone id %s is invalid.")
+    OperationFailedException invalidTimeZoneId(String zoneId);
 }

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -118,6 +118,68 @@ undertow.access-log.use-server-log=If the log should be written to the server lo
 undertow.access-log.relative-to=The directory the path is relative to
 undertow.access-log.extended=If the log uses the extended log file format
 undertow.access-log.predicate=Predicate that determines if the request should be logged
+undertow.console-access-log=Allows the access log to be written to the console.
+undertow.console-access-log.add=Adds an access logger which writes to the console. The data is written in a JSON format.
+undertow.console-access-log.remove=Stops the access logger from writing to the console.
+undertow.console-access-log.attributes=The attributes to be included in the structured output.
+undertow.console-access-log.attributes.authentication-type=The authentication type used.
+undertow.console-access-log.attributes.bytes-sent=The number of bytes, excluding HTTP headers, sent.
+undertow.console-access-log.attributes.date-time=The date and time.
+undertow.console-access-log.attributes.date-format=The pattern, in the SimpleDateFormatter pattern, used to \
+  format the date with.
+undertow.console-access-log.attributes.time-zone=The time zone used to format the date and/or time assuming the date \
+  format was defined. This must be a valid java.util.TimeZone.
+undertow.console-access-log.attributes.host-and-port=The host and port for the request.
+undertow.console-access-log.attributes.local-ip=The IP address of the local connection.
+undertow.console-access-log.attributes.local-port=The port of the local connection.
+undertow.console-access-log.attributes.local-server-name=The local server name.
+undertow.console-access-log.attributes.path-parameter=The name of a parameter in the path. Note that the key for the \
+  structured output will be the parameter name and the value will be the value of of the parameter.
+undertow.console-access-log.attributes.predicate=The name of the predicate context. Note that the key will be the name \
+  of the predicate and the value will be the resolved from the predicate context.
+undertow.console-access-log.attributes.query-parameter=The name of a query parameter. Note that the key for the \
+  structured output will be the query parameter name.
+undertow.console-access-log.attributes.query-string=The query string.
+undertow.console-access-log.attributes.include-question-mark=Indicates whether or not the query string should be include the \
+  question mark.
+undertow.console-access-log.attributes.relative-path=The relative path of the request.
+undertow.console-access-log.attributes.remote-host=The remote host name.
+undertow.console-access-log.attributes.remote-ip=The remote IP address.
+undertow.console-access-log.attributes.remote-user=Remote user that was authenticated.
+undertow.console-access-log.attributes.request-header=The name of a request header. Note that the key for the \
+  structured data will be the headers name and the value will be the value of the header.
+undertow.console-access-log.attributes.request-line=The request line.
+undertow.console-access-log.attributes.request-method=The request method.
+undertow.console-access-log.attributes.request-path=The relative path for the request.
+undertow.console-access-log.attributes.request-protocol=The protocol for the request.
+undertow.console-access-log.attributes.request-scheme=The request URI's scheme.
+undertow.console-access-log.attributes.request-url=The original request URI. This will include the host name, protocol \
+  etc. if it was specified by the client.
+undertow.console-access-log.attributes.resolved-path=The resolved path.
+undertow.console-access-log.attributes.response-code=The response code.
+undertow.console-access-log.attributes.response-header=The name of the response header. Note the key for the \
+  structured data will be the header name and the value will be the value of the header.
+undertow.console-access-log.attributes.response-reason-phrase=The text reason for the response code.
+undertow.console-access-log.attributes.response-time=The time used to process the request.
+undertow.console-access-log.attributes.time-unit=The unit of time used for the response time.
+undertow.console-access-log.attributes.secure-exchange=Indicates whether or not the exchange was secure.
+undertow.console-access-log.attributes.ssl-cipher=The SSL cipher.
+undertow.console-access-log.attributes.ssl-client-cert=The SSL client certificate.
+undertow.console-access-log.attributes.ssl-session-id=The SSL session id.
+undertow.console-access-log.attributes.stored-response=The stored response.
+undertow.console-access-log.attributes.thread-name=The thread name of the current thread.
+undertow.console-access-log.attributes.transport-protocol=The protocol used to transmit messages on this connection.
+undertow.console-access-log.attributes.key=The key for the structured output.
+undertow.console-access-log.attributes.key-prefix=The prefix used to help keep unique keys. The name will be appended \
+  to the prefix if the prefix is defined. Otherwise just the name will be used as the key for the structured data.
+undertow.console-access-log.attributes.names=A list of names used to resolve the exchange values.
+undertow.console-access-log.attributes.obfuscated=Indicates whether or not the IP address should be obfuscated.
+undertow.console-access-log.include-host-name=Indicates whether or not the host name should included in the JSON \
+  structured output. If set to true the key will be hostName in the structured data and the value will be the host \
+  this console-access-log belongs to.
+undertow.console-access-log.metadata=Any additional metadata to add to the JSON structured output.
+undertow.console-access-log.predicate=Predicate that determines if the request should be logged.
+undertow.console-access-log.worker=Name of the worker to use for logging.
 undertow.single-sign-on=An SSO authentication mechanism configuration.
 undertow.single-sign-on.add=Adds an SSO authentication mechanism.
 undertow.single-sign-on.remove=Removes the SSO authentication mechanism.

--- a/undertow/src/main/resources/schema/wildfly-undertow_9_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_9_0.xsd
@@ -169,7 +169,7 @@
                             Reference to the SSLContext that should be used by this listener.
 
                             If neither ssl-context or security-realm are set the JVM wide default SSLContext will be used instead.
-                            
+
                             If this attribute is defined, the attributes 'verify-client', 'enabled-cipher-suites', 'enabled-protocols',
                             'ssl-session-cache-size', and 'ssl-session-timeout' must not be set.
                         </xs:documentation>
@@ -298,6 +298,7 @@
         <xs:sequence>
             <xs:element name="location" type="locationType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="access-log" type="accessLogType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="console-access-log" type="consoleAccessLogType" minOccurs="0"/>
             <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="single-sign-on" minOccurs="0" maxOccurs="1" type="singleSignOnType"/>
             <xs:element name="http-invoker" minOccurs="0" maxOccurs="1" type="http-invokerType"/>
@@ -420,6 +421,259 @@
         <xs:attribute name="extended" use="optional" type="xs:string" default="false" />
         <xs:attribute name="predicate" use="optional" type="xs:string" />
     </xs:complexType>
+    <xs:complexType name="consoleAccessLogType">
+        <xs:sequence minOccurs="0">
+            <xs:element name="attributes" type="attributesType" minOccurs="0"/>
+            <xs:element name="metadata" type="propertiesType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="include-host-name" type="xs:boolean" default="true"/>
+        <xs:attribute name="worker" type="xs:string" default="default"/>
+        <xs:attribute name="predicate" type="xs:string" />
+    </xs:complexType>
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form meta-data properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="attributesType">
+        <xs:annotation>
+            <xs:documentation>
+                The available attributes to be included in the structured access log output.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="authentication-type" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="bytes-sent" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="date-time" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="date-format" type="xs:string"/>
+                    <xs:attribute name="time-zone" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="host-and-port" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-ip" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-port" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="local-server-name" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="path-parameter" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="predicate" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="query-parameter" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="query-string" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="include-question-mark" type="xs:boolean" default="false"/>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="relative-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-host" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-ip" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="obfuscated" type="xs:boolean" default="false"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="remote-user" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-header" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-line" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-method" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-scheme" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="request-url" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="resolved-path" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-code" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-header" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="name" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="value" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="key-prefix"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-reason-phrase" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="response-time" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                    <xs:attribute name="time-unit" default="MILLISECONDS">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="NANOSECONDS"/>
+                                <xs:enumeration value="MICROSECONDS"/>
+                                <xs:enumeration value="MILLISECONDS"/>
+                                <xs:enumeration value="SECONDS"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="secure-exchange" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-cipher" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-client-cert" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ssl-session-id" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="stored-response" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="thread-name" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="transport-protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="key" type="xs:string"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
     <xs:complexType name="errorPageType">
         <xs:attribute name="name" use="required" type="xs:string"/>
         <xs:attribute name="code" use="required" type="xs:string"/>
@@ -708,10 +962,10 @@
         <xs:attribute name="security-domain" type="xs:string">
             <xs:annotation>
                 <xs:documentation>
-                    Reference to the security-domain that should be associated with the deployment, where a 
+                    Reference to the security-domain that should be associated with the deployment, where a
                     security-domain is referenced instead of a http-authentication-factory the authentication mechanisms
                     BASIC, DIGEST, FORM and CLIENT_CERT will be availble for the deployment to use - additionally the deployment
-                    can make use of the programatic login API. 
+                    can make use of the programatic login API.
 
                     Exactly one of http-authentication-factory or security-domain must be defined.
                 </xs:documentation>
@@ -736,8 +990,8 @@
             <xs:annotation>
                 <xs:documentation>
                     When integrated-jaspi is enabled during JASPI authentication the resulting
-                    identity will be loaded from the SecurityDomain referenced by the deployment, if 
-                    this is switched off AdHoc identities will be created instead. 
+                    identity will be loaded from the SecurityDomain referenced by the deployment, if
+                    this is switched off AdHoc identities will be created instead.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/undertow/src/main/resources/schema/wildfly-undertow_9_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_9_0.xsd
@@ -1,0 +1,814 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:undertow:9.0"
+           targetNamespace="urn:jboss:domain:undertow:9.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+    <!-- The undertow subsystem root element -->
+    <xs:element name="subsystem" type="undertow-subsystemType"/>
+
+    <xs:complexType name="undertow-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the undertow subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="byte-buffer-pool" type="byte-buffer-poolType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="buffer-cache" type="buffer-cacheType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="server" type="serverType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="servlet-container" type="servletContainerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="handlers" type="handlerType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="filters" type="filterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="application-security-domains" type="applicationSecurityDomainsType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="default-server" type="xs:string" default="default-server"/>
+        <xs:attribute name="default-virtual-host" type="xs:string" default="default-host"/>
+        <xs:attribute name="default-servlet-container" type="xs:string" default="default"/>
+        <xs:attribute name="instance-id" type="xs:string" use="optional"/>
+        <xs:attribute name="default-security-domain" type="xs:string" use="optional" default="other"/>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+          <xs:annotation>
+            <xs:documentation>Whether statistics are to be gathered for undertow subsystem.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="serverType">
+        <xs:sequence>
+            <xs:element name="ajp-listener" type="ajp-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-listener" type="http-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="https-listener" type="https-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="host" type="hostType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="default-host" use="optional" type="xs:string" default="default-host"/>
+        <xs:attribute name="servlet-container" use="optional" type="xs:string" default="default"/>
+    </xs:complexType>
+
+    <xs:complexType name="socket-options-type">
+        <xs:attribute name="receive-buffer" type="xs:int"/>
+        <xs:attribute name="send-buffer" type="xs:int"/>
+        <xs:attribute name="tcp-backlog" type="xs:int" default="10000"/>
+        <xs:attribute name="tcp-keep-alive" type="xs:boolean"/>
+        <xs:attribute name="read-timeout" type="xs:long"/>
+        <xs:attribute name="write-timeout" type="xs:long"/>
+        <xs:attribute name="max-connections" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="listener-type">
+        <xs:complexContent>
+            <xs:extension base="socket-options-type">
+                <xs:attribute name="name" use="required" type="xs:string"/>
+                <xs:attribute name="socket-binding" use="required" type="xs:string"/>
+                <xs:attribute name="worker" type="xs:string" default="default"/>
+                <xs:attribute name="buffer-pool" type="xs:string" default="default"/>
+                <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+                <xs:attribute name="resolve-peer-address" type="xs:boolean" default="false"/>
+                <xs:attribute name="max-post-size" type="xs:long" default="10485760"/>
+                <xs:attribute name="buffer-pipelined-data" type="xs:boolean" default="false"/>
+                <xs:attribute name="max-header-size" type="xs:long" default="1048576"/>
+                <xs:attribute name="max-parameters" type="xs:long" default="1000"/>
+                <xs:attribute name="max-headers" type="xs:long" default="200"/>
+                <xs:attribute name="max-cookies" type="xs:long" default="200"/>
+                <xs:attribute name="allow-encoded-slash" type="xs:boolean" default="false"/>
+                <xs:attribute name="decode-url" type="xs:boolean" default="true"/>
+                <xs:attribute name="url-charset" type="xs:string" default="UTF-8"/>
+                <xs:attribute name="always-set-keep-alive" type="xs:boolean" default="true"/>
+                <xs:attribute name="max-buffered-request-size" type="xs:long" default="16384"/>
+                <xs:attribute name="record-request-start-time" type="xs:boolean" default="false"/>
+                <xs:attribute name="allow-equals-in-cookie-value" type="xs:boolean" default="false"/>
+                <xs:attribute name="no-request-timeout" type="xs:int" default="60000"/>
+                <xs:attribute name="request-parse-timeout" type="xs:int"/>
+                <xs:attribute name="disallowed-methods" type="stringList" default="TRACE"/>
+                <xs:attribute name="secure" type="xs:boolean" default="false"/>
+                <xs:attribute name="rfc6265-cookie-validation" type="xs:boolean" default="false"/>
+                <xs:attribute name="allow-unescaped-characters-in-url" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+               <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT
+                                attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                undertow will automatically redirect the request to the socket binding port specified here.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="enable-http2" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              Enables HTTP2 upgrade and prior knowledge connections
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+                <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+                <xs:attribute name="require-host-http11" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="proxy-protocol" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="https-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SSLContext that should be used by this listener.
+
+                            If neither ssl-context or security-realm are set the JVM wide default SSLContext will be used instead.
+                            
+                            If this attribute is defined, the attributes 'verify-client', 'enabled-cipher-suites', 'enabled-protocols',
+                            'ssl-session-cache-size', and 'ssl-session-timeout' must not be set.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="certificate-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT
+                                                attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="security-realm" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the legacy security realm to use to obtain an SSLContext.
+
+                            If neither ssl-context or security-realm are set the JVM wide default SSLContext will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="verify-client" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-cipher-suites" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-protocols" use="optional" type="xs:string"/>
+                <xs:attribute name="enable-http2" use="optional" type="xs:string"/>
+                <xs:attribute name="enable-spdy" use="optional" type="xs:string"/>
+                <xs:attribute name="ssl-session-cache-size" use="optional" type="xs:string"/>
+                <xs:attribute name="ssl-session-timeout" use="optional" type="xs:string"/>
+                <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+                <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+                <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+                <xs:attribute name="require-host-http11" type="xs:boolean" use="optional" default="false"/>
+                <xs:attribute name="proxy-protocol" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ajp-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="scheme" type="xs:string"/>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                                undertow will automatically redirect the request to the socket binding port specified here.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="max-ajp-packet-size" type="xs:int"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="servletContainerType">
+        <xs:sequence>
+            <xs:element name="jsp-config" type="jsp-configurationType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="session-cookie" type="session-cookieType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="persistent-sessions" type="persistent-sessionsType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="websockets" type="websocketsType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="mime-mappings" type="mime-mappingsType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="welcome-files" type="welcome-filesType" maxOccurs="1" minOccurs="0" />
+            <xs:element name="crawler-session-management" type="crawler-session-managementType" maxOccurs="1" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="allow-non-standard-wrappers" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-buffer-cache" use="optional" type="xs:string"/>
+        <xs:attribute name="stack-trace-on-error" use="optional" default="local-only"/>
+        <xs:attribute name="default-encoding" type="xs:string" use="optional"/>
+        <xs:attribute name="use-listener-encoding" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="ignore-flush" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="eager-filter-initialization" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="default-session-timeout" type="xs:integer" use="optional" default="30"/>
+        <xs:attribute name="disable-caching-for-secured-pages" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="directory-listing" type="xs:boolean" use="optional" />
+        <xs:attribute name="proactive-authentication" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="session-id-length" type="xs:int" use="optional" default="30" />
+        <xs:attribute name="max-sessions" type="xs:int" use="optional" />
+        <xs:attribute name="disable-file-watch-service" type="xs:boolean" use="optional" />
+        <xs:attribute name="disable-session-id-reuse" type="xs:boolean" use="optional" />
+        <xs:attribute name="file-cache-max-file-size" type="xs:integer" use="optional" default="10485760"/>
+        <xs:attribute name="file-cache-metadata-size" type="xs:integer" use="optional" default="100"/>
+        <xs:attribute name="file-cache-time-to-live" type="xs:integer" use="optional"/>
+        <xs:attribute name="default-cookie-version" type="xs:integer"  use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="mime-mappingsType">
+        <xs:sequence>
+            <xs:element name="mime-mapping" type="mime-mappingType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mime-mappingType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="welcome-filesType">
+        <xs:sequence>
+            <xs:element name="welcome-file" type="welcome-fileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="welcome-fileType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="hostType">
+        <xs:sequence>
+            <xs:element name="location" type="locationType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="access-log" type="accessLogType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="single-sign-on" minOccurs="0" maxOccurs="1" type="singleSignOnType"/>
+            <xs:element name="http-invoker" minOccurs="0" maxOccurs="1" type="http-invokerType"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="alias" use="optional" type="xs:string"/>
+        <xs:attribute name="default-web-module" use="optional" type="xs:string" default="ROOT.war"/>
+        <xs:attribute name="default-response-code" use="optional" type="xs:int" default="404">
+            <xs:annotation>
+                <xs:documentation>Default response code should be set in case server should respond with nonstandard code( other than 404 ) for unavailable resource.
+                    For instance, server behind load balancer might want to respond with 5xx code to avoid being dropped by it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="disable-console-redirect" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="queue-requests-on-start" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="http-invokerType">
+        <xs:attribute name="path" use="optional" type="xs:string" default="wildfly-services"/>
+        <xs:attribute name="http-authentication-factory" type="xs:string" use="optional"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="websocketsType">
+        <xs:attribute name="worker" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="buffer-pool" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="dispatch-to-worker" use="optional" type="xs:boolean" default="true"/>
+        <xs:attribute name="per-message-deflate" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="deflater-level" use="optional" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="crawler-session-managementType">
+        <xs:attribute name="user-agents" use="optional" type="xs:string"/>
+        <xs:attribute name="session-timeout" use="optional" type="xs:integer"/>
+    </xs:complexType>
+
+    <xs:complexType name="jsp-configurationType">
+        <xs:attribute name="disabled" default="false" type="xs:boolean"/>
+        <xs:attribute name="development" default="false" type="xs:boolean"/>
+        <xs:attribute name="keep-generated" default="true" type="xs:boolean"/>
+        <xs:attribute name="trim-spaces" default="false" type="xs:boolean"/>
+        <xs:attribute name="tag-pooling" default="true" type="xs:boolean"/>
+        <xs:attribute name="mapped-file" default="true" type="xs:boolean"/>
+        <xs:attribute name="check-interval" default="0" type="xs:int"/>
+        <xs:attribute name="modification-test-interval" default="4" type="xs:int"/>
+        <xs:attribute name="recompile-on-fail" default="false" type="xs:boolean"/>
+        <xs:attribute name="smap" default="true" type="xs:boolean"/>
+        <xs:attribute name="dump-smap" default="false" type="xs:boolean"/>
+        <xs:attribute name="generate-strings-as-char-arrays" default="false" type="xs:boolean"/>
+        <xs:attribute name="error-on-use-bean-invalid-class-attribute" default="false" type="xs:boolean"/>
+        <xs:attribute name="scratch-dir" type="xs:string"/>
+        <xs:attribute name="source-vm" default="1.8" type="xs:string"/>
+        <xs:attribute name="target-vm" default="1.8" type="xs:string"/>
+        <xs:attribute name="java-encoding" default="UTF8" type="xs:string"/>
+        <xs:attribute name="x-powered-by" default="true" type="xs:boolean"/>
+        <xs:attribute name="display-source-fragment" default="true" type="xs:boolean"/>
+        <xs:attribute name="optimize-scriptlets" default="false" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="session-cookieType">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="domain" type="xs:string"/>
+        <xs:attribute name="comment" type="xs:string"/>
+        <xs:attribute name="http-only" type="xs:boolean"/>
+        <xs:attribute name="secure" type="xs:boolean"/>
+        <xs:attribute name="max-age" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="persistent-sessionsType">
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                  The path to store the session data. If not specified the data will just be stored in memory only.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerType">
+        <xs:sequence>
+            <xs:element name="file" type="file-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reverse-proxy" type="reverse-proxy-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:complexType name="filterType">
+        <xs:sequence>
+            <xs:element name="request-limit" type="request-limitType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="response-header" type="response-headerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="gzip" type="gzipType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="error-page" type="errorPageType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="mod-cluster" type="modClusterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="filter" type="customFilterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="expression-filter" type="expressionFilterType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="rewrite" type="rewriteFilterType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="locationType">
+        <xs:sequence>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="handler" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="accessLogType">
+        <xs:attribute name="pattern" use="optional" type="xs:string" default="common"/>
+        <xs:attribute name="worker" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="directory" use="optional" type="xs:string" default="${jboss.server.log.dir}"/>
+        <xs:attribute name="relative-to" use="optional" type="xs:string" />
+        <xs:attribute name="prefix" use="optional" type="xs:string" default="access_log."/>
+        <xs:attribute name="suffix" use="optional" type="xs:string" default="log"/>
+        <xs:attribute name="rotate" use="optional" type="xs:string" default="true"/>
+        <xs:attribute name="use-server-log" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="extended" use="optional" type="xs:string" default="false" />
+        <xs:attribute name="predicate" use="optional" type="xs:string" />
+    </xs:complexType>
+    <xs:complexType name="errorPageType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="code" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+
+
+    <xs:complexType name="customFilterType">
+        <xs:sequence>
+            <xs:element name="param" type="paramType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="class-name" use="required" type="xs:string"/>
+        <xs:attribute name="module" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="expressionFilterType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="expression" use="required" type="xs:string"/>
+        <xs:attribute name="module" use="optional" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="rewriteFilterType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="target" use="required" type="xs:string"/>
+        <xs:attribute name="redirect" use="optional" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="file-handlerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+        <xs:attribute name="cache-buffer-size" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="cache-buffers" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="directory-listing" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="follow-symlink" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="safe-symlink-paths" use="optional" type="stringList"/>
+        <xs:attribute name="case-sensitive" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:simpleType name="stringList">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="reverse-proxy-handlerType">
+        <xs:sequence>
+            <xs:element name="host" type="reverse-proxy-hostType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="connections-per-thread" use="optional" type="xs:integer"/>
+        <xs:attribute name="session-cookie-names" use="optional" type="xs:string"/>
+        <xs:attribute name="problem-server-retry" use="optional" type="xs:integer"/>
+        <xs:attribute name="max-request-time" use="optional" type="xs:integer"/>
+        <xs:attribute name="request-queue-size" use="optional" type="xs:integer"/>
+        <xs:attribute name="cached-connections-per-thread" use="optional" type="xs:integer"/>
+        <xs:attribute name="connection-idle-timeout" use="optional" type="xs:integer"/>
+        <xs:attribute name="max-retries" type="xs:int" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="reverse-proxy-hostType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="outbound-socket-binding" use="required" type="xs:string"/>
+        <xs:attribute name="scheme" use="optional" type="xs:string" default="http"/>
+        <xs:attribute name="path" use="optional" type="xs:string" default=""/>
+        <xs:attribute name="instance-id" use="optional" type="xs:string"/>
+        <xs:attribute name="ssl-context" type="xs:string" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional" />
+        <xs:attribute name="enable-http2" type="xs:boolean" use="optional" default="false" />
+    </xs:complexType>
+
+    <xs:complexType name="filter-refType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="predicate" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                          Predicates provide a simple way of making a true/false decision  based on an exchange. Many handlers have a requirement that they be applied conditionally, and predicates provide a general way to specify a condition. Predicates can be created programatically (they are just java classes that implement the Predicate interface), however there is also a simple language for specifying a predicate. Some examples below:
+                          regex['/resources/*.\.css'] - regular expression match of the relative URL
+                          regex[pattern='text/.*', value='%{i,Content-Type}, full-match=true] - Matches requests with a text/.* content type
+                          equals[{'%{i,Content-Type}', 'text/xml'}] - Matches if the content type header is text/xml
+                          contains[search='MSIE', value='%{i,User-Agent}'] and path-suffix['.js'] - User agent contains MSIE and request URL ends with .js
+                          regex['/resources/(*.)\.css'] and equals[{'$1', 'myCssFile'}] - regex match, with a reference to match group 1 later in the expression
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="priority" use="optional" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="singleSignOnType">
+        <xs:attribute name="domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie domain to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie path to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-only" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie httpOnly attribute
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="secure" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie secure attribute
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cookie-name" type="xs:string" default="JSESSIONIDSSO">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cooke name
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="buffer-cacheType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                  A buffer cache. I cache consists of 1 or more regions, that are split up into smaller buffers.
+                  The total cache size is the buffer size * the buffers per region * the number of regions.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:string"/>
+        <xs:attribute name="buffers-per-region" use="optional" type="xs:string"/>
+        <xs:attribute name="max-regions" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="byte-buffer-poolType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The buffer pool used for IO operations
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:int"/>
+        <xs:attribute name="direct" use="optional" type="xs:boolean"/>
+        <xs:attribute name="thread-local-cache-size" use="optional" type="xs:int"/>
+        <xs:attribute name="max-pool-size" use="optional" type="xs:int"/>
+        <xs:attribute name="leak-detection-percent" use="optional" type="xs:int"/>
+    </xs:complexType>
+    <xs:complexType name="request-limitType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="max-concurrent-requests" use="required" type="xs:integer"/>
+        <xs:attribute name="queue-size" use="optional" type="xs:integer" default="0"/>
+    </xs:complexType>
+    <xs:complexType name="response-headerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="header-name" use="required" type="xs:string"/>
+        <xs:attribute name="header-value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="gzipType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="modClusterType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="management-socket-binding" type="xs:string" use="required"/>
+        <xs:attribute name="advertise-socket-binding" type="xs:string" use="optional"/>
+        <xs:attribute name="security-key" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-protocol" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-path" type="xs:string" use="optional"/>
+        <xs:attribute name="advertise-frequency" type="xs:int" use="optional"/>
+        <xs:attribute name="failover-strategy" type="failoverStrategy" default="LOAD_BALANCED" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Determines how a failover node is chosen, in the event that the node to which a session has affinity is not available.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="health-check-interval" type="xs:int" use="optional"/>
+        <xs:attribute name="broken-node-timeout" type="xs:int" use="optional"/>
+        <xs:attribute name="worker" type="xs:string" use="optional" />
+        <xs:attribute name="max-request-time" type="xs:int" use="optional"/>
+        <xs:attribute name="management-access-predicate" type="xs:string" use="optional"/>
+        <xs:attribute name="connections-per-thread" type="xs:int" use="optional" />
+        <xs:attribute name="cached-connections-per-thread" type="xs:int" use="optional" />
+        <xs:attribute name="connection-idle-timeout" type="xs:int" use="optional" />
+        <xs:attribute name="request-queue-size" type="xs:int" use="optional" />
+        <xs:attribute name="ssl-context" type="xs:string" />
+        <xs:attribute name="security-realm" type="xs:string" use="optional" />
+        <xs:attribute name="use-alias" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="enable-http2" type="xs:string" use="optional" default="false" />
+        <xs:attribute name="max-ajp-packet-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-enable-push" type="xs:boolean" use="optional" />
+        <xs:attribute name="http2-header-table-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-initial-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-concurrent-streams" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-frame-size" type="xs:int" use="optional" />
+        <xs:attribute name="http2-max-header-list-size" type="xs:int" use="optional" />
+        <xs:attribute name="max-retries" type="xs:int" use="optional" />
+    </xs:complexType>
+
+    <xs:simpleType name="failoverStrategy">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="LOAD_BALANCED">
+                <xs:annotation>
+                    <xs:documentation>
+                        Failover target chosen via load balancing mechanism.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="DETERMINISTIC">
+                <xs:annotation>
+                    <xs:documentation>
+                        Failover target chosen deterministically from the associated session identifier.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="applicationSecurityDomainsType">
+        <xs:annotation>
+            <xs:documentation>
+                Listing of security domains from applications that should be mapped to an Elytron
+                backed authentication policy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="application-security-domain" type="applicationSecurityDomainType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="applicationSecurityDomainType">
+        <xs:sequence>
+            <xs:element name="single-sign-on" type="applicationSecurityDomainSingleSignOnType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the security domain as specified in deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-authentication-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the HttpAuthenticationFactory that should be used.
+
+                    Exactly one of http-authentication-factory or security-domain must be defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="override-deployment-config" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    The references HttpServerAuthenticationMechanismFactory contains it's own policy configuration
+                    to control the authentication mechanisms it supports, if this attribute is set to 'true'
+                    that policy will override the methods specified within the deployment.
+
+                    This attribute can only be specified if a http-authentication-factory is also specified.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the security-domain that should be associated with the deployment, where a 
+                    security-domain is referenced instead of a http-authentication-factory the authentication mechanisms
+                    BASIC, DIGEST, FORM and CLIENT_CERT will be availble for the deployment to use - additionally the deployment
+                    can make use of the programatic login API. 
+
+                    Exactly one of http-authentication-factory or security-domain must be defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-jacc" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable authorization using JACC.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-jaspi" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Should deployments matching against this 'application-security-domain' have
+                    JASPI enabled, by setting to false JASPI will be completely disabled for the deployment.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="integrated-jaspi" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    When integrated-jaspi is enabled during JASPI authentication the resulting
+                    identity will be loaded from the SecurityDomain referenced by the deployment, if 
+                    this is switched off AdHoc identities will be created instead. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="applicationSecurityDomainSingleSignOnType">
+        <xs:complexContent>
+            <xs:extension base="singleSignOnType">
+                <xs:sequence>
+                    <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0"/>
+                </xs:sequence>
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References key store containing the key used to sign and verify logout requests.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-alias" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The alias of the key used to sign and verify logout requests.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="client-ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The ssl context used to secure back-channel logout connections.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- Copied from elytron subsystem schema -->
+    <xs:attributeGroup name="credentialReferenceStoreBased">
+        <xs:annotation>
+            <xs:documentation>
+                Group of attributes used when referencing credential through credential store.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential store name used to fetch credential with given 'alias' from.
+                    Credential store name has to be defined elsewhere.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Alias of credential in the credential store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Type of credential to be fetched from credential store.
+                    It is usually fully qualified class name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:complexType name="credentialReferenceType">
+        <xs:attributeGroup ref="credentialReferenceStoreBased"/>
+        <xs:attribute name="clear-text" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential/password in clear text. Use just for testing purpose.
+                    Otherwise use credential store to mask the actual credential from your configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+    <subsystem xmlns="urn:jboss:domain:undertow:9.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"  />

--- a/undertow/src/main/resources/subsystem-templates/undertow.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+    <subsystem xmlns="urn:jboss:domain:undertow:9.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <?AJP?>

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem80TestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem80TestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.undertow;
+
+import java.io.IOException;
+
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.junit.Test;
+
+/**
+ * This is the barebone test example that tests subsystem
+ *
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ */
+public class UndertowSubsystem80TestCase extends AbstractUndertowSubsystemTestCase {
+
+    private final String virtualHostName = "some-server";
+    private final int flag = 1;
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("undertow-8.0.xml");
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws Exception {
+        return "schema/wildfly-undertow_8_0.xsd";
+    }
+
+    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
+        return super.standardSubsystemTest(configId, false);
+    }
+
+    @Test
+    public void testRuntime() throws Exception {
+        setProperty();
+        KernelServicesBuilder builder = createKernelServicesBuilder(RUNTIME).setSubsystemXml(getSubsystemXml());
+        KernelServices mainServices = builder.build();
+        testRuntime(mainServices, virtualHostName, flag);
+        testRuntimeOther(mainServices);
+        testRuntimeLast(mainServices);
+    }
+}

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystemTestCase.java
@@ -40,12 +40,12 @@ public class UndertowSubsystemTestCase extends AbstractUndertowSubsystemTestCase
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("undertow-8.0.xml");
+        return readResource("undertow-9.0.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-undertow_8_0.xsd";
+        return "schema/wildfly-undertow_9_0.xsd";
     }
 
     @Override

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -73,8 +74,7 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testTransformersEAP_7_2_0() throws Exception {
-        // TODO Enable once we can transform to 7.2
-        //testTransformers(ModelTestControllerVersion.EAP_7_1_0, "7.2", EAP7_2_0);
+        testTransformers(ModelTestControllerVersion.EAP_7_2_0, "7.2", EAP7_2_0);
     }
 
     @Test
@@ -135,6 +135,7 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
                 .addFailedAttribute(ajpAddress,
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 ALLOW_UNESCAPED_CHARACTERS_IN_URL, RFC6265_COOKIE_VALIDATION))
+                .addFailedAttribute(hostAddress.append(PathElement.pathElement(Constants.SETTING, "console-access-log")), FailedOperationTransformationConfig.REJECTED_RESOURCE)
         );
     }
 
@@ -172,14 +173,18 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
                 .addFailedAttribute(ajpAddress,
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 ALLOW_UNESCAPED_CHARACTERS_IN_URL))
+                .addFailedAttribute(hostAddress.append(PathElement.pathElement(Constants.SETTING, "console-access-log")), FailedOperationTransformationConfig.REJECTED_RESOURCE)
         );
     }
 
     @Test
     public void testRejectTransformersEAP_7_2_0() throws Exception {
-        // TODO Enable once we can transform to 7.2
-        //doRejectTest(ModelTestControllerVersion.EAP_7_1_0, EAP7_2_0, new FailedOperationTransformationConfig()
-        //        );
+        final PathAddress subsystemAddress = PathAddress.pathAddress(UndertowExtension.SUBSYSTEM_PATH);
+        final PathAddress serverAddress = subsystemAddress.append(UndertowExtension.SERVER_PATH);
+        final PathAddress hostAddress = serverAddress.append(UndertowExtension.HOST_PATH);
+        doRejectTest(ModelTestControllerVersion.EAP_7_2_0, EAP7_2_0, new FailedOperationTransformationConfig()
+                .addFailedAttribute(hostAddress.append(PathElement.pathElement(Constants.SETTING, "console-access-log")), FailedOperationTransformationConfig.REJECTED_RESOURCE)
+        );
     }
 
     @Test
@@ -289,11 +294,12 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
     }
 
     private void addExtraMavenUrls(ModelTestControllerVersion controllerVersion, LegacyKernelServicesInitializer init) throws Exception {
-        if (controllerVersion == ModelTestControllerVersion.EAP_7_1_0) {
+        if (controllerVersion == ModelTestControllerVersion.EAP_7_1_0 || controllerVersion == ModelTestControllerVersion.EAP_7_2_0) {
             init.addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-clustering-common:" + controllerVersion.getMavenGavVersion());
             init.addMavenResourceURL(controllerVersion.getMavenGroupId() + ":wildfly-web-common:" + controllerVersion.getMavenGavVersion());
-            init.addMavenResourceURL("io.undertow:undertow-servlet:2.0.4.Final");
-            init.addMavenResourceURL("io.undertow:undertow-core:2.0.4.Final");
+            // The version here appears to be required to be set to the current version of undertow
+            init.addMavenResourceURL("io.undertow:undertow-servlet:2.0.20.Final");
+            init.addMavenResourceURL("io.undertow:undertow-core:2.0.20.Final");
         }
     }
 

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-9.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-9.0.xml
@@ -1,0 +1,95 @@
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:undertow:9.0" default-server="some-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+   <byte-buffer-pool name="test" thread-local-cache-size="45" buffer-size="1000" direct="false" leak-detection-percent="50" max-pool-size="1000"/>
+   <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
+   <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
+   <server default-host="other-host" name="some-server" servlet-container="myContainer">
+      <ajp-listener disallowed-methods="FOO TRACE" allow-unescaped-characters-in-url="true" max-parameters="5000" name="ajp-connector" no-request-timeout="10000" receive-buffer="5000" redirect-socket="ajps" request-parse-timeout="2000" resolve-peer-address="true" secure="true" send-buffer="50000" socket-binding="ajp" tcp-backlog="500" tcp-keep-alive="true" max-ajp-packet-size="10000"/>
+      <http-listener always-set-keep-alive="${prop.smth:false}" certificate-forwarding="true" name="default" proxy-address-forwarding="${prop.smth:false}" redirect-socket="ajp" resolve-peer-address="true" socket-binding="http" proxy-protocol="true"/>
+      <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="second" redirect-socket="https-non-default" require-host-http11="true" socket-binding="http-2" url-charset="windows-1250"/>
+      <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="no-redirect" socket-binding="http-3" url-charset="windows-1250" worker="non-default"/>
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https" record-request-start-time="true" require-host-http11="true" resolve-peer-address="true" security-realm="UndertowRealm" socket-binding="https-non-default" verify-client="REQUESTED"/>
+      <https-listener certificate-forwarding="true" allow-unescaped-characters-in-url="true" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" name="https-2" proxy-address-forwarding="true" read-timeout="-1" security-realm="UndertowRealm" socket-binding="https-2" write-timeout="-1"/>
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-3" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-3" ssl-context="TestContext" rfc6265-cookie-validation="true" proxy-protocol="true"/>
+      <!--<https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-4" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-4" />--> <!-- this one must fail-->
+      <host alias="localhost,some.host" default-response-code="503" default-web-module="something.war" name="default-virtual-host">
+         <location handler="welcome-content" name="/">
+            <filter-ref name="limit-connections"/>
+            <filter-ref name="headers" priority="${some.priority:10}"/>
+            <filter-ref name="404-handler"/>
+            <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
+         </location>
+         <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
+      </host>
+      <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host" queue-requests-on-start="false">
+         <location handler="welcome-content" name="/">
+            <filter-ref name="limit-connections"/>
+            <filter-ref name="headers"/>
+            <filter-ref name="static-gzip" predicate="path-suffix('.js') or path-suffix('.css') or path-prefix('/resources')"/>
+            <filter-ref name="404-handler"/>
+            <filter-ref name="mod-cluster"/>
+         </location>
+         <filter-ref name="headers"/>
+         <http-invoker http-authentication-factory="factory" path="services"/>
+      </host>
+   </server>
+   <servlet-container default-buffer-cache="extra" default-encoding="utf-8" default-session-timeout="100" directory-listing="true" eager-filter-initialization="true" ignore-flush="true" name="myContainer" proactive-authentication="${prop.pro:false}" use-listener-encoding="${prop.foo:false}"  disable-session-id-reuse="${prop.foo:true}" disable-file-watch-service="${prop.foo:true}" file-cache-metadata-size="50" file-cache-max-file-size="5000" file-cache-time-to-live="1000"  default-cookie-version="1">
+      <jsp-config check-interval="${prop.check-interval:20}" disabled="${prop.disabled:false}" display-source-fragment="${prop.display-source-fragment:true}" dump-smap="${prop.dump-smap:true}" error-on-use-bean-invalid-class-attribute="${prop.error-on-use-bean-invalid-class-attribute:true}" generate-strings-as-char-arrays="${prop.generate-strings-as-char-arrays:true}" java-encoding="${prop.java-encoding:utf-8}" keep-generated="${prop.keep-generated:true}" mapped-file="${prop.mapped-file:true}" modification-test-interval="${prop.modification-test-interval:1000}" optimize-scriptlets="${prop.optimise-scriptlets:true}" recompile-on-fail="${prop.recompile-on-fail:true}" scratch-dir="${prop.scratch-dir:/some/dir}" smap="${prop.smap:true}" source-vm="${prop.source-vm:1.7}" tag-pooling="${prop.tag-pooling:true}" target-vm="${prop.target-vm:1.7}" trim-spaces="${prop.trim-spaces:true}" x-powered-by="${prop.x-powered-by:true}"/>
+      <session-cookie comment="session cookie" domain="example.com" http-only="true" max-age="1000" name="MYSESSIONCOOKIE" secure="true"/>
+      <websockets deflater-level="0" dispatch-to-worker="false" per-message-deflate="false"/>
+      <mime-mappings>
+         <mime-mapping name="txt" value="text/plain"/>
+      </mime-mappings>
+      <welcome-files>
+         <welcome-file name="index.seam"/>
+      </welcome-files>
+      <crawler-session-management session-timeout="2" user-agents=".*googlebot.*"/>
+   </servlet-container>
+   <handlers>
+      <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
+      <reverse-proxy connection-idle-timeout="60" connections-per-thread="30" max-retries="10" name="reverse-proxy">
+         <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
+         <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
+      </reverse-proxy>
+   </handlers>
+   <filters>
+      <request-limit max-concurrent-requests="15000" name="limit-connections" queue-size="100"/>
+      <response-header header-name="MY_HEADER" header-value="someValue" name="headers"/>
+      <gzip name="static-gzip"/>
+      <error-page code="404" name="404-handler" path="/opt/data/404.html"/>
+      <mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp"
+                   advertise-socket-binding="advertise-socket-binding" broken-node-timeout="1000"
+                   cached-connections-per-thread="10" connection-idle-timeout="10"
+                   failover-strategy="DETERMINISTIC" health-check-interval="600"
+                   management-access-predicate="method[GET]" management-socket-binding="test3"
+                   max-request-time="1000" max-retries="10" name="mod-cluster"
+                   security-key="password" ssl-context="TestContext" max-ajp-packet-size="10000" />
+      <filter class-name="io.undertow.server.handlers.HttpTraceHandler" module="io.undertow.core" name="custom-filter"/>
+      <expression-filter expression="dump-request" name="requestDumper"/>
+      <rewrite name="redirects" redirect="true" target="'/foo/'"/>
+   </filters>
+   <application-security-domains>
+      <application-security-domain enable-jacc="true" http-authentication-factory="elytron-factory" name="other" override-deployment-config="true" enable-jaspi="false" integrated-jaspi="false">
+         <single-sign-on client-ssl-context="my-ssl-context" cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" key-alias="my-key-alias" key-store="my-key-store" path="/path" secure="true">
+            <credential-reference alias="my-credential-alias" store="my-credential-store" type="password"/>
+         </single-sign-on>
+      </application-security-domain>
+      <application-security-domain security-domain="elytron-domain" name="domain-ref" />
+   </application-security-domains>
+</subsystem>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-9.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-9.0.xml
@@ -35,6 +35,25 @@
             <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
          </location>
          <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <console-access-log predicate="not path-suffix(*.css)" worker="default">
+            <attributes>
+               <authentication-type/>
+               <date-time date-format="yyyy-MM-dd'T'HH:mm:ss" key="timestamp"/>
+               <query-parameter>
+                  <name value="test"/>
+               </query-parameter>
+               <request-header key-prefix="requestHeader">
+                  <name value="Content-Type"/>
+                  <name value="Content-Encoding"/>
+               </request-header>
+               <response-code/>
+               <response-time time-unit="MICROSECONDS"/>
+            </attributes>
+            <metadata>
+               <property name="@version" value="1"/>
+               <property name="host" value="${jboss.host.name:localhost}"/>
+            </metadata>
+         </console-access-log>
          <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
       </host>
       <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host" queue-requests-on-start="false">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:8.0" default-server="default-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+<subsystem xmlns="urn:jboss:domain:undertow:9.0" default-server="default-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
    <server default-host="other-host" name="default-server" servlet-container="myContainer">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
@@ -39,6 +39,25 @@
             <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
          </location>
          <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <console-access-log predicate="not path-suffix(*.css)">
+            <attributes>
+               <date-time date-format="yyyy-MM-dd'T'HH:mm:ss" key="timestamp"/>
+               <query-parameter>
+                  <name value="test"/>
+                  <name value="foo"/>
+               </query-parameter>
+               <response-code/>
+               <response-header key-prefix="responseHeader">
+                  <name value="Content-Type"/>
+                  <name value="Content-Encoding"/>
+               </response-header>
+               <response-time time-unit="MICROSECONDS"/>
+            </attributes>
+            <metadata>
+               <property name="@version" value="1"/>
+               <property name="qualifiedHost" value="${jboss.qualified.host.name:unknown}"/>
+            </metadata>
+         </console-access-log>
          <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
       </host>
       <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-reject.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-reject.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:6.0" default-server="some-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+<subsystem xmlns="urn:jboss:domain:undertow:9.0" default-server="some-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
    <byte-buffer-pool name="test-buffers" buffer-size="1000" leak-detection-percent="0" direct="true" max-pool-size="10" thread-local-cache-size="1" />
@@ -40,6 +40,25 @@
             <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
          </location>
          <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <console-access-log predicate="not path-suffix(*.css)">
+            <attributes>
+               <date-time date-format="yyyy-MM-dd'T'HH:mm:ss" key="timestamp"/>
+               <query-parameter>
+                  <name value="test"/>
+                  <name value="foo"/>
+               </query-parameter>
+               <response-code/>
+               <response-header key-prefix="responseHeader">
+                  <name value="Content-Type"/>
+                  <name value="Content-Encoding"/>
+               </response-header>
+               <response-time time-unit="MICROSECONDS"/>
+            </attributes>
+            <metadata>
+               <property name="@version" value="1"/>
+               <property name="qualifiedHost" value="${jboss.qualified.host.name:unknown}"/>
+            </metadata>
+         </console-access-log>
          <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
       </host>
       <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host">


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11031

**Note:** This PR currently requires a SNAPSHOT build of WildFly Core until Beta5 is release.

@fl4via Can you please have a look at this as I went a slight different route than what we discussed previously. I added a `setting=console-access-log` resource instead of keeping everything under the `setting=access-log` resource. I felt it made the resource too complicated.

There had been some email discussions with using the standard `pattern` attribute for determining the exchange attributes to include in the JSON structured output. While I realize these are well known patterns I felt it just didn't fit right when we need the ability for defined keys in structured output. I went with a complex `attributes` management model attribute with known exchange attribute types. 