### PR TITLE
[WFLY-12256] Upgrade WildFly Core 9.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>9.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>9.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.10.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12256

----


## Release Notes - WildFly Core - Version 9.0.2.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4495'>WFCORE-4495</a>] -         Upgrade wildfly-openssl from 1.0.6.Final to 1.0.7.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4539'>WFCORE-4539</a>] -         Upgrade JBoss MSC to 1.4.8.Final
</li>
</ul>
                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4544'>WFCORE-4544</a>] -         Missing license info
</li>
</ul>
                                            