### PR TITLE
Fix for WFLY-11990, Separate opentracing from observability layer

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -122,6 +122,7 @@ Basic layers:
 * _jms-activemq_: Support for connections to a remote jms broker. 
 * _jpa_: Support for jpa (latest WildFly supported hibernate release).
 * _observability_: Support for microprofile monitoring and configuration features (config, health, metrics, open-tracing).
+* _open-tracing_: Support for microprofile open-tracing. This layer is an optional dependency of _observability_ layer.
 * _resource-adapters_: Support for deployment of JCA adapters.
 * _h2-driver_: Support for h2 driver.
 * _h2-datasource_: Support for h2 datasource.

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -3,9 +3,9 @@
     <dependencies>
         <layer name="management"/>
         <layer name="cdi"/>
+        <layer name="open-tracing" optional="true"/>
     </dependencies>
     <feature-group name="health"/>
     <feature-group name="metrics"/>
     <feature spec="subsystem.microprofile-config-smallrye"/>
-    <feature spec="subsystem.microprofile-opentracing-smallrye"/>
 </layer-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="open-tracing">
+    <dependencies>
+        <layer name="cdi"/>
+    </dependencies>
+    <feature spec="subsystem.microprofile-opentracing-smallrye"/>
+</layer-spec>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2083,6 +2083,54 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>open-tracing-provisioning</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <install-dir>${layers.install.dir}/open-tracing</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                </feature-pack>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                </feature-pack>
+                                <feature-pack>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                            </feature-packs>
+                            <configurations>
+                                <config>
+                                    <model>standalone</model>
+                                    <name>standalone.xml</name>
+                                    <layers>
+                                        <layer>open-tracing</layer>
+                                    </layers>
+                                </config>
+                            </configurations>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>resource-adapters-provisioning</id>
                         <goals>
                             <goal>provision</goal>
@@ -2347,6 +2395,7 @@
                                         <layer>jms-activemq</layer>
                                         <layer>jpa</layer>
                                         <layer>observability</layer>
+                                        <layer>open-tracing</layer>
                                         <layer>resource-adapters</layer>
                                         <layer>transactions</layer>
                                         <layer>undertow</layer>


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFLY-11990,
opentracing in its own layer, optional dependency of observability layer.