### PR TITLE
[WFLY-12132] Upgrade WildFly Core 9.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>9.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12132

---

## Release Notes - WildFly Core - Version 9.0.0.Beta7
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4469'>WFCORE-4469</a>] -         Upgrade Remoting JMX to 3.0.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4476'>WFCORE-4476</a>] -         Upgrade WildFly Elytron to 1.9.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4479'>WFCORE-4479</a>] -         Upgrade jboss-logmanager from 2.1.10.Final to 2.1.11.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4480'>WFCORE-4480</a>] -         Upgrade Remoting JMX to 3.0.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-323'>WFCORE-323</a>] -         Validate composite operation steps just before executing them
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4333'>WFCORE-4333</a>] -         async-handler not working / logging.properties incompletely updated
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4400'>WFCORE-4400</a>] -         Validation of &#39;host-context-map&#39; attribute of &#39;server-ssl-sni-context&#39; does not allow regular expressions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4407'>WFCORE-4407</a>] -         Cannot configure Elytron security domain using embedded server in admin mode
</li>
</ul>
                                            