### PR TITLE
[JBJCA-1389] - NullPointerException raised when calling isWrapperFor(…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceDefinitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceDefinitionTestCase.java
@@ -120,4 +120,21 @@ public class DataSourceDefinitionTestCase {
         DataSourceBean bean = (DataSourceBean)ctx.lookup("java:module/" + DataSourceBean.class.getSimpleName());
         Assert.assertEquals(bean.getDataSource5().getConnection().nativeSQL("dse"),"dse");
     }
+
+    @Test
+    /**
+     * Test if NullPointerException ir raised when connection is closed and then method connection.isWrapperFor(...) is called
+     * See https://issues.jboss.org/browse/JBJCA-1389
+     */
+    public void testCloseConnectionWrapperFor() throws NamingException, SQLException {
+        DataSourceBean bean = (DataSourceBean)ctx.lookup("java:module/" + DataSourceBean.class.getSimpleName());
+        DataSource ds = bean.getDataSource();
+        Connection c = ds.getConnection();
+        c.close();
+        try {
+            c.isWrapperFor(ResultSet.class);
+        }catch (NullPointerException e){
+            Assert.fail("Wrong exception is raised. The exception should be Connection is not associated with a managed connection: ... See JBJCA-1389.");
+        }
+    }
 }


### PR DESCRIPTION
Description of issue: When calling Connection.isWrapperFor(...) on a connection which has been closed (i.e. returned to the pool, managed connection disassociated) previously, a NullPointerException is raised. The exception should be "Connection is not associated with a managed connection: ..."

Jira issue: [https://issues.jboss.org/browse/JBJCA-1389](https://issues.jboss.org/browse/JBJCA-1389)
