### PR TITLE
WFLY-12325 Upgrade Jackson2 databind to 2.9.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
         <version.antlr>2.7.7</version.antlr>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.9.9</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.9.9.1</version.com.fasterxml.jackson.databind>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>
@@ -1188,7 +1189,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
+                <version>${version.com.fasterxml.jackson.databind}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12325
