### PR TITLE
[WFLY-12277] Avoid doubled 'image' in docs image URLs; use correct if…

### DIFF
--- a/docs/src/main/asciidoc/Getting_Started_Guide.adoc
+++ b/docs/src/main/asciidoc/Getting_Started_Guide.adoc
@@ -9,6 +9,7 @@ WildFly team;
 :doctype: book
 :icons: font
 :source-highlighter: coderay
+ifdef::env-github[:imagesdir: images/]
 
 // ifndef::ebook-format[:leveloffset: 1]
 
@@ -389,7 +390,7 @@ As with previous WildFly releases, you can point your browser to
 *_http://localhost:8080_* (if using the default configured http port)
 which brings you to the Welcome Screen:
 
-image:images/wildfly.png[wildfly.png]
+image:wildfly.png[images/wildfly.png]
 
 From here you can access links to the WildFly community documentation
 set, stay up-to-date on the latest project information, have a

--- a/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Default_HTTP_Interface_Security.adoc
@@ -1,6 +1,6 @@
 [[Default_HTTP_Interface_Security]]
 = Default HTTP Interface Security
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 WildFly is distributed secured by default. The default security
 mechanism is username / password based making use of HTTP Digest for the
@@ -14,7 +14,7 @@ default user in the distribution.
 If you attempt to connect to the admin console before you have added a
 user to the server you will be presented with the following screen.
 
-image:images/no-users.png[no-users.png]
+image:no-users.png[images/no-users.png]
 
 The user are stored in a properties file called mgmt-users.properties
 under standalone/configuration and domain/configuration depending on the
@@ -32,7 +32,7 @@ the same password.
 To manipulate the files and add users we provide a utility add-user.sh
 and add-user.bat to add the users and generate the hashes, to add a user
 you should execute the script and follow the guided process.
-image:images/add-user.png[Add User] +
+image:add-user.png[images/add-user.png] +
 The full details of the add-user utility are described later but for the
 purpose of accessing the management interface you need to enter the
 following values: -

--- a/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Operating_modes.adoc
@@ -1,6 +1,6 @@
 [[Operating_modes]]
 = Operating mode
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 WildFly can be booted in two different modes. A _managed domain_ allows
 you to run and manage a multi-server topology. Alternatively, you can
@@ -50,7 +50,7 @@ Controller. See <<Domain_Setup,Domain Setup>> for details.
 
 The following is an example managed domain topology:
 
-image:images/DC-HC-Server.png[DC-HC-Server]
+image:DC-HC-Server.png[images/DC-HC-Server.png]
 
 [[host]]
 === Host

--- a/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/RBAC.adoc
@@ -1,6 +1,6 @@
 [[RBAC]]
 = Authorizing management actions with Role Based Access Control
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 WildFly introduces a Role Based Access Control scheme that allows
 different administrative users to have different sets of permissions to
@@ -257,7 +257,7 @@ admin console.
 Navigate to the "Administration" tab and the "Users" subtab. From there
 individual user mappings can be added, removed, or edited.
 
-image:images/usermapping.png[images/usermapping.png,width=450]
+image:usermapping.png[images/usermapping.png,width=450]
 
 The CLI can also be used to map individuals users to roles.
 
@@ -342,7 +342,7 @@ console.
 Navigate to the "Administration" tab and the "Groups" subtab. From there
 group mappings can be added, removed, or edited.
 
-image:images/groupmapping.png[images/groupmapping.png,width=450]
+image:groupmapping.png[images/groupmapping.png,width=450]
 
 The CLI can also be used to map groups to roles. The only difference to
 individual user mapping is the value of the `type` attribute should be
@@ -394,7 +394,7 @@ In the web based admin console, navigate to the "Administration" tab,
 "Roles" subtab, highlight the relevant role, click the "Edit" button and
 click on the "Include All" checkbox:
 
-image:images/includeall.png[images/includeall.png,width=450]
+image:includeall.png[images/includeall.png,width=450]
 
 The same change can be made using the CLI:
 
@@ -421,7 +421,7 @@ where the `include-all` attribute is set to true for a role.
 In the admin console, excludes are done in the same screens as includes.
 In the add dialog, simply change the "Type" pulldown to "Exclude".
 
