### PR TITLE
[WFLY-12306] Opentracing 1.3

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_OpenTracing_SmallRye.adoc
@@ -30,7 +30,7 @@ element to the xml or by using the following CLI operation:
 
 == Supported instrumentation libraries
 
-WildFly's MicroProfile OpenTracing subsystem implements MicroProfile 1.1, which includes support for tracing JAX-RS and
+WildFly's MicroProfile OpenTracing subsystem implements MicroProfile 1.3, which includes support for tracing JAX-RS and
 CDI.
 
 Additionally, applications being deployed are able to provide their own tracers via the

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -3185,6 +3185,17 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-interceptors</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.jaegertracing</groupId>
             <artifactId>jaeger-core</artifactId>
             <exclusions>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -555,6 +555,17 @@
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-interceptors</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-jaxrs2</artifactId>
       <licenses>
         <license>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-interceptors/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-interceptors/main/module.xml
@@ -14,29 +14,27 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<module xmlns="urn:jboss:module:1.8" name="io.smallrye.opentracing">
+<module xmlns="urn:jboss:module:1.8" name="io.opentracing.contrib.opentracing-interceptors">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${io.smallrye:smallrye-opentracing}"/>
+        <artifact name="${io.opentracing.contrib:opentracing-interceptors}"/>
     </resources>
 
     <dependencies>
         <module name="java.logging"/>
+
         <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api" />
+        <module name="javax.enterprise.api"/>
         <module name="javax.inject.api"/>
         <module name="javax.ws.rs.api"/>
 
         <module name="io.opentracing.opentracing-api"/>
-        <module name="io.opentracing.contrib.opentracing-jaxrs2"/>
-        <module name="io.opentracing.contrib.opentracing-interceptors" services="import"/>
+        <module name="io.opentracing.opentracing-util"/>
+        <module name="io.opentracing.contrib.opentracing-tracerresolver"/>
         <module name="org.eclipse.microprofile.opentracing"/>
         <module name="org.wildfly.microprofile.opentracing-smallrye"/>
-        <module name="org.eclipse.microprofile.restclient"/>
-
-        <module name="org.eclipse.microprofile.config.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/opentracing/contrib/opentracing-jaxrs2/main/module.xml
@@ -35,5 +35,7 @@
         <module name="io.opentracing.contrib.opentracing-web-servlet-filter"/>
 
         <module name="org.eclipse.microprofile.opentracing"/>
+        <module name="org.eclipse.microprofile.config.api"/>
+        <module name="io.smallrye.config"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/opentracing-smallrye/main/module.xml
@@ -43,10 +43,13 @@
         <module name="io.opentracing.contrib.opentracing-jaxrs2"/>
         <module name="io.opentracing.contrib.opentracing-tracerresolver"/>
         <module name="io.opentracing.contrib.opentracing-web-servlet-filter"/>
+        <module name="io.opentracing.contrib.opentracing-interceptors" services="import"/>
         <module name="io.smallrye.opentracing"/>
 
         <module name="org.eclipse.microprofile.opentracing"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
