### PR TITLE
[WFLY-12418] Move to jakarta.security.enterprise:jakarta.security.ent…

### DIFF
--- a/ee-security/pom.xml
+++ b/ee-security/pom.xml
@@ -54,7 +54,7 @@
 
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>javax.security.enterprise</artifactId>
+            <artifactId>jakarta.security.enterprise</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -323,7 +323,7 @@
 
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>javax.security.enterprise</artifactId>
+            <artifactId>jakarta.security.enterprise</artifactId>
         </dependency>
 
         <dependency>
@@ -2220,6 +2220,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
             <exclusions>
@@ -2228,11 +2233,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -653,6 +653,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>jakarta.security.enterprise</groupId>
+      <artifactId>jakarta.security.enterprise-api</artifactId>
+      <licenses>
+        <license>
+          <name>Common Development and Distribution License 1.1</name>
+          <url>https://javaee.github.io/glassfish/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only, with Classpath exception</name>
+          <url>https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>javax.jws</groupId>
       <artifactId>jsr181-api</artifactId>
       <licenses>
@@ -680,22 +696,6 @@
         <license>
           <name>Eclipse Distribution License, Version 1.0</name>
           <url>http://repository.jboss.org/licenses/edl-1.0.txt</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>javax.security.enterprise</groupId>
-      <artifactId>javax.security.enterprise-api</artifactId>
-      <licenses>
-        <license>
-          <name>Common Development and Distribution License 1.1</name>
-          <url>https://javaee.github.io/glassfish/LICENSE</url>
-          <distribution>repo</distribution>
-        </license>
-        <license>
-          <name>GNU General Public License v2.0 only, with Classpath exception</name>
-          <url>https://fedoraproject.org/wiki/Licensing/GPL_Classpath_Exception</url>
           <distribution>repo</distribution>
         </license>
       </licenses>
@@ -1928,7 +1928,7 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.soteria</groupId>
-      <artifactId>javax.security.enterprise</artifactId>
+      <artifactId>jakarta.security.enterprise</artifactId>
       <licenses>
         <license>
           <name>Common Development and Distribution License 1.1</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/security/enterprise/api/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${javax.security.enterprise:javax.security.enterprise-api}"/>
+        <artifact name="${jakarta.security.enterprise:jakarta.security.enterprise-api}"/>
     </resources>
 
     <dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/soteria/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/soteria/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.glassfish.soteria:javax.security.enterprise}"/>
+        <artifact name="${org.glassfish.soteria:jakarta.security.enterprise}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -417,7 +417,7 @@
 
         <dependency>
             <groupId>org.glassfish.soteria</groupId>
-            <artifactId>javax.security.enterprise</artifactId>
+            <artifactId>jakarta.security.enterprise</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -2784,8 +2784,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -279,13 +279,13 @@
         <version.io.smallrye.opentracing>1.1.1</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
+        <version.jakarta.security.enterprise>1.0.1</version.jakarta.security.enterprise>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0.SP1</version.javax.enterprise>
         <version.javax.json.bind.api>1.0</version.javax.json.bind.api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.2</version.javax.mail>
         <version.javax.persistence>2.2</version.javax.persistence>
-        <version.javax.security.enterprise>1.0</version.javax.security.enterprise>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.3.GA</version.jboss.jaxbintros>
@@ -328,7 +328,7 @@
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
-        <version.org.glassfish.soteria>1.0</version.org.glassfish.soteria>
+        <version.org.glassfish.soteria>1.0.1</version.org.glassfish.soteria>
         <version.org.harmcrest>1.3</version.org.harmcrest>
         <version.org.hibernate>5.3.11.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
@@ -1643,6 +1643,12 @@
             </dependency>
 
             <dependency>
+                <groupId>jakarta.security.enterprise</groupId>
+                <artifactId>jakarta.security.enterprise-api</artifactId>
+                <version>${version.jakarta.security.enterprise}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>javax.activation</groupId>
                 <artifactId>activation</artifactId>
                 <version>${version.javax.activation}</version>
@@ -1686,12 +1692,6 @@
                 <groupId>javax.persistence</groupId>
                 <artifactId>javax.persistence-api</artifactId>
                 <version>${version.javax.persistence}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.security.enterprise</groupId>
-                <artifactId>javax.security.enterprise-api</artifactId>
-                <version>${version.javax.security.enterprise}</version>
             </dependency>
 
             <dependency>
@@ -5278,7 +5278,7 @@
 
             <dependency>
                 <groupId>org.glassfish.soteria</groupId>
-                <artifactId>javax.security.enterprise</artifactId>
+                <artifactId>jakarta.security.enterprise</artifactId>
                 <version>${version.org.glassfish.soteria}</version>
             </dependency>
 

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -88,6 +88,11 @@
             <artifactId>undertow-websockets-jsr</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Required for Java 11 -->
         <dependency>
             <groupId>javax.activation</groupId>
@@ -108,11 +113,6 @@
         <dependency>
             <groupId>javax.persistence</groupId>
             <artifactId>javax.persistence-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -62,8 +62,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.security.enterprise</groupId>
-            <artifactId>javax.security.enterprise-api</artifactId>
+            <groupId>jakarta.security.enterprise</groupId>
+            <artifactId>jakarta.security.enterprise-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…erprise-api and org.glassfish.soteria:jakarta.security.enterprise

[WFLY-12418](https://issues.jboss.org/browse/WFLY-12418)

For now EE security will not be forked and there are jakarta releases already available that we can use.