### PR TITLE
WFLY-12309 Need to include the schedule expression value in the toStr…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/CalendarTimer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/CalendarTimer.java
@@ -365,4 +365,14 @@ public class CalendarTimer extends TimerImpl {
         // no match found
         return null;
     }
+
+    /**
+     * {@inheritDoc}. For calendar-based timer, the string output also includes its schedule expression value.
+     *
+     * @return a string representation of calendar-based timer
+     */
+    @Override
+    public String toString() {
+        return super.toString() + " " + getScheduleExpression();
+    }
 }


### PR DESCRIPTION
…ing() output of a calendar-based timer.  The proposed change will include the schedule expression details to the toString() output of a calendar-based timer.  It does not affect non-calendar-based timers.

JIRA: https://issues.jboss.org/browse/WFLY-12309