### PR TITLE
WFLY-12351 Upgrade Weld core to 3.1.2.Final and Weld API to 3.1.SP1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,8 +382,8 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.6.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>1.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.1.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>3.1.Final</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>3.1.2.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>3.1.SP1</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.2.3.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.2.Final</version.org.jboss.ws.common.tools>


### PR DESCRIPTION
JIRA - https://issues.jboss.org/browse/WFLY-12351

Updates Weld to latest released version, both core and API.