### PR TITLE
[WFLY-12152] Remove redundant subString endIndex .length() calls

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
@@ -252,7 +252,7 @@ public final class Main {
                         value = "true";
                     } else {
                         name = arg.substring(2, idx);
-                        value = arg.substring(idx + 1, arg.length());
+                        value = arg.substring(idx + 1);
                     }
                     systemProperties.setProperty(name, value);
                     WildFlySecurityManager.setPropertyPrivileged(name, value);

--- a/ee/src/main/java/org/jboss/as/ee/resource/definition/ResourceDefinitionInjectionSource.java
+++ b/ee/src/main/java/org/jboss/as/ee/resource/definition/ResourceDefinitionInjectionSource.java
@@ -74,7 +74,7 @@ public abstract class ResourceDefinitionInjectionSource extends InjectionSource 
                 String propertyValue;
                 if (index != -1) {
                     propertyName = annotationProperty.substring(0, index);
-                    propertyValue = annotationProperty.length() > index ? annotationProperty.substring(index + 1, annotationProperty.length()) : "";
+                    propertyValue = annotationProperty.length() > index ? annotationProperty.substring(index + 1) : "";
                 } else {
                     propertyName = annotationProperty;
                     propertyValue = "";

--- a/ee/src/main/java/org/jboss/as/ee/utils/DescriptorUtils.java
+++ b/ee/src/main/java/org/jboss/as/ee/utils/DescriptorUtils.java
@@ -144,7 +144,7 @@ public class DescriptorUtils {
     }
 
     public static String returnType(String methodDescriptor) {
-        return methodDescriptor.substring(methodDescriptor.lastIndexOf(')') + 1, methodDescriptor.length());
+        return methodDescriptor.substring(methodDescriptor.lastIndexOf(')') + 1);
     }
 
 

--- a/naming/src/main/java/org/wildfly/naming/java/permission/JndiPermission.java
+++ b/naming/src/main/java/org/wildfly/naming/java/permission/JndiPermission.java
@@ -364,7 +364,7 @@ public final class JndiPermission extends Permission {
         for (;;) {
             String str;
             if (idx == -1) {
-                str = actionsString.substring(pos, actionsString.length()).trim();
+                str = actionsString.substring(pos).trim();
                 if (! str.isEmpty()) actions |= parseAction(str);
                 return actions;
             } else {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestImpl.java
@@ -205,7 +205,7 @@ public abstract class RequestDumpingHandlerTestImpl {
 
         // Split into request and response part:
         String request = content.substring(0, content.indexOf("-RESPONSE-"));
-        String response = content.substring(content.indexOf("-RESPONSE-"), content.length());
+        String response = content.substring(content.indexOf("-RESPONSE-"));
 
         // Check request dump part...
         searchInFile(request, "-+REQUEST-+");


### PR DESCRIPTION
Issue - [https://issues.jboss.org/browse/WFLY-12152](https://issues.jboss.org/browse/WFLY-12152)

[substring(int beginIndex, int endIndex) Javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#substring(int,%20int))
[substring(int beginIndex) Javadoc](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#substring(int))