### PR TITLE
[WFLY-12384] enforce managed executors use thread factory without a c…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedExecutorServiceImpl.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 
 /**

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -23,7 +23,6 @@ package org.jboss.as.ee.concurrent;
 
 import static org.jboss.as.ee.concurrent.SecurityIdentityUtils.doIdentityWrap;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.wildfly.extension.requestcontroller.ControlPoint;
 
 import javax.enterprise.concurrent.LastExecution;

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedThreadFactoryImpl.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/ManagedThreadFactoryImpl.java
@@ -24,7 +24,6 @@ package org.jboss.as.ee.concurrent;
 
 import org.glassfish.enterprise.concurrent.AbstractManagedThread;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.glassfish.enterprise.concurrent.spi.ContextHandle;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -39,16 +38,30 @@ import java.security.PrivilegedAction;
  *
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
-public class ElytronManagedThreadFactory extends ManagedThreadFactoryImpl {
+public class ManagedThreadFactoryImpl extends org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl {
+
+    /**
+     * the priority set on new threads
+     */
+    private final int priority;
 
     /**
      * the factory's ACC
      */
     private final AccessControlContext accessControlContext;
 
-    public ElytronManagedThreadFactory(String name, ContextServiceImpl contextService, int priority) {
+    public ManagedThreadFactoryImpl(String name, ContextServiceImpl contextService, int priority) {
         super(name, contextService, priority);
+        this.priority = priority;
         this.accessControlContext = AccessController.getContext();
+    }
+
+    /**
+     *
+     * @return the priority set on new threads
+     */
+    public int getPriority() {
+        return priority;
     }
 
     protected AbstractManagedThread createThread(Runnable r, final ContextHandle contextHandleForSetup) {
@@ -81,7 +94,7 @@ public class ElytronManagedThreadFactory extends ManagedThreadFactoryImpl {
 
         @Override
         public AbstractManagedThread run() {
-            return ElytronManagedThreadFactory.super.createThread(r, contextHandleForSetup);
+            return ManagedThreadFactoryImpl.super.createThread(r, contextHandleForSetup);
         }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorServiceService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedExecutorServiceService.java
@@ -25,8 +25,7 @@ package org.jboss.as.ee.concurrent.service;
 import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
 import org.glassfish.enterprise.concurrent.ManagedExecutorServiceAdapter;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
-import org.jboss.as.ee.concurrent.ElytronManagedThreadFactory;
+import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.ee.concurrent.ManagedExecutorServiceImpl;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;
@@ -77,7 +76,7 @@ public class ManagedExecutorServiceService extends EEConcurrentAbstractService<M
      * @param threadLifeTime
      * @param queueCapacity
      * @param rejectPolicy
-     * @see ManagedExecutorServiceImpl#ManagedExecutorServiceImpl(String, org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl, long, boolean, int, int, long, java.util.concurrent.TimeUnit, long, int, org.glassfish.enterprise.concurrent.ContextServiceImpl, org.glassfish.enterprise.concurrent.AbstractManagedExecutorService.RejectPolicy, org.wildfly.extension.requestcontroller.ControlPoint)
+     * @see ManagedExecutorServiceImpl#ManagedExecutorServiceImpl(String, org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl, long, boolean, int, int, long, java.util.concurrent.TimeUnit, long, int, org.glassfish.enterprise.concurrent.ContextServiceImpl, org.glassfish.enterprise.concurrent.AbstractManagedExecutorService.RejectPolicy, org.wildfly.extension.requestcontroller.ControlPoint)
      */
     public ManagedExecutorServiceService(String name, String jndiName, long hungTaskThreshold, boolean longRunningTasks, int corePoolSize, int maxPoolSize, long keepAliveTime, TimeUnit keepAliveTimeUnit, long threadLifeTime, int queueCapacity, AbstractManagedExecutorService.RejectPolicy rejectPolicy) {
         super(jndiName);
@@ -97,27 +96,19 @@ public class ManagedExecutorServiceService extends EEConcurrentAbstractService<M
     @Override
     void startValue(StartContext context) throws StartException {
         ManagedThreadFactoryImpl managedThreadFactory = managedThreadFactoryInjectedValue.getOptionalValue();
-        if(managedThreadFactory == null) {
-            // if not injected create one using normal thread priority
-            final String threadFactoryName = "EE-ManagedExecutorService-"+name;
-            managedThreadFactory = new ElytronManagedThreadFactory(threadFactoryName, null, Thread.NORM_PRIORITY);
-        }
-
+        final int priority = managedThreadFactory != null ? managedThreadFactory.getPriority() : Thread.NORM_PRIORITY;
+        managedThreadFactory = new ManagedThreadFactoryImpl("EE-ManagedExecutorService-"+name, null, priority);
         if(requestController.getOptionalValue() != null) {
             controlPoint = requestController.getValue().getControlPoint(name, "managed-executor-service");
         }
         executorService = new ManagedExecutorServiceImpl(name, managedThreadFactory, hungTaskThreshold, longRunningTasks, corePoolSize, maxPoolSize, keepAliveTime, keepAliveTimeUnit, threadLifeTime, queueCapacity, contextService.getOptionalValue(), rejectPolicy, controlPoint);
-
     }
 
     @Override
     void stopValue(StopContext context) {
         if (executorService != null) {
             executorService.shutdownNow();
-            if(managedThreadFactoryInjectedValue.getOptionalValue() == null) {
-                // if not injected the thread factory was created on start, and now needs to stop
-                executorService.getManagedThreadFactory().stop();
-            }
+            executorService.getManagedThreadFactory().stop();
             this.executorService = null;
         }
         if(controlPoint != null) {

--- a/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedThreadFactoryService.java
+++ b/ee/src/main/java/org/jboss/as/ee/concurrent/service/ManagedThreadFactoryService.java
@@ -23,8 +23,7 @@
 package org.jboss.as.ee.concurrent.service;
 
 import org.glassfish.enterprise.concurrent.ContextServiceImpl;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
-import org.jboss.as.ee.concurrent.ElytronManagedThreadFactory;
+import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.StartContext;
@@ -47,7 +46,7 @@ public class ManagedThreadFactoryService extends EEConcurrentAbstractService<Man
      * @param name
      * @param jndiName
      * @param priority
-     * @see ManagedThreadFactoryImpl#ManagedThreadFactoryImpl(String, org.glassfish.enterprise.concurrent.ContextServiceImpl, int)
+     * @see org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl#ManagedThreadFactoryImpl(String, org.glassfish.enterprise.concurrent.ContextServiceImpl, int)
      */
     public ManagedThreadFactoryService(String name, String jndiName, int priority) {
         super(jndiName);
@@ -59,7 +58,7 @@ public class ManagedThreadFactoryService extends EEConcurrentAbstractService<Man
     @Override
     void startValue(StartContext context) throws StartException {
         final String threadFactoryName = "EE-ManagedThreadFactory-"+name;
-        managedThreadFactory = new ElytronManagedThreadFactory(threadFactoryName, contextService.getOptionalValue(), priority);
+        managedThreadFactory = new ManagedThreadFactoryImpl(threadFactoryName, contextService.getOptionalValue(), priority);
     }
 
     @Override

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceAdd.java
@@ -22,13 +22,13 @@
 package org.jboss.as.ee.subsystem;
 
 import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ee.concurrent.ContextServiceImpl;
+import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.ee.concurrent.service.ManagedExecutorServiceService;
 import org.jboss.as.ee.logging.EeLogger;
 import org.jboss.as.ee.subsystem.ManagedExecutorServiceResourceDefinition.ExecutorQueueValidationStepHandler;

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceAdd.java
@@ -24,12 +24,12 @@ package org.jboss.as.ee.subsystem;
 import java.util.concurrent.TimeUnit;
 
 import org.glassfish.enterprise.concurrent.AbstractManagedExecutorService;
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.ee.concurrent.ContextServiceImpl;
+import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.ee.concurrent.service.ManagedScheduledExecutorServiceService;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.common.cpu.ProcessorInfo;

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedThreadFactoryResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedThreadFactoryResourceDefinition.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.ee.subsystem;
 
-import org.glassfish.enterprise.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -35,6 +34,7 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.ee.concurrent.ManagedThreadFactoryImpl;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 


### PR DESCRIPTION
…ontext service

Issue: https://issues.jboss.org/browse/WFLY-12384
Description:  Manage executors, when configured with a thread factory reference, should only use it as the source of config for their own thread factory (atm that's only threads priority), not use it directly. This is due to the executor thread factory must have no context service, otherwise it behaves as if it was apps creating threads directly, leaving deployment resources linked in its runnable during whole thread life.