### PR TITLE
[WFLY-12219] Disabling SSL failing tests for now on JDK13+

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
@@ -50,6 +50,8 @@ import org.jboss.security.auth.spi.CertRolesLoginModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -81,6 +83,12 @@ public class CertificateRolesLoginModuleTestCase extends AbstractCertificateLogi
     private static AutoCloseable snapshot;
 
     private static ManagementClient managementClient;
+
+    @BeforeClass
+    public static void noJDK13Plus() {
+        Assume.assumeFalse("Avoiding JDK 13 due to https://issues.jboss.org/browse/WFCORE-4532", "13".equals(System.getProperty("java.specification.version")));
+        Assume.assumeFalse("Avoiding JDK 14 due to https://issues.jboss.org/browse/WFCORE-4532", "14".equals(System.getProperty("java.specification.version")));
+    }
 
     @Deployment(name = APP_NAME, testable = false, managed = false)
     public static WebArchive deployment() {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
@@ -58,6 +58,8 @@ import org.jboss.logging.Logger;
 import org.jboss.security.auth.spi.DatabaseCertLoginModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -88,6 +90,12 @@ public class DatabaseCertLoginModuleTestCase extends AbstractCertificateLoginMod
     private static ManagementClient managementClient;
 
     private static AutoCloseable snapshot;
+
+    @BeforeClass
+    public static void noJDK13Plus() {
+        Assume.assumeFalse("Avoiding JDK 13 due to https://issues.jboss.org/browse/WFCORE-4532", "13".equals(System.getProperty("java.specification.version")));
+        Assume.assumeFalse("Avoiding JDK 14 due to https://issues.jboss.org/browse/WFCORE-4532", "14".equals(System.getProperty("java.specification.version")));
+    }
 
     @Deployment(name = APP_NAME, testable = false, managed = false)
     public static WebArchive deployment() {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -82,6 +82,7 @@ import org.jboss.security.auth.spi.BaseCertLoginModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -140,6 +141,12 @@ public class HTTPSWebConnectorTestCase {
 
     @ArquillianResource
     private Deployer deployer;
+
+    @BeforeClass
+    public static void noJDK13Plus() {
+        Assume.assumeFalse("Avoiding JDK 13 due to https://issues.jboss.org/browse/WFCORE-4532", "13".equals(System.getProperty("java.specification.version")));
+        Assume.assumeFalse("Avoiding JDK 14 due to https://issues.jboss.org/browse/WFCORE-4532", "14".equals(System.getProperty("java.specification.version")));
+    }
 
     @Deployment(name = APP_CONTEXT, testable = false, managed = false)
     public static WebArchive deployment() {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12219