### PR TITLE
Fix for WFLY-12299, More fine grain dependency for galleon basic layers

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -116,7 +116,7 @@ WildFly defined layers to assemble a custom configuration. <<galleon-cli-recipes
 Basic layers:
 
 * _cdi_: Support for cdi.
-* _jaxrs_: Support for jaxrs.
+* _jaxrs_: Support for jaxrs. Depends on _web-server_ (layer defined in the WildFly servlet feature-pack).
 * _jms-activemq_: Support for connections to a remote jms broker. 
 * _jpa_: Support for jpa (latest WildFly supported hibernate release).
 * _observability_: Support for microprofile monitoring and configuration features (config, health, metrics, open-tracing).
@@ -127,14 +127,7 @@ Basic layers:
 
 Aggregation layers:
 
-* _cloud-profile_, an aggregation of the basic layers (except _h2-*_ layers).
-
-[NOTE]
-====
-These layers depend at least on the _web-server_ layer defined in the WildFly servlet 
-feature-pack (on which WildFly feature-pack depends). This means that when creating an 
-installation with these layers, the installed WildFly server is also configured to be a servlet container. 
-====
+* _cloud-profile_, an aggregation of the basic layers (except _h2-*_ layers) and a _web-server_ .
 
 ==== WildFly servlet layers
 

--- a/galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cdi">
     <dependencies>
-        <layer name="web-server"/>
+        <layer name="base-server"/>
     </dependencies>
     <feature spec="subsystem.bean-validation"/>
     <feature spec="subsystem.weld"/>

--- a/galleon-pack/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/cloud-profile/layer-spec.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cloud-profile">
     <dependencies>
+        <layer name="web-server"/>
         <layer name="cdi" optional="true"/>
         <layer name="jaxrs" optional="true"/>
         <layer name="jms-activemq" optional="true"/>

--- a/galleon-pack/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jms-activemq">
     <dependencies>
-        <layer name="web-server"/>
         <layer name="transactions"/>
     </dependencies>
     <feature-group name="jca"/>

--- a/galleon-pack/src/main/resources/layers/standalone/jpa/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/jpa/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa">
     <dependencies>
-        <layer name="web-server"/>
         <layer name="transactions"/>
     </dependencies>
     <feature spec="subsystem.datasources"/>

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
-        <layer name="web-server"/>
         <layer name="management"/>
         <layer name="cdi"/>
     </dependencies>

--- a/galleon-pack/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/resource-adapters/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="resource-adapters">
     <dependencies>
-        <layer name="web-server"/>
         <layer name="transactions"/>
     </dependencies>
     <feature-group name="jca"/>


### PR DESCRIPTION
Un-needed dependencies on web-server have been removed. cloud-profile explicitly depends on web-server.