### PR TITLE
[WFLY-12153] Replace redundant StringBuilder append String.subString with append CharSequence

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/JBossLogPrintWriter.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/JBossLogPrintWriter.java
@@ -107,12 +107,12 @@ public final class JBossLogPrintWriter extends PrintWriter {
             for (i = 0; i < len; i++) {
                 final char c = str.charAt(off + i);
                 if (c == '\n') {
-                    buffer.append(str.substring(mark + off, off + i));
+                    buffer.append(str, mark + off, off + i);
                     outputLogger();
                     mark = i + 1;
                 }
             }
-            buffer.append(str.substring(mark + off, off + i));
+            buffer.append(str, mark + off, off + i);
         }
     }
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/rmi/ContainerAnalysis.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/rmi/ContainerAnalysis.java
@@ -621,7 +621,7 @@ public abstract class ContainerAnalysis  extends ClassAnalysis {
                         b.append(s);
                         s = "";
                     } else {
-                        b.append(s.substring(0, idx));
+                        b.append(s, 0, idx);
                         if (s.length() > idx + 2 && s.charAt(idx + 2) == '_') {
                             // remove leading underscore in IDL escaped identifier
                             s = s.substring(idx + 3);

--- a/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
@@ -706,7 +706,7 @@ public class WebMigrateOperation implements OperationStepHandler {
         StringBuilder sb = new StringBuilder();
         int lastIndex = 0;
         while (m.find()) {
-            sb.append(legacyPattern.substring(lastIndex, m.start()));
+            sb.append(legacyPattern, lastIndex, m.start());
             lastIndex = m.end();
             sb.append("%{");
             sb.append(m.group(2));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -97,7 +97,7 @@ public abstract class BuildConfigurationTestBase {
                     start = line.indexOf("<inet-address value=\"");
                     if (start >= 0) {
                         StringBuilder sb = new StringBuilder();
-                        sb.append(line.substring(0, start))
+                        sb.append(line, 0, start)
                             .append("<inet-address value=\"")
                             .append(hostAddress)
                             .append("\"/>");
@@ -106,7 +106,7 @@ public abstract class BuildConfigurationTestBase {
                         start = line.indexOf("<option value=\"");
                         if (start >= 0 && !processedOpt) {
                             StringBuilder sb = new StringBuilder();
-                            sb.append(line.substring(0, start));
+                            sb.append(line, 0, start);
                             List<String> opts = new ArrayList<String>();
                             TestSuiteEnvironment.getIpv6Args(opts);
                             for (String opt : opts) {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacySubsystemConfigurationUtil.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacySubsystemConfigurationUtil.java
@@ -110,7 +110,7 @@ public class LegacySubsystemConfigurationUtil {
                 if (!line.contains(SUBSYSTEM_CLOSE)) {
                     sb.append(line);
                 } else {
-                    sb.append(line.substring(0, line.indexOf(SUBSYSTEM_CLOSE) + SUBSYSTEM_CLOSE.length()));
+                    sb.append(line, 0, line.indexOf(SUBSYSTEM_CLOSE) + SUBSYSTEM_CLOSE.length());
                     break;
                 }
             }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/PropertiesValueResolver.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/PropertiesValueResolver.java
@@ -154,7 +154,7 @@ public class PropertiesValueResolver {
                 case DEFAULT: {
                     if (ch == '}') {
                         state = INITIAL;
-                        builder.append(value.substring(start, i));
+                        builder.append(value, start, i);
                     }
                     continue;
                 }


### PR DESCRIPTION
Issue - [WFLY-12153](https://issues.jboss.org/browse/WFLY-12153)
This removes an intermediate String construction during append
[Relevant Stack Overflow discussion](https://stackoverflow.com/questions/52559564/call-to-substring-is-redundant)