### PR TITLE
WFLY-12066 Upgrade jgroups-azure to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,7 +372,7 @@
         <version.org.jboss.ws.spi>3.2.3.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.6.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jgroups>4.0.19.Final</version.org.jgroups>
-        <version.org.jgroups.azure>1.2.0.Final</version.org.jgroups.azure>
+        <version.org.jgroups.azure>1.2.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.6.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-12066

Only resolves the non-secure repositories issue.

