### PR TITLE
WFLY-12161 Expressions not working in XA DS attr share-prepared-state…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
@@ -111,7 +111,6 @@ import org.jboss.as.connector.util.ModelNodeUtil;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
-import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.Capacity;
 import org.jboss.jca.common.api.metadata.common.Extension;
 import org.jboss.jca.common.api.metadata.common.FlushStrategy;
@@ -187,7 +186,7 @@ class DataSourceModelNodeUtil {
         final DsSecurity security = new DsSecurityImpl(username, password,
                 elytronEnabled? authenticationContext: securityDomain, elytronEnabled, credentialSourceSupplier, reauthPlugin);
 
-        final boolean sharePreparedStatements = ModelNodeUtil.getBooleanIfSetOrGetDefault(operationContext, dataSourceNode, SHARE_PREPARED_STATEMENTS);
+        final boolean sharePreparedStatements = SHARE_PREPARED_STATEMENTS.resolveModelAttribute(operationContext, dataSourceNode).asBoolean();
         final Long preparedStatementsCacheSize = ModelNodeUtil.getLongIfSetOrGetDefault(operationContext, dataSourceNode, PREPARED_STATEMENTS_CACHE_SIZE);
         final String trackStatementsString = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, TRACK_STATEMENTS);
         final Statement.TrackStatementsEnum trackStatements = Statement.TrackStatementsEnum.valueOf(trackStatementsString.toUpperCase(Locale.ENGLISH));
@@ -288,8 +287,7 @@ class DataSourceModelNodeUtil {
         final DsSecurity security = new DsSecurityImpl(username, password,
                 elytronEnabled? authenticationContext: securityDomain, elytronEnabled, credentialSourceSupplier, reauthPlugin);
 
-        final Boolean sharePreparedStatements = dataSourceNode.hasDefined(SHARE_PREPARED_STATEMENTS.getName()) ? dataSourceNode.get(
-                SHARE_PREPARED_STATEMENTS.getName()).asBoolean() : Defaults.SHARE_PREPARED_STATEMENTS;
+        final boolean sharePreparedStatements = SHARE_PREPARED_STATEMENTS.resolveModelAttribute(operationContext, dataSourceNode).asBoolean();
         final Long preparedStatementsCacheSize = ModelNodeUtil.getLongIfSetOrGetDefault(operationContext, dataSourceNode, PREPARED_STATEMENTS_CACHE_SIZE);
         final String trackStatementsString = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, TRACK_STATEMENTS);
         final Statement.TrackStatementsEnum trackStatements = Statement.TrackStatementsEnum.valueOf(trackStatementsString.toUpperCase(Locale.ENGLISH));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DataSourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DataSourceTestCase.java
@@ -96,6 +96,28 @@ public class DataSourceTestCase extends AbstractCliTestBase {
         testRemoveXaDataSource();
     }
 
+    /**
+     * https://issues.jboss.org/browse/WFLY-12161
+     */
+    @Test
+    public void testSharedPreparedStatementsEpxr() throws Exception {
+        cli.sendLine("/system-property=prop:add(value=true)");
+        testAddDataSourceWithSharedPreparedStatementsEpxr();
+        testRemoveDataSource();
+        cli.sendLine("/system-property=prop:remove()");
+    }
+
+    /**
+     * https://issues.jboss.org/browse/WFLY-12161
+     */
+    @Test
+    public void testXaSharedPreparedStatementsEpxr() throws Exception {
+        cli.sendLine("/system-property=prop:add(value=true)");
+        testAddXaDataSourceWithSharedPreparedStatementsEpxr();
+        testRemoveXaDataSource();
+        cli.sendLine("/system-property=prop:remove()");
+    }
+
     private void testAddDataSource() throws Exception {
 
         // add data source
@@ -222,6 +244,34 @@ public class DataSourceTestCase extends AbstractCliTestBase {
         assertTrue(result.getResult() instanceof Map);
         Map<String,Object> dsProps = (Map<String, Object>) result.getResult();
         for (String[] props : DS_PROPS) assertTrue(dsProps.get(props[0]).equals(props[1]));
+
+    }
+
+    private void testAddDataSourceWithSharedPreparedStatementsEpxr() throws Exception {
+
+        // add data source
+        cli.sendLine("data-source add --name=TestDS --jndi-name=java:jboss/datasources/TestDS --driver-name=h2" +
+                " --datasource-class=org.h2.jdbcx.JdbcDataSource --connection-properties={\"url\"=>\"jdbc:h2:mem:test;DB_CLOSE_DELAY=-1\"}");
+
+        // check the data source is listed
+        cli.sendLine("cd /subsystem=datasources/data-source");
+        cli.sendLine("ls");
+        String ls = cli.readOutput();
+        assertTrue(ls.contains("TestDS"));
+
+    }
+
+    private void testAddXaDataSourceWithSharedPreparedStatementsEpxr() throws Exception {
+
+        // add data source
+        cli.sendLine("xa-data-source add --name=TestXADS --jndi-name=java:jboss/datasources/TestXADS --driver-name=h2" +
+                " --xa-datasource-properties={\"url\"=>\"jdbc:h2:mem:test\"} --share-prepared-statements=${prop}");
+
+        //check the data source is listed
+        cli.sendLine("cd /subsystem=datasources/xa-data-source");
+        cli.sendLine("ls");
+        String ls = cli.readOutput();
+        assertTrue(ls.contains("TestXADS"));
 
     }
 


### PR DESCRIPTION
…ments

https://issues.jboss.org/browse/WFLY-12161

XA DS failed when expression was used in share-prepared-statement attribute. Attribute has `allowExpressions = true` and also the non-XA equivalent works with expressions.