### PR TITLE
WFLY-11159 Upgrade mod_cluster to 1.4.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.metadata>13.0.0.Final</version.org.jboss.metadata>
-        <version.org.jboss.mod_cluster>1.4.0.Final</version.org.jboss.mod_cluster>
+        <version.org.jboss.mod_cluster>1.4.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.9.5.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.3.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>3.6.3.Final</version.org.jboss.resteasy>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-11159

Mostly only resolves the non-secure repositories issue with a couple of trivial logging and licensing fixes.

