### PR TITLE
[WFLY-11959] AbstractSimpleApplicationClientTestCase pollutes the build/target/ installation

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -34,6 +34,10 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
+
+        <!-- Used to provide an absolute location for the distribution under test. -->
+        <jboss.dist>${project.build.directory}/wildfly</jboss.dist>
+        <jboss.home>${jbossas.project.dir}/${wildfly.build.output.dir}</jboss.home>
     </properties>
 
     <dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -206,7 +206,7 @@
 
                <!--
                    A build of target/wildfly which is shared by all modules.
-                   Modules and bundles are not copied as they are read-only (see surefire props).
+                   Bundles are not copied as they are read-only (see surefire props).
                -->
                <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
@@ -231,7 +231,6 @@
                                            <exclude>bin/*.bat</exclude>
                                            <exclude>bin/*.ps1</exclude>
                                            <exclude>docs/</exclude>
-                                           <exclude>modules/</exclude>
                                            <exclude>welcome-content/*.png</exclude>
                                            <exclude>standalone/data</exclude>
                                            <exclude>standalone/log</exclude>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11959
- Change distribution which basic tests used and polluted to one which is created especially for them