### PR TITLE
[WFLY-12090] At TransactionSubsystemAdd, make RemoteTransactionServic…

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -454,7 +454,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
             serviceTarget.addService(TxnServices.JBOSS_TXN_REMOTE_TRANSACTION_SERVICE, remoteTransactionServiceService)
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, remoteTransactionServiceService.getLocalTransactionContextInjector())
                 .addDependency(context.getCapabilityServiceName(REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class), Endpoint.class, remoteTransactionServiceService.getEndpointInjector())
-                .setInitialMode(Mode.LAZY)
+                .setInitialMode(Mode.ACTIVE)
                 .install();
         }
 


### PR DESCRIPTION
…eService ACTIVE, when adding the optional capability dependency of TRANSACTION_CAPABILITY on REMOTING_ENDPOINT_CAPABILITY_NAME, to guarantee that remoting transaction service is UP if a XA Recovery of remote SubordinateXAResources has to be performed

Jira: https://issues.jboss.org/browse/WFLY-12090