### PR TITLE
[WFLY-12187] Add documentation and test updates for TLS 1.3 support

### DIFF
--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -382,13 +382,13 @@ The <ssl-contexts /> element holds individual names SSLContext definitions that 
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
-    <authentication-client xmlns="urn:elytron:1.0">
+    <authentication-client xmlns="urn:elytron:1.4">
         <ssl-contexts>
             <default-ssl-context name="..."/>
             <ssl-context name="...">
                 <key-store-ssl-certificate>...</key-store-ssl-certificate>
                 <trust-store key-store-name="..." />
-                <cipher-suite selector="..." />
+                <cipher-suite selector="..." names="..." />
                 <protocol names="... ..." />
                 <provider-name name="..." />
                 <providers>...</providers>
@@ -424,16 +424,24 @@ This structure is identical to the structure use in [<key-store-credential />|#k
 
  <trust-store-key-store-name />:: A reference to a KeyStore that will be used to initialise the TrustManager.
 
- <cipher-suite-selector />:: Configuration to filter the enabled cipher suites, the format of the selector is [org.wildfly.security.ssl.CipherSuiteSelector.fromString(selector)|http://wildfly-security.github.io/wildfly-elytron/1.1.x/org/wildfly/security/ssl/CipherSuiteSelector.html#fromString-java.lang.String-].
+ <cipher-suite selector="..." names="..." />:: Configuration to filter the enabled cipher suites. This element must contain at least one of the following two attributes: -
 
-The following would be a cipher suite selector performing the default filtering.
+ selector:: _(Optional)_ Used to configure the enabled cipher suites for TLSv1.2 and below. The format of the `selector` attribute is described in detail
+ in http://wildfly-security.github.io/wildfly-elytron/master/org/wildfly/security/ssl/CipherSuiteSelector.html#fromString-java.lang.String-[org.wildfly.security.ssl.CipherSuiteSelector.fromString(selector)].
+ The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and excludes any cipher suites that have no authentication.
+
+ names:: _(Optional)_ Used to configure the enabled cipher suites for TLSv1.3. The format of the `names` attribute is a simple colon (":")
+ separated list of TLSv1.3 cipher suite names. The default value is `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+
+The following example configuration specifies that the default filtering should be used for TLSv1.2 and below and specifies that the
+`TLS_AES_128_CCM_8_SHA256` and `TLS_AES_256_GCM_SHA384` cipher suites should be used for TLSv1.3.
 
 [source,xml,options="nowrap"]
 ----
-<cipher-suite selector="DEFAULT" />
+<cipher-suite selector="DEFAULT" names="TLS_AES_128_CCM_8_SHA256:TLS_AES_256_GCM_SHA384"/>
 ----
 
- <protocol />:: used to define a space separated list of the protocols to be supported.
+ <protocol names="..."/>:: Used to define a space separated list of the protocols to be supported. The default value is `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`. Note that the TLSv1.3 protocol will only be usable when running against JDK 11 or higher.
 
  <provider-name />:: Once the available providers have been identified only the provider with the name defined on this element will be used.
 

--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -431,7 +431,8 @@ This structure is identical to the structure use in [<key-store-credential />|#k
  The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and excludes any cipher suites that have no authentication.
 
  names:: _(Optional)_ Used to configure the enabled cipher suites for TLSv1.3. The format of the `names` attribute is a simple colon (":")
- separated list of TLSv1.3 cipher suite names. The default value is `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+ separated list of TLSv1.3 cipher suite names (e.g., `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`).
+ This attribute must be specified in order for TLSv1.3 to be enabled.
 
 The following example configuration specifies that the default filtering should be used for TLSv1.2 and below and specifies that the
 `TLS_AES_128_CCM_8_SHA256` and `TLS_AES_256_GCM_SHA384` cipher suites should be used for TLSv1.3.

--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -2231,7 +2231,12 @@ by this SSLContext. The format of this attribute is described in detail in
 http://wildfly-security.github.io/wildfly-elytron/master/org/wildfly/security/ssl/CipherSuiteSelector.html#fromString-java.lang.String-[org.wildfly.security.ssl.CipherSuiteSelector.fromString(selector)].
 The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and
 excludes any cipher suites that have no authentication.
-protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`.
+cipher-suite-names:: _(Optional)_ The enabled cipher suites for TLSv1.3. The format of this attribute is a simple colon
+(":") separated list of TLSv1.3 cipher suite names. The default value is
+`TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`. The default value
+is `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`. Note that the TLSv1.3 protocol will only be usable when running against JDK 11 or
+higher.
 want-client-auth:: _(Optional)_ To request (but not to require) a client certificate on SSL handshake. If a
 `security-domain` is configured and supports X509 evidence, this will be set to `true` automatically. Ignored when
 `need-client-auth` is set. The default value is `false`.
@@ -2278,10 +2283,21 @@ by this SSLContext. The format of this attribute is described in detail in
 http://wildfly-security.github.io/wildfly-elytron/master/org/wildfly/security/ssl/CipherSuiteSelector.html#fromString-java.lang.String-[org.wildfly.security.ssl.CipherSuiteSelector.fromString(selector)].
 The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and
 excludes any cipher suites that have no authentication.
-protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`.
+cipher-suite-names:: _(Optional)_ The enabled cipher suites for TLSv1.3. The format of this attribute is a simple colon
+(":") separated list of TLSv1.3 cipher suite names. The default value is
+`TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`. The default value
+is `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`. Note that the TLSv1.3 protocol will only be usable when running against JDK 11 or higher.
 provider-name:: _(Optional)_ The name of the provider to use. If not specified, all providers from `providers` will be
 passed to the `SSLContext`.
 providers:: _(Optional)_ The name of the providers to obtain the `Provider[]` to use to load the `SSLContext`.
+
+*Note:* As described in the previous two sections, the TLSv1.3 protocol can be used when running against JDK 11 or
+higher. One thing that is important to note about TLSv1.3 is that session IDs have become essentially obsolete. This
+means that the session ID can no longer reliably be used to test if a session was resumed. Instead, creation time can be
+used to test if a session was resumed. Currently, clients need to read from the server after the first handshake in
+order to receive the `NewSessionTicket` that can be used for resumption. However, this may change once
+https://bugs.openjdk.java.net/browse/JDK-8209953[JDK-8209953] is resolved.
 
 
 === Default SSLContext

--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -2232,8 +2232,8 @@ http://wildfly-security.github.io/wildfly-elytron/master/org/wildfly/security/ss
 The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and
 excludes any cipher suites that have no authentication.
 cipher-suite-names:: _(Optional)_ The enabled cipher suites for TLSv1.3. The format of this attribute is a simple colon
-(":") separated list of TLSv1.3 cipher suite names. The default value is
-`TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+(":") separated list of TLSv1.3 cipher suite names (e.g., `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`).
+This attribute must be specified in order for TLSv1.3 to be enabled.
 protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`. The default value
 is `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`. Note that the TLSv1.3 protocol will only be usable when running against JDK 11 or
 higher.
@@ -2284,20 +2284,28 @@ http://wildfly-security.github.io/wildfly-elytron/master/org/wildfly/security/ss
 The default value is `DEFAULT`, which corresponds to all known cipher suites that do not have NULL encryption and
 excludes any cipher suites that have no authentication.
 cipher-suite-names:: _(Optional)_ The enabled cipher suites for TLSv1.3. The format of this attribute is a simple colon
-(":") separated list of TLSv1.3 cipher suite names. The default value is
-`TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`.
+(":") separated list of TLSv1.3 cipher suite names (e.g., `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256`).
+This attribute must be specified in order for TLSv1.3 to be enabled.
 protocols:: _(Optional)_ A space separated list of the protocols to be supported by this `SSLContext`. The default value
 is `TLSv1 TLSv1.1 TLSv1.2 TLSv1.3`. Note that the TLSv1.3 protocol will only be usable when running against JDK 11 or higher.
 provider-name:: _(Optional)_ The name of the provider to use. If not specified, all providers from `providers` will be
 passed to the `SSLContext`.
 providers:: _(Optional)_ The name of the providers to obtain the `Provider[]` to use to load the `SSLContext`.
 
-*Note:* As described in the previous two sections, the TLSv1.3 protocol can be used when running against JDK 11 or
-higher. One thing that is important to note about TLSv1.3 is that session IDs have become essentially obsolete. This
-means that the session ID can no longer reliably be used to test if a session was resumed. Instead, creation time can be
-used to test if a session was resumed. Currently, clients need to read from the server after the first handshake in
-order to receive the `NewSessionTicket` that can be used for resumption. However, this may change once
-https://bugs.openjdk.java.net/browse/JDK-8209953[JDK-8209953] is resolved.
+*WARNING* It is possible to use TLSv1.3 with WildFly when running against JDK 11 or higher. However, if JDK 11
+is in use and if there is a very large number of TLSv1.3 requests being made, it is possible that a drop in
+performance (throughput and response time) will occur compared to TLSv1.2. Upgrading to newer JDK versions
+should improve performance. For this reason, the use of TLSv1.3 is currently disabled by default. TLSv1.3 can
+be enabled by configuring the new `cipher-suite-names` attribute in the SSL Context resource definition in the
+Elytron subsystem as described in the previous two sections. It is recommended to test for performance
+degradation prior to enabling TLSv1.3 in a production environment. See https://issues.redhat.com/browse/WFWIP-160[WFWIP-160]
+for more details.
+
+*Note:* When using TLSv1.3, it is important to keep in mind that session IDs have become essentially obsolete.
+This means that the session ID can no longer reliably be used to test if a session was resumed. Instead,
+creation time can be used to test if a session was resumed. Currently, clients need to read from the server after
+the first handshake in order to receive the `NewSessionTicket` that can be used for resumption. However, this may
+change once https://bugs.openjdk.java.net/browse/JDK-8209953[JDK-8209953] is resolved.
 
 
 === Default SSLContext


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12187

This also contains the documentation on server and client SSL contexts included in https://github.com/wildfly/wildfly/pull/12360.

Requires https://github.com/wildfly/wildfly-core/pull/3815 to be merged.