### PR TITLE
WFLY-12242 Default VERIFY_SUSPECT timeout is too high

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -57,7 +57,7 @@
         timeout="60000"
         timeout_check_interval="5000"/>
     <FD_SOCK/>
-    <VERIFY_SUSPECT timeout="5000"/>
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2
         xmit_interval="100"
         xmit_table_num_rows="50"


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12242