### PR TITLE
WFLY-12086 Hibernate 2lc should be enabled if Hibernate cache properties are enabled and shared cache mode is not set to NONE

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
@@ -406,7 +406,7 @@ The Hibernate native API application will also need a MANIFEST.MF:
 Dependencies: org.infinispan,org.hibernate
 ....
 
-http://infinispan.org/docs/9.3.x/user_guide/user_guide.html#jpa_hibernate_2l_cache[Infinispan
+http://infinispan.org/docs/9.4.x/user_guide/user_guide.html#integrations_jpa_hibernate[Infinispan
 Hibernate/JPA second level cache provider documentation] contains
 advanced configuration information but you should bear in mind that when
 Hibernate runs within WildFly {wildflyVersion}, some of those configuration options,

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/secondlevelcache/persistence.xml
@@ -3,7 +3,6 @@
     <persistence-unit name="mypc">
         <description>Persistence Unit.</description>
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
-        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>
@@ -25,7 +24,6 @@
     <persistence-unit name="mypc2">
         <description>Persistence Unit.</description>
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
-        <shared-cache-mode>ENABLE_SELECTIVE</shared-cache-mode>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="hibernate.show_sql" value="false"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-16901
https://issues.jboss.org/browse/WFLY-12086

HibernatePersistenceProviderAdaptor.addProviderDependencies() should be easier to understand now and has been changed to state the precedence of different cache settings (Hibernate cache properties versus SharedCacheMode).  

Also corrected handling of SharedCacheMode.UNSPECIFIED, to explicitly tell Hibernate to use SharedCacheMode.ENABLE_SELECTIVE (Hibernate treats SharedCacheMode.UNSPECIFIED as caching being disabled, which is not what the JPA container expects, so the JPA container changes UNSPECIFIED to SharedCacheMode.ENABLE_SELECTIVE).  
