### PR TITLE
[WFLY-12264] Upgrade WildFly Core 10.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>9.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.15.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12264

---


##  Release Notes - WildFly Core - Version 10.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4391'>WFCORE-4391</a>] -         Upgrade apacheds-all to 2.0.0-M24 for Elytron tests
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4495'>WFCORE-4495</a>] -         Upgrade wildfly-openssl from 1.0.6.Final to 1.0.7.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4526'>WFCORE-4526</a>] -         Upgrade Undertow to 2.0.22.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4528'>WFCORE-4528</a>] -         Upgrade WildFly Elytron to 1.10.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4529'>WFCORE-4529</a>] -         Upgrade Elytron Web to 1.6.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4533'>WFCORE-4533</a>] -         Upgrade jboss-logmanager from 2.1.11.Final to 2.1.13.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4539'>WFCORE-4539</a>] -         Upgrade JBoss MSC to 1.4.8.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4546'>WFCORE-4546</a>] -         Upgrade WildFly Elytron to 1.10.0.CR2
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3747'>WFCORE-3747</a>] -         Enhance credential-store description related to location and type attributes
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4314'>WFCORE-4314</a>] -         Enchance keystore CLI commands
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4477'>WFCORE-4477</a>] -         Introduce CapabilityServiceBuilder.setInstance(RuntimeCapability cap) overriding method
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4478'>WFCORE-4478</a>] -         Eliminate CapabilityServiceTarget &amp; CapabilityServiceBuilder deprecated methods usages
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4501'>WFCORE-4501</a>] -         Provide XML schema for credential-reference
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4531'>WFCORE-4531</a>] -         Eliminate WF naming workaround
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4538'>WFCORE-4538</a>] -         Disable failing SSL &amp; SASL tests on JDK13+
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-629'>WFCORE-629</a>] -         Enabled automatic encryption of passwords stored in configuration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-2496'>WFCORE-2496</a>] -         Functionality in WildFly to encrypt database passwords
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3947'>WFCORE-3947</a>] -         Support SSL Certificate revocation using OCSP
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4150'>WFCORE-4150</a>] -         Support automatically adding / updating credentials in the CredentialStore
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4172'>WFCORE-4172</a>] -         Add support for TLS 1.3
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4227'>WFCORE-4227</a>] -         Add the ability for the CLI SSL security commands to be able to obtain a server certificate from Let&#39;s Encrypt
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4360'>WFCORE-4360</a>] -         Support encrypted expression resolution using a CredentialStore
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4361'>WFCORE-4361</a>] -         Enhanced mapping of X509Certificate to the underlying identity
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4362'>WFCORE-4362</a>] -         Make the certificate authority used by a certificate-authority-account configurable
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4394'>WFCORE-4394</a>] -         Enhanced Audit Logging - RFC support and reliability/speed customization
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4447'>WFCORE-4447</a>] -         Elytron: Ability to load the attributes of an identity from multiple sources
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4483'>WFCORE-4483</a>] -         Add support for missing MP-JWT requirements
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-944'>WFCORE-944</a>] -         truststore path is ignored if provider is not JKS
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4440'>WFCORE-4440</a>] -         Changes made via CLI in static-discovery are not reflected in host.xml
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4502'>WFCORE-4502</a>] -         Unify line-endings of bat and ps1 scripts (regression against WF15)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4517'>WFCORE-4517</a>] -         Restore adding the java.se module in the launcher API
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4519'>WFCORE-4519</a>] -         Slave Host Controller deployment repository is cleaned after a full deployment replacement
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4521'>WFCORE-4521</a>] -         add-user script fails when there is no domain configuration
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4540'>WFCORE-4540</a>] -         Add error message with information that is not allowed to read secret-value and entry-type from Credential Store
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4543'>WFCORE-4543</a>] -         CLI output is doubled after embed-server reload
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4544'>WFCORE-4544</a>] -         Missing license info
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4545'>WFCORE-4545</a>] -         Incomplete fix for WFCORE-4406
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4282'>WFCORE-4282</a>] -         Remove use of java.security.acl APIs in Elytron PolicyDefinitions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4352'>WFCORE-4352</a>] -         When on JDK 12, disable tests that hang due to https://bugs.openjdk.java.net/browse/JDK-8219658
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4471'>WFCORE-4471</a>] -         Bump the Elytron subsystem version
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4487'>WFCORE-4487</a>] -         Migrate domain-management module to new MSC API
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4498'>WFCORE-4498</a>] -         HttpServerDefinitions should reuse the Provider[] it obtains to check HTTP mechs are supported
</li>
</ul>