### PR TITLE
[WFLY-11768] Upgrade Jaeger client to 0.34.0 and libthrift to 0.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <version.groovy-all>2.4.7</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
-        <version.io.jaegertracing>0.30.6</version.io.jaegertracing>
+        <version.io.jaegertracing>0.34.0</version.io.jaegertracing>
         <version.io.netty>4.1.29.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.1.0</version.io.opentracing.concurrent>
@@ -304,7 +304,7 @@
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
         <version.org.apache.qpid.proton>0.32.0</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.3</version.org.apache.santuario>
-        <version.org.apache.thrift>0.11.0</version.org.apache.thrift>
+        <version.org.apache.thrift>0.12.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>
         <version.org.apache.ws.security>2.2.3</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.4</version.org.apache.ws.xmlschema>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-11768

@jpkrohling @jmesnil @jamezp FYI.  Per discussion on https://issues.jboss.org/browse/TRACING-389 I think this is ok. Please advise ASAP if not as we want to tag WF 17 on Friday.

With this the versions in WF will align with what is in https://github.com/jaegertracing/jaeger-client-java/blob/v0.34.0/build.gradle#L20 except for slf4j-api where we use 1.7.22.jbossorg-1. And that difference vs jaeger-client-java has always been present.