### PR TITLE
[WFLY-12296] Upgrade WildFly Core 10.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12296

---


## Release Notes - WildFly Core - Version 10.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4566'>WFCORE-4566</a>] -         Upgrade WildFly Elytron to 1.10.0.CR3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4565'>WFCORE-4565</a>] -         Use ModelNode.TRUE, ModelNode.FALSE, ModelNode.ZERO and ModelNode.ZERO_LONG
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3255'>WFCORE-3255</a>] -         Complex type AttributeDefinition variants don&#39;t handle ParameterCorrector properly
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4398'>WFCORE-4398</a>] -         WorkerResourceDefinition.WorkerWriteAttributeHandler implementations incorrectly handle undefined values
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4553'>WFCORE-4553</a>] -         Logging on IBM Java doesn&#39;t create log
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4557'>WFCORE-4557</a>] -         The read http-upgrade-enabled attribute operation acquires the write lock unnecessarily
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4558'>WFCORE-4558</a>] -         Comparing log configuration values do not correctly compare null values
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4559'>WFCORE-4559</a>] -         Incorrectly formatted result produced by LocalPatchOperationTarget.info(stream)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4560'>WFCORE-4560</a>] -         HTTP management interface fails to start if backed by a &quot;https&quot; socket-binding
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4561'>WFCORE-4561</a>] -         JMX audit log does not show operation parameters
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4550'>WFCORE-4550</a>] -         Create a test to validate CLI embedded server output after a reload
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4554'>WFCORE-4554</a>] -         Enabled the embedded JBoss Log Manager tests for the IBM JVM
</li>
</ul>
                                    