### PR TITLE
WFLY-12333 Skip redundant put operations when distributable web sessions use local, non-persistent cache configuration

### DIFF
--- a/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheMutatorFactory.java
+++ b/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheMutatorFactory.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ee.hotrod;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.wildfly.clustering.ee.Mutator;
+import org.wildfly.clustering.ee.MutatorFactory;
+
+/**
+ * Factory for creating a {@link Mutator} for a remote cache entry.
+ * @author Paul Ferraro
+ */
+public class RemoteCacheMutatorFactory<K, V> implements MutatorFactory<K, V> {
+
+    private final RemoteCache<K, V> cache;
+
+    public RemoteCacheMutatorFactory(RemoteCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public Mutator createMutator(K key, V value) {
+        return new RemoteCacheEntryMutator<>(this.cache, key, value);
+    }
+}

--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/InfinispanMutatorFactory.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/InfinispanMutatorFactory.java
@@ -1,0 +1,30 @@
+package org.wildfly.clustering.ee.infinispan;
+
+import org.infinispan.Cache;
+import org.wildfly.clustering.ee.Mutator;
+import org.wildfly.clustering.ee.MutatorFactory;
+import org.wildfly.clustering.ee.cache.CacheProperties;
+
+/**
+ * Factory for creating {@link Mutator} objects for an Infinispan cache.
+ * @author Paul Ferraro
+ */
+public class InfinispanMutatorFactory<K, V> implements MutatorFactory<K, V> {
+
+    private final Cache<K, V> cache;
+    private final CacheProperties properties;
+
+    public InfinispanMutatorFactory(Cache<K, V> cache) {
+        this(cache, new InfinispanCacheProperties(cache.getCacheConfiguration()));
+    }
+
+    public InfinispanMutatorFactory(Cache<K, V> cache, CacheProperties properties) {
+        this.cache = cache;
+        this.properties = properties;
+    }
+
+    @Override
+    public Mutator createMutator(K key, V value) {
+        return this.properties.isPersistent() ? new CacheEntryMutator<>(this.cache, key, value) : Mutator.PASSIVE;
+    }
+}

--- a/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/MutatorFactory.java
+++ b/clustering/ee/spi/src/main/java/org/wildfly/clustering/ee/MutatorFactory.java
@@ -1,0 +1,26 @@
+package org.wildfly.clustering.ee;
+
+import java.util.Map;
+
+/**
+ * Creates a mutator instance for a given cache entry.
+ * @author Paul Ferraro
+ */
+public interface MutatorFactory<K, V> {
+    /**
+     * Creates a mutator for the specified cache entry.
+     * @param entry a cache entry
+     * @return a mutator
+     */
+    default Mutator createMutator(Map.Entry<K, V> entry) {
+        return this.createMutator(entry.getKey(), entry.getValue());
+    }
+
+    /**
+     * Creates a mutator for the specified cache entry.
+     * @param key a cache key
+     * @param value a cache value
+     * @return a mutator
+     */
+    Mutator createMutator(K key, V value);
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributesFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributesFactory.java
@@ -35,8 +35,9 @@ import org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent
 import org.wildfly.clustering.infinispan.spi.distribution.Key;
 import org.wildfly.clustering.ee.Immutability;
 import org.wildfly.clustering.ee.Mutator;
+import org.wildfly.clustering.ee.MutatorFactory;
 import org.wildfly.clustering.ee.cache.CacheProperties;
-import org.wildfly.clustering.ee.infinispan.CacheEntryMutator;
+import org.wildfly.clustering.ee.infinispan.InfinispanMutatorFactory;
 import org.wildfly.clustering.marshalling.spi.InvalidSerializedFormException;
 import org.wildfly.clustering.marshalling.spi.Marshaller;
 import org.wildfly.clustering.web.cache.session.SessionAttributes;
@@ -58,12 +59,14 @@ public class CoarseSessionAttributesFactory<V> implements SessionAttributesFacto
     private final Marshaller<Map<String, Object>, V> marshaller;
     private final CacheProperties properties;
     private final Immutability immutability;
+    private final MutatorFactory<SessionAttributesKey, V> mutatorFactory;
 
     public CoarseSessionAttributesFactory(Cache<SessionAttributesKey, V> cache, Marshaller<Map<String, Object>, V> marshaller, Immutability immutability, CacheProperties properties) {
         this.cache = cache;
         this.marshaller = marshaller;
         this.immutability = immutability;
         this.properties = properties;
+        this.mutatorFactory = new InfinispanMutatorFactory<>(cache, properties);
     }
 
     @Override
@@ -98,7 +101,7 @@ public class CoarseSessionAttributesFactory<V> implements SessionAttributesFacto
     @Override
     public SessionAttributes createSessionAttributes(String id, Map.Entry<Map<String, Object>, V> entry) {
         SessionAttributesKey key = new SessionAttributesKey(id);
-        Mutator mutator = this.properties.isTransactional() && this.cache.getAdvancedCache().getCacheEntry(key).isCreated() ? Mutator.PASSIVE : new CacheEntryMutator<>(this.cache, key, entry.getValue());
+        Mutator mutator = this.properties.isTransactional() && this.cache.getAdvancedCache().getCacheEntry(key).isCreated() ? Mutator.PASSIVE : this.mutatorFactory.createMutator(key, entry.getValue());
         return new CoarseSessionAttributes(entry.getKey(), mutator, this.marshaller, this.immutability, this.properties);
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12333