### PR TITLE
WFLY-12334 Using hotrod session manager with near cache throws IllegalAccessError

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
@@ -20,7 +20,10 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.infinispan.client.hotrod">
+<!-- Workaround for ISPN-10248 -->
+<!-- Absorb into org.wildfly.clustering.infinispan.client to prevent linkage errors -->
+<module-alias xmlns="urn:jboss:module:1.5" name="org.infinispan.client.hotrod" target-name="org.wildfly.clustering.infinispan.client"/>
+<!--module xmlns="urn:jboss:module:1.5" name="org.infinispan.client.hotrod">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
@@ -38,4 +41,4 @@
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.logging"/>
     </dependencies>
-</module>
+</module-->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
@@ -29,16 +29,26 @@
 
     <resources>
         <artifact name="${org.wildfly:wildfly-clustering-infinispan-client}"/>
+        <!-- Workaround for ISPN-10248 -->
+        <artifact name="${org.infinispan:infinispan-client-hotrod}"/>
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
         <module name="com.github.ben-manes.caffeine"/>
-        <module name="org.infinispan.client.hotrod"/>
+        <!-- Workaround for ISPN-10248 -->
+        <!--module name="org.infinispan.client.hotrod"/-->
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.jboss.msc"/>
+
+        <!-- org.infinispan.client.hotrod dependencies -->
+        <module name="com.google.protobuf" optional="true"/>
+        <module name="io.netty"/>
+        <module name="org.jboss.logging"/>
+
     </dependencies>
 </module>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -34,6 +34,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=11622,host=%s)", AbstractClusteringTestCase.TESTSUITE_NODE0)
                 .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod)")
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
+                .setup("/subsystem=infinispan/remote-cache-container=web/near-cache=invalidation:add()")
                 .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server-1:remove")
                 ;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12334

N.B. The changes here are temporary, until Infinispan 9.4.16.Final is released and integrated.