### PR TITLE
WFLY-10057 EJB subsystem configure max threads and core threads independently

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EJB3.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EJB3.adoc
@@ -9,7 +9,7 @@ of each
 
 [source,xml,options="nowrap"]
 ----
-<subsystem xmlns="urn:jboss:domain:ejb3:1.2">
+<subsystem xmlns="urn:jboss:domain:ejb3:6.0">
   <session-bean>
     <stateless>
       <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
@@ -41,15 +41,18 @@ of each
     <cluster-passivation-store name="infinispan" cache-container="ejb"/>
   </passivation-stores>
   <async thread-pool-name="default"/>
-  <timer-service thread-pool-name="default">
-    <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
+  <timer-service thread-pool-name="default" default-data-store="default-file-store">
+    <data-stores>
+      <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+    </data-stores>
   </timer-service>
   <remote connector-ref="remoting-connector" thread-pool-name="default"/>
   <thread-pools>
     <thread-pool name="default">
       <max-threads count="10"/>
-      <keepalive-time time="100" unit="milliseconds"/>
-      </thread-pool>
+      <core-threads count="10"/>
+      <keepalive-time time="60" unit="seconds"/>
+    </thread-pool>
   </thread-pools>
   <iiop enable-by-default="false" use-qualified-name="false"/>
   <in-vm-remote-interface-invocation pass-by-value="false"/> <!-- Warning see notes below about possible issues -->
@@ -170,6 +173,16 @@ and the thread pool to use for remote invocations.
 
 This is used to configure the thread pools used by async, timer and
 remote invocations.
+
+* `max-threads` specifies the maximum number of threads in the thread pool.
+It is a required attribute and defaults to `10`.
+
+* `core-threads` specifies the number of core threads in the thread pool.
+It is an optional attribute and defaults to `max-threads` value.
+
+* `keepalive-time` specifies the amount of time that non-core threads can
+stay idle before they become eligible for removal. It is an optional
+attribute and defaults to `60` seconds.
 
 [[iiop]]
 == <iiop>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -22,22 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.as.threads.Namespace;
