### PR TITLE
[WFLY-11759] Revert UndertowTransformersTestCase workaround

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
@@ -213,17 +213,6 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
 
         List<ModelNode> ops = builder.parseXmlResource("undertow-reject.xml");
 
-        if (controllerVersion == ModelTestControllerVersion.EAP_7_1_0) {
-            // The EAP 7.1 tests load a legacy version of undertow in the child first classloader
-            // But the current version is in the parent. PredicateValidator's use of PredicateParser
-            // fails in this situation as it results in ServiceLoader trying to load classes from both
-            // jars. So just disable testing of params that involve PredicateValidator.
-            for (ModelNode op : ops) {
-                op.remove(Constants.PREDICATE);
-                op.remove(Constants.MANAGEMENT_ACCESS_PREDICATE);
-            }
-        }
-
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, targetVersion, ops, config);
     }
 

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-7.1-transformers.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-7.1-transformers.xml
@@ -36,19 +36,17 @@
             <filter-ref name="limit-connections"/>
             <filter-ref name="headers" priority="${some.priority:10}"/>
             <filter-ref name="404-handler"/>
-            <!--
             <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
-            -->
          </location>
-         <!--<access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>-->
-         <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" prefix="access" rotate="false"/>
+         <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
+         <!-- <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" prefix="access" rotate="false"/> -->
          <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
       </host>
       <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host">
          <location handler="welcome-content" name="/">
             <filter-ref name="limit-connections"/>
             <filter-ref name="headers"/>
-            <!--<filter-ref name="static-gzip" predicate="path-suffix('.js') or path-suffix('.css') or path-prefix('/resources')"/>-->
+            <filter-ref name="static-gzip" predicate="path-suffix('.js') or path-suffix('.css') or path-prefix('/resources')"/>
             <filter-ref name="404-handler"/>
             <filter-ref name="mod-cluster"/>
          </location>
@@ -80,13 +78,9 @@
       <response-header header-name="MY_HEADER" header-value="someValue" name="headers"/>
       <gzip name="static-gzip"/>
       <error-page code="404" name="404-handler" path="/opt/data/404.html"/>
-      <!--<mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp" advertise-socket-binding="advertise-socket-binding"
-                   name="mod-cluster" broken-node-timeout="1000" cached-connections-per-thread="10" connection-idle-timeout="10"
-                   health-check-interval="600" management-access-predicate="method[GET]" management-socket-binding="test3" max-request-time="1000"
-                   failover-strategy="DETERMINISTIC" max-retries="10" security-key="password" security-realm="UndertowRealm" />-->
       <mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp" advertise-socket-binding="advertise-socket-binding"
                    name="mod-cluster" broken-node-timeout="1000" cached-connections-per-thread="10" connection-idle-timeout="10"
-                   health-check-interval="600" management-socket-binding="test3" max-request-time="1000"
+                   health-check-interval="600" management-access-predicate="method[GET]" management-socket-binding="test3" max-request-time="1000"
                    failover-strategy="DETERMINISTIC" max-retries="10" security-key="password" security-realm="UndertowRealm" />
       <filter class-name="io.undertow.server.handlers.HttpTraceHandler" module="io.undertow.core" name="custom-filter"/>
       <expression-filter expression="dump-request" name="requestDumper"/>


### PR DESCRIPTION
KernelServicesBuilder.excludeResourceFromParent API is no longer needed, the test runs okay

Jira: https://issues.jboss.org/browse/WFLY-11759