-image:images/excludemapping.png[images/excludemapping.png,width=450]
+image:excludemapping.png[images/excludemapping.png,width=450]
 
 In the CLI, excludes are identical to includes, except the resource
 address has `exclude` instead of `include` as the key for the last
@@ -588,14 +588,14 @@ Both server-group and host scoped roles can be added, removed or edited
 via the admin console. Select "Scoped Roles" from the "Administration"
 tab, "Roles" subtab:
 
-image:images/scopedroles.png[images/scopedroles.png,width=450]
+image:scopedroles.png[images/scopedroles.png,width=450]
 
 When adding a new scoped role, use the dialogue's "Type" pull down to
 choose between a host scoped role and a server-group scoped role. Then
 place the names of the relevant hosts or server groups in the "Scope"
 text are.
 
-image:images/addscopedrole.png[images/addscopedrole.png,width=450]
+image:addscopedrole.png[images/addscopedrole.png,width=450]
 
 [[configuring-constraints]]
 == Configuring constraints
@@ -1171,7 +1171,7 @@ Users can learn in which roles they are operating. In the admin console,
 click on your name in the top right corner; the roles you are in will be
 shown.
 
-image:images/callersroles.png[images/callersroles.png,width=450]
+image:callersroles.png[images/callersroles.png,width=450]
 
 CLI users should use the `whoami` operation with the `verbose` attribute
 set:
@@ -1251,11 +1251,11 @@ Admin console users can change the role in which they operate by
 clicking on their name in the top right corner and clicking on the "Run
 as..." link.
 
-image:images/callersroles.png[images/callersroles.png,width=450]
+image:callersroles.png[images/callersroles.png,width=450]
 
 Then select the role in which you wish to operate:
 
-image:images/runasrole.png[images/runasrole.png,width=450]
+image:runasrole.png[images/runasrole.png,width=450]
 
 The console will need to be restarted in order for the change to take
 effect.

--- a/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/add-user-utility.adoc
@@ -1,6 +1,6 @@
 [[add-user-utility]]
 = add-user utility
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 For use with the default configuration we supply a utility `add-user`
 which can be used to manage the properties files for the default realms
@@ -58,7 +58,7 @@ unless you have switched to a different realm.
 [[interactive-mode]]
 ==== Interactive Mode
 
-image:images/add-mgmt-user-interactive.png[Add mgmt user interactive]
+image:add-mgmt-user-interactive.png[images/add-mgmt-user-interactive.png]
 
 Here we have added a new Management User called `adminUser`, as you can
 see some of the questions offer default responses so you can just press
@@ -74,7 +74,7 @@ management chapter.
 To add a user in non-interactive mode the command
 `./add-user.sh {username} {password`} can be used.
 
-image:images/add-mgmt-user-non-interactive.png[add-mgmt-user-non-interactive.png]
+image:add-mgmt-user-non-interactive.png[images/add-mgmt-user-non-interactive.png]
 
 [WARNING]
 
@@ -94,7 +94,7 @@ user.
 [[interactive-mode-1]]
 ==== Interactive Mode
 
-image:images/add-app-user-interactive.png[add-app-user-interactive.png]
+image:add-app-user-interactive.png[images/add-app-user-interactive.png]
 
 Here a new user called `appUser` has been added, in this case a comma
 separated list of roles has also been specified.
@@ -109,7 +109,7 @@ a connection from one server to another.
 To add an application user non-interactively use the command
 `./add-user.sh -a {username} {password`}.
 
-image:images/add-app-user-non-interactive.png[add-app-user-non-interactive.png]
+image:add-app-user-non-interactive.png[images/add-app-user-non-interactive.png]
 
 [NOTE]
 
@@ -130,7 +130,7 @@ your intention.
 [[interactive-mode-2]]
 ==== Interactive Mode
 
-image:images/update-mgmt-user-interactive.png[update-mgmt-user-interactive.png]
+image:update-mgmt-user-interactive.png[images/update-mgmt-user-interactive.png]
 
 [[non-interactive-mode-2]]
 ==== Non-Interactive Mode
@@ -143,7 +143,7 @@ with no confirmation prompt.
 
 ==== Interactive Mode
 
