### PR TITLE
[WFLY-12427] Add org.jboss.logging dependency to the io.smallrye.heal…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
@@ -37,5 +37,6 @@
         <module name="javax.enterprise.api" />
         <module name="javax.annotation.api" />
         <module name="javax.json.api" />
+        <module name="org.jboss.logging" />
     </dependencies>
 </module>


### PR DESCRIPTION
…th module as its artifact's pom declares that

https://issues.jboss.org/browse/WFLY-12427