### PR TITLE
[WFLY-12294] Upgrade MicroProfile Metrics 2.0.1

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -3020,7 +3020,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics</artifactId>
+            <artifactId>smallrye-metrics-2.0</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -621,6 +621,17 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-metrics-2.0</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing</artifactId>
       <licenses>
         <license>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${io.smallrye:smallrye-metrics}"/>
+        <artifact name="${io.smallrye:smallrye-metrics-2.0}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1519,7 +1519,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics</artifactId>
+            <artifactId>smallrye-metrics-2.0</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics</artifactId>
+            <artifactId>smallrye-metrics-2.0</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -1,18 +1,18 @@
-classloader.currentLoadedClass.count.displayName: Current Loaded Class Count
-classloader.currentLoadedClass.count.type: counter
-classloader.currentLoadedClass.count.unit: none
-classloader.currentLoadedClass.count.description: Displays the number of classes that are currently loaded in the Java virtual machine.
-classloader.currentLoadedClass.count.mbean: java.lang:type=ClassLoading/LoadedClassCount
-classloader.totalLoadedClass.count.displayName: Total Loaded Class Count
-classloader.totalLoadedClass.count.type: counter
-classloader.totalLoadedClass.count.unit: none
-classloader.totalLoadedClass.count.description: Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
-classloader.totalLoadedClass.count.mbean: java.lang:type=ClassLoading/TotalLoadedClassCount
-classloader.totalUnloadedClass.count.displayName: Total Unloaded Class Count
-classloader.totalUnloadedClass.count.type: counter
-classloader.totalUnloadedClass.count.unit: none
-classloader.totalUnloadedClass.count.description: Displays the total number of classes unloaded since the Java virtual machine has started execution.
-classloader.totalUnloadedClass.count.mbean: java.lang:type=ClassLoading/UnloadedClassCount
+classloader.loadedClasses.count.displayName: Current Loaded Class Count
+classloader.loadedClasses.count.type: gauge
+classloader.loadedClasses.count.unit: none
+classloader.loadedClasses.count.description: Displays the number of classes that are currently loaded in the Java virtual machine.
+classloader.loadedClasses.count.mbean: java.lang:type=ClassLoading/LoadedClassCount
+classloader.loadedClasses.total.displayName: Total Loaded Class Count
+classloader.loadedClasses.total.type: counter
+classloader.loadedClasses.total.unit: none
+classloader.loadedClasses.total.description: Displays the total number of classes that have been loaded since the Java virtual machine has started execution.
+classloader.loadedClasses.total.mbean: java.lang:type=ClassLoading/TotalLoadedClassCount
+classloader.unloadedClasses.total.displayName: Total Unloaded Class Count
+classloader.unloadedClasses.total.type: counter
+classloader.unloadedClasses.total.unit: none
+classloader.unloadedClasses.total.description: Displays the total number of classes unloaded since the Java virtual machine has started execution.
+classloader.unloadedClasses.total.mbean: java.lang:type=ClassLoading/UnloadedClassCount
 cpu.availableProcessors.displayName: Available Processors
 cpu.availableProcessors.type: gauge
 cpu.availableProcessors.unit: none
@@ -28,18 +28,20 @@ cpu.systemLoadAverage.type: gauge
 cpu.systemLoadAverage.unit: none
 cpu.systemLoadAverage.description: Displays the system load average for the last minute. The system load average is the sum of the number of runnable entities queued to the available processors and the number of runnable entities running on the available processors averaged over a period of time. The way in which the load average is calculated is operating system specific but is typically a damped time-dependent average. If the load average is not available, a negative value is displayed. This attribute is designed to provide a hint about the system load and may be queried frequently. The load average may be unavailable on some platform where it is expensive to implement this method.
 cpu.systemLoadAverage.mbean: java.lang:type=OperatingSystem/SystemLoadAverage
