### PR TITLE
[WFLY-12373] Avoided contended reads of MSC Supplier instances

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/interceptors/Jsr299BindingsCreateInterceptor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/interceptors/Jsr299BindingsCreateInterceptor.java
@@ -56,6 +56,7 @@ public class Jsr299BindingsCreateInterceptor implements org.jboss.invocation.Int
     private final String ejbName;
     private final ComponentInterceptorSupport interceptorSupport;
     private volatile BeanManagerImpl beanManager;
+    private volatile InterceptorBindings interceptorBindings;
 
     public Jsr299BindingsCreateInterceptor(final Supplier<WeldBootstrapService> weldContainerSupplier,
                                            final Supplier<InterceptorBindings> interceptorBindingsSupplier,
@@ -92,7 +93,11 @@ public class Jsr299BindingsCreateInterceptor implements org.jboss.invocation.Int
                 bean = beanManager.getBean(descriptor);
             }
         }
-        InterceptorBindings interceptorBindings = interceptorBindingsSupplier.get();
+        InterceptorBindings interceptorBindings = this.interceptorBindings;
+        if (interceptorBindings == null) {
+            // Cache the bindings as reading the interceptorBindingsSupplier is contended
+            interceptorBindings = this.interceptorBindings = interceptorBindingsSupplier.get();
+        }
 
         final ComponentInstance componentInstance = interceptorContext.getPrivateData(ComponentInstance.class);
         InterceptorInstances existing = interceptorSupport.getInterceptorInstances(componentInstance);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12373

This PR caches the result of Supplier lookups instead of doing them per-invocation.

The 3rd commit, changing WeldClassIntrospector, may not be needed as I'm not sure if any of the calls in there are heavily contended; i.e. they may all be called during deployment.