### PR TITLE
[WFLY-12301] Ensure that EJBComponentDescription#setSecurityRequired only gets called if security is actually required to avoid resetting the value when there are multiple views

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -145,7 +145,9 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
         }
 
         final boolean securityRequired = beanHasMethodLevelSecurityMetadata || ejbComponentDescription.hasBeanLevelSecurityMetadata();
-        ejbComponentDescription.setSecurityRequired(securityRequired);
+        if (securityRequired) {
+            ejbComponentDescription.setSecurityRequired(securityRequired);
+        }
         // setup the security context interceptor
         if (isSecurityDomainKnown) {
             final HashMap<Integer, InterceptorFactory> elytronInterceptorFactories = ejbComponentDescription.getElytronInterceptorFactories(contextID, ejbComponentDescription.isEnableJacc(), true);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12301