-gc.%s.count.displayName: Garbage Collection Count
-gc.%s.count.type: counter
-gc.%s.count.unit: none
-gc.%s.count.multi: true
-gc.%s.count.description:  Displays the total number of collections that have occurred. This attribute lists -1 if the collection count is undefined for this collector.
-gc.%s.count.mbean: java.lang:type=GarbageCollector,name=%s/CollectionCount
-gc.%s.time.displayName: Garbage Collection Time
-gc.%s.time.type: counter
-gc.%s.time.unit: milliseconds
-gc.%s.time.multi: true
-gc.%s.time.description: Displays the approximate accumulated collection elapsed time in milliseconds. This attribute displays -1 if the collection elapsed time is undefined for this collector. The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. This attribute may display the same value even if the collection count has been incremented if the collection elapsed time is very short.
-gc.%s.time.mbean: java.lang:type=GarbageCollector,name=%s/CollectionTime
+gc.total.displayName: Garbage Collection Count
+gc.total.type: counter
+gc.total.unit: none
+gc.total.multi: true
+gc.total.description:  Displays the total number of collections that have occurred. This attribute lists -1 if the collection count is undefined for this collector.
+gc.total.mbean: java.lang:type=GarbageCollector,name=%s/CollectionCount
+gc.total.tags: name=%s1
+gc.time.displayName: Garbage Collection Time
+gc.time.type: counter
+gc.time.unit: milliseconds
+gc.time.multi: true
+gc.time.description: Displays the approximate accumulated collection elapsed time in milliseconds. This attribute displays -1 if the collection elapsed time is undefined for this collector. The Java virtual machine implementation may use a high resolution timer to measure the elapsed time. This attribute may display the same value even if the collection count has been incremented if the collection elapsed time is very short.
+gc.time.mbean: java.lang:type=GarbageCollector,name=%s/CollectionTime
+gc.time.tags: name=%s1
 jvm.uptime.displayName: JVM Uptime
 jvm.uptime.type: gauge
 jvm.uptime.unit: milliseconds
@@ -60,11 +62,6 @@ memory.maxHeap.displayName: Max Heap Memory
 memory.maxHeap.description: Displays the maximum amount of memory in bytes that can be used for memory management.
 memory.maxHeap.unit: bytes
 memory.maxHeap.type: gauge
-#memory.maxHeap.    labels:
-#memory.maxHeap.      - key: domain
-#memory.maxHeap.        value: memory
-#memory.maxHeap.      - key: type
-#memory.maxHeap.        value: heap
 memory.maxNonHeap.mbean: java.lang:type=Memory/NonHeapMemoryUsage#max
 memory.maxNonHeap.displayName: Max Non Heap Memory
 memory.maxNonHeap.description: Displays the maximum amount of memory in bytes that can be used for memory management.
@@ -83,15 +80,15 @@ memory.usedNonHeap.unit: bytes
 thread.count.mbean: java.lang:type=Threading/ThreadCount
 thread.count.description: Number of currently deployed threads
 thread.count.unit: none
-thread.count.type: counter
+thread.count.type: gauge
 thread.count.displayName: Current Thread count
 thread.daemon.count.displayName: Daemon Thread Count
-thread.daemon.count.type: counter
+thread.daemon.count.type: gauge
 thread.daemon.count.unit: none
 thread.daemon.count.description: Displays the current number of live daemon threads.
 thread.daemon.count.mbean: java.lang:type=Threading/DaemonThreadCount
 thread.max.count.displayName: Peak Thread Count
-thread.max.count.type: counter
+thread.max.count.type: gauge
 thread.max.count.unit: none
 thread.max.count.description: Displays the peak live thread count since the Java virtual machine started or peak was reset. This includes daemon and non-daemon threads.
 thread.max.count.mbean: java.lang:type=Threading/PeakThreadCount

--- a/pom.xml
+++ b/pom.xml
@@ -268,10 +268,11 @@
         <version.io.opentracing.tracerresolver>0.1.5</version.io.opentracing.tracerresolver>
         <version.io.opentracing.servlet>0.1.0</version.io.opentracing.servlet>
         <version.io.reactivex.rxjava>2.2.2</version.io.reactivex.rxjava>
