### PR TITLE
[WFLY-12147] Update MinimalWebAuthenticationTestCase so that it doesn't use an authentication factory as specified in the test description

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/web/MinimalWebAuthenticationTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/web/MinimalWebAuthenticationTestCase.java
@@ -35,7 +35,7 @@ import org.wildfly.test.security.common.elytron.ServletElytronDomainSetup;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 @RunWith(Arquillian.class)
-@ServerSetup({ WebAuthenticationTestCaseBase.ElytronDomainSetupOverride.class, ServletElytronDomainSetup.class })
+@ServerSetup({ WebAuthenticationTestCaseBase.ElytronDomainSetupOverride.class, MinimalWebAuthenticationTestCase.ElytronServletSetupOverride.class })
 public class MinimalWebAuthenticationTestCase extends WebAuthenticationTestCaseBase {
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12147