### PR TITLE
Feature vs galleon packs

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/PropertiesAttributeDefinition.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/PropertiesAttributeDefinition.java
@@ -85,7 +85,16 @@ public class PropertiesAttributeDefinition extends MapAttributeDefinition {
                 for (Property property : model.get(attribute.getName()).asPropertyList()) {
                     writer.writeStartElement(Element.PROPERTY.getLocalName());
                     writer.writeAttribute(Element.NAME.getLocalName(), property.getName());
-                    writer.writeCharacters(property.getValue().asString());
+                    // TODO if WFCORE-4625 goes in, use the util method.
+                    String content = property.getValue().asString();
+                    if (content.indexOf('\n') > -1) {
+                        // Multiline content. Use the overloaded variant that staxmapper will format
+                        writer.writeCharacters(content);
+                    } else {
+                        // Staxmapper will just output the chars without adding newlines if this is used
+                        char[] chars = content.toCharArray();
+                        writer.writeCharacters(chars, 0, chars.length);
+                    }
                     writer.writeEndElement();
                 }
             }

--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -7,11 +7,6 @@
     </subsystem>
     <supplement name="default">
         <replacement placeholder="CACHE-CONTAINERS">
-            <cache-container name="server" default-cache="default" module="org.wildfly.clustering.server">
-                <local-cache name="default">
-                    <transaction mode="BATCH"/>
-                </local-cache>
-            </cache-container>
             <cache-container name="web" default-cache="passivation" module="org.wildfly.clustering.web.infinispan">
                 <local-cache name="passivation">
                     <locking isolation="REPEATABLE_READ"/>
@@ -23,6 +18,11 @@
                     <transaction mode="BATCH"/>
                 </local-cache>
                 <local-cache name="routing"/>
+            </cache-container>
+            <cache-container name="server" default-cache="default" module="org.wildfly.clustering.server">
+                <local-cache name="default">
+                    <transaction mode="BATCH"/>
+                </local-cache>
             </cache-container>
             <cache-container name="ejb" aliases="sfsb" default-cache="passivation" module="org.wildfly.clustering.ejb.infinispan">
                 <local-cache name="passivation">
@@ -46,24 +46,24 @@
     </supplement>
     <supplement name="ha">
         <replacement placeholder="CACHE-CONTAINERS">
-            <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
-                <transport lock-timeout="60000"/>
-                <replicated-cache name="default">
-                    <transaction mode="BATCH"/>
-                </replicated-cache>
-            </cache-container>
             <cache-container name="web" default-cache="dist" module="org.wildfly.clustering.web.infinispan">
                 <transport lock-timeout="60000"/>
-                <distributed-cache name="dist">
-                    <locking isolation="REPEATABLE_READ"/>
-                    <transaction mode="BATCH"/>
-                    <file-store/>
-                </distributed-cache>
                 <replicated-cache name="sso">
                     <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                 </replicated-cache>
                 <replicated-cache name="routing"/>
+                <distributed-cache name="dist">
+                    <locking isolation="REPEATABLE_READ"/>
+                    <transaction mode="BATCH"/>
+                    <file-store/>
+                </distributed-cache>
+            </cache-container>
+            <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
+                <transport lock-timeout="60000"/>
+                <replicated-cache name="default">
+                    <transaction mode="BATCH"/>
+                </replicated-cache>
             </cache-container>
             <cache-container name="ejb" aliases="sfsb" default-cache="dist" module="org.wildfly.clustering.ejb.infinispan">
                 <transport lock-timeout="60000"/>

--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -114,7 +114,7 @@
     </supplement>
     <supplement name="gossip-discovery">
         <replacement placeholder="TCP-DISCOVERY">
-            <protocol type="TCPGOSSIP">
+            <protocol type="org.jgroups.protocols.TCPGOSSIP">
                 <property name="initial_hosts">
                     ${jboss.jgroups.gossip.initial_hosts}
                 </property>
@@ -124,7 +124,7 @@
             </protocol>
         </replacement>
         <replacement placeholder="UDP-DISCOVERY">
-            <protocol type="TCPGOSSIP">
+            <protocol type="org.jgroups.protocols.TCPGOSSIP">
                 <property name="initial_hosts">
                     ${jboss.jgroups.gossip.initial_hosts}
                 </property>

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -259,7 +259,15 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
 
         writer.writeStartElement(localName);
         writer.writeAttribute("name", name);
