### PR TITLE
[WFLY-12307] Fix the build-legacy module by combining the two profile…

### DIFF
--- a/build-legacy/pom.xml
+++ b/build-legacy/pom.xml
@@ -215,18 +215,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>legacy-release</id>
-            <activation>
-                <property>
-                    <name>legacyRelease</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
…s of the same name into one.

https://issues.jboss.org/browse/WFLY-12307

Remove the extra profile as only one will be activated since they have the same name. We may also be to a point where we could consider removing the `build-legacy` and `dist-legacy` modules.