### PR TITLE
WFLY-12258 Upgrade wildfly-transaction-client from 1.1.4.Final to 1.1…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.1.4.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>1.1.5.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.1</version.sun.jaxb>


### PR DESCRIPTION
….5.Final

JIRA: https://issues.jboss.org/browse/WFLY-12258

This component upgrade consists of a couple of important bug fixes (see diff below)
diff between wildfly-transaction-client 1.1.4.Final and 1.1.5.Final: https://github.com/wildfly/wildfly-transaction-client/compare/1.1.4.Final...1.1.5.Final