-image:images/update-app-user-interactive.png[images/update-app-user-interactive.png]
+image:update-app-user-interactive.png[images/update-app-user-interactive.png]
 
 [NOTE]
 

--- a/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Security.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/jax-ws/WS-Security.adoc
@@ -1,6 +1,6 @@
 [[WS-Security]]
 = WS-Security
-ifdef::env-github[:imagesdir: ../../]
+ifdef::env-github[:imagesdir: ../../images/]
 
 [[ws-security-overview]]
 == WS-Security overview
@@ -23,7 +23,7 @@ configure WS-Security. With public key cryptography, a user has a pair
 of public and private keys. These are generated using a large prime
 number and a key function.
 
-image:images/Public_key_making.png[Public_key_making.png]
+image:Public_key_making.png[images/Public_key_making.png]
 
 The keys are related mathematically, but cannot be derived from one
 another. With these keys we can encrypt messages. For example, if Bob
@@ -32,7 +32,7 @@ public key. Alice can then decrypt this message using her private key.
 Only Alice can decrypt this message as she is the only one with the
 private key.
 
-image:images/Public_key_encryption-mod.svg.png[images/Public_key_encryption-mod.svg.png]
+image:Public_key_encryption-mod.svg.png[images/Public_key_encryption-mod.svg.png]
 
 Messages can also be signed. This allows you to ensure the authenticity
 of the message. If Alice wants to send a message to Bob, and Bob wants
@@ -40,7 +40,7 @@ to be sure that it is from Alice, Alice can sign the message using her
 private key. Bob can then verify that the message is from Alice by using
 her public key.
 
-image:images/250px-Public_key_making.svg.png[images/250px-Public_key_making.svg.png]
+image:250px-Public_key_making.svg.png[images/250px-Public_key_making.svg.png]
 
 [[jboss-ws-security-support]]
 == JBoss WS-Security support

--- a/docs/src/main/asciidoc/_extras/Developing_JSF_Project_Using,_Maven_and_IntelliJ.adoc
+++ b/docs/src/main/asciidoc/_extras/Developing_JSF_Project_Using,_Maven_and_IntelliJ.adoc
@@ -1,6 +1,6 @@
 [[Developing_JSF_Project_Using,_Maven_and_IntelliJ]]
 = Developing JSF Project Using JBoss AS7, Maven and IntelliJ
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 JBoss AS7 is a very 'modern' application server that has very fast
 startup speed. So it's an excellent container to test your JSF project.
@@ -75,7 +75,7 @@ mvn archetype:create -DarchetypeGroupId=org.apache.maven.archetypes \
 
 If everything goes fine maven will generate the project for us:
 
-image:images/jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg[images/jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg]
+image:jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg[images/jsf/8108c4f111aab2c3465472eb84cf1d9b7cf912d0.jpg]
 
 The contents of the project is shown as above.
 
@@ -215,12 +215,12 @@ mvn -q jboss-as:deploy
 Maven will use some time to download necessary components for a while,
 so please wait patiently. After a while, we can see the result:
 
-image:images/jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg[images/jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg]
+image:jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg[images/jsf/97d781c6be9db755aef80a110f1d9b29590610d6.jpg]
 
 And if you check the console output of AS7, you can see the project is
 deployed:
 
-image:images/jsf/2._java.jpg[images/jsf/2._java.jpg]
+image:jsf/2._java.jpg[images/jsf/2._java.jpg]
 
 Now we have learnt how to create a JSF project and deploy it to AS7
 without any help from graphical tools. Next let's see how to use
@@ -232,29 +232,29 @@ IntelliJ IDEA to go on developing/debugging our project.
 Now it's time to import the project into IntelliJ. Now let's open
 IntelliJ, and choose 'New Project...':
 
-image:images/jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg[images/jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg]
+image:jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg[images/jsf/05222f3059e387df96ce04d2aea156c82af15096.jpg]
 
 The we choose 'Import project from external model':
 
-image:images/jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg[images/jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg]
+image:jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg[images/jsf/d68a0cdbc8c90db3db8af998f34616f73c7fe809.jpg]
 
 Next step is choosing 'Maven':
 
