### PR TITLE
[WFLY-12180] no NPE on registering synchronization on no active transaction

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
+++ b/transactions/src/main/java/org/jboss/as/txn/logging/TransactionLogger.java
@@ -253,4 +253,7 @@ public interface TransactionLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 39, value = "A value of zero is not permitted for the maximum timeout, as such the timeout has been set to %s")
     void timeoutValueIsSetToMaximum(int maximum_timeout);
+
+    @Message(id = 40, value = "There is no active transaction at the current context to register synchronization '%s'")
+    IllegalStateException noActiveTransactionToRegisterSynchronization(Synchronization sync);
 }

--- a/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/TransactionSynchronizationRegistryWrapper.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/internal/tsr/TransactionSynchronizationRegistryWrapper.java
@@ -25,6 +25,7 @@ import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.TransactionSynchronizationRegistry;
 
+import org.jboss.as.txn.logging.TransactionLogger;
 import org.wildfly.transaction.client.AbstractTransaction;
 import org.wildfly.transaction.client.ContextTransactionManager;
 import org.wildfly.transaction.client.ContextTransactionSynchronizationRegistry;
@@ -61,6 +62,9 @@ public class TransactionSynchronizationRegistryWrapper implements TransactionSyn
         throws IllegalStateException {
         try {
             AbstractTransaction tx = ContextTransactionManager.getInstance().getTransaction();
+            if(tx == null) {
+                throw TransactionLogger.ROOT_LOGGER.noActiveTransactionToRegisterSynchronization(sync);
+            }
             JCAOrderedLastSynchronizationList jcaOrderedLastSynchronization = (JCAOrderedLastSynchronizationList) tx.getResource(key);
             if (jcaOrderedLastSynchronization == null) {
                 final ContextTransactionSynchronizationRegistry tsr = ContextTransactionSynchronizationRegistry.getInstance();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12180

Throwing `IllegalStateException` instead of `NPE`.