-import org.jboss.as.threads.ThreadsParser;
-import org.jboss.dmr.ModelNode;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -63,6 +47,22 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVICE;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STRICT_MAX_BEAN_INSTANCE_POOL;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.THREAD_POOL;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.threads.Namespace;
+import org.jboss.as.threads.ThreadsParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  * @author Jaikiran Pai

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -22,6 +22,12 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
@@ -31,13 +37,6 @@ import org.jboss.as.threads.ThreadsParser;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -740,7 +739,7 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> 
             EJB3SubsystemNamespace readerNS = EJB3SubsystemNamespace.forUri(reader.getNamespaceURI());
             switch (EJB3SubsystemXMLElement.forName(reader.getLocalName())) {
                 case THREAD_POOL: {
-                    ThreadsParser.getInstance().parseUnboundedQueueThreadPool(reader, readerNS.getUriString(),
+                    ThreadsParser.getInstance().parseEnhancedQueueThreadPool(reader, readerNS.getUriString(),
                             Namespace.THREADS_1_1, parentAddress, operations, THREAD_POOL, null);
                     break;
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -147,7 +147,8 @@ public interface EJB3SubsystemModel {
     PathElement FILE_DATA_STORE_PATH = PathElement.pathElement(FILE_DATA_STORE);
     PathElement DATABASE_DATA_STORE_PATH = PathElement.pathElement(DATABASE_DATA_STORE);
 
-    ServiceName BASE_THREAD_POOL_SERVICE_NAME = ThreadsServices.EXECUTOR.append("ejb3");
+    String BASE_EJB_THREAD_POOL_NAME = "ejb3";
+    ServiceName BASE_THREAD_POOL_SERVICE_NAME = ThreadsServices.EXECUTOR.append(BASE_EJB_THREAD_POOL_NAME);
     String EXECUTE_IN_WORKER = "execute-in-worker";
 
     // Elytron integration

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -22,6 +22,12 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.concurrent.ExecutorService;
+
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -56,10 +62,6 @@ import org.jboss.as.threads.ThreadFactoryResolver;
 import org.jboss.as.threads.ThreadsServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-
-import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the EJB3 subsystem's root management resource.
@@ -353,7 +355,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                 new EJB3ThreadFactoryResolver(),
                 EJB3SubsystemModel.BASE_THREAD_POOL_SERVICE_NAME,
                 registerRuntimeOnly,
-                EnhancedQueueExecutorResourceDefinition.CAPABILITY,
+                ThreadsServices.createCapability(EJB3SubsystemModel.BASE_EJB_THREAD_POOL_NAME, ExecutorService.class),
                 false));
 
         // subsystem=ejb3/service=iiop

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -22,10 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -55,11 +51,15 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.ejb3.deployment.processors.EJBDefaultSecurityDomainProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.MissingMethodPermissionsDenyAccessMergingProcessor;
 import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.as.threads.EnhancedQueueExecutorResourceDefinition;
 import org.jboss.as.threads.ThreadFactoryResolver;
 import org.jboss.as.threads.ThreadsServices;
-import org.jboss.as.threads.UnboundedQueueThreadPoolResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the EJB3 subsystem's root management resource.
@@ -348,8 +348,13 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         subsystemRegistration.registerSubModel(new TimerServiceResourceDefinition(pathManager));
 
         // subsystem=ejb3/thread-pool=*
-        subsystemRegistration.registerSubModel(UnboundedQueueThreadPoolResourceDefinition.create(EJB3SubsystemModel.THREAD_POOL,
-                new EJB3ThreadFactoryResolver(), EJB3SubsystemModel.BASE_THREAD_POOL_SERVICE_NAME, registerRuntimeOnly));
+        subsystemRegistration.registerSubModel(EnhancedQueueExecutorResourceDefinition.create(
+                PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL),
+                new EJB3ThreadFactoryResolver(),
+                EJB3SubsystemModel.BASE_THREAD_POOL_SERVICE_NAME,
+                registerRuntimeOnly,
+                EnhancedQueueExecutorResourceDefinition.CAPABILITY,
+                false));
 
         // subsystem=ejb3/service=iiop
         subsystemRegistration.registerSubModel(EJB3IIOPResourceDefinition.INSTANCE);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import java.util.List;
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.remoting.Attribute;
@@ -30,10 +33,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import javax.xml.stream.XMLStreamException;
-
-import java.util.List;
 
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
 
@@ -304,7 +303,7 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
 
     private void writeThreadPools(final XMLExtendedStreamWriter writer, final ModelNode threadPoolsModel) throws XMLStreamException {
         for (Property threadPool : threadPoolsModel.asPropertyList()) {
-            ThreadsParser.getInstance().writeUnboundedQueueThreadPool(writer, threadPool, EJB3SubsystemXMLElement.THREAD_POOL.getLocalName(), true);
+            ThreadsParser.getInstance().writeEnhancedQueueThreadPool(writer, threadPool, EJB3SubsystemXMLElement.THREAD_POOL.getLocalName(), true);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
+
 import java.util.List;
 import javax.xml.stream.XMLStreamException;
 
@@ -33,8 +35,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
 
 /**
  * The {@link XMLElementWriter} that handles the EJB subsystem. As we only write out the most recent version of

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -22,7 +22,31 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.*;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EJB_NAME_REGEX;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ASYNC;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CHANNEL_CREATION_OPTIONS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_DISTINCT_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SECURITY_DOMAIN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SINGLETON_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DISABLE_DEFAULT_EJB_PERMISSIONS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ENABLE_GRACEFUL_TXN_SHUTDOWN;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IDENTITY;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IIOP;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IN_VM_REMOTE_INTERFACE_INVOCATION_PASS_BY_VALUE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.LOG_SYSTEM_EXCEPTIONS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.PROFILE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTING_EJB_RECEIVER;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTING_PROFILE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVER_INTERCEPTORS;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVICE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STATISTICS_ENABLED;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.THREAD_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.TIMER_SERVICE;
 
 import java.util.List;
 import javax.xml.stream.XMLStreamException;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
@@ -207,10 +207,9 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
 
         builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
+        registerThreadPoolTransformers(builder);
 
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_5_0_0);
-
-        registerThreadPoolTransformers(builder);
     }
 
     private static void registerRemoteTransformers(ResourceTransformationDescriptionBuilder parent) {
@@ -240,7 +239,8 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
     private static void registerThreadPoolTransformers(ResourceTransformationDescriptionBuilder parent) {
         parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL))
                 .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.DEFINED, PoolAttributeDefinitions.CORE_THREADS);
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, PoolAttributeDefinitions.CORE_THREADS)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, PoolAttributeDefinitions.CORE_THREADS).end();
     }
 
     private static void registerMdbDeliveryGroupTransformers(ResourceTransformationDescriptionBuilder parent) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
@@ -22,6 +22,20 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EXECUTION;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.EXECUTE_IN_WORKER;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REFRESH_INTERVAL;
+import static org.jboss.as.ejb3.subsystem.StrictMaxPoolResourceDefinition.DERIVE_SIZE;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,20 +66,6 @@ import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.threads.PoolAttributeDefinitions;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfiguration;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EXECUTION;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.EXECUTE_IN_WORKER;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REFRESH_INTERVAL;
-import static org.jboss.as.ejb3.subsystem.StrictMaxPoolResourceDefinition.DERIVE_SIZE;
 
 /**
  * @author Tomaz Cerar (c) 2017 Red Hat Inc.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
@@ -22,20 +22,6 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EXECUTION;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.EXECUTE_IN_WORKER;
-import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REFRESH_INTERVAL;
-import static org.jboss.as.ejb3.subsystem.StrictMaxPoolResourceDefinition.DERIVE_SIZE;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,8 +49,23 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.as.threads.PoolAttributeDefinitions;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfiguration;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EXECUTION;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.EXECUTE_IN_WORKER;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REFRESH_INTERVAL;
+import static org.jboss.as.ejb3.subsystem.StrictMaxPoolResourceDefinition.DERIVE_SIZE;
 
 /**
  * @author Tomaz Cerar (c) 2017 Red Hat Inc.
@@ -140,6 +141,8 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         registerStrictMaxPoolTransformers(builder);
         registerApplicationSecurityDomainDTransformers(builder);
         registerIdentityTransformers(builder);
+        registerThreadPoolTransformers(builder);
+
         builder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
         if (version.equals(VERSION_1_2_1)) {
             registerTimerTransformers_1_2_0(builder);
@@ -168,6 +171,7 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         registerStrictMaxPoolTransformers(builder);
         registerApplicationSecurityDomainDTransformers(builder);
         registerIdentityTransformers(builder);
+        registerThreadPoolTransformers(builder);
 
         // Rename new statistics-enabled attribute to old enable-statistics
         builder.getAttributeBuilder().addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
@@ -179,6 +183,7 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
 
         registerApplicationSecurityDomainDTransformers(builder);
         registerIdentityTransformers(builder);
+        registerThreadPoolTransformers(builder);
         builder.addChildResource(RemotingProfileResourceDefinition.INSTANCE).getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.DEFINED, StaticEJBDiscoveryDefinition.INSTANCE)
                 .end();
@@ -204,6 +209,8 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
 
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_5_0_0);
+
+        registerThreadPoolTransformers(builder);
     }
 
     private static void registerRemoteTransformers(ResourceTransformationDescriptionBuilder parent) {
@@ -228,6 +235,12 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
                 .getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(StrictMaxPoolResourceDefinition.DeriveSize.NONE.toString())), DERIVE_SIZE)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, DERIVE_SIZE);
+    }
+
+    private static void registerThreadPoolTransformers(ResourceTransformationDescriptionBuilder parent) {
+        parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL))
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, PoolAttributeDefinitions.CORE_THREADS);
     }
 
     private static void registerMdbDeliveryGroupTransformers(ResourceTransformationDescriptionBuilder parent) {

--- a/ejb3/src/main/resources/schema/wildfly-ejb3_6_0.xsd
+++ b/ejb3/src/main/resources/schema/wildfly-ejb3_6_0.xsd
@@ -342,15 +342,15 @@
         <xs:annotation>
             <xs:documentation>
                 <![CDATA[
-                A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no
-                upper bound.  When a task is submitted, if the number of running threads is less than the core size,
-                a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be
-                submitted to this type of executor, an out of memory condition may occur.
+                A thread pool executor with core threads, max threads and unbounded queue.  When a task is submitted,
+                it will be assigned to an available thread for execution. If no thread is available, a new thread will
+                be created, subject to max-threads restriction.  Otherwise, the task is placed in queue.
+                If too many tasks are allowed to be submitted to this type of executor, an out of memory condition may occur.
 
                 The "name" attribute is the name of the created executor.
 
                 The "max-threads" attribute must be used to specify the thread pool size.  The nested
-                "keepalive-time" element may used to specify the amount of time that pool threads should
+                "keepalive-time" element may used to specify the amount of time that non-core threads should
                 be kept running when idle; if not specified, threads will run until the executor is shut down.
                 The "thread-factory" element specifies the bean name of a specific threads subsystem thread factory to
                 use to create worker threads. Usually it will not be set for an EJB3 thread pool and an appropriate
@@ -360,6 +360,7 @@
         </xs:annotation>
         <xs:all>
             <xs:element name="max-threads" type="threads:countType"/>
+            <xs:element name="core-threads" type="threads:countType" minOccurs="0"/>
             <xs:element name="keepalive-time" type="threads:time" minOccurs="0"/>
             <xs:element name="thread-factory" type="threads:ref" minOccurs="0"/>
         </xs:all>

--- a/ejb3/src/main/resources/subsystem-templates/ejb3.xml
+++ b/ejb3/src/main/resources/subsystem-templates/ejb3.xml
@@ -38,7 +38,7 @@
        <thread-pools>
            <thread-pool name="default">
                <max-threads count="10"/>
-               <keepalive-time time="100" unit="milliseconds"/>
+               <keepalive-time time="60" unit="seconds"/>
            </thread-pool>
        </thread-pools>
        <server-interceptors>

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.as.threads.PoolAttributeDefinitions;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -260,6 +261,8 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
             // reject the resource /subsystem=ejb3/service=identity
             config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.IDENTITY_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
 
+            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
 
             //Special handling for this test!!!!
             //Don't transform the resulting composite, instead rather transform the individual steps
@@ -307,6 +310,9 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
 
             // reject the resource /subsystem=ejb3/service=identity
             config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.IDENTITY_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+
+            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
         }
 
         return config;

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform-reject.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform-reject.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:5.0">
+<subsystem xmlns="urn:jboss:domain:ejb3:6.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
@@ -70,7 +70,9 @@
     <thread-pools>
         <thread-pool name="default">
             <max-threads count="${prop.max-thread-count:10}"/>
-            <keepalive-time time="${prop.keepalive-time:100}" unit="${prop.idle-timeout-unit:milliseconds}"/>
+            <!-- core-threads should be rejected -->
+            <core-threads count="${prop.core-thread-count:10}"/>
+            <keepalive-time time="${prop.keepalive-time:60}" unit="${prop.idle-timeout-unit:seconds}"/>
         </thread-pool>
     </thread-pools>
 

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem-ejb3-transform.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:5.0">
+<subsystem xmlns="urn:jboss:domain:ejb3:6.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -67,7 +67,8 @@
     <thread-pools>
         <thread-pool name="default">
             <max-threads count="${prop.max-thread-count:10}"/>
-            <keepalive-time time="${prop.keepalive-time:100}" unit="${prop.idle-timeout-unit:milliseconds}"/>
+            <core-threads count="${prop.core-thread-count:10}"/>
+            <keepalive-time time="${prop.keepalive-time:60}" unit="${prop.idle-timeout-unit:seconds}"/>
         </thread-pool>
     </thread-pools>
 

--- a/galleon-pack/src/main/resources/feature_groups/ejb3.xml
+++ b/galleon-pack/src/main/resources/feature_groups/ejb3.xml
@@ -60,8 +60,8 @@
             <param name="thread-pool" value="default"/>
             <param name="max-threads" value="10"/>
             <feature spec="subsystem.ejb3.thread-pool.keepalive-time">
-                <param name="time" value="100"/>
-                <param name="unit" value="MILLISECONDS"/>
+                <param name="time" value="60"/>
+                <param name="unit" value="SECONDS"/>
             </feature>
         </feature>
     </feature>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3NonCoreThreadTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3NonCoreThreadTimeoutTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.threadpool;
+
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Ejb3NonCoreThreadTimeoutTestCase - start EJB singleton with 1 sec timer and check that threads timeout
+ * <p>
+ *
+ * @author Miroslav Novak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(Ejb3NonCoreThreadTimeoutTestCase.ServerSetup.class)
+public class Ejb3NonCoreThreadTimeoutTestCase extends Ejb3ThreadPoolBase {
+
+    private static final int MAX_THREADS = 10;
+    private static final int CORE_THREADS = 0;
+    private static final long KEEEP_ALIVE_TIME = 10;
+    private static final String KEEP_ALIVE_TIME_UNIT = "MILLISECONDS";
+
+    @Test
+    public void testThreadTimeout() throws Exception {
+        ScheduleSingletonOneTimer scheduleSingletonLocal = (ScheduleSingletonOneTimer) iniCtx.lookup("java:module/"
+                + ScheduleSingletonOneTimer.class.getSimpleName() + "!" + ScheduleSingletonOneTimer.class.getName());
+        waitUntilThreadPoolProcessedAtLeast(2, 10000);
+        Assert.assertTrue("There must be at least 2 different threads as at least 2 tasks were processed and" +
+                " in different threads", scheduleSingletonLocal.getThreadNames().size() > 1);
+    }
+
+    public static class ServerSetup extends SnapshotRestoreSetupTask {
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            // create one
+            ModelNode writeMaxThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "max-threads", MAX_THREADS);
+            ModelNode writeCoreThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "core-threads", CORE_THREADS);
+            ModelNode writeKeepAliveTimeOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time",
+                    new ModelNode().get("keepalive-time").set(new ModelNode().add("unit", KEEP_ALIVE_TIME_UNIT)
+                            .add("time", KEEEP_ALIVE_TIME)));
+            ManagementOperations.executeOperation(client.getControllerClient(), writeMaxThreadsOp);
+            ManagementOperations.executeOperation(client.getControllerClient(), writeCoreThreadsOp);
+            ManagementOperations.executeOperation(client.getControllerClient(), writeKeepAliveTimeOp);
+        }
+    }
+}
+
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.threadpool;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+
+import javax.naming.InitialContext;
+
+public class Ejb3ThreadPoolBase {
+
+    static PathAddress DEFAULT_THREAD_POOL_ADDRESS = PathAddress.pathAddress("subsystem", "ejb3").append("thread-pool", "default");
+
+    @ArquillianResource
+    static ManagementClient managementClient;
+
+    @ArquillianResource
+    InitialContext iniCtx;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb3singleton.jar");
+        jar.addClass(ScheduleSingletonOneTimer.class);
+        jar.addClasses(Ejb3ThreadPoolBase.class, Ejb3NonCoreThreadTimeoutTestCase.class, ModelNode.class, PathAddress.class,
+                ManagementOperations.class, MgmtOperationException.class);
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller\n"), "MANIFEST.MF");
+        return jar;
+    }
+
+    void waitUntilThreadPoolProcessedAtLeast(int tasks, long timeoutInMillis) throws Exception {
+        long startTime = System.currentTimeMillis();
+        ModelNode readTasks = Util.getReadAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "completed-task-count");
+        while (executeOperation(readTasks).asInt() < tasks) {
+            if (System.currentTimeMillis() - startTime > timeoutInMillis) {
+                Assert.fail("There are not enough tasks (expected: " + tasks + ") processed by thread pool in timeout " + timeoutInMillis);
+            }
+            Thread.sleep(500);
+        }
+    }
+
+    ModelNode readAttribute(String attribute) throws Exception {
+        return executeOperation(Util.getReadAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, attribute));
+    }
+
+    static ModelNode executeOperation(ModelNode op) throws Exception {
+        ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        return result;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolBase.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
+import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -37,6 +38,9 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 
 import javax.naming.InitialContext;
+import java.io.FilePermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 public class Ejb3ThreadPoolBase {
 
@@ -54,7 +58,12 @@ public class Ejb3ThreadPoolBase {
         jar.addClass(ScheduleSingletonOneTimer.class);
         jar.addClasses(Ejb3ThreadPoolBase.class, Ejb3NonCoreThreadTimeoutTestCase.class, ModelNode.class, PathAddress.class,
                 ManagementOperations.class, MgmtOperationException.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.remoting3, org.jboss.as.controller\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new RemotingPermission("createEndpoint"),
+                new RemotingPermission("connect"),
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
+        ), "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolModelTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadPoolModelTestCase.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.threadpool;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.common.DefaultConfiguration;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.util.Set;
+
+/**
+ * @author Miroslav Novak
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(SnapshotRestoreSetupTask.class)
+public class Ejb3ThreadPoolModelTestCase extends Ejb3ThreadPoolBase {
+
+    private PathAddress myPoolPathAddress = PathAddress.pathAddress("subsystem", "ejb3").append("thread-pool", "myPool");
+
+    @Test
+    public void testCreateRemoveThreadPool() throws Exception {
+        int maxThreads = 27;
+        int coreThreads = 6;
+        long keepAliveTime = 18;
+        String keepAliveTimeUnit = "SECONDS";
+
+        // we don't know exact name of thread pool created for ejb3 subsystem in jboss-threads
+        // thus we create one and query based on attributes
+        // first make sure there is no such thread pool
+        final MBeanServerConnection mbs = getMBeanServerConnection();
+        Set<ObjectName> objs = mbs.queryNames(new ObjectName("jboss.threads:name=*,type=thread-pool"), null);
+        Assert.assertEquals("There is already thread pool with given params but it shouldn't be.", 0,
+                objs.stream()
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs, o, "MaximumPoolSize")) == maxThreads)
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs, o, "CorePoolSize")) == coreThreads)
+                        .filter((o) -> ((long) readAttributeValueFromMBeanObject(mbs, o, "KeepAliveTimeSeconds")) == keepAliveTime)
+                        .count());
+
+        // create one
+        ModelNode addThreadPool = Util.createAddOperation(myPoolPathAddress);
+        addThreadPool.get("max-threads").set(maxThreads);
+        addThreadPool.get("core-threads").set(coreThreads);
+        addThreadPool.get("keepalive-time").set(new ModelNode().add("unit", keepAliveTimeUnit)
+                .add("time", keepAliveTime));
+        executeOperation(addThreadPool);
+
+        final MBeanServerConnection mbs2 = getMBeanServerConnection();
+        objs = mbs2.queryNames(new ObjectName("jboss.threads:name=*,type=thread-pool"), null);
+        Assert.assertEquals("Thread pool was not created or does not have given params.", 1,
+                objs.stream()
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs2, o, "MaximumPoolSize")) == maxThreads)
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs2, o, "CorePoolSize")) == coreThreads)
+                        .filter((o) -> ((long) readAttributeValueFromMBeanObject(mbs2, o, "KeepAliveTimeSeconds")) == keepAliveTime)
+                        .count());
+        ModelNode removeThreadPool = Util.createRemoveOperation(myPoolPathAddress);
+        executeOperation(removeThreadPool);
+
+    }
+
+    @Test
+    public void testWriteReadAttributes() throws Exception {
+        int maxThreads = 12;
+        int coreThreads = 4;
+        long keepAliveTime = 5;
+        String keepAliveTimeUnit = "SECONDS";
+
+        // create one
+        ModelNode writeMaxThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "max-threads", maxThreads);
+        ModelNode writeCoreThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "core-threads", coreThreads);
+        ModelNode writeKeepAliveTimeOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time",
+                new ModelNode().get("keepalive-time").set(new ModelNode().add("unit", keepAliveTimeUnit)
+                        .add("time", keepAliveTime)));
+
+        executeOperation(writeMaxThreadsOp);
+        executeOperation(writeCoreThreadsOp);
+        executeOperation(writeKeepAliveTimeOp);
+
+        // read from mbean
+        final MBeanServerConnection mbs2 = getMBeanServerConnection();
+        Set<ObjectName> objs = mbs2.queryNames(new ObjectName("jboss.threads:name=*,type=thread-pool"), null);
+        Assert.assertEquals("Parameters were not applied into thread-pool " + DEFAULT_THREAD_POOL_ADDRESS, 1,
+                objs.stream()
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs2, o, "MaximumPoolSize")) == maxThreads)
+                        .filter((o) -> ((int) readAttributeValueFromMBeanObject(mbs2, o, "CorePoolSize")) == coreThreads)
+                        .filter((o) -> ((long) readAttributeValueFromMBeanObject(mbs2, o, "KeepAliveTimeSeconds")) == keepAliveTime)
+                        .count());
+
+        // read from CLI
+        ModelNode readMaxThreadsOp = Util.getReadAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "max-threads");
+        ModelNode readCoreThreadsOp = Util.getReadAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "core-threads");
+        ModelNode readKeepAliveOp = Util.getReadAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time");
+        Assert.assertEquals(maxThreads, executeOperation(readMaxThreadsOp).asInt());
+        Assert.assertEquals(coreThreads, executeOperation(readCoreThreadsOp).asInt());
+        ModelNode readKeepAliveTime = executeOperation(readKeepAliveOp);
+        Assert.assertEquals(readKeepAliveTime.get("time").asLong(), keepAliveTime);
+        Assert.assertEquals(readKeepAliveTime.get("unit").asString(), keepAliveTimeUnit);
+    }
+
+    @Test(expected = Exception.class)
+    public void testNegativeMaxThreadValue() throws Exception {
+        ModelNode writeMaxThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "max-threads", -12);
+        executeOperation(writeMaxThreadsOp);
+    }
+
+    @Test(expected = Exception.class)
+    public void testNegativeCoreThreadValue() throws Exception {
+        ModelNode writeCoreThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "core-threads", -12);
+        executeOperation(writeCoreThreadsOp);
+    }
+
+    @Test(expected = Exception.class)
+    public void testNegativeKeepAliveTimeoutValue() throws Exception {
+        ModelNode writeKeepAliveTimeOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time",
+                new ModelNode().get("keepalive-time").set(new ModelNode().add("unit", "SECONDS")
+                        .add("time", -12)));
+        executeOperation(writeKeepAliveTimeOp);
+    }
+
+    @Test(expected = Exception.class)
+    public void testIllegalTimeUnitValue() throws Exception {
+        ModelNode writeKeepAliveTimeOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time",
+                new ModelNode().get("keepalive-time").set(new ModelNode().add("unit", "BADUNIT")
+                        .add("time", 12)));
+        executeOperation(writeKeepAliveTimeOp);
+    }
+
+    private MBeanServerConnection getMBeanServerConnection() throws Exception {
+        final String address = managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort();
+        JMXConnector connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remote+http://" + address), DefaultConfiguration.credentials());
+        return connector.getMBeanServerConnection();
+    }
+
+    private Object readAttributeValueFromMBeanObject(MBeanServerConnection mbs, ObjectName o, String attribute) {
+        try {
+            return mbs.getAttribute(o, attribute);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadReuseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/Ejb3ThreadReuseTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.threadpool;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Ejb3ThreadReuseTestCase - start EJB singleton with 1 sec timer and check that single thread is reused
+ * <p>
+ *
+ * @author Miroslav Novak
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(Ejb3ThreadReuseTestCase.ServerSetup.class)
+public class Ejb3ThreadReuseTestCase extends Ejb3ThreadPoolBase {
+
+    private static final int MAX_THREADS = 10;
+    private static final int CORE_THREADS = 0;
+    private static final long KEEEP_ALIVE_TIME = 100;
+    private static final String KEEP_ALIVE_TIME_UNIT = "SECONDS";
+
+    @Test
+    public void testNonCoreThreadReused() throws Exception {
+        ScheduleSingletonOneTimer scheduleSingletonLocal = (ScheduleSingletonOneTimer) iniCtx.lookup("java:module/"
+                + ScheduleSingletonOneTimer.class.getSimpleName() + "!" + ScheduleSingletonOneTimer.class.getName());
+
+        // check that at least 3 tasks were processed by thread pool and then verify that there is still just one thread
+        waitUntilThreadPoolProcessedAtLeast(2, 10000);
+
+        Assert.assertEquals("Number of threads in pool must be 1.", 1,
+                readAttribute("current-thread-count").asInt());
+
+        // verify that it's still the same thread
+        Assert.assertEquals("There is always different thread processing tasks but it should be one.",
+                1, scheduleSingletonLocal.getThreadNames().size());
+    }
+
+    public static class ServerSetup extends SnapshotRestoreSetupTask {
+        protected void doSetup(ManagementClient client, String containerId) throws Exception {
+            // create one
+            ModelNode writeMaxThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "max-threads", MAX_THREADS);
+            ModelNode writeCoreThreadsOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "core-threads", CORE_THREADS);
+            ModelNode writeKeepAliveTimeOp = Util.getWriteAttributeOperation(DEFAULT_THREAD_POOL_ADDRESS, "keepalive-time",
+                    new ModelNode().get("keepalive-time").set(new ModelNode().add("unit", KEEP_ALIVE_TIME_UNIT)
+                            .add("time", KEEEP_ALIVE_TIME)));
+
+            executeOperation(writeMaxThreadsOp);
+            executeOperation(writeCoreThreadsOp);
+            executeOperation(writeKeepAliveTimeOp);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/ScheduleSingletonOneTimer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/threadpool/ScheduleSingletonOneTimer.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.threadpool;
+
+import javax.ejb.Schedule;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.ejb.Timer;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+@Startup
+@Singleton
+public class ScheduleSingletonOneTimer {
+    private final ConcurrentSkipListSet<String> threadNames = new ConcurrentSkipListSet<String>();
+
+    @Schedule(second="*/1", minute="*", hour="*", persistent=false)
+    public void timeout(Timer t) {
+        threadNames.add(Thread.currentThread().getName());
+    }
+
+    public Set<String> getThreadNames() {
+        return Collections.unmodifiableSet(threadNames);
+    }
+}
+
+


### PR DESCRIPTION
This PR adds a `core-threads` attribute to wildfly ejb3 subsystem thread-pool configuration, to support independent configuration of `core-threads` and `max-threads`, proper timeout of non-core threads, and reuse existing threads as much as possible without creating new threads.  The implementation of this feature uses an executor service backed by `org.jboss.threads.EnhancedQueueExecutor`.  This PR requires wildfly-core to be upgraded to incorporate wildfly-core PR:
https://github.com/wildfly/wildfly-core/pull/3880/

JIRA: https://issues.jboss.org/browse/WFLY-10057

Related analysis document proposal:
https://github.com/wildfly/wildfly-proposals/pull/227

Related Issues:  
https://issues.jboss.org/browse/EAP7-488
Fine-grained control on ejb3 thread-pool and reuse idle threads in pool before creating new

https://issues.jboss.org/browse/WFCORE-1446
EJB thread pool keepalive not honored and is not reusing inactive threads


