### PR TITLE
WFLY-12139 Mutations following HttpSession.setAttribute(...) lost on failover ...

### DIFF
--- a/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/coarse/CoarseSessionAttributes.java
+++ b/clustering/web/cache/src/main/java/org/wildfly/clustering/web/cache/session/coarse/CoarseSessionAttributes.java
@@ -75,7 +75,12 @@ public class CoarseSessionAttributes extends CoarseImmutableSessionAttributes im
         Object old = this.attributes.put(name, value);
         this.mutator.mutate();
         if (this.mutations != null) {
-            this.mutations.remove(name);
+            // If the object is mutable, we need to indicate trigger a mutation on close
+            if (this.immutability.test(value)) {
+                this.mutations.remove(name);
+            } else {
+                this.mutations.add(name);
+            }
         }
         return old;
     }


### PR DESCRIPTION
… when using SESSION granularity distributed web session with a non-transactional cache

https://issues.jboss.org/browse/WFLY-12139