### PR TITLE
[WFLY-12189] Add MicroProfile Config TCK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,7 @@
         <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
+        <version.org.harmcrest>1.3</version.org.harmcrest>
         <version.org.hibernate>5.3.10.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.5.Final</version.org.hibernate.search>
@@ -5097,7 +5098,12 @@
                 <artifactId>microprofile-config-api</artifactId>
                 <version>${version.org.eclipse.microprofile.config.api}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.eclipse.microprofile.config</groupId>
+                <artifactId>microprofile-config-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.config.api}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-api</artifactId>
@@ -5233,6 +5239,13 @@
                 <groupId>org.glassfish.soteria</groupId>
                 <artifactId>javax.security.enterprise</artifactId>
                 <version>${version.org.glassfish.soteria}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-all</artifactId>
+                <version>${version.org.harmcrest}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -169,6 +169,11 @@
             <artifactId>picketbox</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>commons-logging-jboss-logmanager</artifactId>
         </dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -229,6 +229,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.classfilewriter</groupId>
             <artifactId>jboss-classfilewriter</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>wildfly-clustering-singleton-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Used for the infinispan-server-feature-pack -->
         <dependency>
             <groupId>org.wildfly</groupId>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -87,6 +87,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -41,6 +41,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/legacy-ejb-client/pom.xml
+++ b/testsuite/integration/legacy-ejb-client/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>jboss-ejb-client-legacy</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- HACK!!! We must override anything that brings in the standard jboss-ejb-client, and forcefully exclude it.
              Otherwise there will be classpath conflicts, since they define the same package.  -->
         <dependency>

--- a/testsuite/integration/legacy/pom.xml
+++ b/testsuite/integration/legacy/pom.xml
@@ -42,6 +42,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <!-- use the Netty version required by HornetQ 2.4.7.Final -->

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/microprofile-tck/config/pom.xml
+++ b/testsuite/integration/microprofile-tck/config/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ts-integ-mp</artifactId>
+        <version>18.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-ts-integ-mp-config</artifactId>
+    <name>WildFly Test Suite: Integration - MicroProfile - Config</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/../..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <ts.elytron.cli>${jbossas.ts.dir}/shared/enable-elytron.cli</ts.elytron.cli>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>tck-suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <!-- These env variables are required for org.eclipse.microprofile.config.tck.CDIPropertyNameMatchingTest -->
+                    <environmentVariables>
+                        <my_int_property>45</my_int_property>
+                        <MY_BOOLEAN_PROPERTY>true</MY_BOOLEAN_PROPERTY>
+                        <my_string_property>haha</my_string_property>
+                        <MY_STRING_PROPERTY>woohoo</MY_STRING_PROPERTY>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
+++ b/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
@@ -1,0 +1,30 @@
+package org.wildfly.extension.microprofile.config.test;
+
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.internal.ReflectiveTypeFinder;
+import org.hamcrest.number.IsCloseTo;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class DeploymentProcessor implements ApplicationArchiveProcessor {
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if (archive instanceof WebArchive) {
+            JavaArchive extensionsJar = ShrinkWrap.create(JavaArchive.class, "extension.jar");
+
+            extensionsJar.addPackage(Matchers.class.getPackage());
+            extensionsJar.addPackage(IsEqual.class.getPackage());
+            extensionsJar.addPackage(IsCloseTo.class.getPackage());
+            extensionsJar.addPackage(ReflectiveTypeFinder.class.getPackage());
+
+            WebArchive war = WebArchive.class.cast(archive);
+            war.addAsLibraries(extensionsJar);
+        }
+    }
+}

--- a/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/WildFlyArquillianExtension.java
+++ b/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/WildFlyArquillianExtension.java
@@ -1,0 +1,14 @@
+package org.wildfly.extension.microprofile.config.test;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2019 Red Hat inc.
+ */
+public class WildFlyArquillianExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(ApplicationArchiveProcessor.class, DeploymentProcessor.class);
+    }
+}

--- a/testsuite/integration/microprofile-tck/config/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/testsuite/integration/microprofile-tck/config/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.wildfly.extension.microprofile.config.test.WildFlyArquillianExtension

