### PR TITLE
[WFLY-12177] Replace deprecated Mockito Matchers class with ArgumentMatchers

### DIFF
--- a/clustering/ee/infinispan/src/test/java/org/wildfly/clustering/ee/infinispan/CacheEntryMutatorTestCase.java
+++ b/clustering/ee/infinispan/src/test/java/org/wildfly/clustering/ee/infinispan/CacheEntryMutatorTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.wildfly.clustering.ee.infinispan;
 
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/clustering/singleton/api/src/test/java/org/wildfly/clustering/server/singleton/election/PreferredSingletonElectionPolicyTestCase.java
+++ b/clustering/singleton/api/src/test/java/org/wildfly/clustering/server/singleton/election/PreferredSingletonElectionPolicyTestCase.java
@@ -23,7 +23,7 @@ package org.wildfly.clustering.server.singleton.election;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionExpirationListenerTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionExpirationListenerTestCase.java
@@ -22,8 +22,8 @@
 package org.wildfly.clustering.web.undertow.session;
 
 import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Matchers.same;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/ejb3/src/test/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptorTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptorTestCase.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
[https://issues.jboss.org/browse/WFLY-12177](https://issues.jboss.org/browse/WFLY-12177)

Matchers class got replaced with ArgumentMatchers, the following is from the [Javadoc](https://static.javadoc.io/org.mockito/mockito-core/2.18.0/org/mockito/Matchers.html):

> Deprecated.
> Use ArgumentMatchers. This class is now deprecated in order to avoid a name clash with Hamcrest org.hamcrest.Matchers class. This class will likely be removed in version 3.0.
> 