### PR TITLE
WFLY-12167 Don't return from ServiceSupplier.get() until one-time service is removed.

### DIFF
--- a/clustering/service/src/main/java/org/wildfly/clustering/service/ServiceSupplier.java
+++ b/clustering/service/src/main/java/org/wildfly/clustering/service/ServiceSupplier.java
@@ -99,8 +99,14 @@ public class ServiceSupplier<T> implements Supplier<T> {
             Thread.currentThread().interrupt();
             throw new IllegalStateException(e);
         } finally {
-            monitor.removeController(controller);
             controller.setMode(ServiceController.Mode.REMOVE);
+            try {
+                monitor.awaitStability();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                monitor.removeController(controller);
+            }
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12167

jboss-msc 1.4.7.Final is required to completely address WFLY-12167, but this should prevent the rapid accumulation of to-be-removed services waiting for an available MSC thread to perform the removal.