### PR TITLE
WFLY-12233 Upgrade Hibernate ORM from 5.3.10 to 5.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
         <version.org.harmcrest>1.3</version.org.harmcrest>
-        <version.org.hibernate>5.3.10.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.11.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.5.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.16.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12233
List of fixes from release notes are here [https://hibernate.atlassian.net/projects/HHH/versions/31770/tab/release-report-all-issues]