### PR TITLE
Add a missing letter in the logging documentation

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/Logging.adoc
@@ -163,7 +163,7 @@ subdirectory of the distribution:
 
 |accept |accept |Accepts all log messages. |None |accept
 
-|deny |deny |enies all log messages. |None |deny
+|deny |deny |Denies all log messages. |None |deny
 
 |not |not(filterExpression) |Accepts a filter as an argument and inverts
 the returned value. |The expression takes a single filter for it's


### PR DESCRIPTION
Since this change was so small I didn't create a JIRA, however I can if that is required for this. It just felt small enough not to open a JIRA for it.

I'm not sure why that last part of the diff is there too, but every time I make the change it shows up.