### PR TITLE
[WFLY-12160] Upgrade jboss-common-beans to 2.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <version.org.jberet>1.3.4.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
-        <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>
+        <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>4.0.18.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12160

POM and javadoc corrections.

https://github.com/jboss/jboss-common-beans/compare/2.0.0.Final...2.0.1.Final