+        <module name="org.eclipse.microprofile.config.api"/>
+        <module name="io.smallrye.config"/>
     </dependencies>
 </module>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1488,6 +1488,17 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-interceptors</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
             <scope>provided</scope>

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
@@ -49,11 +49,13 @@ public class SubsystemDefinition extends PersistentResourceDefinition {
             "io.opentracing.opentracing-api",
             "io.opentracing.opentracing-util",
             "org.eclipse.microprofile.opentracing",
+            "org.eclipse.microprofile.restclient"
     };
 
     static final String[] EXPORTED_MODULES = {
             "io.smallrye.opentracing",
             "org.wildfly.microprofile.opentracing-smallrye",
+            "io.opentracing.contrib.opentracing-interceptors",
     };
     protected SubsystemDefinition() {
         super( new SimpleResourceDefinition.Parameters(SubsystemExtension.SUBSYSTEM_PATH, SubsystemExtension.getResourceDescriptionResolver(SubsystemExtension.SUBSYSTEM_NAME))

--- a/microprofile/opentracing-smallrye/pom.xml
+++ b/microprofile/opentracing-smallrye/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>opentracing-jaxrs2</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-interceptors</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>smallrye-opentracing</artifactId>
         </dependency>

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerDynamicFeature.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerDynamicFeature.java
@@ -19,12 +19,13 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.wildfly.microprofile.opentracing.smallrye;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.jaxrs2.server.OperationNameProvider;
+import io.opentracing.contrib.jaxrs2.server.OperationNameProvider.ClassNameOperationName;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
+import java.util.Optional;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.container.DynamicFeature;
@@ -32,14 +33,20 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 @Provider
 public class TracerDynamicFeature implements DynamicFeature {
+
     @Context
     ServletContext servletContext;
 
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        Config config = ConfigProvider.getConfig();
+        Optional<String> skipPattern = config.getOptionalValue("mp.opentracing.server.skip-pattern", String.class);
+        Optional<String> operationNameProvider = config.getOptionalValue("mp.opentracing.server.operation-name-provider", String.class);
         Tracer tracer;
 
         Object tracerObject = servletContext.getAttribute(TracerInitializer.SMALLRYE_OPENTRACING_TRACER);
@@ -52,10 +59,21 @@ public class TracerDynamicFeature implements DynamicFeature {
             return;
         }
 
-        ServerTracingDynamicFeature delegate = new ServerTracingDynamicFeature.Builder(tracer)
-                .withOperationNameProvider(OperationNameProvider.ClassNameOperationName.newBuilder())
-                .withTraceSerialization(false)
-                .build();
+        ServerTracingDynamicFeature.Builder builder = new ServerTracingDynamicFeature.Builder(tracer)
+                .withOperationNameProvider(ClassNameOperationName.newBuilder())
+                .withTraceSerialization(false);
+        if (skipPattern.isPresent()) {
+            builder.withSkipPattern(skipPattern.get());
+        }
+        if (operationNameProvider.isPresent()) {
+            if ("http-path".equalsIgnoreCase(operationNameProvider.get())) {
+                builder.withOperationNameProvider(OperationNameProvider.WildcardOperationName.newBuilder());
+            } else if (!"class-method".equalsIgnoreCase(operationNameProvider.get())) {
+                TracingLogger.ROOT_LOGGER.wrongOperationNameProvider();
+            }
+        }
+
+        ServerTracingDynamicFeature delegate = builder.build();
 
         delegate.configure(resourceInfo, context);
     }

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerInitializer.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerInitializer.java
@@ -67,17 +67,17 @@ public class TracerInitializer implements ServletContextListener {
 
         TracingLogger.ROOT_LOGGER.registeringTracer(tracer.getClass().getName());
         sce.getServletContext().setAttribute(SMALLRYE_OPENTRACING_TRACER, tracer);
-        addJaxRsIntegration(sce.getServletContext(), tracer);
+        addJaxRsIntegration(sce.getServletContext());
 
         TracingLogger.ROOT_LOGGER.initializing(tracer.toString());
     }
 
-    private void addJaxRsIntegration(ServletContext servletContext, Tracer tracer) {
+    private void addJaxRsIntegration(ServletContext servletContext) {
         servletContext.setInitParameter("resteasy.providers", TracerDynamicFeature.class.getName());
         FilterRegistration.Dynamic filterRegistration = servletContext.addFilter(SpanFinishingFilter.class.getName(),
-                new SpanFinishingFilter(tracer));
+                new SpanFinishingFilter());
         filterRegistration.setAsyncSupported(true);
-        filterRegistration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "*");
+        filterRegistration.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), true, "*");
     }
 
     @Override

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerProducer.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerProducer.java
@@ -37,6 +37,7 @@ public class TracerProducer {
     @Produces
     public Tracer getTracer() {
         Object tracerObject = servletContext.getAttribute(TracerInitializer.SMALLRYE_OPENTRACING_TRACER);
+        TracingLogger.ROOT_LOGGER.producingTracer(tracerObject);
         if (tracerObject instanceof Tracer) {
             return (Tracer) tracerObject;
         }

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingCDIExtension.java
@@ -23,7 +23,6 @@
 package org.wildfly.microprofile.opentracing.smallrye;
 
 import io.opentracing.Tracer;
-import io.smallrye.opentracing.SmallRyeTracingCDIInterceptor;
 
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.spi.BeanManager;
@@ -36,7 +35,6 @@ public class TracingCDIExtension implements Extension {
     public void observeBeforeBeanDiscovery(@Observes BeforeBeanDiscovery bbd, BeanManager manager) {
         String extensionName = TracingCDIExtension.class.getName();
         bbd.addAnnotatedType(manager.createAnnotatedType(TracerProducer.class), extensionName + "-" + TracerProducer.class.getName());
-        bbd.addAnnotatedType(manager.createAnnotatedType(SmallRyeTracingCDIInterceptor.class), extensionName + "-" + SmallRyeTracingCDIInterceptor.class.getName());
     }
 
     public void skipTracerBeans(@Observes ProcessAnnotatedType<? extends Tracer> processAnnotatedType) {

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingLogger.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracingLogger.java
@@ -58,4 +58,12 @@ public interface TracingLogger extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 6, value = "Extra Tracer bean found: %s. Vetoing it, please use TracerResolver to specify a custom tracer to use.")
     void extraTracerBean(String clazz);
+
+    @LogMessage(level = WARN)
+    @Message(id = 7, value = "Provided operation name does not match 'http-path' or 'class-method'. Using default 'class-method'.")
+    void wrongOperationNameProvider();
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 8, value = "Producing tracer from ServletContext, using %s.")
+    void producingTracer(Object tracerObject);
 }

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/WildFlyClientTracingRegistrarProvider.java
@@ -55,7 +55,7 @@ public class WildFlyClientTracingRegistrarProvider implements ClientTracingRegis
 
         ResteasyClientBuilder resteasyClientBuilder = (ResteasyClientBuilder) clientBuilder;
         return resteasyClientBuilder
-                .asyncExecutor(new TracedExecutorService(executorService, tracer))
+                .executorService(new TracedExecutorService(executorService, tracer))
                 .register(new SmallRyeClientTracingFeature(tracer));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -266,17 +266,18 @@
         <version.io.jaegertracing>0.34.0</version.io.jaegertracing>
         <version.io.netty>4.1.34.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
-        <version.io.opentracing.concurrent>0.1.0</version.io.opentracing.concurrent>
-        <version.io.opentracing.jaxrs2>0.1.7</version.io.opentracing.jaxrs2>
+        <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>
+        <version.io.opentracing.interceptors>0.0.4</version.io.opentracing.interceptors>
+        <version.io.opentracing.jaxrs2>0.4.1</version.io.opentracing.jaxrs2>
         <version.io.opentracing.tracerresolver>0.1.5</version.io.opentracing.tracerresolver>
-        <version.io.opentracing.servlet>0.1.0</version.io.opentracing.servlet>
+        <version.io.opentracing.servlet>0.2.3</version.io.opentracing.servlet>
         <version.io.reactivex.rxjava>2.2.2</version.io.reactivex.rxjava>
         <version.io.rest-assured>3.0.0</version.io.rest-assured>
         <version.io.prometheus.simpleclient>0.6.0</version.io.prometheus.simpleclient>
         <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-metrics>1.1.0</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
+        <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.javax.activation>1.1.1</version.javax.activation>
@@ -322,7 +323,7 @@
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.health.api>2.0.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.metrics.api>2.0.1</version.org.eclipse.microprofile.metrics.api>
-        <version.org.eclipse.microprofile.opentracing>1.1</version.org.eclipse.microprofile.opentracing>
+        <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
@@ -1574,6 +1575,11 @@
                 <version>${version.io.opentracing.concurrent}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.opentracing.contrib</groupId>
+                <artifactId>opentracing-interceptors</artifactId>
+                <version>${version.io.opentracing.interceptors}</version>
+            </dependency>
 
             <dependency>
                 <groupId>io.prometheus</groupId>
@@ -5171,7 +5177,11 @@
                 <artifactId>microprofile-opentracing-tck</artifactId>
                 <version>${version.org.eclipse.microprofile.opentracing}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.eclipse.microprofile.opentracing</groupId>
+                <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
+                <version>${version.org.eclipse.microprofile.opentracing}</version>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.rest.client</groupId>
                 <artifactId>microprofile-rest-client-api</artifactId>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -194,6 +194,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-opentracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/AbstractEarOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/AbstractEarOpenTracingTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import java.net.URL;
 
@@ -28,66 +28,34 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.microprofile.opentracing.application.TracerIdentityApplication;
 import org.jboss.as.test.shared.ServerReload;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 /**
- * Test verifying the assumption that different services provided by multiple WARs have different tracers.
+ * A parent for EAR-based OpenTracing tests
  *
- * @author <a href="mailto:mjurc@redhat.com">Michal Jurc</a> (c) 2018 Red Hat, Inc.
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
  */
-@RunWith(Arquillian.class)
-@RunAsClient
-public class MultiWarOpenTracingTestCase {
+public abstract class AbstractEarOpenTracingTestCase {
 
     @ContainerResource
     ManagementClient managementClient;
 
     @ArquillianResource
-    @OperateOnDeployment("ServiceOne.war")
-    private URL serviceOneUrl;
-
-    @ArquillianResource
-    @OperateOnDeployment("ServiceTwo.war")
-    private URL serviceTwoUrl;
-
-    @Deployment(name = "ServiceOne.war")
-    public static Archive<?> deployServiceOne() {
-        WebArchive serviceOne = ShrinkWrap.create(WebArchive.class, "ServiceOne.war")
-                .addClass(TracerIdentityApplication.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        return serviceOne;
-    }
-
-    @Deployment(name = "ServiceTwo.war")
-    public static Archive<?> deployServiceTwo() {
-        WebArchive serviceTwo = ShrinkWrap.create(WebArchive.class, "ServiceTwo.war")
-                .addClass(TracerIdentityApplication.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
-        return serviceTwo;
-    }
+    private URL url;
 
     @Test
-    public void testMultipleWarServicesUseDifferentTracers() throws Exception {
+    public void testEarServicesUseDifferentTracers() throws Exception {
         testHttpInvokation();
     }
 
     @Test
-    public void testMultipleWarServicesUseDifferentTracersAfterReload() throws Exception {
+    public void testEarServicesUseDifferentTracersAfterReload() throws Exception {
+        //TODO the tracer instance is same after reload as before it - check whether this is correct or no
         testHttpInvokation();
         ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
         testHttpInvokation();
@@ -95,14 +63,15 @@ public class MultiWarOpenTracingTestCase {
 
     private void testHttpInvokation() throws Exception {
         try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
-            HttpResponse svcOneResponse = client.execute(new HttpGet(serviceOneUrl.toString() + "service-endpoint/app"));
+            HttpResponse svcOneResponse = client.execute(new HttpGet(url.toString() + "/ServiceOne/service-endpoint/app"));
             Assert.assertEquals(200, svcOneResponse.getStatusLine().getStatusCode());
             String serviceOneTracer = EntityUtils.toString(svcOneResponse.getEntity());
-            HttpResponse svcTwoResponse = client.execute(new HttpGet(serviceTwoUrl.toString() + "service-endpoint/app"));
+
+            HttpResponse svcTwoResponse = client.execute(new HttpGet(url.toString() + "/ServiceTwo/service-endpoint/app"));
             Assert.assertEquals(200, svcTwoResponse.getStatusLine().getStatusCode());
             String serviceTwoTracer = EntityUtils.toString(svcTwoResponse.getEntity());
             Assert.assertNotEquals("Service one and service two tracer instance hash is same - " + serviceTwoTracer,
-                    serviceOneTracer, serviceTwoTracer);
+                serviceOneTracer, serviceTwoTracer);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/BasicOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/BasicOpenTracingTestCase.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Tracer;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/DeploymentWithTracerProducerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/DeploymentWithTracerProducerTestCase.java
@@ -1,11 +1,11 @@
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerFactory;
 import io.opentracing.mock.MockTracer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.integration.microprofile.opentracing.application.MockTracerFactory;
+import org.wildfly.test.integration.microprofile.opentracing.application.MockTracerFactory;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingTestCase.java
@@ -19,12 +19,12 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.integration.microprofile.opentracing.application.TracerIdentityApplication;
+import org.wildfly.test.integration.microprofile.opentracing.application.TracerIdentityApplication;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingWithWeldProbeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingWithWeldProbeTestCase.java
@@ -19,12 +19,12 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.integration.microprofile.opentracing.application.TracerIdentityApplication;
+import org.wildfly.test.integration.microprofile.opentracing.application.TracerIdentityApplication;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 import static org.jboss.as.test.shared.ServerReload.executeReloadAndWaitForCompletion;
@@ -45,7 +45,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
-import jboss.as.test.integration.microprofile.opentracing.application.SimpleJaxRs;
+import org.wildfly.test.integration.microprofile.opentracing.application.SimpleJaxRs;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
@@ -10,10 +10,10 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
-import org.jboss.as.test.integration.microprofile.opentracing.application.CustomOperationNameBean;
-import org.jboss.as.test.integration.microprofile.opentracing.application.MockTracerFactory;
-import org.jboss.as.test.integration.microprofile.opentracing.application.OpenTracingApplication;
-import org.jboss.as.test.integration.microprofile.opentracing.application.WithCustomOperationNameEndpoint;
+import org.wildfly.test.integration.microprofile.opentracing.application.CustomOperationNameBean;
+import org.wildfly.test.integration.microprofile.opentracing.application.MockTracerFactory;
+import org.wildfly.test.integration.microprofile.opentracing.application.OpenTracingApplication;
+import org.wildfly.test.integration.microprofile.opentracing.application.WithCustomOperationNameEndpoint;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/SimpleRestClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/SimpleRestClientTestCase.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing;
+package org.wildfly.test.integration.microprofile.opentracing;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
@@ -11,9 +11,9 @@ import org.eclipse.microprofile.opentracing.ClientTracingRegistrar;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.as.test.integration.microprofile.opentracing.application.MockTracerFactory;
-import org.jboss.as.test.integration.microprofile.opentracing.application.OpenTracingApplication;
-import org.jboss.as.test.integration.microprofile.opentracing.application.TracedEndpoint;
+import org.wildfly.test.integration.microprofile.opentracing.application.MockTracerFactory;
+import org.wildfly.test.integration.microprofile.opentracing.application.OpenTracingApplication;
+import org.wildfly.test.integration.microprofile.opentracing.application.TracedEndpoint;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/CustomOperationNameBean.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/CustomOperationNameBean.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import org.eclipse.microprofile.opentracing.Traced;
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/MockTracerFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/MockTracerFactory.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerFactory;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/NotTracedEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/NotTracedEndpoint.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import org.eclipse.microprofile.opentracing.Traced;
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/OpenTracingApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/OpenTracingApplication.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/SimpleJaxRs.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/SimpleJaxRs.java
@@ -18,36 +18,46 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
  */
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.inject.Inject;
-import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
 
-import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Tracer;
 
 /**
- * @author <a href="mailto:mjurc@redhat.com">Michal Jurc</a> (c) 2018 Red Hat, Inc.
+ * A simple REST service which is able to respond with simple message or perform request to another URI.
+ *
+ * @author jstourac@redhat.com
  */
-@ApplicationPath("service-endpoint")
-public class TracerIdentityApplication extends Application {
 
-    @Path("/app")
-    public static class TestResource {
+@Path("/")
+public class SimpleJaxRs extends Application {
 
-        @Inject
-        private Tracer tracer;
+    public static final String GET_TRACER = "/getTracer";
 
-        @GET
-        @Produces("text/plain")
-        public String get() {
-            JaegerTracer jTracer = (JaegerTracer) tracer;
-            return Integer.toString(System.identityHashCode(jTracer));
+    public static final String TRACER_NOT_INITIALIZED = "No Tracer instance initialized!";
+
+    @Inject
+    Tracer tracer;
+
+    @QueryParam("uri")
+    String uri;
+
+    @GET
+    @Path(GET_TRACER)
+    @Produces({"text/html"})
+    public String getTracer() {
+        if (tracer == null) {
+            return TRACER_NOT_INITIALIZED;
+        } else {
+            return "Tracer instance is: " + tracer.toString();
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracedBean.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import org.eclipse.microprofile.opentracing.Traced;
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracedEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracedEndpoint.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracerIdentityApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracerIdentityApplication.java
@@ -18,46 +18,36 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
- *
  */
-package jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.inject.Inject;
+import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
 
+import io.jaegertracing.internal.JaegerTracer;
 import io.opentracing.Tracer;
 
 /**
- * A simple REST service which is able to respond with simple message or perform request to another URI.
- *
- * @author jstourac@redhat.com
+ * @author <a href="mailto:mjurc@redhat.com">Michal Jurc</a> (c) 2018 Red Hat, Inc.
  */
+@ApplicationPath("service-endpoint")
+public class TracerIdentityApplication extends Application {
 
-@Path("/")
-public class SimpleJaxRs extends Application {
+    @Path("/app")
+    public static class TestResource {
 
-    public static final String GET_TRACER = "/getTracer";
+        @Inject
+        private Tracer tracer;
 
-    public static final String TRACER_NOT_INITIALIZED = "No Tracer instance initialized!";
-
-    @Inject
-    Tracer tracer;
-
-    @QueryParam("uri")
-    String uri;
-
-    @GET
-    @Path(GET_TRACER)
-    @Produces({"text/html"})
-    public String getTracer() {
-        if (tracer == null) {
-            return TRACER_NOT_INITIALIZED;
-        } else {
-            return "Tracer instance is: " + tracer.toString();
+        @GET
+        @Produces("text/plain")
+        public String get() {
+            JaegerTracer jTracer = (JaegerTracer) tracer;
+            return Integer.toString(System.identityHashCode(jTracer));
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithBeanTracedEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithBeanTracedEndpoint.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithCustomOperationNameEndpoint.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/WithCustomOperationNameEndpoint.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.microprofile.opentracing.application;
+package org.wildfly.test.integration.microprofile.opentracing.application;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;

--- a/testsuite/integration/microprofile-tck/opentracing/pom.xml
+++ b/testsuite/integration/microprofile-tck/opentracing/pom.xml
@@ -49,8 +49,33 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.opentracing</groupId>
+            <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.opentracing</groupId>
+            <artifactId>microprofile-opentracing-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-opentracing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -84,6 +109,7 @@
                     </suiteXmlFiles>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.opentracing:microprofile-opentracing-tck</dependency>
+                        <dependency>org.eclipse.microprofile.opentracing:microprofile-opentracing-tck-rest-client</dependency>
                     </dependenciesToScan>
                 </configuration>
             </plugin>

--- a/testsuite/integration/microprofile-tck/opentracing/src/test/java/io/smallrye/opentracing/ResteasyClientTracingRegistrarProvider.java
+++ b/testsuite/integration/microprofile-tck/opentracing/src/test/java/io/smallrye/opentracing/ResteasyClientTracingRegistrarProvider.java
@@ -38,15 +38,17 @@ import org.eclipse.microprofile.opentracing.ClientTracingRegistrarProvider;
  */
 public class ResteasyClientTracingRegistrarProvider implements ClientTracingRegistrarProvider {
 
+    @Override
     public ClientBuilder configure(ClientBuilder clientBuilder) {
         // Make sure executor is the same as a default in resteasy ClientBuilder
         return configure(clientBuilder, Executors.newFixedThreadPool(10));
     }
 
+    @Override
     public ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService) {
         ResteasyClientBuilder resteasyClientBuilder = (ResteasyClientBuilder) clientBuilder;
         Tracer tracer = CDI.current().select(Tracer.class).get();
-        return resteasyClientBuilder.asyncExecutor(new TracedExecutorService(executorService, tracer)).register(
+        return resteasyClientBuilder.executorService(new TracedExecutorService(executorService, tracer)).register(
                 new SmallRyeClientTracingFeature(tracer));
     }
 }

--- a/testsuite/integration/microprofile-tck/opentracing/src/test/java/io/smallrye/opentracing/arquillian/DeploymentProcessor.java
+++ b/testsuite/integration/microprofile-tck/opentracing/src/test/java/io/smallrye/opentracing/arquillian/DeploymentProcessor.java
@@ -72,7 +72,7 @@ public class DeploymentProcessor implements ApplicationArchiveProcessor {
             final File archiveDir = new File("target/archives");
             archiveDir.mkdirs();
             File moduleFile = new File(archiveDir, "testapp.war");
-            war.as(ZipExporter.class).exportTo(moduleFile);
+            war.as(ZipExporter.class).exportTo(moduleFile, true);
         }
     }
 }

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -232,6 +232,15 @@
             </modules>
         </profile>
 
+        <!-- -Dts.microprofile -->
+        <profile>
+            <id>ts.integ.group.microprofile</id>
+            <activation><property><name>ts.microprofile</name></property></activation>
+            <modules>
+                <module>microprofile-tck</module>
+            </modules>
+        </profile>
+
         <!-- -Dts.elytron -->
         <profile>
             <id>ts.integ.group.elytron</id>
@@ -434,18 +443,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile.opentracing</groupId>
-            <artifactId>microprofile-opentracing-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.opentracing.contrib</groupId>
-            <artifactId>opentracing-tracerresolver</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -453,11 +452,7 @@
             <artifactId>resteasy-client</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-opentracing</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>


### PR DESCRIPTION
[WFLY-11270]: OpenTracing tests are in legacy org.jboss.as package in widlfly-ts-integ-basic
* Moving the tests to the proper package
Jira: https://issues.jboss.org/browse/WFLY-11270

[WFLY-12306]: Transition OpenTracing to the latest supported version by Thorntail
* Upgrade jars to Microprofile 3.0
Jira: https://issues.jboss.org/browse/WFLY-12306
        https://issues.jboss.org/browse/WFLY-12398