### PR TITLE
WFLY-11601 Weld vs Undertow bootstrap: Race condition

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/WeldDeploymentProcessor.java
@@ -58,6 +58,7 @@ import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.weld.ServiceNames;
 import org.jboss.as.weld.WeldBootstrapService;
 import org.jboss.as.weld._private.WeldDeploymentMarker;
+import org.jboss.as.weld.WeldStartCompletionService;
 import org.jboss.as.weld.WeldStartService;
 import org.jboss.as.weld.deployment.BeanDeploymentArchiveImpl;
 import org.jboss.as.weld.deployment.BeanDeploymentModule;
@@ -125,7 +126,9 @@ public class WeldDeploymentProcessor implements DeploymentUnitProcessor {
         //add a dependency on the weld service to web deployments
         final ServiceName weldBootstrapServiceName = parent.getServiceName().append(WeldBootstrapService.SERVICE_NAME);
         ServiceName weldStartServiceName = parent.getServiceName().append(WeldStartService.SERVICE_NAME);
+        ServiceName weldStartCompletionServiceName = parent.getServiceName().append(WeldStartCompletionService.SERVICE_NAME);
         deploymentUnit.addToAttachmentList(Attachments.WEB_DEPENDENCIES, weldStartServiceName);
+        deploymentUnit.addToAttachmentList(Attachments.WEB_DEPENDENCIES, weldStartCompletionServiceName);
 
         final Set<ServiceName> dependencies = new HashSet<ServiceName>();
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-11601

Changes to the WELD subsystem splitted some finalization logic to a new service named WeldStartCompletionService (WFLY-9732 / WFLY-10784). The UndertowDeploymentService only had WeldStartService as a dependency. Therefore some race conditions may occur if undertow's service executed before weld's completion service.

The fix additionally adds the completion service as a dependency to undertow using the attachment WEB_DEPENDENCIES.