-image:images/jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg[images/jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg]
+image:jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg[images/jsf/0b3d1cb5794fb54a2465da93648b5a0d1a6643f3.jpg]
 
 Then IntelliJ will ask you the position of the project you want to
 import. In 'Root directory' input your project's directory and leave
 other options as default:
 
-image:images/jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg[images/jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg]
+image:jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg[images/jsf/2f192d02993248c97e2ac42ea8f3105d855e5cdf.jpg]
 
 For next step, just click 'Next':
 
-image:images/jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg[images/jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg]
+image:jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg[images/jsf/3a3ee36eb581930822c4a66362795345f5d2f9a7.jpg]
 
 Finally click 'Finish':
 
-image:images/jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg[images/jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg]
+image:jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg[images/jsf/91e40cd0b1545cff4622857d6dc9959f96faf056.jpg]
 
 Hooray! We've imported the project into IntelliJ now icon:smile-o[role="yellow"]
 
@@ -264,20 +264,20 @@ Hooray! We've imported the project into IntelliJ now icon:smile-o[role="yellow"]
 Let's see how to use IntelliJ and AS7 to debug the project. First we
 need to add 'JSF' facet into project. Open project setting:
 
-image:images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg[images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg]
+image:jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg[images/jsf/8b8d0051f4f15033f17cb859c65f2d8481914678.jpg]
 
 Click on 'Facets' section on left; Select 'Web' facet that we already
 have, and click the '+' on top, choose 'JSF':
 
-image:images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg[images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg]
+image:jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg[images/jsf/e6947b84a56a698ca1392a440081bddfb5cae284.jpg]
 
 Select 'Web' as parent facet:
 
-image:images/jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg[images/jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg]
+image:jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg[images/jsf/6b2296be1bb2d8a81952caef0f025a139a39b381.jpg]
 
 Click 'Ok':
 
-image:images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg[images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg]
+image:jsf/9988c572bad281146f405e9287f645a3da201885.jpg[images/jsf/9988c572bad281146f405e9287f645a3da201885.jpg]
 
 Now we have enabled IntelliJ's JSF support for project.
 
@@ -287,28 +287,28 @@ Now we have enabled IntelliJ's JSF support for project.
 Let's add JBoss AS7 into IntelliJ and use it to debug our project. First
 please choose 'Edit Configuration' in menu tab:
 
-image:images/jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg[images/jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg]
+image:jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg[images/jsf/dc0550785aae11f9d3eb439fdc0c51069affd25d.jpg]
 
 Click '+' and choose 'JBoss Server' -> 'Local':
 
-image:images/jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg[images/jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg]
+image:jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg[images/jsf/1231420c938f087030cb3dcd37237b5585beb154.jpg]
 
 Click 'configure':
 
-image:images/jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg[images/jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg]
+image:jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg[images/jsf/d7e6ab58230b2d31fdcd8fd5f14cd4eb47b05f64.jpg]
 
 and choose your JBoss AS7:
 
-image:images/jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg[images/jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg]
+image:jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg[images/jsf/f7b29ac8009f04fc7f209222ced0bcf54f4b8d9a.jpg]
 
 Now we need to add our project into deployment. Click the 'Deployment'
 tab:
 
-image:images/jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg[images/jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg]
+image:jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg[images/jsf/6802fb7e29283d0e064a7cc4466b918995ba5645.jpg]
 
 Choose 'Artifact', and add our project:
 
-image:images/jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg[images/jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg]
+image:jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg[images/jsf/359484b8f6f2c655d94132e9cb6f9dbe5a058656.jpg]
 
 Leave everything as default and click 'Ok', now we've added JBoss AS7
 into IntelliJ
@@ -351,7 +351,7 @@ bin/standalone.sh --debug --server-config=standalone.xml
 
 Now we start AS7 in IntelliJ:
 
-image:images/jsf/52369d67f9117c924213de24dd6642b48e47a436.png[images/jsf/52369d67f9117c924213de24dd6642b48e47a436.png]
+image:jsf/52369d67f9117c924213de24dd6642b48e47a436.png[images/jsf/52369d67f9117c924213de24dd6642b48e47a436.png]
 
 Please note we should undeploy the existing 'jsfdemo' project in AS7 as
 we've added by maven jboss deploy plugin before. Or AS7 will tell us
