### PR TITLE
[WFLY-12162] Upgrading Naming Client to 1.0.11.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.org.wildfly.core>9.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
-        <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.3.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12162

Incorporates:
 * [WFNC-55] Naming Client must always set thread context class loader
