### PR TITLE
WFLY-12245 Default routing cache in HA profiles should use replicated-cache

### DIFF
--- a/galleon-pack/src/main/resources/feature_groups/infinispan-dist.xml
+++ b/galleon-pack/src/main/resources/feature_groups/infinispan-dist.xml
@@ -47,8 +47,8 @@
                     <param name="mode" value="BATCH"/>
                 </feature>
             </feature>
-            <feature spec="subsystem.infinispan.cache-container.distributed-cache">
-                <param name="distributed-cache" value="routing"/>
+            <feature spec="subsystem.infinispan.cache-container.replicated-cache">
+                <param name="replicated-cache" value="routing"/>
             </feature>
         </feature>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12245

Unfortunate oversight...
Legacy configuration is already correct.