### PR TITLE
WFLY-12369 Upgrade jboss-ejb-client from 4.0.21 to 4.0.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.21.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.22.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.1.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12369
Diff between jboss-ejb-client 4.0.21 and 4.0.22: https://github.com/wildfly/jboss-ejb-client/compare/4.0.21.Final...4.0.22.Final

This jboss-ejb-client releases includes important fixes to customer issues, as outlined in the above diff link.  [WFLY-12322](https://issues.jboss.org/browse/WFLY-12322) (Avoid redispatching to a worker the ejb call if it is not async (at AssociationImpl)) also needs this new release.