### PR TITLE
[WFLY-12085]: java.net.URISyntaxException: Illegal character in opaque part at index 7: file:C:\Java\jboss\jboss-as\standalone\configuration/logging.properties

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -559,6 +559,8 @@ class ServerAdd extends AbstractAddStepHandler {
             Configuration configuration = new ConfigurationImpl();
 
             configuration.setName(serverName);
+            //To avoid the automatic reloading of the logging.properties by the broker.
+            configuration.setConfigurationFileRefreshPeriod(-1);
 
             configuration.setEnabledAsyncConnectionExecution(ASYNC_CONNECTION_EXECUTION_ENABLED.resolveModelAttribute(context, model).asBoolean());
 


### PR DESCRIPTION
* Setting the configurationFileRefreshPeriod to -1 to avoid reloading of
logging.properties

Jira: https://issues.jboss.org/browse/WFLY-12085