### PR TITLE
Fix for WFLY-12080, Upgrade galleon-plugins to 4.0.1

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -202,12 +202,35 @@
                                 </goals>
                                 <phase>package</phase>
                                 <configuration>
+                                    <offline>true</offline>
                                     <fpGroupId>org.wildfly</fpGroupId>
                                     <fpArtifactId>wildfly-galleon-pack</fpArtifactId>
                                     <fpVersion>${project.version}</fpVersion>
                                 </configuration>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jboss.universe</groupId>
+                                <artifactId>community-universe</artifactId>
+                                <version>${version.org.jboss.universe.community-universe}</version>
+                                <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jboss.universe.producer</groupId>
+                                <artifactId>wildfly-producers</artifactId>
+                                <version>${version.org.jboss.universe.producer.wildfly-producers}</version>
+                                <scope>runtime</scope>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.wildfly.core</groupId>
+                                <artifactId>wildfly-core-galleon-pack</artifactId>
+                                <version>${version.org.wildfly.core}</version>
+                                <type>txt</type>
+                                <classifier>artifact-list</classifier>
+                                <scope>runtime</scope>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,8 +195,10 @@
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>4.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.0.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.0.0.Final</version.org.wildfly.maven.plugins>
+        <version.org.jboss.universe.producer.wildfly-producers>1.0.0.Final</version.org.jboss.universe.producer.wildfly-producers>
+        <version.org.jboss.universe.community-universe>1.0.0.Final</version.org.jboss.universe.community-universe>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>


### PR DESCRIPTION
Fix for: https://issues.jboss.org/browse/WFLY-12080
- Upgrade galleon wildfly plugins to 4.0.1.
- Make generate-all-artifacts-list plugin to run in offline mode
- Added needed dependencies not resolved during build.

Galleon changes:
https://github.com/wildfly/galleon-plugins/compare/4.0.0.Final...4.0.1.Final