### PR TITLE
WFLY-12314 Fix inadvertent inverse tautology in local command dispatching assertion

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/LocalCommandDispatcher.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/LocalCommandDispatcher.java
@@ -54,7 +54,7 @@ public class LocalCommandDispatcher<C> implements CommandDispatcher<C> {
 
     @Override
     public <R> CompletionStage<R> executeOnMember(Command<R, ? super C> command, Node member) throws CommandDispatcherException {
-        if (!this.node.equals(this.node)) {
+        if (!this.node.equals(member)) {
             throw new IllegalArgumentException(member.getName());
         }
         try {


### PR DESCRIPTION
:man_facepalming: 
https://issues.jboss.org/browse/WFLY-12314