### PR TITLE
[WFLY-12175] Fix some wrong links in the documentation

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Management_resources.adoc
@@ -289,7 +289,7 @@ exposes.
 == Children
 
 Management resources may support child resources. The
-<<children,_types_ of children>> a
+<<address,_types_ of children>> a
 resource supports (e.g. `connector` for the web subsystem resource) can
 be obtained by querying the resource's description (see
 <<descriptions,Descriptions>> below)

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Description_of_the_Management_Model.adoc
@@ -7,7 +7,7 @@ make up the management model provided by an individual WildFly instance
 or by any Domain Controller or slave Host Controller process can be
 queried using the `read-resource-description`, `read-operation-names`,
 `read-operation-description` and `read-child-types` operations described
-in the link:Global_operations{outfilesuffix}[Global operations] section. In this
+in the <<Global_operations,Global operations>> section. In this
 section we provide details on what's included in those descriptions.
 
 [[description-of-the-wildfly-managed-resources]]
@@ -15,7 +15,7 @@ section we provide details on what's included in those descriptions.
 
 All portions of the management model exposed by WildFly are addressable
 via an ordered list of key/value pairs. For each addressable
-<<Management_resources#management-resources, Management Resource>>, the following
+<<management-resources, Management Resource>>, the following
 descriptive information will be available:
 
 * `description` – String – text description of this portion of the model
@@ -76,7 +76,7 @@ For example:
 
 An attribute is a portion of the management model that is not directly
 addressable. Instead, it is conceptually a property of an addressable
-link:../Management_resources{outfilesuffix}[management resource]. For
+<<management-resources,management resource>>. For
 each attribute in the model, the following descriptive information will
 be available:
 

--- a/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-api/Global_operations.adoc
@@ -8,8 +8,8 @@ every resource.
 == The read-resource operation
 
 Reads a management resource's attribute values along with either basic
-or complete information about any child resources. Supports the +
-following parameters, none of which are required:
+or complete information about any child resources. Supports the following
+parameters, none of which are required:
 
 * `recursive` – (boolean, default is `false`) – whether to include
 complete information about child resources, recursively.
@@ -209,8 +209,7 @@ Management Model>> for details on the result of this operation.
 == The read-children-types operation
 
 Returns a list of the
-link:Management_resources.html#src-557064_Managementresources-Address[types
-of child resources] the resource supports. Takes two optional
+<<address,_types_ of child resources>> the resource supports. Takes two optional
 parameters:
 
 * `include-aliases` – (boolean, default is `false`) – whether to include
@@ -227,7 +226,7 @@ discussion around this topic].
 == The read-children-names operation
 
 Returns a list of the names of all child resources of a given
-link:Management_resources.html#src-557064_Managementresources-Address[type].
+<<address,type>>.
 Takes a single, required, parameter:
 
 * `child-type` – (string) – the name of the type
@@ -236,8 +235,7 @@ Takes a single, required, parameter:
 == The read-children-resources operation
 
 Returns information about all of a resource's children that are of a
-given
-link:Management_resources.html#src-557064_Managementresources-Address[type].
+given <<address,type>>.
 For each child resource, the returned information is equivalent to
 executing the `read-resource` operation on that resource. Takes the
 following parameters, of which only \{\{child-type} is required:
@@ -267,8 +265,7 @@ will include the default value for such parameters.
 == The read-attribute-group operation
 
 Returns a list of attributes of a
-link:Management_resources.html#src-557064_Managementresources-Address[type]
-for a given attribute group name. For each attribute the returned
+<<address,type>> for a given attribute group name. For each attribute the returned
 information is equivalent to executing the `read-attribute` operation of
 that resource. Takes the following parameters, of which only \{\{name}
 is required:
@@ -290,8 +287,7 @@ response.
 [[the-read-attribute-group-names-operation]]
 == The read-attribute-group-names operation
 
-Returns a list of attribute groups names for a given
-link:Management_resources.html#src-557064_Managementresources-Address[type].
+Returns a list of attribute groups names for a given <<address,type>>.
 Takes no parameters.
 
 [[standard-operations]]

--- a/docs/src/main/asciidoc/_extending-wildfly/Key_Interfaces_and_Classes_Relevant_to_Extension_Developers.adoc
+++ b/docs/src/main/asciidoc/_extending-wildfly/Key_Interfaces_and_Classes_Relevant_to_Extension_Developers.adoc
@@ -67,7 +67,7 @@ interface) relate to the notion of managed resources in the AS.
 
 Each subsystem is responsible for managing one or more management
 resources. The conceptual characteristics of a management resource are
-covered in some detail in the link:Admin_Guide{outfilesuffix}#Management_resources[Admin
+covered in some detail in the link:Admin_Guide{outfilesuffix}#management-resources[Admin
 Guide]; here we'll just summarize the main points. A management resource
 has
 


### PR DESCRIPTION
Fixed incorrect links in the documentation in :

https://docs.wildfly.org/17/Admin_Guide.html#Description_of_the_Management_Model 
https://docs.wildfly.org/17/Admin_Guide.html#management-resources
https://docs.wildfly.org/17/Admin_Guide.html#description-of-an-attribute
https://docs.wildfly.org/17/Admin_Guide.html#Global_operations
https://docs.wildfly.org/17/Extending_WildFly.html#wildfly-managed-resources

Jira issue: https://issues.jboss.org/browse/WFLY-12175