### PR TITLE
[WFLY-12204] Update wildfly-transaction-client to 1.1.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.1.3.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>1.1.4.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.1</version.sun.jaxb>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12204
https://issues.jboss.org/browse/WFLY-12077

<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFTC-61'>WFTC-61</a>] -         Failure to connect when dealing with transactions should return XAER_RMFAIL even for rollback
</li>
<li>[<a href='https://issues.jboss.org/browse/WFTC-62'>WFTC-62</a>] -         ejb-xa-recovery logs are not being cleared after recovery
</li>
<li>[<a href='https://issues.jboss.org/browse/WFTC-64'>WFTC-64</a>] -         ejb-xa-recovery logs are not being cleared if peer server provides no Xids to recover
</li>
<li>[<a href='https://issues.jboss.org/browse/WFTC-65'>WFTC-65</a>] -         NullPointerException should not be thrown when txn provider for uri is not available
</li>
<li>[<a href='https://issues.jboss.org/browse/WFTC-66'>WFTC-66</a>] -         TransactionServerChannel.handleXaTxnRollbackOnly returns XAER_NOTA if xid cannot be imported
</li>
<li>[<a href='https://issues.jboss.org/browse/WFTC-67'>WFTC-67</a>] -         WFLY transaction client does not provide information for transaction recovery in case of failure after prepare
</li>
</ul>