@@ -361,46 +361,46 @@ deploy the project anymore.
 If the project start correctly we can see from the IntelliJ console
 window, and please check the debug option is enabled:
 
-image:images/jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png[images/jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png]
+image:jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png[images/jsf/eaac5cb1a836809ab29513346b527fe051b7c7ac.png]
 
 Now we will setup the debug configuration, click 'debug' option on menu:
 
-image:images/jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg[images/jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg]
+image:jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg[images/jsf/b8323caf6980c40c3d635db5e308b03847618d06.jpg]
 
 Choose 'Edit Configurations':
 
-image:images/jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg[images/jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg]
+image:jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg[images/jsf/8327bbe0e83cb7170dd84767631c98956e91c42c.jpg]
 
 Then we click 'Add' and choose Remote:
 
-image:images/jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg[images/jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg]
+image:jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg[images/jsf/7103da6b6323e515a03a04cafe111aa7c6b3169d.jpg]
 
 Set the 'port' to the one you used in AS7 config file 'standalone.conf':
 
-image:images/jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png[images/jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png]
+image:jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png[images/jsf/30bbef45137c7d45ae300ba8d551423d1feefc96.png]
 
 Leave other configurations as default and click 'Ok'. Now we need to set
 breakpoints in project, let's choose TimeBean.java and set a breakpoint
 on 'getNow()' method by clicking the left side of that line of code:
 
-image:images/jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg[images/jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg]
+image:jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg[images/jsf/a96b7d32e04aa67956bd00a187f09b75a5af241e.jpg]
 
 Now we can use the profile to do debug:
 
-image:images/jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png[images/jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png]
+image:jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png[images/jsf/5ea6987d1635c2c58d3ccdb1f5718f29d6a0fac3.png]
 
 If everything goes fine we can see the console output:
 
-image:images/jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg[images/jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg]
+image:jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg[images/jsf/1096ebbbf2b29e694e300e02a48d0fa4207cb746.jpg]
 
 Now we go to web browser and see our project's main page, try to click
 on 'Get current time':
 
-image:images/jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png[images/jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png]
+image:jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png[images/jsf/5ad5d0216d3326e9bc29705042db59f11c3c1e70.png]
 
 Then IntelliJ will popup and the code is pausing on break point:
 
-image:images/jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg[images/jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg]
+image:jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg[images/jsf/2499d43c0dce2cab72ba472c8452a2b57999ac84.jpg]
 
 And we could inspect our project now.
 

--- a/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
+++ b/docs/src/main/asciidoc/_high-availability/Clustering_and_Domain_Setup_Walkthrough.adoc
@@ -1,6 +1,6 @@
 [[Clustering_and_Domain_Setup_Walkthrough]]
 = Clustering and Domain Setup Walkthrough
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 In this article, I'd like to show you how to setup WildFly in domain
 mode and enable clustering so we could get HA and session replication

--- a/docs/src/main/asciidoc/_javaee-guide/Java_API_for_RESTful_Web_Services_(JAX-RS).adoc
+++ b/docs/src/main/asciidoc/_javaee-guide/Java_API_for_RESTful_Web_Services_(JAX-RS).adoc
@@ -1,7 +1,7 @@
 [[Java_API_for_RESTful_Web_Services_JAX-RS]]
 = Java API for RESTful Web Services (JAX-RS)
 
-ifdef::env-github[:imagesdir: ../]
+ifdef::env-github[:imagesdir: ../images/]
 
 [[content-java-api-restful-web-services]]
 == Content
@@ -364,7 +364,7 @@ http://www.eclipse.org/downloads/packages/eclipse-classic-37/indigor[Eclipse].
 First, go to File|Import... and choose "Existing Maven Projects" to
 import the tutorial sources
 
-image:images/jaxrs/ImportExistingMavenProject.png[images/jaxrs/ImportExistingMavenProject.png]
+image:jaxrs/ImportExistingMavenProject.png[images/jaxrs/ImportExistingMavenProject.png]
 
 You project view should look like this
 