-        writer.writeCharacters(value);
+        // TODO if WFCORE-4625 goes in, use the util method.
+        if (value.indexOf('\n') > -1) {
+            // Multiline content. Use the overloaded variant that staxmapper will format
+            writer.writeCharacters(value);
+        } else {
+            // Staxmapper will just output the chars without adding newlines if this is used
+            char[] chars = value.toCharArray();
+            writer.writeCharacters(chars, 0, chars.length);
+        }
         writer.writeEndElement();
 
     }

--- a/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/dist-legacy/src/test/java/org/wildfly/dist/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -214,6 +214,8 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
         result = result.replace("${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
         result = result.replace("${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}", "false");
+        result = result.replace("${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}", "UP");
+        result = result.replace("${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}", "UP");
         return result;
     }
 }

--- a/ejb3/src/main/resources/subsystem-templates/ejb3.xml
+++ b/ejb3/src/main/resources/subsystem-templates/ejb3.xml
@@ -41,9 +41,6 @@
                <keepalive-time time="100" unit="milliseconds"/>
            </thread-pool>
        </thread-pools>
-       <server-interceptors>
-           <server-interceptor module="foo:interceptors:1.0" class="org.bar.FooInterceptor"/>
-       </server-interceptors>
        <?IIOP?>
        <default-security-domain value="other"/>
        <default-missing-method-permissions-deny-access value="true" />

--- a/galleon-pack/src/main/resources/feature_groups/standalone-gossip-ha.xml
+++ b/galleon-pack/src/main/resources/feature_groups/standalone-gossip-ha.xml
@@ -19,7 +19,7 @@
                     <param name="socket-binding" value="jgroups-tcp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">
-                    <param name="protocol" value="TCPGOSSIP"/>
+                    <param name="protocol" value="org.jgroups.protocols.TCPGOSSIP"/>
                     <param name="properties" value="initial_hosts=&quot;${jboss.jgroups.gossip.initial_hosts}&quot;,num_initial_members=&quot;${jboss.jgroups.gossip.num_initial_members}&quot;"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">
@@ -57,7 +57,7 @@
                     <param name="socket-binding" value="jgroups-udp"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">
-                    <param name="protocol" value="TCPGOSSIP"/>
+                    <param name="protocol" value="org.jgroups.protocols.TCPGOSSIP"/>
                     <param name="properties" value="initial_hosts=&quot;${jboss.jgroups.gossip.initial_hosts}&quot;,num_initial_members=&quot;${jboss.jgroups.gossip.num_initial_members}&quot;"/>
                 </feature>
                 <feature spec="subsystem.jgroups.stack.protocol">

--- a/microprofile/health-smallrye/src/main/resources/subsystem-templates/microprofile-health-smallrye.xml
+++ b/microprofile/health-smallrye/src/main/resources/subsystem-templates/microprofile-health-smallrye.xml
@@ -3,6 +3,8 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.microprofile.health-smallrye</extension-module>
-    <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:2.0" security-enabled="false">
-    </subsystem>
+    <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:2.0" security-enabled="false"
+               empty-liveness-checks-status="${env.MP_HEALTH_EMPTY_LIVENESS_CHECKS_STATUS:UP}"
+               empty-readiness-checks-status="${env.MP_HEALTH_EMPTY_READINESS_CHECKS_STATUS:UP}"/>
+
 </config>

--- a/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
@@ -35,7 +35,9 @@
         </server>
         <servlet-container name="default" />
         <filters>
-            <mod-cluster name="load-balancer" management-socket-binding="mcmp-management" advertise-socket-binding="modcluster" enable-http2="true" max-retries="3"  />
+            <mod-cluster name="load-balancer" management-socket-binding="mcmp-management" advertise-socket-binding="modcluster" enable-http2="true" max-retries="3">
+                <single-affinity/>
+            </mod-cluster>
         </filters>
     </subsystem>
     <socket-binding name="http" port="${jboss.http.port:8080}"/>


### PR DESCRIPTION
Cleans up various issues in the legacy feature packs subsystem templates that result in config file differences between legacy builds and current galleon-driven builds.

In cases where the problem is due to a WF 18 change not being applied to the subsystem template, I used the JIRA id of the change that missed this part. There's also a commit related to infinispan where some ordering has just drifted between the two config styles, perhaps in WF 17. No bug there; the change is just to make them consistent to make diffing cleaner.