--- a/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/config/src/test/resources/arquillian.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true" >
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <!-- Pass the my_string_property and MY_STRING_PROPERTY as sysprop to exclude them from the
+                 ConfigProviderTest#testEnvironmentConfigSource that does not deal with case-sensitive environment variables on Windows
+            -->
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m ${modular.jdk.args} -Dmy_string_property=haha -DMY_STRING_PROPERTY=woohoo</property>
+            <property name="serverConfig">standalone.xml</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="waitForPorts">9990</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/testsuite/integration/microprofile-tck/config/tck-suite.xml
+++ b/testsuite/integration/microprofile-tck/config/tck-suite.xml
@@ -1,0 +1,32 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-config-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-config 1.2 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.config.tck.*">
+            </package>
+        </packages>
+        <classes>
+            <!-- Exclude these 3 classes as they rely on a @ShouldThrowException(DeploymentException.class)
+                 that is not working with Arquillian WildFly container (https://issues.jboss.org/browse/WFARQ-59)
+            -->
+            <class name="org.eclipse.microprofile.config.tck.broken.MissingConverterOnInstanceInjectionTest">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.config.tck.broken.MissingValueOnInstanceInjectionTest">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.config.tck.broken.WrongConverterOnInstanceInjectionTest">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+</suite>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -44,6 +44,7 @@
     </properties>
 
     <modules>
+        <module>config</module>
         <module>health</module>
         <module>opentracing</module>
     </modules>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -48,6 +48,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/picketlink/pom.xml
+++ b/testsuite/integration/picketlink/pom.xml
@@ -34,6 +34,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.picketlink</groupId>
             <artifactId>picketlink-idm-impl</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -410,11 +410,6 @@
             <artifactId>wildfly-testsuite-shared</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
       <!--  <dependency>
             <groupId>org.jboss.arquillian.testenricher</groupId>
             <artifactId>arquillian-testenricher-initialcontext</artifactId>

--- a/testsuite/integration/rbac/pom.xml
+++ b/testsuite/integration/rbac/pom.xml
@@ -35,6 +35,13 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
     <profiles>
 
         <profile>

--- a/testsuite/integration/rts/pom.xml
+++ b/testsuite/integration/rts/pom.xml
@@ -87,6 +87,11 @@
         </dependency>
         <!-- End JAXB Java 11 Requirements -->
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.ws.rs</groupId>
             <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>jboss-ejb-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -110,6 +110,11 @@
         </dependency>
         <!-- End JAXB Java 11 Requirements -->
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_2.0_spec</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/vdx/pom.xml
+++ b/testsuite/integration/vdx/pom.xml
@@ -45,6 +45,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.extras.creaper</groupId>
             <artifactId>creaper-core</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -67,6 +67,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.security</groupId>
             <artifactId>jbossxacml</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -134,6 +134,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>jbossxts</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Required for Java 11 -->
         <dependency>
             <groupId>org.jboss.spec.javax.xml.ws</groupId>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -100,6 +100,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
         </dependency>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -69,6 +69,7 @@
             <artifactId>wildfly-security-api</artifactId>
         </dependency>
 
+
         <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
@@ -77,6 +78,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
* add testsuite/integration/microprofile-tck module to run the
  MicroProfile Config TCK
* add the org.eclipse.microprofile.config:microprofile-config-tck
  dependency with the version matching the microprofile-config-api (in
  test scope)
* add the org.hamcrest:hamcrest-all:1.3 dependency (in test scope) used
  by the TCK tests.

This TCK uses the TestNG Arquillian TestRunner and Arquillian does not
allow multiple TestRunners when tests are run.
The org.jboss.arquillian.junit:arquillian-junit-container dependency has
been removed from testsuite/integration/pom.xml and added to the modules
beneath it that require it.

Some TCK test are ignored in tck-suite.xml due to the
https://issues.jboss.org/browse/WFARQ-59 issue but the code is working
as expected (as the deployments from these tests fail).

JIRA: https://issues.jboss.org/browse/WFLY-12189