### PR TITLE
[WFLY-12107] Upgrade JBoss Negotiation to 3.0.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <version.org.jboss.openjdk-orb>8.1.4.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.resteasy>3.7.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
-        <version.org.jboss.security.jboss-negotiation>3.0.5.Final</version.org.jboss.security.jboss-negotiation>
+        <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>
         <!-- only needed here until wildfly-arquillian has this version properly synced with arquillian itslef  -->
         <version.org.jboss.shrinkwrap.descriptors>2.0.0</version.org.jboss.shrinkwrap.descriptors>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12107


        Release Notes - PicketBox  - Version Negotiation_3_0_6_Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/SECURITY-998'>SECURITY-998</a>] -         Upgrade Undertow to 2.0.19.Final
</li>
</ul>
                                                                                    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/SECURITY-997'>SECURITY-997</a>] -         Update repository reference to use https://
</li>
<li>[<a href='https://issues.jboss.org/browse/SECURITY-999'>SECURITY-999</a>] -         Update JBoss Parent to version 35
</li>
<li>[<a href='https://issues.jboss.org/browse/SECURITY-1001'>SECURITY-1001</a>] -         Upgrade JBoss Logging to 3.4.0.Final
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/SECURITY-1000'>SECURITY-1000</a>] -         Release JBoss Negotiation 3.0.6.Final
</li>
</ul>
                    