### PR TITLE
[WFLY-12280] - DatabaseTimerPersistence does not detect mssql driver …

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import javax.sql.DataSource;
 import javax.transaction.HeuristicMixedException;
@@ -236,6 +237,7 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
      * @return A unified dialect identifier
      */
     private String identifyDialect(String name) {
+        Pattern mssqlPattern = Pattern.compile("(sqlserver|microsoft|mssql)");
         String unified = null;
 
         if (name != null) {
@@ -253,7 +255,7 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
                 unified = "h2";
             } else if (name.toLowerCase().contains("oracle")) {
                 unified = "oracle";
-            }else if (name.toLowerCase().contains("microsoft")) {
+            }else if (mssqlPattern.matcher(name.toLowerCase()).find()) {
                 unified = "mssql";
             }else if (name.toLowerCase().contains("jconnect")) {
                 unified = "sybase";

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistenceTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistenceTestCase.java
@@ -130,6 +130,18 @@ public class DatabaseTimerPersistenceTestCase {
         method.invoke(object);
         Assert.assertEquals("mssql", field.get(object));
 
+        field.set(object, "mssql");
+        method.invoke(object);
+        Assert.assertEquals("mssql", field.get(object));
+
+        field.set(object, "MSSQL");
+        method.invoke(object);
+        Assert.assertEquals("mssql", field.get(object));
+
+        field.set(object, "mssql-version-x");
+        method.invoke(object);
+        Assert.assertEquals("mssql", field.get(object));
+
         // test sybase
         field.set(object, "jconnectTest");
         method.invoke(object);


### PR DESCRIPTION
…type

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Upstream issue: https://issues.jboss.org/browse/WFLY-12280
Downstream issue: https://issues.jboss.org/browse/JBEAP-17172

Description:

> The DatabaseTimerPersistence class' identifyDialect method [1] only recognizes the "microsoft" driver when it should also recognize the "mssql" driver, similar to how the code checks for both "hsql" and "hypersonic".

For a more detailed information about the issue please access the issue on Jira.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.