### PR TITLE
[REM3-329 ]- Unable to parse endpoint XML definition if more than one c…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/HelloBean.java
@@ -1,0 +1,22 @@
+package org.jboss.as.test.integration.ejb.remote.client.api.moreconnection;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+
+@Stateless
+public class HelloBean implements HelloBeanRemote {
+
+    @Resource
+    private DataSource injectedResource;
+
+    /**
+     *
+     * @throws Throwable
+     */
+    public String hello(){
+        return VALUE;
+    }
+
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/HelloBeanRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/HelloBeanRemote.java
@@ -1,0 +1,12 @@
+package org.jboss.as.test.integration.ejb.remote.client.api.moreconnection;
+
+import javax.ejb.Remote;
+
+@Remote
+public interface HelloBeanRemote {
+
+    public final String VALUE = "Hello, test is OK.";
+
+    public String hello();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/ParseConfigWithMoreConnectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/client/api/moreconnection/ParseConfigWithMoreConnectionTestCase.java
@@ -1,0 +1,63 @@
+package org.jboss.as.test.integration.ejb.remote.client.api.moreconnection;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.naming.client.WildFlyInitialContextFactory;
+
+/**
+ * Parse wildfly-config.xml with two connection
+ * @author Petr Adamec
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ParseConfigWithMoreConnectionTestCase {
+
+    private static final String MODULE_NAME = "ejb-more-connection-parse";
+
+    @BeforeClass
+    public static void beforeClass(){
+        System.setProperty("wildfly.config.url", "src/test/resources/META-INF/ParseConfigWithMoreConnectionTestCase/wildfly-config.xml");
+    }
+
+    @Deployment(testable = false)
+    public static Archive createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackage(ParseConfigWithMoreConnectionTestCase.class.getPackage());
+        return jar;
+    }
+
+    @Test
+    public void check() throws NamingException {
+        final Properties properties = new Properties();
+        properties.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
+        final InitialContext ejbCtx = new InitialContext(properties);
+        try {
+            HelloBeanRemote bean = (HelloBeanRemote)ejbCtx.lookup(
+                    "ejb:/" + MODULE_NAME + "/" + HelloBean.class.getSimpleName() + "!"
+                            + HelloBeanRemote.class.getName());
+
+            final String valueSeenOnServer = bean.hello();
+            Assert.assertEquals(HelloBeanRemote.VALUE, valueSeenOnServer);
+        } catch (ExceptionInInitializerError e){
+            Assert.fail("Test fails probably due to https://issues.jboss.org/browse/REM3-329 .");
+        }
+        finally {
+            ejbCtx.close();
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/resources/META-INF/ParseConfigWithMoreConnectionTestCase/wildfly-config.xml
+++ b/testsuite/integration/basic/src/test/resources/META-INF/ParseConfigWithMoreConnectionTestCase/wildfly-config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <endpoint xmlns="urn:jboss-remoting:5.0">
+        <connections>
+            <connection destination="remote+http://localhost:8080" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
+            <connection destination="remote+http://localhost:8380" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
+        </connections>
+    </endpoint>
+</configuration>


### PR DESCRIPTION
Description: A client side wildfly-config.xml file with the following endpoint configuration:
`<endpoint xmlns="urn:jboss-remoting:5.0">
        <connections>
            <connection destination="remote+http://localhost:8080" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
            <connection destination="remote+http://localhost:8380" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
        </connections>
    </endpoint>
`
fails with a ConfigXMLParseException

Jira issue: [https://issues.jboss.org/browse/REM3-329](https://issues.jboss.org/browse/REM3-329)
