### PR TITLE
[WFLY-12076] Use maven project.groupId for the aggregation of galleonfeature-pack offliner files

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -202,7 +202,7 @@
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
-                                    <fpGroupId>org.wildfly</fpGroupId>
+                                    <fpGroupId>${project.groupId}</fpGroupId>
                                     <fpArtifactId>wildfly-galleon-pack</fpArtifactId>
                                     <fpVersion>${project.version}</fpVersion>
                                 </configuration>


### PR DESCRIPTION
Jira issue: https://issues.jboss.org/browse/WFLY-12076