### PR TITLE
[WFLY-12069] Upgrade WildFly Core 9.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,7 +384,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>
-        <version.org.wildfly.core>9.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12069

---


## Release Notes - WildFly Core - Version 9.0.0.Beta6
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4466'>WFCORE-4466</a>] -         Upgrade to Galleon and Plugins 4.0.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4467'>WFCORE-4467</a>] -         Upgrade WildFly Elytron to 1.9.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4468'>WFCORE-4468</a>] -         Upgrade Elytron Web to 1.5.0.Final
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4460'>WFCORE-4460</a>] -         jboss-cli.sh doesn&#39;t return json when the output command is &#39;failed&#39;
</li>
</ul>
                                            