### PR TITLE
[WFLY-12268] ${maven.repository.url} in repository url is not evaluat…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,14 +175,6 @@
         <wildfly.build.output.dir>build/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
         <wildfly.web.build.output.dir>servlet-dist/target/${server.output.dir.prefix}-servlet-${server.output.dir.version}</wildfly.web.build.output.dir>
 
-        <!-- Protocol to use for communication with remote maven repositories.
-             You can set to 'http' if you are using a maven proxy and 'https' 
-             interferes with that. Use 'https' for builds that will be released
-             to non-snapshot public maven repos -->
-        <maven.repository.protocol>https</maven.repository.protocol>
-        <!-- The full remote maven repo URL; can be overridden via -D for special use cases -->
-        <maven.repository.url>${maven.repository.protocol}://repository.jboss.org/nexus/content/groups/public/</maven.repository.url>
-
         <!-- Surefire args -->
         <surefire.extra.args></surefire.extra.args>
         <surefire.jpda.args></surefire.jpda.args>
@@ -7904,7 +7896,7 @@
             </snapshots>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>${maven.repository.url}</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
         </repository>
     </repositories>
@@ -7919,7 +7911,7 @@
             </snapshots>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>${maven.repository.url}</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
…ed when org.jboss:jboss-parent is missing

Issue: https://issues.jboss.org/browse/WFLY-12268

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

Changes in this PR:
- Remove the property: `maven.repository.url` because it is not useful for evaluate `jboss-parent` as the repository url ([Known Maven issue](https://issues.apache.org/jira/browse/MNG-5611))
- Added a profile: `http` and can be activated using property: `-Dmaven.repository.protocol=http` to switch to use http repository.

