### PR TITLE
[WFLY-12101] Test for EJBCLIENT-335, display host:port on connecting to server error

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/exception/ExceptionEjbClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/exception/ExceptionEjbClientTestCase.java
@@ -22,15 +22,22 @@
 
 package org.jboss.as.test.integration.ejb.stateful.exception;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.Properties;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+
+import org.codehaus.plexus.util.ExceptionUtils;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.ejb.client.RequestSendFailedException;
+import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.naming.client.WildFlyInitialContextFactory;
 
@@ -66,4 +73,25 @@ public class ExceptionEjbClientTestCase extends ExceptionTestCase {
     protected DestroyMarkerBeanInterface getMarker() throws NamingException {
         return lookup(DestroyMarkerBean.class, DestroyMarkerBeanInterface.class, false);
     }
+
+    /**
+     * Test exception contains destination when there is no server running (wrong server)
+     */
+    @Test
+    public void testConnectException() throws Exception {
+        try {
+            Properties props = new Properties();
+            props.put(Context.INITIAL_CONTEXT_FACTORY,  "org.wildfly.naming.client.WildFlyInitialContextFactory");
+            //Wrong server so an exception will be thrown
+            props.put(Context.PROVIDER_URL, "remote+http://localhost:1000");
+            Context ctx = new InitialContext(props);
+
+            DestroyMarkerBeanInterface destroyM = (DestroyMarkerBeanInterface) ctx.lookup(String.format("ejb:/%s/%s!%s", ARCHIVE_NAME, DestroyMarkerBean.class.getSimpleName(), DestroyMarkerBeanInterface.class.getName()));
+            destroyM.is();
+            Assert.fail("It was expected a RequestSendFailedException being thrown");
+        } catch (RequestSendFailedException e) {
+            assertTrue("Destination should be displayed", ExceptionUtils.getFullStackTrace(e).contains("remote+http://localhost:1000"));
+        }
+    }
+
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12101

Related Issues: https://issues.jboss.org/browse/EJBCLIENT-335
It depends on the component upgrade https://issues.jboss.org/browse/WFLY-12200

This test verifies that the exception is propagated from the ejb client module to Wildfly, so when Widlfly displays the error "No more destinations are available" you also get the host and port that the ejb client was using to connect, that facilitates the analysis of the problems in the client without looking at the code.