### PR TITLE
[WFLY-12301] Tests if EJB2 application shows the correct user when getCallerPrincipal method is used inside the EJB.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/Ejb2GetCallerPrincipalServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/Ejb2GetCallerPrincipalServerSetupTask.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+/**
+ *
+ * Server setup task for test Ejb2GetCallerPrincipalTestCase.
+ * Configures security domain and http connector in EJB3 and remoting subsystems.
+ *
+ * @author Daniel Cihak
+ */
+public class Ejb2GetCallerPrincipalServerSetupTask extends SnapshotRestoreSetupTask {
+
+    @Override
+    public void doSetup(ManagementClient managementClient, String containerId) throws Exception {
+        List<ModelNode> operations = new ArrayList<>();
+
+        // /subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+        ModelNode addEjbDomain = createOpNode("subsystem=ejb3/application-security-domain=other", ADD);
+        addEjbDomain.get("security-domain").set("ApplicationDomain");
+        operations.add(addEjbDomain);
+
+        // /subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
+        ModelNode updateRemotingConnector = createOpNode("subsystem=remoting/http-connector=http-remoting-connector", WRITE_ATTRIBUTE_OPERATION);
+        updateRemotingConnector.get(ClientConstants.NAME).set("sasl-authentication-factory");
+        updateRemotingConnector.get(ClientConstants.VALUE).set("application-sasl-authentication");
+        operations.add(updateRemotingConnector);
+
+        ModelNode updateOp = Operations.createCompositeOperation(operations);
+        updateOp.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        updateOp.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        CoreUtils.applyUpdate(updateOp, managementClient.getControllerClient());
+
+        ServerReload.reloadIfRequired(managementClient);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/Ejb2GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/Ejb2GetCallerPrincipalTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Hashtable;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests if EJB2 application shows the correct user when getCallerPrincipal method is used inside the EJB.
+ * Test for [ WFLY-12301 ].
+ *
+ * @author Daniel Cihak
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(Ejb2GetCallerPrincipalServerSetupTask.class)
+public class Ejb2GetCallerPrincipalTestCase {
+
+    private static final String DEPLOYMENT = "DEPLOYMENT";
+    private static final String ROLE1 = "Users";
+
+    @Deployment
+    public static Archive<?> deploy() {
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, DEPLOYMENT + ".ear");
+
+        JavaArchive ejb2 = ShrinkWrap.create(JavaArchive.class, "ejb2.jar");
+        ejb2.addClasses(TestEJB2.class, TestEJB2Bean.class, TestEJB2Int.class, TestEJB2Home.class);
+        ejb2.addAsManifestResource(Ejb2GetCallerPrincipalTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        ear.addAsModule(ejb2);
+
+        JavaArchive ejb3 = ShrinkWrap.create(JavaArchive.class, "ejb3.jar");
+        ejb3.addClasses(TestEJB3Remote.class, TestEJB3.class);
+        ear.addAsModule(ejb3);
+
+        return ear;
+    }
+
+    @Test
+    public void testEjb2GetCallerPrincipal() throws Exception {
+        Context ctx = getInitialContext();
+
+        TestEJB3Remote ejb3 = (TestEJB3Remote) ctx.lookup("ejb:DEPLOYMENT/ejb3/TestEJB3!org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB3Remote");
+        assertTrue("Caller must be user1 and must be in the role Users.", ejb3.isCallerInRole(ROLE1));
+
+        TestEJB2 ejb2X = (TestEJB2) ctx.lookup("ejb:DEPLOYMENT/ejb2/TestEJB2Bean!org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB2");
+        assertTrue("Caller must be user1 and must be in the role Users.", ejb2X.isCallerInRole(ROLE1));
+
+        TestEJB2Home ejb2Home = (TestEJB2Home) ctx.lookup("ejb:DEPLOYMENT/ejb2/TestEJB2Bean!org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB2Home");
+        TestEJB2 ejb2 = ejb2Home.create();
+        assertTrue("Caller must be user1 and must be in the role Users.", ejb2.isCallerInRole(ROLE1));
+    }
+
+    private InitialContext getInitialContext() throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.as.naming.InitialContextFactory");
+        jndiProperties.put(Context.SECURITY_PRINCIPAL, "user1");
+        jndiProperties.put(Context.SECURITY_CREDENTIALS, "password1");
+        jndiProperties.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getHttpPort());
+        return new InitialContext(jndiProperties);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import javax.ejb.EJBObject;
+
+public interface TestEJB2 extends EJBObject, TestEJB2Int {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Bean.java
@@ -1,0 +1,41 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import javax.ejb.CreateException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import java.rmi.RemoteException;
+import java.util.logging.Logger;
+
+public class TestEJB2Bean implements SessionBean, TestEJB2Int {
+
+    private static final Logger log = Logger.getLogger(TestEJB2Bean.class.getName());
+
+    private static final String USER = "user1";
+
+    public boolean isCallerInRole(String role) throws Exception {
+        String caller = ctx.getCallerPrincipal().getName();
+        if (!USER.equals(caller)) {
+            throw new Exception("Caller name is not " + USER + ", but " + caller);
+        }
+
+        return ctx.isCallerInRole(role);
+    }
+
+    private SessionContext ctx;
+
+    public void setSessionContext(SessionContext pCtx) {
+        ctx = pCtx;
+    }
+
+    public void ejbCreate() throws RemoteException, CreateException {
+    }
+
+    public void ejbRemove() throws RemoteException {
+    }
+
+    public void ejbActivate() throws RemoteException {
+    }
+
+    public void ejbPassivate() throws RemoteException {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Home.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Home.java
@@ -1,0 +1,11 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+import java.rmi.RemoteException;
+
+public interface TestEJB2Home extends EJBHome {
+
+   TestEJB2 create() throws RemoteException, CreateException;
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Int.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB2Int.java
@@ -1,0 +1,8 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+public interface TestEJB2Int {
+
+    boolean isCallerInRole(String role) throws Exception;
+
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB3.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB3.java
@@ -1,0 +1,31 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateless;
+import java.util.logging.Logger;
+
+@Stateless
+@Remote(TestEJB3Remote.class)
+@RolesAllowed({ "Users" })
+public class TestEJB3 implements TestEJB3Remote {
+
+    private static final Logger log = Logger.getLogger(TestEJB3.class.getName());
+
+    private static final String USER = "user1";
+
+    @Resource
+    private SessionContext ctx;
+
+    public boolean isCallerInRole(String role) throws Exception {
+        String caller = ctx.getCallerPrincipal().getName();
+        if (!USER.equals(caller)) {
+            throw new Exception("Caller name is not " + USER + ", but " + caller);
+        }
+
+        return ctx.isCallerInRole(role);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB3Remote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/TestEJB3Remote.java
@@ -1,0 +1,7 @@
+package org.jboss.as.test.integration.ejb.stateless.callerprincipal;
+
+public interface TestEJB3Remote {
+
+   boolean isCallerInRole(String role) throws Exception;
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateless/callerprincipal/ejb-jar.xml
@@ -1,0 +1,34 @@
+<!DOCTYPE ejb-jar PUBLIC '-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN' 'http://java.sun.com/dtd/ejb-jar_2_0.dtd'>
+
+<ejb-jar>
+  <enterprise-beans>
+    <session>
+      <ejb-name>TestEJB2Bean</ejb-name>
+      <home>org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB2Home</home>
+      <remote>org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB2</remote>
+      <ejb-class>org.jboss.as.test.integration.ejb.stateless.callerprincipal.TestEJB2Bean</ejb-class>
+      <session-type>Stateless</session-type>
+      <transaction-type>Container</transaction-type>
+    </session>
+  </enterprise-beans>
+
+  <assembly-descriptor>
+    <method-permission>
+      <role-name>Users</role-name>
+      <method>
+        <ejb-name>TestEJB2Bean</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>*</method-name>
+      </method>
+    </method-permission>
+    <container-transaction>
+      <method>
+        <ejb-name>TestEJB2Bean</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>*</method-name>
+      </method>
+      <trans-attribute>Required</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+
+</ejb-jar>


### PR DESCRIPTION
Automated test for upstream issue [WFLY-12301](https://issues.jboss.org/browse/WFLY-12301).