### PR TITLE
[WFLY-12096] Do not use hardcoded name to point to the provisioned server dist module

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -173,7 +173,7 @@
                     <!-- Parameters to test cases. -->
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
-                        <jboss.actual.dist>${basedir}/target/wildfly-${project.version}</jboss.actual.dist>
+                        <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
- We should use a non-hardcoded name for jboss.actual.dist property to facilitate the transition to product branches

Jira issue: https://issues.jboss.org/browse/WFLY-12096