@@ -373,27 +373,27 @@ image:images/jaxrs/ProjectExplorerA.png[images/jaxrs/ProjectExplorerA.png]
 Then go to File|New|Android Project and fill out the first wizard page
 like this
 
-image:images/jaxrs/NewAndroidProject.png[images/jaxrs/NewAndroidProject.png]
+image:jaxrs/NewAndroidProject.png[images/jaxrs/NewAndroidProject.png]
 
 Click Finish. Next, go to Project|Properties|Build Path|Libraries and
 add these external libraries to your android project.
 
-image:images/jaxrs/AndroidLibraries.png[images/jaxrs/AndroidLibraries.png]
+image:jaxrs/AndroidLibraries.png[images/jaxrs/AndroidLibraries.png]
 
 You final project view should look like this
 
-image:images/jaxrs/ProjectExplorerB.png[images/jaxrs/ProjectExplorerB.png]
+image:jaxrs/ProjectExplorerB.png[images/jaxrs/ProjectExplorerB.png]
 
 To run the application in the emulator, we need an Android Virtual
 Device (AVD). Go to Window|Android SDK and AVD Manager and create a new
 AVD like this
 
-image:images/jaxrs/CreateAVD_.png[images/jaxrs/CreateAVD_.png]
+image:jaxrs/CreateAVD_.png[images/jaxrs/CreateAVD_.png]
 
 Now go to Run|Configuration to create a new run configuration for the
 client app.
 
-image:images/jaxrs/RunConfiguration.png[images/jaxrs/RunConfiguration.png]
+image:jaxrs/RunConfiguration.png[images/jaxrs/RunConfiguration.png]
 
 Now you should be able to launch the application in the debugger. Right
 click on the javaee-tutorial-jaxrs-android project and select Debug
@@ -402,28 +402,28 @@ though a series of boot screens until it eventually displays the Android
 home screen. This will take a minute or two if you do this for the first
 time.
 
-image:images/jaxrs/2_2_HVGA_Initial.png[images/jaxrs/2_2_HVGA_Initial.png]
+image:jaxrs/2_2_HVGA_Initial.png[images/jaxrs/2_2_HVGA_Initial.png]
 
-image:images/jaxrs/2_2_HVGA_Next.png[images/jaxrs/2_2_HVGA_Next.png]
+image:jaxrs/2_2_HVGA_Next.png[images/jaxrs/2_2_HVGA_Next.png]
 
-image:images/jaxrs/2_2_HVGA_Final.png[images/jaxrs/2_2_HVGA_Final.png]
+image:jaxrs/2_2_HVGA_Final.png[images/jaxrs/2_2_HVGA_Final.png]
 
 When you unlock the home screen by dragging the little green lock to the
 right. You should see the the running JAX-RS client application.
 
-image:images/jaxrs/NoBooks.png[images/jaxrs/NoBooks.png]
+image:jaxrs/NoBooks.png[images/jaxrs/NoBooks.png]
 
 Finally, you need to configure the host that the client app connects to.
 This would be the same as you used above to curl the library list. In
 the emulator click Menu|Host Settings and enter the host address of your
 OpenShift application.
 
-image:images/jaxrs/HostSettings.png[images/jaxrs/HostSettings.png]
+image:jaxrs/HostSettings.png[images/jaxrs/HostSettings.png]
 
 When going back to the application using the little back arrow next to
 Menu, you should see a list of books.
 
-image:images/jaxrs/ListOfBooks.png[images/jaxrs/ListOfBooks.png]
+image:jaxrs/ListOfBooks.png[images/jaxrs/ListOfBooks.png]
 
 You can now add, edit and delete books and switch between your browser
 and the emulator to verify that the client app is not cheating and that

--- a/docs/src/main/asciidoc/index.adoc
+++ b/docs/src/main/asciidoc/index.adoc
@@ -1,6 +1,7 @@
 [[index]]
 = WildFly Documentation
 :ext-relative: {outfilesuffix}
+ifdef::env-github[:imagesdir: images/]
 :toc!:
 
 image:splash_wildflylogo_small.png[WildFly, align="center"]


### PR DESCRIPTION
…def path to view images in github rendered adoc files

https://issues.jboss.org/browse/WFLY-12277