+        <version.io.rest-assured>3.0.0</version.io.rest-assured>
         <version.io.prometheus.simpleclient>0.6.0</version.io.prometheus.simpleclient>
         <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-metrics>1.1.3</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>1.1.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -317,7 +318,7 @@
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.health.api>1.0</version.org.eclipse.microprofile.health.api>
-        <version.org.eclipse.microprofile.metrics.api>1.1</version.org.eclipse.microprofile.metrics.api>
+        <version.org.eclipse.microprofile.metrics.api>2.0.1</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
@@ -1590,6 +1591,13 @@
             </dependency>
 
             <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>rest-assured</artifactId>
+                <version>${version.io.rest-assured}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${version.io.smallrye.smallrye-config}</version>
@@ -1609,7 +1617,7 @@
 
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-metrics</artifactId>
+                <artifactId>smallrye-metrics-2.0</artifactId>
                 <version>${version.io.smallrye.smallrye-metrics}</version>
             </dependency>
 
@@ -5120,6 +5128,18 @@
                 <groupId>org.eclipse.microprofile.metrics</groupId>
                 <artifactId>microprofile-metrics-api</artifactId>
                 <version>${version.org.eclipse.microprofile.metrics.api}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-rest-tck</artifactId>
+                <version>${version.org.eclipse.microprofile.metrics.api}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/MetricsHelper.java
@@ -63,13 +63,13 @@ public class MetricsHelper {
         String[] lines = prometheusContent.split("\\R");
 
         for (String line : lines) {
-            if (line.startsWith(scope + ":" + metricName)) {
-                String longStr = line.substring((scope + ":" + metricName).length()).trim();
-                return Double.parseDouble(longStr);
+            if (line.startsWith(scope + "_" + metricName)) {
+                String longStr = line.substring(line.lastIndexOf(' '));
+                return Double.parseDouble(longStr.trim());
             }
         }
 
-        Assert.fail(scope + ":" + metricName + " metric not found in " + prometheusContent);
+        Assert.fail(scope + "_" + metricName + " metric not found in " + prometheusContent);
         return -1;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/MicroProfileMetricsApplicationTestCase.java
@@ -129,7 +129,7 @@ public class MicroProfileMetricsApplicationTestCase {
     @InSequence(2)
     @OperateOnDeployment("MicroProfileMetricsApplicationTestCase")
     public void testApplicationMetricWithPrometheusAfterDeployment(@ArquillianResource URL url) throws Exception {
-        getPrometheusMetrics(managementClient, "application", false);
+        getPrometheusMetrics(managementClient, "application", true);
 
         String text = performCall(url);
         assertNotNull(text);

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/resource/ResourceSimple.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/application/resource/ResourceSimple.java
@@ -27,7 +27,7 @@ import javax.ws.rs.core.Response;
 public class ResourceSimple {
     @GET
     @Produces("text/plain")
-    @Counted(description = "counter of the Hello call", absolute = true, monotonic = true)
+    @Counted(description = "counter of the Hello call", absolute = true)
     public Response hello() {
         return Response.ok("Hello From WildFly!").build();
     }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/metadata/resources/MicroProfileMetricsCounterResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/metadata/resources/MicroProfileMetricsCounterResource.java
@@ -16,14 +16,14 @@
 
 package org.wildfly.test.integration.microprofile.metrics.metadata.resources;
 
-import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricType;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 
 @Path("/counter")
 public class MicroProfileMetricsCounterResource {
@@ -34,10 +34,10 @@ public class MicroProfileMetricsCounterResource {
    @GET
    @Path("/hello")
    public Response hello() {
-      Metadata counterMetadata = new Metadata("helloCounter", MetricType.COUNTER);
-
-      // TODO: Remove following line once https://github.com/smallrye/smallrye-metrics/issues/43 is fixed
-      counterMetadata.setReusable(true); // workaround
+      Metadata counterMetadata = Metadata.builder()
+              .withName("helloCounter")
+              .withType(MetricType.COUNTER)
+              .build();
 
       registry.counter(counterMetadata).inc();
       return Response.ok("Hello World!").build();

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/metadata/resources/MicroProfileMetricsHistogramResource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/metadata/resources/MicroProfileMetricsHistogramResource.java
@@ -16,16 +16,16 @@
 
 package org.wildfly.test.integration.microprofile.metrics.metadata.resources;
 
-import org.eclipse.microprofile.metrics.Histogram;
-import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.MetricRegistry;
-import org.eclipse.microprofile.metrics.MetricType;
-
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 
 @Path("/histogram")
 public class MicroProfileMetricsHistogramResource {
@@ -36,10 +36,10 @@ public class MicroProfileMetricsHistogramResource {
    @GET
    @Path("/hello/{n}")
    public Response hello(@PathParam("n") String n) {
-      Metadata histogramMetadata = new Metadata("helloHistogram", MetricType.HISTOGRAM);
-
-      // TODO: Remove following line once https://github.com/smallrye/smallrye-metrics/issues/42 is fixed
-      histogramMetadata.setReusable(true); // workaround
+      Metadata histogramMetadata =  Metadata.builder()
+              .withName("helloHistogram")
+              .withType(MetricType.HISTOGRAM)
+              .build();
 
       Histogram histogram = registry.histogram(histogramMetadata);
       histogram.update(Long.valueOf(n));

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/secured/MicroProfileMetricsSecuredEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/secured/MicroProfileMetricsSecuredEndpointTestCase.java
@@ -89,7 +89,9 @@ public class MicroProfileMetricsSecuredEndpointTestCase {
             assertEquals(200, resp.getStatusLine().getStatusCode());
             String content = EntityUtils.toString(resp.getEntity());
             resp.close();
-            assertTrue("'base:jvm_uptime_seconds' message is expected in the response", content.contains("base:jvm_uptime_seconds"));
+            // MicroProfile Metrics 2.0 has changed its Prometheus conversion format from "base:x" to "base_x"
+            String expectedMetric = "base_jvm_uptime_seconds";
+            assertTrue(expectedMetric + " metric is expected in the response", content.contains(expectedMetric));
         }
     }
 }

--- a/testsuite/integration/microprofile-tck/metrics/pom.xml
+++ b/testsuite/integration/microprofile-tck/metrics/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ts-integ-mp</artifactId>
+        <version>18.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wildfly-ts-integ-mp-metrics</artifactId>
+    <name>WildFly Test Suite: Integration - MicroProfile - Metrics</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/../..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <ts.elytron.cli>${jbossas.ts.dir}/shared/enable-elytron.cli</ts.elytron.cli>
+        <wildfly.build.output.dir>dist/target/${server.output.dir.prefix}-${server.output.dir.version}</wildfly.build.output.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-api-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-rest-tck</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>microprofile-metrics-${project.version}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
+                        <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+                    </dependenciesToScan>
+                    <environmentVariables>
+                        <MP_METRICS_TAGS>tier=integration</MP_METRICS_TAGS>
+                    </environmentVariables>
+                    <systemProperties>
+                        <test.url>http://localhost:9990/metrics</test.url>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/testsuite/integration/microprofile-tck/metrics/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/metrics/src/test/resources/arquillian.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="jboss" default="true" >
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m ${modular.jdk.args} -DMP_METRICS_TAGS=tier=integration</property>
+            <property name="serverConfig">standalone.xml</property>
+            <property name="managementAddress">127.0.0.1</property>
+            <property name="managementPort">9990</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="waitForPorts">9990</property>
+            <property name="waitForPortsTimeoutInSeconds">10</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -46,6 +46,7 @@
     <modules>
         <module>config</module>
         <module>health</module>
+        <module>metrics</module>
         <module>opentracing</module>
     </modules>
 </project>


### PR DESCRIPTION
* Update org.eclipse.microprofile-metrics to 2.0.1
* Update smallrye-metrics to io.smallrye-metrics-2.0:1.1.0
  (both Maven A and V have changed)
* Fix integration tests due to specifitions changes in Prometheus
* conversion (and HTTP status errors)

JIRA: https://issues.jboss.org/browse/WFLY-12294
