### PR TITLE
[WFLY-12218] Add support for automatically adding and updating credentials in a credential store

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
@@ -188,7 +188,14 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
             AttributeAccess attribute = registration.getAttributeAccess(PathAddress.EMPTY_ADDRESS, attributeName);
             AttributeDefinition definition = attribute.getAttributeDefinition();
             if ((attribute.getStorageType() == AttributeAccess.Storage.CONFIGURATION) && !translations.containsKey(definition)) {
-                definition.validateAndSet(operation, model);
+                OperationStepHandler writeHandler = this.descriptor.getCustomAttributes().get(definition);
+                if (writeHandler != null) {
+                    // If attribute has custom handling, perform a separate write-attribute operation
+                    ModelNode writeAttributeOperation = Util.getWriteAttributeOperation(currentAddress, definition.getName(), definition.validateOperation(operation));
+                    context.addStep(writeAttributeOperation, writeHandler, OperationContext.Stage.MODEL);
+                } else {
+                    definition.validateAndSet(operation, model);
+                }
             }
         }
 
@@ -254,6 +261,9 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
             builder.addParameter(SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ADD_INDEX, ModelType.INT, true).build());
         }
         for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
+            builder.addParameter(attribute);
+        }
+        for (AttributeDefinition attribute : this.descriptor.getCustomAttributes().keySet()) {
             builder.addParameter(attribute);
         }
         for (AttributeDefinition parameter : this.descriptor.getExtraParameters()) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandlerDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandlerDescriptor.java
@@ -39,6 +39,12 @@ import org.jboss.as.controller.registry.Resource;
 public interface AddStepHandlerDescriptor extends WriteAttributeStepHandlerDescriptor, RemoveStepHandlerDescriptor {
 
     /**
+     * Custom attributes of the add operation, processed using a specific write-attribute handler.
+     * @return a map of attributes and their write-attribute handler
+     */
+    Map<AttributeDefinition, OperationStepHandler> getCustomAttributes();
+
+    /**
      * Extra parameters (not specified by {@link #getAttributes()}) for the add operation.
      * @return a collection of attributes
      */

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredResourceRegistration.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
 /**
  * @author Paul Ferraro
  */
@@ -29,5 +31,9 @@ public class ReloadRequiredResourceRegistration extends ResourceRegistration {
 
     public ReloadRequiredResourceRegistration(AddStepHandlerDescriptor descriptor) {
         super(descriptor, new ReloadRequiredAddStepHandler(descriptor), new ReloadRequiredRemoveStepHandler(descriptor), new WriteAttributeStepHandler(descriptor));
+    }
+
+    public ReloadRequiredResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> addRegistration, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
+        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredResourceRegistration.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
 /**
  * @author Paul Ferraro
  */
@@ -31,9 +29,5 @@ public class ReloadRequiredResourceRegistration extends ResourceRegistration {
 
     public ReloadRequiredResourceRegistration(AddStepHandlerDescriptor descriptor) {
         super(descriptor, new ReloadRequiredAddStepHandler(descriptor), new ReloadRequiredRemoveStepHandler(descriptor), new WriteAttributeStepHandler(descriptor));
-    }
-
-    public ReloadRequiredResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> addRegistration, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
-        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
@@ -65,6 +65,7 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     private final ResourceDescriptionResolver resolver;
     private final Map<Capability, Predicate<ModelNode>> capabilities = new HashMap<>();
     private final List<AttributeDefinition> attributes = new LinkedList<>();
+    private final Map<AttributeDefinition, OperationStepHandler> customAttributes = new HashMap<>();
     private final List<AttributeDefinition> parameters = new LinkedList<>();
     private final Set<PathElement> requiredChildren = new TreeSet<>(PATH_COMPARATOR);
     private final Set<PathElement> requiredSingletonChildren = new TreeSet<>(PATH_COMPARATOR);
@@ -112,6 +113,16 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
     @Override
     public Map<AttributeDefinition, AttributeTranslation> getAttributeTranslations() {
         return this.attributeTranslations;
+    }
+
+    @Override
+    public Map<AttributeDefinition, OperationStepHandler> getCustomAttributes() {
+        return this.customAttributes;
+    }
+
+    public ResourceDescriptor addAttribute(Attribute attribute, OperationStepHandler writeAttributeHandler) {
+        this.customAttributes.put(attribute.getDefinition(), writeAttributeHandler);
+        return this;
     }
 
     public <E extends Enum<E> & Attribute> ResourceDescriptor addAttributes(Class<E> enumClass) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceRegistration.java
@@ -60,8 +60,13 @@ public class ResourceRegistration implements Registration<ManagementResourceRegi
 
         registration.registerRequirements(this.descriptor.getResourceCapabilityReferences());
 
-        // Register attributes before add operation
+        // Register standard attributes before add operation
         this.writeAttributeRegistration.register(registration);
+
+        // Register attributes with custom write-attribute handlers
+        for (Map.Entry<AttributeDefinition, OperationStepHandler> entry : this.descriptor.getCustomAttributes().entrySet()) {
+            registration.registerReadWriteAttribute(entry.getKey(), null, entry.getValue());
+        }
 
         // Register attribute translations
         for (Map.Entry<AttributeDefinition, AttributeTranslation> entry : this.descriptor.getAttributeTranslations().entrySet()) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistration.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
 /**
  * Registers a {@link RestartParentResourceAddStepHandler}, {@link RestartParentResourceRemoveStepHandler}, and {@link RestartParentResourceWriteAttributeHandler} on behalf of a resource definition.
  * @author Paul Ferraro
@@ -36,9 +34,5 @@ public class RestartParentResourceRegistration extends ResourceRegistration {
 
     public RestartParentResourceRegistration(ResourceServiceConfiguratorFactory parentFactory, ResourceDescriptor descriptor, ResourceServiceHandler handler) {
         super(descriptor, new RestartParentResourceAddStepHandler(parentFactory, descriptor, handler), new RestartParentResourceRemoveStepHandler(parentFactory, descriptor, handler), new RestartParentResourceWriteAttributeHandler(parentFactory, descriptor));
-    }
-
-    public RestartParentResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<ManagementResourceRegistration> addRegistration, Registration<ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
-        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceRegistration.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
 /**
  * Registers a {@link RestartParentResourceAddStepHandler}, {@link RestartParentResourceRemoveStepHandler}, and {@link RestartParentResourceWriteAttributeHandler} on behalf of a resource definition.
  * @author Paul Ferraro
@@ -34,5 +36,9 @@ public class RestartParentResourceRegistration extends ResourceRegistration {
 
     public RestartParentResourceRegistration(ResourceServiceConfiguratorFactory parentFactory, ResourceDescriptor descriptor, ResourceServiceHandler handler) {
         super(descriptor, new RestartParentResourceAddStepHandler(parentFactory, descriptor, handler), new RestartParentResourceRemoveStepHandler(parentFactory, descriptor, handler), new RestartParentResourceWriteAttributeHandler(parentFactory, descriptor));
+    }
+
+    public RestartParentResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<ManagementResourceRegistration> addRegistration, Registration<ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
+        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/SimpleResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/SimpleResourceRegistration.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
 /**
  * Registers a {@link AddStepHandler}, {@link RemoveStepHandler}, and {@link WriteAttributeStepHandler} on behalf of a resource definition.
  * @author Paul Ferraro
@@ -30,5 +32,9 @@ public class SimpleResourceRegistration extends ResourceRegistration {
 
     public SimpleResourceRegistration(ResourceDescriptor descriptor, ResourceServiceHandler handler) {
         super(descriptor, new AddStepHandler(descriptor, handler), new RemoveStepHandler(descriptor, handler), new WriteAttributeStepHandler(descriptor, handler));
+    }
+
+    public SimpleResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> addRegistration, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
+        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/SimpleResourceRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/SimpleResourceRegistration.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
 /**
  * Registers a {@link AddStepHandler}, {@link RemoveStepHandler}, and {@link WriteAttributeStepHandler} on behalf of a resource definition.
  * @author Paul Ferraro
@@ -32,9 +30,5 @@ public class SimpleResourceRegistration extends ResourceRegistration {
 
     public SimpleResourceRegistration(ResourceDescriptor descriptor, ResourceServiceHandler handler) {
         super(descriptor, new AddStepHandler(descriptor, handler), new RemoveStepHandler(descriptor, handler), new WriteAttributeStepHandler(descriptor, handler));
-    }
-
-    public SimpleResourceRegistration(AddStepHandlerDescriptor descriptor, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> addRegistration, Registration<org.jboss.as.controller.registry.ManagementResourceRegistration> removeRegistration, Registration<ManagementResourceRegistration> writeAttributeRegistration) {
-        super(descriptor, addRegistration, removeRegistration, writeAttributeRegistration);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
@@ -161,9 +161,9 @@ public class AbstractProtocolResourceDefinition extends ChildResourceDefinition<
         PropertyResourceDefinition.buildTransformation(version, builder);
     }
 
-    private final UnaryOperator<ResourceDescriptor> configurator;
-    private final ResourceServiceHandler handler;
-    private final ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory;
+    protected final UnaryOperator<ResourceDescriptor> configurator;
+    protected final ResourceServiceHandler handler;
+    protected final ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory;
 
     AbstractProtocolResourceDefinition(Parameters parameters, UnaryOperator<ResourceDescriptor> configurator, ResourceServiceConfiguratorFactory serviceConfiguratorFactory, ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory) {
         super(parameters);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolResourceDefinition.java
@@ -161,9 +161,9 @@ public class AbstractProtocolResourceDefinition extends ChildResourceDefinition<
         PropertyResourceDefinition.buildTransformation(version, builder);
     }
 
-    protected final UnaryOperator<ResourceDescriptor> configurator;
-    protected final ResourceServiceHandler handler;
-    protected final ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory;
+    private final UnaryOperator<ResourceDescriptor> configurator;
+    private final ResourceServiceHandler handler;
+    private final ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory;
 
     AbstractProtocolResourceDefinition(Parameters parameters, UnaryOperator<ResourceDescriptor> configurator, ResourceServiceConfiguratorFactory serviceConfiguratorFactory, ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory) {
         super(parameters);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthProtocolResourceDefinition.java
@@ -48,6 +48,10 @@ public class AuthProtocolResourceDefinition extends ProtocolResourceDefinition {
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
 
         ProtocolResourceDefinition.addTransformations(version, builder);
+
+        PlainAuthTokenResourceDefinition.buildTransformation(version, builder);
+        DigestAuthTokenResourceDefinition.buildTransformation(version, builder);
+        CipherAuthTokenResourceDefinition.buildTransformation(version, builder);
     }
 
     private static class ResourceDescriptorConfigurator implements UnaryOperator<ResourceDescriptor> {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AuthTokenResourceDefinition.java
@@ -22,38 +22,24 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.clustering.jgroups.subsystem.AuthTokenResourceDefinition.Attribute.SHARED_SECRET;
-import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
-import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
-
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.AddStepHandlerDescriptor;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceConfiguratorFactory;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceRegistration;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
-import org.jboss.as.clustering.controller.WriteAttributeStepHandler;
-import org.jboss.as.clustering.controller.WriteAttributeStepHandlerDescriptor;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.dmr.ModelNode;
 import org.jgroups.auth.AuthToken;
 import org.wildfly.clustering.service.UnaryRequirement;
 
@@ -98,8 +84,11 @@ public class AuthTokenResourceDefinition<T extends AuthToken> extends ChildResou
     }
 
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
-
-        ProtocolResourceDefinition.addTransformations(version, builder);
+        if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
+            builder.getAttributeBuilder()
+                    .addRejectCheck(CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, Attribute.SHARED_SECRET.getName())
+                    .end();
+        }
     }
 
     protected final UnaryOperator<ResourceDescriptor> configurator;
@@ -115,61 +104,10 @@ public class AuthTokenResourceDefinition<T extends AuthToken> extends ChildResou
     public ManagementResourceRegistration register(ManagementResourceRegistration parent) {
         ManagementResourceRegistration registration = parent.registerSubModel(this);
         ResourceDescriptor descriptor = this.configurator.apply(new ResourceDescriptor(this.getResourceDescriptionResolver()))
-                .addAttributes(Attribute.class)
+                .addAttribute(Attribute.SHARED_SECRET, new CredentialReferenceWriteAttributeHandler(Attribute.SHARED_SECRET.getDefinition()))
                 .addCapabilities(Capability.class)
                 ;
-        new TokenResourceRegistration(descriptor, new SimpleResourceServiceHandler(this.serviceConfiguratorFactory)).register(registration);
-
+        new SimpleResourceRegistration(descriptor, new SimpleResourceServiceHandler(this.serviceConfiguratorFactory)).register(registration);
         return registration;
-    }
-
-    private static class TokenResourceRegistration extends SimpleResourceRegistration {
-
-        public TokenResourceRegistration(ResourceDescriptor descriptor, ResourceServiceHandler handler) {
-            super(descriptor, new TokenAddStepHandler(descriptor, handler), new RemoveStepHandler(descriptor, handler), new TokenWriteAttributeStepHandler(descriptor));
-        }
-    }
-
-    private static class TokenAddStepHandler extends AddStepHandler {
-
-        public TokenAddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
-            super(descriptor, handler);
-        }
-
-        @Override
-        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-            super.populateModel(context, operation, resource);
-            final ModelNode model = resource.getModel();
-            handleCredentialReferenceUpdate(context, model.get(SHARED_SECRET.getName()), SHARED_SECRET.getName());
-        }
-
-        @Override
-        protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
-            rollbackCredentialStoreUpdate(SHARED_SECRET.getDefinition(), context, resource);
-            super.rollbackRuntime(context, operation, resource);
-        }
-    }
-
-    private static class TokenWriteAttributeStepHandler extends WriteAttributeStepHandler {
-
-        private final WriteAttributeStepHandlerDescriptor descriptor;
-
-        public TokenWriteAttributeStepHandler(WriteAttributeStepHandlerDescriptor descriptor) {
-            super(descriptor, null);
-            this.descriptor = descriptor;
-        }
-
-        @Override
-        public void register(ManagementResourceRegistration registration) {
-            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(SHARED_SECRET.getDefinition());
-            for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
-                if (attribute.equals(SHARED_SECRET.getDefinition())) {
-                    registration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
-                } else {
-                    registration.registerReadWriteAttribute(attribute, null, this);
-                }
-            }
-        }
-
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/CipherAuthTokenResourceDefinition.java
@@ -22,17 +22,33 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
+
 import java.util.function.UnaryOperator;
 
+import org.jboss.as.clustering.controller.AddStepHandler;
+import org.jboss.as.clustering.controller.AddStepHandlerDescriptor;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
+import org.jboss.as.clustering.controller.RemoveStepHandler;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
+import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceDescriptorConfigurator;
+import org.jboss.as.clustering.controller.SimpleResourceRegistration;
+import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
+import org.jboss.as.clustering.controller.WriteAttributeStepHandler;
+import org.jboss.as.clustering.controller.WriteAttributeStepHandlerDescriptor;
 import org.jboss.as.clustering.jgroups.auth.CipherAuthToken;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -93,5 +109,67 @@ public class CipherAuthTokenResourceDefinition extends AuthTokenResourceDefiniti
 
     CipherAuthTokenResourceDefinition() {
         super(PATH, new SimpleResourceDescriptorConfigurator<>(Attribute.class), CipherAuthTokenServiceConfigurator::new);
+    }
+
+    @Override
+    public org.jboss.as.controller.registry.ManagementResourceRegistration register(org.jboss.as.controller.registry.ManagementResourceRegistration parent) {
+        org.jboss.as.controller.registry.ManagementResourceRegistration registration = parent.registerSubModel(this);
+        ResourceDescriptor descriptor = this.configurator.apply(new ResourceDescriptor(this.getResourceDescriptionResolver()))
+                .addAttributes(AuthTokenResourceDefinition.Attribute.class)
+                .addCapabilities(Capability.class)
+                ;
+        new CipherAuthTokenResourceRegistration(descriptor, new SimpleResourceServiceHandler(this.serviceConfiguratorFactory)).register(registration);
+
+        return registration;
+    }
+
+    private static class CipherAuthTokenResourceRegistration extends SimpleResourceRegistration {
+
+        public CipherAuthTokenResourceRegistration(ResourceDescriptor descriptor, ResourceServiceHandler handler) {
+            super(descriptor, new CipherAuthTokenAddStepHandler(descriptor, handler), new RemoveStepHandler(descriptor, handler), new CipherAuthTokenWriteAttributeStepHandler(descriptor));
+        }
+    }
+
+    private static class CipherAuthTokenAddStepHandler extends AddStepHandler {
+
+        public CipherAuthTokenAddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
+            super(descriptor, handler);
+        }
+
+        @Override
+        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
+            super.populateModel(context, operation, resource);
+            final ModelNode model = resource.getModel();
+            handleCredentialReferenceUpdate(context, model.get(Attribute.KEY_CREDENTIAL.getName()), Attribute.KEY_CREDENTIAL.getName());
+        }
+
+        @Override
+        protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+            rollbackCredentialStoreUpdate(Attribute.KEY_CREDENTIAL.getDefinition(), context, resource);
+            super.rollbackRuntime(context, operation, resource);
+        }
+    }
+
+    private static class CipherAuthTokenWriteAttributeStepHandler extends WriteAttributeStepHandler {
+
+        private final WriteAttributeStepHandlerDescriptor descriptor;
+
+        public CipherAuthTokenWriteAttributeStepHandler(WriteAttributeStepHandlerDescriptor descriptor) {
+            super(descriptor, null);
+            this.descriptor = descriptor;
+        }
+
+        @Override
+        public void register(org.jboss.as.controller.registry.ManagementResourceRegistration registration) {
+            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(Attribute.KEY_CREDENTIAL.getDefinition());
+            for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
+                if (attribute.equals(Attribute.KEY_CREDENTIAL.getDefinition())) {
+                    registration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
+                } else {
+                    registration.registerReadWriteAttribute(attribute, null, this);
+                }
+            }
+        }
+
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/DigestAuthTokenResourceDefinition.java
@@ -25,9 +25,11 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import org.jboss.as.clustering.controller.SimpleResourceDescriptorConfigurator;
 import org.jboss.as.clustering.jgroups.auth.BinaryAuthToken;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -56,6 +58,12 @@ public class DigestAuthTokenResourceDefinition extends AuthTokenResourceDefiniti
         public AttributeDefinition getDefinition() {
             return this.definition;
         }
+    }
+
+    static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder builder = parent.addChildResource(PATH);
+
+        AuthTokenResourceDefinition.addTransformations(version, builder);
     }
 
     DigestAuthTokenResourceDefinition() {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -22,21 +22,37 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
+
 import java.security.KeyStore;
 import java.util.function.UnaryOperator;
 
+import org.jboss.as.clustering.controller.AddStepHandlerDescriptor;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceConfigurator;
 import org.jboss.as.clustering.controller.ResourceServiceConfiguratorFactory;
+import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
+import org.jboss.as.clustering.controller.RestartParentResourceRegistration;
+import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
+import org.jboss.as.clustering.controller.RestartParentResourceWriteAttributeHandler;
+import org.jboss.as.clustering.controller.WriteAttributeStepHandlerDescriptor;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -121,5 +137,72 @@ public class EncryptProtocolResourceDefinition<E extends KeyStore.Entry> extends
 
     public EncryptProtocolResourceDefinition(String name, Class<E> entryClass, UnaryOperator<ResourceDescriptor> configurator, ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory) {
         super(pathElement(name), new ResourceDescriptorConfigurator(configurator), new EncryptProtocolConfigurationConfiguratorFactory<>(entryClass), parentServiceConfiguratorFactory);
+    }
+
+    @Override
+    public ManagementResourceRegistration register(ManagementResourceRegistration parent) {
+        ManagementResourceRegistration registration = parent.registerSubModel(this);
+
+        ResourceDescriptor descriptor = this.configurator.apply(new ResourceDescriptor(this.getResourceDescriptionResolver()))
+                .addAttributes(AbstractProtocolResourceDefinition.Attribute.class)
+                .addExtraParameters(DeprecatedAttribute.class)
+                ;
+        new ProtocolResourceRegistration(this.parentServiceConfiguratorFactory, descriptor, this.handler).register(registration);
+
+        if (registration.getPathAddress().getLastElement().isWildcard()) {
+            new PropertyResourceDefinition().register(registration);
+        }
+
+        return registration;
+    }
+
+    private static class ProtocolResourceRegistration extends RestartParentResourceRegistration {
+
+        public ProtocolResourceRegistration(ResourceServiceConfiguratorFactory parentFactory, ResourceDescriptor descriptor, ResourceServiceHandler handler) {
+            super(descriptor, new ProtocolAddStepHandler(parentFactory, descriptor, handler), new RestartParentResourceRemoveStepHandler(parentFactory, descriptor, handler), new ProtocolWriteAttributeHandler(parentFactory, descriptor));
+        }
+    }
+
+    private static class ProtocolAddStepHandler extends RestartParentResourceAddStepHandler {
+
+        public ProtocolAddStepHandler(ResourceServiceConfiguratorFactory parentFactory, AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
+            super(parentFactory, descriptor, handler);
+        }
+
+        @Override
+        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
+            super.populateModel(context, operation, resource);
+            final ModelNode model = resource.getModel();
+            handleCredentialReferenceUpdate(context, model.get(Attribute.KEY_CREDENTIAL.getName()), Attribute.KEY_CREDENTIAL.getName());
+        }
+
+        @Override
+        protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+            rollbackCredentialStoreUpdate(Attribute.KEY_CREDENTIAL.getDefinition(), context, resource);
+            super.rollbackRuntime(context, operation, resource);
+        }
+    }
+
+    private static class ProtocolWriteAttributeHandler extends RestartParentResourceWriteAttributeHandler {
+
+        private final WriteAttributeStepHandlerDescriptor descriptor;
+
+        public ProtocolWriteAttributeHandler(ResourceServiceConfiguratorFactory parentFactory, WriteAttributeStepHandlerDescriptor descriptor) {
+            super(parentFactory, descriptor);
+            this.descriptor = descriptor;
+        }
+
+        @Override
+        public void register(ManagementResourceRegistration registration) {
+            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(Attribute.KEY_CREDENTIAL.getDefinition());
+            for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
+                if (attribute.equals(Attribute.KEY_CREDENTIAL.getDefinition())) {
+                    registration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
+                } else {
+                    registration.registerReadWriteAttribute(attribute, null, this);
+                }
+            }
+        }
+
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/EncryptProtocolResourceDefinition.java
@@ -22,37 +22,23 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
-import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
-
 import java.security.KeyStore;
+import java.util.EnumSet;
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.AddStepHandlerDescriptor;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceConfigurator;
 import org.jboss.as.clustering.controller.ResourceServiceConfiguratorFactory;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceRegistration;
-import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceWriteAttributeHandler;
-import org.jboss.as.clustering.controller.WriteAttributeStepHandlerDescriptor;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -101,6 +87,11 @@ public class EncryptProtocolResourceDefinition<E extends KeyStore.Entry> extends
     }
 
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
+        if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
+            builder.getAttributeBuilder()
+                    .addRejectCheck(CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, Attribute.KEY_CREDENTIAL.getName())
+                    .end();
+        }
 
         ProtocolResourceDefinition.addTransformations(version, builder);
     }
@@ -115,7 +106,8 @@ public class EncryptProtocolResourceDefinition<E extends KeyStore.Entry> extends
         @Override
         public ResourceDescriptor apply(ResourceDescriptor descriptor) {
             return this.configurator.apply(descriptor)
-                    .addAttributes(Attribute.class)
+                    .addAttributes(EnumSet.complementOf(EnumSet.of(Attribute.KEY_CREDENTIAL)))
+                    .addAttribute(Attribute.KEY_CREDENTIAL, new CredentialReferenceWriteAttributeHandler(Attribute.KEY_CREDENTIAL.getDefinition()))
                     .setAddOperationTransformation(new LegacyAddOperationTransformation(Attribute.class))
                     .setOperationTransformation(LEGACY_OPERATION_TRANSFORMER)
                     ;
@@ -137,72 +129,5 @@ public class EncryptProtocolResourceDefinition<E extends KeyStore.Entry> extends
 
     public EncryptProtocolResourceDefinition(String name, Class<E> entryClass, UnaryOperator<ResourceDescriptor> configurator, ResourceServiceConfiguratorFactory parentServiceConfiguratorFactory) {
         super(pathElement(name), new ResourceDescriptorConfigurator(configurator), new EncryptProtocolConfigurationConfiguratorFactory<>(entryClass), parentServiceConfiguratorFactory);
-    }
-
-    @Override
-    public ManagementResourceRegistration register(ManagementResourceRegistration parent) {
-        ManagementResourceRegistration registration = parent.registerSubModel(this);
-
-        ResourceDescriptor descriptor = this.configurator.apply(new ResourceDescriptor(this.getResourceDescriptionResolver()))
-                .addAttributes(AbstractProtocolResourceDefinition.Attribute.class)
-                .addExtraParameters(DeprecatedAttribute.class)
-                ;
-        new ProtocolResourceRegistration(this.parentServiceConfiguratorFactory, descriptor, this.handler).register(registration);
-
-        if (registration.getPathAddress().getLastElement().isWildcard()) {
-            new PropertyResourceDefinition().register(registration);
-        }
-
-        return registration;
-    }
-
-    private static class ProtocolResourceRegistration extends RestartParentResourceRegistration {
-
-        public ProtocolResourceRegistration(ResourceServiceConfiguratorFactory parentFactory, ResourceDescriptor descriptor, ResourceServiceHandler handler) {
-            super(descriptor, new ProtocolAddStepHandler(parentFactory, descriptor, handler), new RestartParentResourceRemoveStepHandler(parentFactory, descriptor, handler), new ProtocolWriteAttributeHandler(parentFactory, descriptor));
-        }
-    }
-
-    private static class ProtocolAddStepHandler extends RestartParentResourceAddStepHandler {
-
-        public ProtocolAddStepHandler(ResourceServiceConfiguratorFactory parentFactory, AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
-            super(parentFactory, descriptor, handler);
-        }
-
-        @Override
-        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-            super.populateModel(context, operation, resource);
-            final ModelNode model = resource.getModel();
-            handleCredentialReferenceUpdate(context, model.get(Attribute.KEY_CREDENTIAL.getName()), Attribute.KEY_CREDENTIAL.getName());
-        }
-
-        @Override
-        protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
-            rollbackCredentialStoreUpdate(Attribute.KEY_CREDENTIAL.getDefinition(), context, resource);
-            super.rollbackRuntime(context, operation, resource);
-        }
-    }
-
-    private static class ProtocolWriteAttributeHandler extends RestartParentResourceWriteAttributeHandler {
-
-        private final WriteAttributeStepHandlerDescriptor descriptor;
-
-        public ProtocolWriteAttributeHandler(ResourceServiceConfiguratorFactory parentFactory, WriteAttributeStepHandlerDescriptor descriptor) {
-            super(parentFactory, descriptor);
-            this.descriptor = descriptor;
-        }
-
-        @Override
-        public void register(ManagementResourceRegistration registration) {
-            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(Attribute.KEY_CREDENTIAL.getDefinition());
-            for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
-                if (attribute.equals(Attribute.KEY_CREDENTIAL.getDefinition())) {
-                    registration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
-                } else {
-                    registration.registerReadWriteAttribute(attribute, null, this);
-                }
-            }
-        }
-
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsModel.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsModel.java
@@ -38,8 +38,9 @@ public enum JGroupsModel implements Model {
     VERSION_5_0_0(5, 0, 0), // WildFly 11, EAP 7.1
     VERSION_6_0_0(6, 0, 0), // WildFly 12-16, EAP 7.2
     VERSION_7_0_0(7, 0, 0), // WildFly 17
+    VERSION_8_0_0(8, 0, 0), // WildFly 20
     ;
-    static final JGroupsModel CURRENT = VERSION_7_0_0;
+    static final JGroupsModel CURRENT = VERSION_8_0_0;
 
     private final ModelVersion version;
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSchema.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSchema.java
@@ -39,8 +39,9 @@ public enum JGroupsSchema implements Schema<JGroupsSchema> {
     VERSION_5_0(5, 0), // WildFly 11
     VERSION_6_0(6, 0), // WildFly 12-16
     VERSION_7_0(7, 0), // WildFly 17
+    VERSION_8_0(8, 0), // WildFly 20
     ;
-    public static final JGroupsSchema CURRENT = VERSION_7_0;
+    public static final JGroupsSchema CURRENT = VERSION_8_0;
 
     private final int major;
     private final int minor;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PlainAuthTokenResourceDefinition.java
@@ -25,7 +25,9 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import java.util.function.UnaryOperator;
 
 import org.jboss.as.clustering.jgroups.auth.BinaryAuthToken;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
 /**
  * @author Paul Ferraro
@@ -33,6 +35,12 @@ import org.jboss.as.controller.PathElement;
 public class PlainAuthTokenResourceDefinition extends AuthTokenResourceDefinition<BinaryAuthToken> {
 
     static final PathElement PATH = pathElement("plain");
+
+    static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder builder = parent.addChildResource(PATH);
+
+        AuthTokenResourceDefinition.addTransformations(version, builder);
+    }
 
     PlainAuthTokenResourceDefinition() {
         super(PATH, UnaryOperator.identity(), PlainAuthTokenServiceConfigurator::new);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
+
 import java.util.EnumSet;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -76,6 +78,17 @@ public class ProtocolResourceDefinition extends AbstractProtocolResourceDefiniti
 
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
         AbstractProtocolResourceDefinition.addTransformations(version, builder);
+
+        if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
+            builder.getAttributeBuilder()
+                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL.getName())
+                    .end();
+            builder.addChildResource(PathElement.pathElement("token"))
+                    .getAttributeBuilder()
+                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, AuthTokenResourceDefinition.Attribute.SHARED_SECRET.getName())
+                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CipherAuthTokenResourceDefinition.Attribute.KEY_CREDENTIAL.getName())
+                    .end();
+        }
 
         if (JGroupsModel.VERSION_4_1_0.requiresTransformation(version)) {
             // See WFLY-6782, add-index parameter was missing from add operation definition

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
-
 import java.util.EnumSet;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -78,17 +76,6 @@ public class ProtocolResourceDefinition extends AbstractProtocolResourceDefiniti
 
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
         AbstractProtocolResourceDefinition.addTransformations(version, builder);
-
-        if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
-            builder.getAttributeBuilder()
-                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, EncryptProtocolResourceDefinition.Attribute.KEY_CREDENTIAL.getName())
-                    .end();
-            builder.addChildResource(PathElement.pathElement("token"))
-                    .getAttributeBuilder()
-                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, AuthTokenResourceDefinition.Attribute.SHARED_SECRET.getName())
-                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CipherAuthTokenResourceDefinition.Attribute.KEY_CREDENTIAL.getName())
-                    .end();
-        }
 
         if (JGroupsModel.VERSION_4_1_0.requiresTransformation(version)) {
             // See WFLY-6782, add-index parameter was missing from add operation definition

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
@@ -23,12 +23,12 @@
 <xs:schema targetNamespace="urn:jboss:domain:jgroups:7.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="urn:jboss:domain:jgroups:7.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="7.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_8_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_8_0.xsd
@@ -23,12 +23,12 @@
 <xs:schema targetNamespace="urn:jboss:domain:jgroups:8.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="urn:jboss:domain:jgroups:8.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="8.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_8_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_8_0.xsd
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema targetNamespace="urn:jboss:domain:jgroups:8.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="urn:jboss:domain:jgroups:8.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="8.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+    <xs:element name="subsystem" type="tns:subsystem">
+        <xs:annotation>
+            <xs:documentation>Enumerates the protocol stacks available to the channel factory.</xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="subsystem">
+        <xs:all>
+            <xs:element name="channels" type="tns:channels" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Enumerates the defined channels.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="stacks" type="tns:stacks">
+                <xs:annotation>
+                    <xs:documentation>Enumerates the defined protocol stacks.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="channels">
+        <xs:sequence>
+            <xs:element name="channel" type="tns:channel" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a channel.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="default" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Identifies the default cluster.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="channel">
+        <xs:sequence>
+            <xs:element name="fork" type="tns:fork" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a fork of this channel.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the name of this channel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stack" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the stack used by this channel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cluster" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the cluster name of this channel.  If undefined, the channel name will be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" default="org.wildfly.clustering.server">
+            <xs:annotation>
+                <xs:documentation>Indicates the module from which to load clustering services.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Indicates whether or not this channel will collect statistics.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fork">
+        <xs:sequence>
+            <xs:element name="protocol" type="tns:protocol" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a protocol to add to the protocol stack of this fork channel.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines the cluster name of this channel.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="stacks">
+        <xs:sequence>
+            <xs:element name="stack" type="tns:stack" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a protocol stack.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="default" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>Deprecated. Identifies the default protocol stack.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="stack">
+        <xs:sequence>
+            <xs:element name="transport" type="tns:transport">
+                <xs:annotation>
+                    <xs:documentation>Defines the transport protocol for a stack.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="protocol" type="tns:protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="socket-protocol" type="tns:socket-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="socket-discovery-protocol" type="tns:socket-discovery-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="jdbc-protocol" type="tns:jdbc-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="encrypt-protocol" type="tns:encrypt-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="auth-protocol" type="tns:auth-protocol">
+                    <xs:annotation>
+                        <xs:documentation>Defines a non-transport protocol for a stack.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="relay" type="tns:relay" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>Defines a relay protocol for a stack.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Uniquely identifies this stack.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Indicates whether or not all protocols in the stack will collect statistics by default.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="generic-protocol">
+        <xs:sequence>
+            <xs:element name="property" type="tns:property" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a property override for a protocol.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="type" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>Identifies the protocol type, e.g. TCP, UDP, PING, etc.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" default="org.jgroups">
+            <xs:annotation>
+                <xs:documentation>Indicates the module from which to load this protocol.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>Indicates whether or not this protocol will collect statistics overriding stack configuration.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:attribute name="socket-binding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Deprecated.  Socket-based protocols should use &lt;socket-protocol/&gt; instead.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="socket-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:attribute name="socket-binding" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Provides a socket binding for a protocol.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="client-socket-binding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The socket-binding used to configure the bind address/port of the socket used to send messages to other members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="socket-discovery-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:attribute name="socket-bindings" type="tns:list" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Provides a list of socket bindings for a protocol.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:attribute name="data-source" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Data source reference for JDBC protocols to be used instead of connection and JNDI lookup properties.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="encrypt-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:sequence>
+                    <xs:element name="key-credential-reference" type="credential-reference:credentialReferenceType">
+                        <xs:annotation>
+                            <xs:documentation>References the password credential with which the key is protected.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References key store containing the key used to encrypt messages.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-alias" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The alias of the key used to encrypt.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auth-protocol">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:choice>
+                    <xs:element name="plain-token" type="tns:plain-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using a plain text shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="digest-token" type="tns:digest-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using a digest of a shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="cipher-token" type="tns:cipher-token">
+                        <xs:annotation>
+                            <xs:documentation>An auth token using an encrypted shared secret.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="plain-token">
+        <xs:sequence>
+            <xs:element name="shared-secret-reference" type="credential-reference:credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>References a shared secret used to authenticate new members.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="digest-token">
+        <xs:complexContent>
+            <xs:extension base="tns:plain-token">
+                <xs:attribute name="algorithm" type="xs:string" default="SHA-265">
+                    <xs:annotation>
+                        <xs:documentation>The digest algorithm with which to obfuscate the shared secret.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="cipher-token">
+        <xs:complexContent>
+            <xs:extension base="tns:plain-token">
+                <xs:sequence>
+                    <xs:element name="key-credential-reference" type="credential-reference:credentialReferenceType">
+                        <xs:annotation>
+                            <xs:documentation>References the credential required to obtain the specified key from the specified store.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>References key store containing the private key and certificate used to authenticate new members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="key-alias" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>The alias of the private key and certificate used to authenticate new members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="algorithm" type="xs:string" default="RSA">
+                    <xs:annotation>
+                        <xs:documentation>The encryption algorithm/transformation used to protect the shared secret during transmission.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="transport">
+        <xs:complexContent>
+            <xs:extension base="tns:generic-protocol">
+                <xs:sequence>
+                    <xs:element name="default-thread-pool" type="tns:thread-pool" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>Defines the thread pool used for default messages received by this transport.</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="shared" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>Indicates whether or not the channels created for this stack should use a single, shared transport.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="socket-binding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The socket-binding used to configure the bind address/port of the socket used to receive messages from other members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="client-socket-binding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>The socket-binding used to configure the bind address/port of the socket used to send messages to other members.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="diagnostics-socket-binding" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>If specified, enables diagnostics and specified the multicast address/port on which to communicate.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="default-executor" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Defines the thread pool used for default messages received by this transport.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="oob-executor" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Defines the thread pool used for OOB messages received by this transport.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="timer-executor" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Defines the timer thread pool used by this transport.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="thread-factory" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Defines the thread factory used by this transport.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="site" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Identifies the site where this node runs.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="rack" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Identifies the rack where this node runs.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="machine" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>Identifies the machine where this node runs.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="socket-transport">
+        <xs:complexContent>
+            <xs:extension base="tns:transport">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="thread-pool">
+        <xs:attribute name="min-threads" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Minimum thread pool size for the thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-threads" type="xs:int" use="optional">
+            <xs:annotation>
+                <xs:documentation>Maximum thread pool size for the thread pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="keepalive-time" type="xs:long" use="optional">
+            <xs:annotation>
+                <xs:documentation>Timeout in milliseconds to remove idle thread from the pool.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Defines the name of a protocol property.</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="relay">
+        <xs:sequence>
+            <xs:element name="remote-site" type="tns:remote-site" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>Defines a remote site to which to bridge.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="site" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The name of our site.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remote-site">
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The name of the remote site.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="channel" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>The bridge channel to this remote site.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="list">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+</xs:schema>

--- a/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
+++ b/clustering/jgroups/extension/src/main/resources/subsystem-templates/jgroups.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
     <extension-module>org.jboss.as.clustering.jgroups</extension-module>
-    <subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+    <subsystem xmlns="urn:jboss:domain:jgroups:8.0">
         <channels default="ee">
             <channel name="ee" stack="udp" cluster="ejb"/>
         </channels>

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
@@ -112,6 +112,8 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
     private static org.jboss.as.subsystem.test.AdditionalInitialization createAdditionalInitialization() {
         return new AdditionalInitialization()
                 .require(CommonUnaryRequirement.SOCKET_BINDING, "jgroups-tcp", "jgroups-udp", "jgroups-udp-fd", "some-binding", "client-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-client-fd", "jgroups-state-xfr")
+                .require(CommonUnaryRequirement.KEY_STORE, "my-key-store")
+                .require(CommonUnaryRequirement.CREDENTIAL_STORE, "my-credential-store")
                 ;
     }
 
@@ -368,6 +370,11 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
         FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
 
         PathAddress subsystemAddress = PathAddress.pathAddress(JGroupsSubsystemResourceDefinition.PATH);
+
+        if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
+            config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.pathElement("credentialReference1")).append(EncryptProtocolResourceDefinition.pathElement("SYM_ENCRYPT")),
+                    FailedOperationTransformationConfig.REJECTED_RESOURCE);
+        }
 
         if (JGroupsModel.VERSION_7_0_0.requiresTransformation(version)) {
             config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.WILDCARD_PATH).append(TransportResourceDefinition.pathElement("TCP_NIO2")), FailedOperationTransformationConfig.REJECTED_RESOURCE);

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsTransformersTestCase.java
@@ -372,7 +372,7 @@ public class JGroupsTransformersTestCase extends OperationTestCaseBase {
         PathAddress subsystemAddress = PathAddress.pathAddress(JGroupsSubsystemResourceDefinition.PATH);
 
         if (JGroupsModel.VERSION_8_0_0.requiresTransformation(version)) {
-            config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.pathElement("credentialReference1")).append(EncryptProtocolResourceDefinition.pathElement("SYM_ENCRYPT")),
+            config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.pathElement("credentialReference1")).append(ProtocolResourceDefinition.pathElement("SYM_ENCRYPT")),
                     FailedOperationTransformationConfig.REJECTED_RESOURCE);
         }
 

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-8_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-8_0.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,38 +21,56 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:jgroups:8.0">
-    <channels default="default">
-        <channel name="default" stack="minimal"/>
-        <channel name="bridge" stack="default"/>
+    <channels default="ee">
+        <channel name="ee" stack="maximal" cluster="${test.expr:mycluster}">
+            <fork name="web">
+                <protocol type="CENTRAL_LOCK" statistics-enabled="true">
+                    <property name="num_backups">1</property>
+                </protocol>
+            </fork>
+        </channel>
+        <channel name="bridge" stack="minimal"/>
     </channels>
-    <stacks default="maximal">
+    <stacks>
+        <stack name="minimal" statistics-enabled="true">
+            <transport type="UDP" socket-binding="some-binding" statistics-enabled="false"/>
+        </stack>
         <stack name="maximal">
             <transport type="TCP"
                        module="org.jgroups"
-                       socket-binding="jgroups-tcp"
+                       socket-binding="some-binding"
                        diagnostics-socket-binding="jgroups-diagnostics"
-                       default-executor="jgroups"
-                       oob-executor="jgroups-oob"
-                       timer-executor="jgroups-timer"
-                       shared="false"
-                       thread-factory="jgroups-thread-factory"
-                       machine="machine1"
-                       rack="rack1"
-                       site="site1">
-                <property name="enable_bundling">true</property>
+                       shared="${test.expr:false}"
+                       machine="${test.expr:machine1}"
+                       rack="${test.expr:rack1}"
+                       site="${test.expr:site1}">
+                <property name="enable_bundling">${test.expr:true}</property>
                 <default-thread-pool min-threads="11"
-                             max-threads="13"
-                             keepalive-time="14"/>
+                             max-threads="12"
+                             keepalive-time="13"/>
             </transport>
-            <socket-protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping"/>
+            <socket-protocol type="MPING" module="org.jgroups" socket-binding="jgroups-mping">
+                <property name="name">${test.expr:value}</property>
+            </socket-protocol>
+            <jdbc-protocol type="JDBC_PING" data-source="ExampleDS"/>
+            <socket-discovery-protocol type="TCPPING" socket-bindings="node1 node2"/>
             <protocol type="MERGE3"/>
             <socket-protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd" client-socket-binding="jgroups-client-fd"/>
             <protocol type="FD"/>
             <protocol type="VERIFY_SUSPECT"/>
+            <encrypt-protocol type="SYM_ENCRYPT" key-store="my-key-store" key-alias="alias">
+                <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
+            </encrypt-protocol>
             <protocol type="pbcast.NAKACK2"/>
             <protocol type="UNICAST3"/>
             <protocol type="pbcast.STABLE"/>
             <protocol type="pbcast.GMS"/>
+            <auth-protocol type="AUTH">
+                <cipher-token algorithm="RSA" key-store="my-key-store" key-alias="alias">
+                    <shared-secret-reference clear-text="changeme"/>
+                    <key-credential-reference store="my-credential-store" alias="credential-alias" type="PASSWORD"/>
+                </cipher-token>
+            </auth-protocol>
             <protocol type="UFC"/>
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>
@@ -61,11 +79,6 @@
                 <remote-site name="SFO" channel="bridge"/>
                 <remote-site name="NYC" channel="bridge"/>
             </relay>
-        </stack>
-        <stack name="minimal">
-            <transport type="TCP_NIO2"
-                       socket-binding="jgroups-tcp"
-                       client-socket-binding="client-binding"/>
         </stack>
     </stacks>
 </subsystem>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-1_3_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-1_3_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+<subsystem xmlns="urn:jboss:domain:jgroups:8.0">
     <stacks default="maximal">
         <stack name="maximal" statistics-enabled="true">
             <transport type="TCP"

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-4_0_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-4_0_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+<subsystem xmlns="urn:jboss:domain:jgroups:8.0">
     <stacks default="maximal">
         <stack name="maximal" statistics-enabled="true">
             <transport type="TCP"

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-5_0_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-5_0_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+<subsystem xmlns="urn:jboss:domain:jgroups:8.0">
     <stacks default="maximal">
         <stack name="maximal" statistics-enabled="true">
             <transport type="TCP"

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-6_0_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-6_0_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:jgroups:7.0">
+<subsystem xmlns="urn:jboss:domain:jgroups:8.0">
     <channels default="ee">
         <channel name="ee" stack="maximal" cluster="${test.expr:mycluster}">
             <fork name="web">

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
@@ -67,5 +67,12 @@
                        socket-binding="jgroups-tcp"
                        client-socket-binding="client-binding"/>
         </stack>
+        <stack name="credentialReference1">
+            <transport type="TCP_NIO2"
+                       socket-binding="jgroups-tcp"/>
+            <encrypt-protocol type="SYM_ENCRYPT" key-store="my-key-store" key-alias="alias">
+                <key-credential-reference store="my-credential-store" alias="credential-alias" clear-text="protocolpass" type="PASSWORD"/>
+            </encrypt-protocol>
+        </stack>
     </stacks>
 </subsystem>

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDefinition.java
@@ -24,6 +24,7 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
+import static org.jboss.as.connector.subsystems.datasources.Constants.CREDENTIAL_REFERENCE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_ATTRIBUTE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_DISABLE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_ENABLE;
@@ -35,6 +36,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_ALL_
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_GRACEFULLY_CONNECTION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_IDLE_CONNECTION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_INVALID_CONNECTION;
+import static org.jboss.as.connector.subsystems.datasources.Constants.RECOVERY_CREDENTIAL_REFERENCE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.TEST_CONNECTION;
 
 import java.util.List;
@@ -56,6 +58,7 @@ import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraint
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.dmr.ModelNode;
@@ -129,11 +132,14 @@ public class DataSourceDefinition extends SimpleResourceDefinition {
 
         } else {
             ReloadRequiredWriteAttributeHandler reloadRequiredWriteAttributeHandler = new ReloadRequiredWriteAttributeHandler(DATASOURCE_ATTRIBUTE);
+            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(CREDENTIAL_REFERENCE, RECOVERY_CREDENTIAL_REFERENCE);
             for (final SimpleAttributeDefinition attribute : DATASOURCE_ATTRIBUTE) {
                 if (PoolConfigurationRWHandler.ATTRIBUTES.contains(attribute.getName())) {
                     resourceRegistration.registerReadWriteAttribute(attribute, PoolConfigurationRWHandler.PoolConfigurationReadHandler.INSTANCE, PoolConfigurationRWHandler.LocalAndXaDataSourcePoolConfigurationWriteHandler.INSTANCE);
                 } else  if (attribute.getName().equals(ENLISTMENT_TRACE.getName())) {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new EnlistmentTraceAttributeWriteHandler());
+                } else if (attribute.getName().equals(CREDENTIAL_REFERENCE) || attribute.getName().equals(RECOVERY_CREDENTIAL_REFERENCE)) {
+                    resourceRegistration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
                 } else {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, reloadRequiredWriteAttributeHandler);
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
@@ -199,6 +199,7 @@ public class DataSourcesExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DATASOURCES_3_0.getUriString(), DataSourceSubsystemParser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DATASOURCES_4_0.getUriString(), DataSourceSubsystemParser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DATASOURCES_5_0.getUriString(), DataSourceSubsystemParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DATASOURCES_6_0.getUriString(), DataSourceSubsystemParser::new);
     }
 
     public static final class DataSourceSubsystemParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>,

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesTransformers.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesTransformers.java
@@ -40,6 +40,7 @@ import static org.jboss.as.connector.subsystems.datasources.JdbcDriverDefinition
 import static org.jboss.as.connector.subsystems.datasources.XaDataSourceDefinition.PATH_XA_DATASOURCE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATISTICS_ENABLED;
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
 
 import java.util.Map;
 
@@ -71,6 +72,8 @@ public class DataSourcesTransformers implements ExtensionTransformerRegistration
     private static final ModelVersion EAP_6_2 = ModelVersion.create(1, 2, 0);
     private static final ModelVersion EAP_6_3 = ModelVersion.create(1, 3, 0);
     private static final ModelVersion EAP_7_0 = ModelVersion.create(4, 0, 0);
+    private static final ModelVersion EAP_7_1 = ModelVersion.create(5, 0, 0);
+
     @Override
     public String getSubsystemName() {
         return SUBSYSTEM_NAME;
@@ -79,7 +82,8 @@ public class DataSourcesTransformers implements ExtensionTransformerRegistration
     @Override
     public void registerTransformers(SubsystemTransformerRegistration subsystemRegistration) {
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemRegistration.getCurrentSubsystemVersion());
-        get400TransformationDescription(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), EAP_7_0));
+        get500TransformationDescription(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), EAP_7_1));
+        get400TransformationDescription(chainedBuilder.createBuilder(EAP_7_1, EAP_7_0));
         get130TransformationDescription(chainedBuilder.createBuilder(EAP_7_0, EAP_6_3));
         get120TransformationDescription(chainedBuilder.createBuilder(EAP_6_3, EAP_6_2));
 
@@ -87,6 +91,7 @@ public class DataSourcesTransformers implements ExtensionTransformerRegistration
                 EAP_6_2,
                 EAP_6_3,
                 EAP_7_0,
+                EAP_7_1
         });
 
     }
@@ -209,6 +214,20 @@ public class DataSourcesTransformers implements ExtensionTransformerRegistration
         parentBuilder.addChildResource(PATH_DRIVER).getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, MODULE_SLOT, JDBC_COMPLIANT, PROFILE,
                         DRIVER_MODULE_NAME, DRIVER_XA_DATASOURCE_CLASS_NAME, DRIVER_CLASS_NAME)
+                .end();
+        return parentBuilder.build();
+    }
+
+    private static TransformationDescription get500TransformationDescription(ResourceTransformationDescriptionBuilder parentBuilder) {
+        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_DATASOURCE);
+        builder.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CREDENTIAL_REFERENCE)
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, RECOVERY_CREDENTIAL_REFERENCE)
+                .end();
+        builder = parentBuilder.addChildResource(PATH_XA_DATASOURCE);
+        builder.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CREDENTIAL_REFERENCE)
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, RECOVERY_CREDENTIAL_REFERENCE)
                 .end();
         return parentBuilder.build();
     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Namespace.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Namespace.java
@@ -43,12 +43,14 @@ public enum Namespace {
 
     DATASOURCES_4_0("urn:jboss:domain:datasources:4.0"),
 
-    DATASOURCES_5_0("urn:jboss:domain:datasources:5.0");
+    DATASOURCES_5_0("urn:jboss:domain:datasources:5.0"),
+
+    DATASOURCES_6_0("urn:jboss:domain:datasources:6.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DATASOURCES_5_0;
+    public static final Namespace CURRENT = DATASOURCES_6_0;
 
     private final String name;
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonIronJacamarParser.java
@@ -1468,7 +1468,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                             break;
                         }
                         case CREDENTIAL_REFERENCE: {
-                            RECOVERY_CREDENTIAL_REFERENCE.getParser().parseAndSetParameter(RECOVERY_CREDENTIAL_REFERENCE, null, node, reader);
+                            RECOVERY_CREDENTIAL_REFERENCE.getParser().parseElement(RECOVERY_CREDENTIAL_REFERENCE, reader, node);
                         }
                         case SECURITY_DOMAIN: {
                             String value = rawElementText(reader);
@@ -1510,7 +1510,7 @@ public abstract class CommonIronJacamarParser extends AbstractParser {
                             break;
                         }
                         case CREDENTIAL_REFERENCE: {
-                            RECOVERY_CREDENTIAL_REFERENCE.getParser().parseAndSetParameter(RECOVERY_CREDENTIAL_REFERENCE, null, node, reader);
+                            RECOVERY_CREDENTIAL_REFERENCE.getParser().parseElement(RECOVERY_CREDENTIAL_REFERENCE, reader, node);
                             break;
                         }
                         case USER_NAME: {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
@@ -39,6 +39,8 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SECUR
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SECURITY_DOMAIN_AND_APPLICATION;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.STATISTICS_ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
 
 import org.jboss.as.connector._private.Capabilities;
 import org.jboss.as.connector.logging.ConnectorLogger;
@@ -72,6 +74,13 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
 
     public static final ConnectionDefinitionAdd INSTANCE = new ConnectionDefinitionAdd();
+
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
+        super.populateModel(context, operation, resource);
+        final ModelNode model = resource.getModel();
+        handleCredentialReferenceUpdate(context, model.get(RECOVERY_CREDENTIAL_REFERENCE.getName()), RECOVERY_CREDENTIAL_REFERENCE.getName());
+    }
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode modelNode) throws OperationFailedException {
@@ -223,6 +232,11 @@ public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
         } catch (Exception e) {
             throw new OperationFailedException(e, new ModelNode().set(ConnectorLogger.ROOT_LOGGER.failedToCreate("ConnectionDefinition", operation, e.getLocalizedMessage())));
         }
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+        rollbackCredentialStoreUpdate(RECOVERY_CREDENTIAL_REFERENCE, context, resource);
     }
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
@@ -23,6 +23,7 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.CONNECTIONDEFINITIONS_NAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT_TRACE;
+import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RECOVERY_CREDENTIAL_REFERENCE;
 
 import org.jboss.as.connector.subsystems.common.pool.PoolConfigurationRWHandler;
 import org.jboss.as.connector.subsystems.common.pool.PoolOperations;
@@ -36,6 +37,7 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 
 /**
  *
@@ -86,6 +88,8 @@ public class ConnectionDefinitionResourceDefinition extends SimpleResourceDefini
                     resourceRegistration.registerReadWriteAttribute(attribute, null, PoolConfigurationRWHandler.RaPoolConfigurationWriteHandler.INSTANCE);
                 } else if (attribute.equals(ENLISTMENT_TRACE)) {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new EnlistmentTraceAttributeWriteHandler());
+                } else if (attribute.equals(RECOVERY_CREDENTIAL_REFERENCE)){
+                    resourceRegistration.registerReadWriteAttribute(attribute, null, new CredentialReferenceWriteAttributeHandler(attribute));
                 } else {
                     resourceRegistration.registerReadWriteAttribute(attribute, null, new ReloadRequiredWriteAttributeHandler(attribute));
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Namespace.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Namespace.java
@@ -43,11 +43,13 @@ public enum Namespace {
 
     RESOURCEADAPTERS_4_0("urn:jboss:domain:resource-adapters:4.0"),
 
-    RESOURCEADAPTERS_5_0("urn:jboss:domain:resource-adapters:5.0");
+    RESOURCEADAPTERS_5_0("urn:jboss:domain:resource-adapters:5.0"),
+
+    RESOURCEADAPTERS_6_0("urn:jboss:domain:resource-adapters:6.0");
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = RESOURCEADAPTERS_5_0;
+    public static final Namespace CURRENT = RESOURCEADAPTERS_6_0;
 
     private final String name;
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterSubsystemParser.java
@@ -469,7 +469,8 @@ public final class ResourceAdapterSubsystemParser implements XMLStreamConstants,
                 case RESOURCEADAPTERS_2_0:
                 case RESOURCEADAPTERS_3_0:
                 case RESOURCEADAPTERS_4_0:
-                case RESOURCEADAPTERS_5_0:{
+                case RESOURCEADAPTERS_5_0:
+                case RESOURCEADAPTERS_6_0:{
                     localName = reader.getLocalName();
                     final Element element = Element.forName(reader.getLocalName());
                     SUBSYSTEM_RA_LOGGER.tracef("%s -> %s", localName, element);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersExtension.java
@@ -91,6 +91,7 @@ public class ResourceAdaptersExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_3_0.getUriString(), () -> ResourceAdapterSubsystemParser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_4_0.getUriString(), () -> ResourceAdapterSubsystemParser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_5_0.getUriString(), () -> ResourceAdapterSubsystemParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.RESOURCEADAPTERS_6_0.getUriString(), () -> ResourceAdapterSubsystemParser.INSTANCE);
     }
 
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersTransformers.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersTransformers.java
@@ -17,6 +17,7 @@ package org.jboss.as.connector.subsystems.resourceadapters;
 
 import static org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.VALIDATE_ON_MATCH;
+import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RECOVERY_CREDENTIAL_REFERENCE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.RESOURCEADAPTER_NAME;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.STATISTICS_ENABLED;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
@@ -31,6 +32,7 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SE
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_MAPPING_REQUIRED;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_MAPPING_USER;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY_MAPPING_USERS;
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
@@ -67,6 +69,10 @@ public class ResourceAdaptersTransformers implements ExtensionTransformerRegistr
         ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PathElement.pathElement(RESOURCEADAPTER_NAME))
                 .getAttributeBuilder()
                 .setValueConverter(AttributeConverter.Factory.createHardCoded(ModelNode.ZERO, true), INITIAL_POOL_SIZE)
+                .end();
+        builder.addChildResource(ConnectionDefinitionResourceDefinition.PATH)
+                .getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, RECOVERY_CREDENTIAL_REFERENCE)
                 .end();
 
         parentBuilder = chainedBuilder.createBuilder(EAP_7_1, EAP_7_0);

--- a/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:datasources:5.0" xmlns="urn:jboss:domain:datasources:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-datasources_6_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_6_0.xsd
@@ -1,0 +1,1134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:datasources:6.0" xmlns="urn:jboss:domain:datasources:6.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+  <xs:element name="subsystem" type="subsystemType"/>
+
+  <xs:complexType name="subsystemType">
+    <xs:all>
+      <xs:element name="datasources" type="datasourcesType" minOccurs="1" maxOccurs="1"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="datasourcesType">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="datasource" type="datasourceType">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies a non-XA datasource, using local transactions
+               ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="xa-datasource" type="xa-datasourceType">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies a XA datasource
+                ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:element name="drivers" type="driversType" maxOccurs="1" minOccurs="0"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="datasourceType" mixed="false">
+    <xs:sequence>
+      <xs:element name="connection-url" type="xs:token">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The JDBC driver connection URL Ex: <connection-url>jdbc:hsqldb:hsql://localhost:1701</connection-url>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC driver class Ex: <driver-class>org.hsqldb.jdbcDriver</driver-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC datasource class Ex: <datasource-class>org.h2.jdbcx.JdbcDataSource</datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An unique reference to the classloader module which contains the JDBC driver
+              The accepted format is driverName#majorVersion.minorVersion
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="connection-property" type="connection-propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The connection-property element allows you to pass in arbitrary connection
+              properties to the Driver.connect(url, props) method. Each connection-property
+              specifies a string name/value pair with the property name coming from the
+              name attribute and the value coming from the element content. Ex:
+              <connection-property name="char.encoding">UTF-8</connection-property>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to execute whenever a connection is added
+              to the connection pool.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Set java.sql.Connection transaction isolation level to use. The constants
+              defined by transaction-isolation-values are the possible transaction isolation
+              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
+              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the delimeter for URLs in connection-url for HA datasources
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-property" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                     Specifies the property for the URL property in the xa-datasource-property values
+                    ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="pool" type="poolType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the pooling settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="security" type="dsSecurityType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the time out settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="statement" type="statementType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the statement settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="jta" type="xs:boolean" default="true" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable JTA integration
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attributeGroup ref="common-datasourceAttributes" />
+  </xs:complexType>
+  <xs:complexType name="xa-datasourceType">
+    <xs:sequence>
+      <xs:element name="xa-datasource-property" type="xa-datasource-propertyType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies a property to assign to the XADataSource implementation class.
+              Each property is identified by the name attribute and the property value
+              is given by the xa-datasource-property element content. The property is mapped
+              onto the XADataSource implementation by looking for a JavaBeans style getter
+              method for the property name. If found, the value of the property is set
+              using the JavaBeans setter with the element text translated to the true property
+              type using the java.beans.PropertyEditor for the type. Ex:
+              <xa-datasource-property name="IfxWAITTIME">10</xa-datasource-property>
+              <xa-datasource-property name="IfxIFXHOST">myhost.mydomain.com</xa-datasource-property>
+              <xa-datasource-property name="PortNumber">1557</xa-datasource-property>
+              <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>
+              <xa-datasource-property name="ServerName">myserver</xa-datasource-property>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the javax.sql.XADataSource implementation
+              class. Ex: <xa-datasource-class>oracle.jdbc.xa.client.OracleXADataSource</xa-datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="driver" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An unique reference to the classloader module which contains the JDBC driver
+              The accepted format is driverName#majorVersion.minorVersion
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-delimiter" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+               Specifies the delimeter for URLs in the connection url for HA datasources
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="url-selector-strategy-class-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+               A class that implements org.jboss.jca.adapters.jdbc.URLSelectorStrategy
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="new-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+               Specifies an SQL statement to execute whenever a connection is added
+               to the connection pool.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-isolation" type="transaction-isolationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Set java.sql.Connection transaction isolation level to use. The constants
+              defined by transaction-isolation-values are the possible transaction isolation
+              levels and include: TRANSACTION_READ_UNCOMMITTED TRANSACTION_READ_COMMITTED
+              TRANSACTION_REPEATABLE_READ TRANSACTION_SERIALIZABLE TRANSACTION_NONE
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-pool" type="xa-poolType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the pooling settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="security" type="dsSecurityType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the time out settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="statement" type="statementType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the statement settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
+    </xs:sequence>
+    <xs:attributeGroup ref="common-datasourceAttributes" />
+  </xs:complexType>
+  <xs:complexType name="boolean-presenceType" />
+  <xs:attributeGroup name="common-datasourceAttributes">
+    <xs:attribute name="jndi-name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the JNDI name for the datasource
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="pool-name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the pool name for the datasource used for management
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enabled" type="xs:boolean" default="true" form="unqualified" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies if the datasource should be enabled
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="true" name="use-java-context" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Setting this to false will bind the DataSource into global JNDI
+            Ex: use-java-context="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="spy" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable spy functionality on the JDBC layer - e.g. log all JDBC traffic to the datasource.
+            Remember to enable the logging category (org.jboss.jdbc) too.
+            Ex: spy="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="true" name="use-ccm" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable the use of a cached connection manager
+            Ex: use-ccm="true"
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="connectable" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+            <![CDATA[[
+                  Enable cmr functionality on this datsource's connections
+                 ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="tracking" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if IronJacamar should track connection handles across transaction boundaries
+          ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="statistics-enabled" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+            <![CDATA[[
+                  Enable statistics for this datasource
+                 ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="mcp" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines the ManagedConnectionPool implementation, f.ex. org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreArrayListManagedConnectionPool
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if WildFly/IronJacamar should record enlistment traces
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+  <xs:simpleType name="transaction-isolationType">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Define constants used as the possible transaction isolation levels in transaction-isolation
+          type. Include: TRANSACTION_READ_UNCOMMITTED, TRANSACTION_READ_COMMITTED, TRANSACTION_REPEATABLE_READ,
+          TRANSACTION_SERIALIZABLE, TRANSACTION_NONE
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="TRANSACTION_READ_UNCOMMITTED" />
+      <xs:enumeration value="TRANSACTION_READ_COMMITTED" />
+      <xs:enumeration value="TRANSACTION_REPEATABLE_READ" />
+      <xs:enumeration value="TRANSACTION_SERIALIZABLE" />
+      <xs:enumeration value="TRANSACTION_NONE" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="xa-datasource-propertyType" mixed="true">
+    <xs:attribute name="name" use="required" type="xs:token" />
+  </xs:complexType>
+  <xs:complexType name="connection-propertyType" mixed="true">
+    <xs:attribute name="name" use="required" type="xs:token" />
+  </xs:complexType>
+  <xs:complexType name="validationType">
+    <xs:sequence>
+      <xs:element name="valid-connection-checker" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.ValidConnectionChecker that provides
+              a SQLException isValidConnection(Connection e) method to validate is a connection
+              is valid. An exception means the connection is destroyed. This overrides
+              the check-valid-connection-sql when present. Ex:
+              <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.vendor.OracleValidConnectionChecker"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="check-valid-connection-sql" type="xs:string" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specify an SQL statement to check validity of a pool connection. This
+              may be called when managed connection is taken from pool for use.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validate-on-match" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The validate-on-match element indicates whether or not connection
+              level validation should be done when a connection factory attempts to match
+              a managed connection for a given set. This is typically exclusive to the
+              use of background validation
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An element to specify that connections should be validated on a background
+              thread versus being validated prior to use
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The background-validation-millis element specifies the amount of
+              time, in millis, that background validation will run.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-fast-fail" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether fail a connection allocation on the first connection if it
+              is invalid (true) or keep trying until the pool is exhausted of all potential
+              connections (false) default false. e.g. <use-fast-fail>true</use-fast-fail>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element minOccurs="0" name="stale-connection-checker" type="extensionType">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.StaleConnectionChecker that provides
+              a boolean isStaleConnection(SQLException e) method which if it it returns
+              true will wrap the exception in an org.jboss.jca.adapters.jdbc.StaleConnectionException
+              which is a subclass of SQLException. Ex:
+              <stale-connection-checker class-name="org.jboss.jca.adapters.jdbc.vendor.OracleStaleConnectionChecker"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="exception-sorter" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An org.jboss.jca.adapters.jdbc.ExceptionSorter that provides a
+              boolean isExceptionFatal(SQLException e) method to validate is an exception
+              should be broadcast to all javax.resource.spi.ConnectionEventListener as
+              a connectionErrorOccurred message. Ex:
+              <exception-sorter class-name="org.jboss.jca.adapters.jdbc.vendor.OracleExceptionSorter"/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="timeoutType">
+    <xs:sequence>
+      <xs:element name="blocking-timeout-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The blocking-timeout-millis element indicates the maximum time in
+              milliseconds to block while waiting for a connection before throwing an exception.
+              Note that this blocks only while waiting for a permit for a connection, and
+              will never throw an exception if creating a new connection takes an inordinately
+              long time. The default is 30000 (30 seconds).
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="idle-timeout-minutes" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The idle-timeout-minutes elements indicates the maximum time in minutes
+              a connection may be idle before being closed. The actual maximum time depends
+              also on the IdleRemover scan time, which is 1/2 the smallest idle-timeout-minutes
+              of any pool.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="set-tx-query-timeout" type="boolean-presenceType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to set the query timeout based on the time remaining until
+              transaction timeout, any configured query timeout will be used if there is
+              no transaction. The default is false. e.g. <set-tx-query-timeout/>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="query-timeout" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Any configured query timeout in seconds The default is no timeout
+              e.g. 5 minutes <query-timeout>300</query-timeout>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-try-lock" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Any configured timeout for internal locks on the resource adapter
+              objects in seconds The default is a 60 second timeout e.g. 5 minutes <use-try-lock>300</use-try-lock>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry element indicates the number of times that allocating
+              a connection should be tried before throwing an exception. The default is 0.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry-wait-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry wait millis element indicates the time in milliseconds
+              to wait between retrying to allocate a connection. The default is 5000 (5 seconds).
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-resource-timeout" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Passed to XAResource.setTransactionTimeout() Default is zero which
+              does not invoke the setter. In seconds e.g. 5 minutes <xa-resource-timeout>300</xa-resource-timeout>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="track-statementsType">
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="true" />
+      <xs:enumeration value="false" />
+      <xs:enumeration value="nowarn" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="statementType">
+    <xs:sequence>
+      <xs:element name="track-statements" type="track-statementsType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to check for unclosed statements when a connection is returned
+              to the pool and result sets are closed when a statement is closed/return
+              to the prepared statement cache. valid values are: false - do not track statements
+              and results true - track statements and result sets and warn when they are
+              not closed nowarn - track statements but do no warn about them being unclosed
+              (the default) e.g. <track-statements>nowarn</track-statements>
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="prepared-statement-cache-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The number of prepared statements per connection in an LRU cache
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="share-prepared-statements" type="boolean-presenceType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to share prepare statements, i.e. whether asking for same
+              statement twice without closing uses the same underlying prepared statement.
+              The default is false. e.g. <share-prepared-statements/>
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="poolType">
+    <xs:sequence>
+      <xs:element name="min-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The min-pool-size element indicates the minimum number of connections
+              a pool should hold. These are not created until a Subject is known from a
+              request for a connection. This default to 0. Ex: <min-pool-size>1</min-pool-size>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="initial-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    The initial-pool-size element indicates the initial number of connections
+                    a pool should hold. This default to 0. Ex: <initial-pool-size>1</initial-pool-size>
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="max-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The max-pool-size element indicates the maximum number of connections
+              for a pool. No more connections will be created in each sub-pool.
+              This defaults to 20.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="prefill" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to attempt to prefill the connection pool. Empty element denotes
+              a true value. e.g. <prefill>true</prefill>.
+              Default is false
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="fair" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Defines if pool use should be fair
+              Default true
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-strict-min" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Define if the min-pool-size should be considered a strictly.
+              Default false
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="flush-strategy" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies how the pool should be flush in case of an error.
+              Valid values are: FailingConnectionOnly (default), InvalidIdleConnections, IdleConnections, Gracefully, EntirePool,
+              AllInvalidIdleConnections, AllIdleConnections, AllGracefully, AllConnections
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allow-multiple-users" type="boolean-presenceType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies if multiple users will access the datasource through the getConnection(user, password)
+              method and hence if the internal pool type should account for that
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="capacity" type="capacityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    Specifies the capacity policies for the pool
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="connection-listener" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    An org.jboss.jca.adapters.jdbc.spi.listener.ConnectionListener that provides
+                    a possible to listen for connection activation and passivation in order to
+                    perform actions before the connection is returned to the application or returned
+                    to the pool. Ex:
+                    <connection-listener class-name="com.acme.jdbc.OracleConnectionListener"/>
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="xa-poolType">
+    <xs:complexContent>
+      <xs:extension base="poolType">
+        <xs:sequence>
+          <xs:element name="is-same-rm-override" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  The is-same-rm-override element allows one to unconditionally
+                  set whether the javax.transaction.xa.XAResource.isSameRM(XAResource) returns
+                  true or false. Ex: <is-same-rm-override>true</is-same-rm-override>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="interleaving" type="boolean-presenceType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  An element to enable interleaving for XA connection factories
+                  Ex: <interleaving/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="no-tx-separate-pools" type="boolean-presenceType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  Oracle does not like XA connections getting used both inside and outside a JTA transaction.
+                  To workaround the problem you can create separate sub-pools for the different contexts
+                  using <no-tx-separate-pools/>
+                  Ex: <no-tx-separate-pools/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="pad-xid" type="xs:boolean" default="false" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the Xid be padded
+                   Ex: <pad-xid>true</pad-xid>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="wrap-xa-resource" type="xs:boolean" default="true" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
+                   instance
+                   Ex: <wrap-xa-resource>true</wrap-xa-resource>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="dsSecurityType">
+      <xs:sequence>
+        <xs:choice>
+          <xs:sequence>
+            <xs:element name="user-name" type="xs:token" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[[
+                    Specify the username used when creating a new connection.
+                            Ex: <user-name>sa</user-name>
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="password" type="xs:token" minOccurs="0">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[[
+                    Specify the password used when creating a new connection.
+                    Ex: <password>sa-pass</password>
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                Credential to be used by the configuration.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        <xs:element name="security-domain" type="xs:token" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Indicates Subject (from security domain) are used to distinguish connections in the pool.
+                The content of the security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+                Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:sequence minOccurs="0">
+          <xs:element name="elytron-enabled" type="boolean-presenceType">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via authentication-context), Elytron will use the specified context
+                for authenticating. Else, Elytron will use the current authentication context of the caller that
+                is retrieving the connection.
+                Ex:
+                  <elytron-enabled/>
+                ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="authentication-context" type="xs:token" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates the Elytron context that will be used for authenticating connections during
+                container-managed sign-on.
+                The resulting Subject will be used to distinguish connections in the pool.
+                The authentication-context name correlates to the authentication context defined in
+                the Elytron subsystem.
+                Ex:
+                  <elytron-enabled/>
+                  <authentication-context>HsqlDbContext</authentication-context>
+                ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:choice>
+      <xs:element name="reauth-plugin" type="extensionType" minOccurs="0" maxOccurs="1"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="extensionType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="config-propertyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Specifies a Java bean property value
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attribute use="required" name="name" type="xs:token">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies the name of the config-property
+               ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="recoverType">
+    <xs:sequence>
+      <xs:element name="recover-credential" type="dsSecurityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security options used when creating a connection during recovery.
+              Note: if this credential are not specified the security credential are used for recover too
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recover-plugin" type="extensionType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the extension plugin used in spi (core.spi.xa)
+              which can be implemented by various plugins to provide better feedback to the XA recovery system.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="no-recovery" type="xs:boolean" default="false" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specify if the xa-datasource should be excluded from recovery.
+            Default false.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="driverType">
+    <xs:sequence>
+      <xs:element name="driver-class" type="xs:token" maxOccurs="1" minOccurs="0">
+      <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the JDBC driver class Ex: <driver-class>org.hsqldb.jdbcDriver</driver-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+      <xs:annotation>
+          <xs:documentation>
+           <![CDATA[[
+              The fully qualifed name of the javax.sql.XADataSource implementation
+              class. Ex: <xa-datasource-class>oracle.jdbc.xa.client.OracleXADataSource</xa-datasource-class>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="datasource-class" type="xs:token" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The fully qualifed name of the javax.sql.DataSource implementation
+              class.
+             ]]>
+          </xs:documentation>
+        </xs:annotation></xs:element>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the symbolic name of this driver used to reference this driver
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="module" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the name of AS7 module providing this driver.
+            This tag is not used in IronJacamar standalone container.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="major-version" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the major version of this driver. If the major and minor versions are omitted the first available
+            Driver in module will be used.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="minor-version" type="xs:int" use="optional">
+    <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the minor version of this driver. If the major and minor versions are omitted the first available
+            Driver in module will be used.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="driversType">
+    <xs:sequence>
+      <xs:element name="driver" type="driverType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="capacityType">
+    <xs:sequence>
+      <xs:element name="incrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Defines the policy for incrementing connections in the pool
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="decrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Defines the policy for decrementing connections in the pool
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/connector/src/main/resources/schema/wildfly-datasources_6_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_6_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:datasources:6.0" xmlns="urn:jboss:domain:datasources:6.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:resource-adapters:5.0" xmlns="urn:jboss:domain:resource-adapters:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_6_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_6_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:resource-adapters:6.0" xmlns="urn:jboss:domain:resource-adapters:6.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_6_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_6_0.xsd
@@ -1,0 +1,1123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:resource-adapters:6.0" xmlns="urn:jboss:domain:resource-adapters:6.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+  <xs:element name="subsystem" type="subsystemType"/>
+
+  <xs:complexType name="subsystemType">
+    <xs:all>
+      <xs:element name="resource-adapters" type="resource-adaptersType" minOccurs="0" maxOccurs="1"/>
+    </xs:all>
+  </xs:complexType>
+
+  <xs:complexType name="boolean-presenceType"></xs:complexType>
+
+  <xs:complexType name="config-propertyType" mixed="true">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Specifies an override for a config-property element in ra.xml or a @ConfigProperty
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="xs:token">
+        <xs:attribute use="required" name="name" type="xs:token">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Specifies the name of the config-property
+               ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="resource-adapterType">
+    <xs:sequence>
+      <xs:element name="archive" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the resource adapter archive to be activated
+              E.g. <archive>myra.rar</archive>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+        <xs:element name="module" type="moduleType" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[[
+                      Specifies the resource adapter module to be activated
+                      E.g. <archive>org.jboss.ironjacamar.ra16out</archive>
+                     ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:element>
+        <xs:element name="bean-validation-groups" type="bean-validation-groupsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies bean validation group that should be used
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="bootstrap-context" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the unique name of the bootstrap context that should be used
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+               The config-property specifies resource adapter configuration properties.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="transaction-support" type="transaction-supportType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the transaction support level of the resource adapter
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="workmanager" type="workmanagerType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    Specifies the settings for the WorkManager used by this resource adapter
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="connection-definitions" type="connection-definitionsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the connection definitions
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="admin-objects" type="admin-objectsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the administration objects
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            An unique identifier for the resource adapter
+                        ]]>
+          </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="statistics-enabled" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>
+                <![CDATA[[
+                      Enable statistics for this resource-adapter
+                     ]]>
+            </xs:documentation>
+          </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:simpleType name="transaction-supportType">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[[
+          Define the type of transaction supported by this resource adapter.
+          Valid values are: NoTransaction, LocalTransaction, XATransaction
+         ]]>
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:token">
+      <xs:enumeration value="NoTransaction" />
+      <xs:enumeration value="LocalTransaction" />
+      <xs:enumeration value="XATransaction" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attributeGroup name="common-attribute">
+    <xs:attribute name="class-name" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the the fully qualified class name of a managed connection factory
+            or admin object
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="jndi-name" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the JNDI name
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enabled" type="xs:boolean" default="true" form="unqualified" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Should the object in question be activated
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="true" name="use-java-context" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies if a java:/ JNDI context should be used
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="pool-name" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specifies the pool name for the object
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:attributeGroup>
+
+  <xs:complexType name="admin-objectType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The config-property specifies administration object configuration properties.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+  </xs:complexType>
+
+  <xs:complexType name="timeoutType">
+    <xs:sequence>
+      <xs:element name="blocking-timeout-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                The blocking-timeout-millis element indicates the maximum time in
+                milliseconds to block while waiting for a connection before throwing an exception.
+                Note that this blocks only while waiting for a permit for a connection, and
+                will never throw an exception if creating a new connection takes an inordinately
+                long time. The default is 30000 (30 seconds).
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="idle-timeout-minutes" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The idle-timeout-minutes elements indicates the maximum time in minutes
+              a connection may be idle before being closed. The actual maximum time depends
+              also on the IdleRemover scan time, which is 1/2 the smallest idle-timeout-minutes
+              of any pool.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry element indicates the number of times that allocating
+              a connection should be tried before throwing an exception. The default is
+              0.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="allocation-retry-wait-millis" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The allocation retry wait millis element indicates the time in milliseconds
+              to wait between retrying to allocate a connection. The default is 5000 (5
+              seconds).
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xa-resource-timeout" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Passed to XAResource.setTransactionTimeout(). Default is zero which does not invoke the setter.
+              Specified in seconds - e.g. 5 minutes
+              <xa-resource-timeout>300</xa-resource-timeout>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="validationType">
+    <xs:sequence>
+      <xs:element name="validate-on-match" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The validate-on-match element indicates whether or not connection
+              level validation should be done when a connection factory attempts to match
+              a managed connection for a given set. This is typically exclusive to the
+              use of background validation
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              An element to specify that connections should be validated on a background
+              thread versus being validated prior to use
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="background-validation-millis" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+               The background-validation-millis element specifies the amount of
+               time, in millis, that background validation will run.
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-fast-fail" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                Whether fail a connection allocation on the first connection if it
+                is invalid (true) or keep trying until the pool is exhausted of all potential
+                connections (false) default false. e.g. <use-fast-fail>true</use-fast-fail>
+              ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="resource-adaptersType">
+    <xs:sequence>
+      <xs:element name="resource-adapter" type="resource-adapterType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies activation of a resource adapter
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="connection-definitionsType">
+    <xs:sequence>
+      <xs:element name="connection-definition" type="connection-defintionType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies a connection definition
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="connection-defintionType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+             The config-property specifies managed connection factory configuration properties.
+            ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice>
+        <xs:element name="pool" type="poolType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+                <![CDATA[[
+                  Specifies pooling settings
+                 ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="xa-pool" type="xa-poolType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+                <![CDATA[[
+                  Specifies xa-pooling settings
+                 ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:element name="security" type="securityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies security settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="timeout" type="timeoutType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies timeout settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validation" type="validationType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies validation settings
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recovery" type="recoverType" minOccurs="0" maxOccurs="1"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="use-ccm" type="xs:boolean" default="true" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Enable cached connection manager
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="sharable" type="xs:boolean" default="true" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Defines the connections as sharable which allows lazy association to be enabled
+                if supported
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enlistment" type="xs:boolean" default="true" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Defines if lazy enlistment should be used if supported by the resource adapter
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute default="false" name="connectable" type="xs:boolean">
+      <xs:annotation>
+        <xs:documentation>
+            <![CDATA[[
+                 Enable CMR functionality on this connection
+                ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="tracking" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if IronJacamar should track connection handles across transaction boundaries
+          ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="mcp" type="xs:token" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines the ManagedConnectionPool implementation, f.ex. org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreArrayListManagedConnectionPool
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Defines if WildFly/IronJacamar should record enlistment traces
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attributeGroup ref="common-attribute"></xs:attributeGroup>
+  </xs:complexType>
+
+  <xs:complexType name="poolType">
+    <xs:sequence>
+      <xs:element name="min-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The min-pool-size element indicates the minimum number of connections
+              a pool should hold. These are not created until a Subject is known from a
+              request for a connection. This default to 0. Ex: <min-pool-size>1</min-pool-size>
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="initial-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                    The initial-pool-size element indicates the initial number of connections
+                    a pool should hold. This default to 0. Ex: <initial-pool-size>1</initial-pool-size>
+                   ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="max-pool-size" type="xs:nonNegativeInteger" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              The max-pool-size element indicates the maximum number of connections
+              for a pool. No more than max-pool-size connections will be created in each sub-pool.
+              This defaults to 20.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="prefill" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Whether to attempt to prefill the connection pool. Default is false.
+              e.g. <prefill>false</prefill>.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="fair" type="xs:boolean" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Defines if pool use should be fair
+              Default true
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="use-strict-min" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Define if the min-pool-size should be considered strict.
+              Default false
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="flush-strategy" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies how the pool should be flush in case of an error.
+              Valid values are: FailingConnectionOnly (default), InvalidIdleConnections, IdleConnections, Gracefully, EntirePool,
+                                              AllInvalidIdleConnections, AllIdleConnections, AllGracefully, AllConnections
+                           ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="capacity" type="capacityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                            Specifies the capacity policies for the pool
+                           ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="xa-poolType">
+    <xs:complexContent>
+      <xs:extension base="poolType">
+        <xs:sequence>
+          <xs:element name="is-same-rm-override" type="xs:boolean" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  The is-same-rm-override element allows one to unconditionally
+                  set whether the javax.transaction.xa.XAResource.isSameRM(XAResource) returns
+                  true or false. Ex: <is-same-rm-override>true</is-same-rm-override>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="interleaving" type="boolean-presenceType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  An element to enable interleaving for XA connection factories
+                  Ex: <interleaving/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="no-tx-separate-pools" type="boolean-presenceType" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                  Oracle does not like XA connections getting used both inside and outside a JTA transaction.
+                  To workaround the problem you can create separate sub-pools for the different contexts
+                  using <no-tx-separate-pools/>
+                  Ex: <no-tx-separate-pools/>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="pad-xid" type="xs:boolean" default="false" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the Xid be padded
+                   Ex: <pad-xid>true</pad-xid>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="wrap-xa-resource" type="xs:boolean" default="true" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
+                   instance
+                   Ex: <wrap-xa-resource>true</wrap-xa-resource>
+                 ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="securityType">
+    <xs:sequence>
+      <xs:choice>
+        <xs:element name="application" type="boolean-presenceType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Indicates that app supplied parameters (such as from getConnection(user, pw))
+                are used to distinguish connections in the pool.
+                Ex:
+                <application/>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="security-domain" type="xs:token" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Indicates Subject (from security domain) are used to distinguish connections in the pool.
+                The content of the security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+                Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="security-domain-and-application" type="xs:token" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+                Indicates that either app supplied parameters (such as from
+                getConnection(user, pw)) or Subject (from security domain) are used to
+                distinguish connections in the pool. The content of the
+                security-domain is the name of the JAAS security manager that will handle
+                authentication. This name correlates to the JAAS login-config.xml descriptor
+                application-policy/name attribute.
+
+                Ex:
+                <security-domain-and-application>HsqlDbRealm</security-domain-and-application>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:sequence minOccurs="0" maxOccurs="1">
+          <xs:element name="elytron-enabled" type="boolean-presenceType" minOccurs="1">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via either authentication-context or authentication-context-and-application),
+                Elytron will use that specified context for authenticating. Else, Elytron will use the
+                current authentication context of the caller that is retrieving the connection.
+                Ex:
+                <elytron-enabled/>
+              ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:choice minOccurs="0" maxOccurs="1">
+            <xs:element name="authentication-context" type="xs:token">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[[
+                  Indicates the Elytron context that will be used for authenticating connections during
+                  container-managed sign-on.
+                  The resulting Subject will be used to distinguish connections in the pool.
+                  The authentication-context name correlates to the authentication context defined in
+                  the Elytron subsystem.
+                  Ex:
+                    <elytron-enabled/>
+                    <authentication-context>HsqlDbContext</authentication-context>
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+            <xs:element name="authentication-context-and-application" type="xs:token">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[[
+                  Indicates that either app supplied parameters (such as from
+                  getConnection(user, pw)) or an authenticated Subject (resulting of container-managed sign-on
+                  authentication) are used to distinguish connections in the pool.
+                  The authentication-context name correlates to the authentication context defined in
+                  the Elytron subsystem.
+                  Ex:
+                    </elytron-enabled/>
+                    <authentication-context-and-application>HsqlDbContext</authentication-context-and-application>
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:element>
+          </xs:choice>
+        </xs:sequence>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="admin-objectsType">
+    <xs:sequence>
+      <xs:element name="admin-object" type="admin-objectType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the setup for an admin object
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="bean-validation-groupsType">
+    <xs:sequence>
+      <xs:element name="bean-validation-group" type="xs:token" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the fully qualified class name for a bean validation group that
+              should be used for validation
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="recoverType">
+    <xs:sequence>
+      <xs:element name="recover-credential" type="credentialType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the security options used when creating a connection during recovery.
+              Note: if this credential is not specified the security credential is used for recovery too
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recover-plugin" type="extensionType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+              Specifies the extension plugin used in spi (core.spi.xa)
+              which can be implemented by various plugins to provide better feedback to the XA recovery system.
+             ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="no-recovery" type="xs:boolean" default="false" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+            Specify if the xa-datasource should be excluded from recovery.
+            Default false.
+           ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="extensionType">
+    <xs:sequence>
+      <xs:element name="config-property" type="config-propertyType"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="class-name" type="xs:token" use="required"></xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="credentialType">
+    <xs:sequence>
+      <xs:element name="user-name" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              <![CDATA[[
+                Specify the username used when creating a new connection.
+                Ex: <user-name>sa</user-name>
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="password" type="xs:token" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+              <![CDATA[[
+                Specify the password used when creating a new connection.
+                Ex: <password>sa-pass</password>
+               ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Credential to be used by the configuration.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:choice minOccurs="0">
+        <xs:element name="security-domain" type="xs:token">
+          <xs:annotation>
+            <xs:documentation>
+              <![CDATA[[
+              Indicates Subject (from security domain) are used to distinguish connections in the pool.
+              The content of the security-domain is the name of the JAAS security manager that will handle
+              authentication. This name correlates to the JAAS login-config.xml descriptor
+              application-policy/name attribute.
+              Ex:
+                <security-domain>HsqlDbRealm</security-domain>
+              ]]>
+            </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:sequence>
+          <xs:element name="elytron-enabled" type="boolean-presenceType">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates that Elytron is responsible for authenticating connections. If authentication-context
+                is configured (via authentication-context), Elytron will use that specified context for authenticating.
+                Else, Elytron will use the current authentication context of the caller that is retrieving the connection.
+                Ex:
+                  <elytron-enabled/>
+                ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="authentication-context" type="xs:token" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>
+                <![CDATA[[
+                Indicates the Elytron context that will be used for authenticating connections during
+                container-managed sign-on.
+                The resulting Subject will be used to distinguish connections in the pool.
+                The authentication-context name correlates to the authentication context defined in
+                the Elytron subsystem.
+                Ex:
+                <elytron-enabled/>
+                <authentication-context>HsqlDbContext</authentication-context>
+            ]]>
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+        </xs:sequence>
+      </xs:choice>
+    </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="moduleType">
+       <xs:attribute name="id" type="xs:token" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   <![CDATA[[
+                   The module id
+                               ]]>
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="slot" type="xs:token" use="optional">
+             <xs:annotation>
+               <xs:documentation>
+                 <![CDATA[[
+                   The module slot
+                               ]]>
+                 </xs:documentation>
+               </xs:annotation>
+           </xs:attribute>
+   </xs:complexType>
+
+  <xs:complexType name="workmanagerType">
+    <xs:sequence>
+      <xs:element name="security" type="workmanagerSecurityType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines the security model used by the WorkManager instance
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityType">
+    <xs:sequence>
+      <xs:element name="mapping-required" type="xs:boolean" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines if a mapping is required for security credentials. A value of false means
+                  "Case 1" as defined in section 16.4.3, and a value of true means "Case 2" as
+                  defined in section 16.4.4.
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="domain" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines the name of the security domain that should be used
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="elytron-security-domain" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Indicates that Elytron is responsible for WorkManager security. It defines the name of the Elytron
+                  security domain that should be used
+                  Ex:
+                    <elytron-security-domain>ApplicationDomain</elytron-security-domain>
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="default-principal" type="xs:token" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines a default principal name that should be added to the used Subject instance
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="default-groups" type="workmanagerSecurityGroupsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines a default groups that should be added to the used Subject instance
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="mappings" type="workmanagerSecurityMappingsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines the mappings that should be applied for Case 2
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityGroupsType">
+    <xs:sequence>
+      <xs:element name="group" type="xs:token" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  The name of the group
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityMappingsType">
+    <xs:sequence>
+      <xs:element name="users" type="workmanagerSecurityMappingsUsersType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  The mappings for the users
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="groups" type="workmanagerSecurityMappingsGroupsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  The mappings for the groups
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityMappingsUsersType">
+    <xs:sequence>
+      <xs:element name="map" type="workmanagerSecurityMappingType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  A user mapping
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityMappingsGroupsType">
+    <xs:sequence>
+      <xs:element name="map" type="workmanagerSecurityMappingType" minOccurs="1" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  A group mapping
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="workmanagerSecurityMappingType">
+    <xs:sequence>
+    </xs:sequence>
+    <xs:attribute name="from" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Specify the original value
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="to" type="xs:token" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          <![CDATA[[
+                Specify the mapped value
+               ]]>
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="capacityType">
+    <xs:sequence>
+      <xs:element name="incrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines the policy for incrementing connections in the pool
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="decrementer" type="extensionType" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[[
+                  Defines the policy for decrementing connections in the pool
+                 ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/connector/src/main/resources/subsystem-templates/datasources.xml
+++ b/connector/src/main/resources/subsystem-templates/datasources.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.connector</extension-module>
-   <subsystem xmlns="urn:jboss:domain:datasources:5.0">
+   <subsystem xmlns="urn:jboss:domain:datasources:6.0">
        <datasources>
            <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
                <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>

--- a/connector/src/main/resources/subsystem-templates/resource-adapters-genericjms.xml
+++ b/connector/src/main/resources/subsystem-templates/resource-adapters-genericjms.xml
@@ -3,7 +3,7 @@
 <config>
     <extension-module>org.jboss.as.connector</extension-module>
 
-    <subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+    <subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
         <resource-adapters>
             <resource-adapter id="generic-jms-ra.rar">
                 <module slot="main" id="org.jboss.genericjms"/>

--- a/connector/src/main/resources/subsystem-templates/resource-adapters.xml
+++ b/connector/src/main/resources/subsystem-templates/resource-adapters.xml
@@ -2,5 +2,5 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.connector</extension-module>
-   <subsystem xmlns="urn:jboss:domain:resource-adapters:5.0"/>
+   <subsystem xmlns="urn:jboss:domain:resource-adapters:6.0"/>
 </config>

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -72,7 +72,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-datasources_5_0.xsd";
+        return "schema/wildfly-datasources_6_0.xsd";
     }
 
     @Override
@@ -95,7 +95,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testElytronConfig() throws Exception {
-        standardSubsystemTest("datasources-elytron-enabled_5_0.xml");
+        standardSubsystemTest("datasources-elytron-enabled_6_0.xml");
     }
 
     @Test
@@ -127,7 +127,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformerElytronEnabledEAP64() throws Exception {
-        testTransformerElytronEnabled("datasources-elytron-enabled_5_0.xml", ModelTestControllerVersion.EAP_6_4_0, ModelVersion.create(1, 3, 0));
+        testTransformerElytronEnabled("datasources-elytron-enabled_6_0.xml", ModelTestControllerVersion.EAP_6_4_0, ModelVersion.create(1, 3, 0));
     }
     @Test
     public void testTransformerEAP7() throws Exception {

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
@@ -77,7 +77,7 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-resource-adapters_5_0.xsd";
+        return "schema/wildfly-resource-adapters_6_0.xsd";
     }
 
     @Override

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
             <resource-adapters>
                 <resource-adapter id="myRA">
                     <archive>some.rar</archive>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled_6_0.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-elytron-enabled_6_0.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
   <datasources>
     <!--You have a CHOICE of the next 2 items at this level-->
     <datasource jta="true" jndi-name="java:/token" pool-name="token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="${test.expr:true}" statistics-enabled="true" tracking="true">

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full-expression.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool"
                     use-java-context="${test.expr:true}" spy="${test.expr:false}" use-ccm="${test.expr:true}" jta="${test.expr:false}"

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-full.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool" jta="false"
                     use-java-context="true" spy="false" use-ccm="true" connectable="false" statistics-enabled="true" tracking="true">

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-minimal.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources-minimal.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS"
                     use-java-context="true">

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources_6_0-reject.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasources_6_0-reject.xml
@@ -1,108 +1,73 @@
 <subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
-        <datasource jndi-name="java:jboss/datasources/complexDs" pool-name="complexDs_Pool" jta="false"
-                    use-java-context="true" spy="false" use-ccm="true" connectable="false" statistics-enabled="true">
-            <connection-url>
-                jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-            </connection-url>
-            <driver-class>
-                org.hsqldb.jdbcDriver
-            </driver-class>
-            <datasource-class>
-                org.jboss.as.connector.subsystems.datasources.ModifiableDataSource
-            </datasource-class>
-            <connection-property name="char.encoding">
-                UTF-8
-            </connection-property>
-            <driver>
-                h2
-            </driver>
-            <new-connection-sql>
-                select 1
-            </new-connection-sql>
-            <transaction-isolation>
-                TRANSACTION_READ_COMMITTED
-            </transaction-isolation>
-            <url-delimiter>
-                :
-            </url-delimiter>
-            <url-selector-strategy-class-name>
-                someClass
-            </url-selector-strategy-class-name>
+        <datasource jta="true" jndi-name="java:/token" pool-name="token" enabled="true" use-java-context="true" spy="false" use-ccm="true" connectable="${test.expr:true}" statistics-enabled="true" tracking="true">
+            <connection-url>token</connection-url>
+            <driver-class>token</driver-class>
+            <datasource-class>token</datasource-class>
+            <!--connection-property name="token">e gero</connection-property-->
+            <driver>token</driver>
+            <new-connection-sql>string</new-connection-sql>
+            <transaction-isolation>TRANSACTION_REPEATABLE_READ</transaction-isolation>
+            <url-delimiter>token</url-delimiter>
+            <url-selector-strategy-class-name>token</url-selector-strategy-class-name>
             <pool>
-                <min-pool-size>1</min-pool-size>
-                <max-pool-size>5</max-pool-size>
+                <min-pool-size>200</min-pool-size>
+                <initial-pool-size>200</initial-pool-size>
+                <max-pool-size>200</max-pool-size>
                 <prefill>true</prefill>
                 <use-strict-min>true</use-strict-min>
                 <flush-strategy>EntirePool</flush-strategy>
                 <allow-multiple-users>true</allow-multiple-users>
+                <connection-listener class-name="token">
+                    <config-property name="token">token</config-property>
+                </connection-listener>
+                <capacity>
+                    <incrementer class-name="token">
+                        <config-property name="token">token</config-property>
+                    </incrementer>
+                    <decrementer class-name="token">
+                        <config-property name="token">token</config-property>
+                    </decrementer>
+                </capacity>
             </pool>
             <security>
-                <user-name>
-                    sa
-                </user-name>
-                <password>
-                    sa
-                </password>
-                <reauth-plugin class-name="someClass1">
-                    <config-property name="name">Property1</config-property>
-                </reauth-plugin>
+                <credential-reference store="test-store" alias="test-alias" clear-text="test-pass" type="org.wildfly.Foo" />
+                <elytron-enabled>true</elytron-enabled>
+                <authentication-context>DsAuthCtxt</authentication-context>
             </security>
             <validation>
-                <valid-connection-checker class-name="someClass2">
-                    <config-property name="name">Property2</config-property>
+                <valid-connection-checker class-name="token">
+                    <config-property name="token">token</config-property>
                 </valid-connection-checker>
-                <check-valid-connection-sql>
-                    select 1
-                </check-valid-connection-sql>
-                <validate-on-match>
-                    true
-                </validate-on-match>
-                <background-validation>
-                    true
-                </background-validation>
-                <background-validation-millis>
-                    2000
-                </background-validation-millis>
-                <use-fast-fail>
-                    true
-                </use-fast-fail>
-                <stale-connection-checker class-name="someClass3">
-                    <config-property name="name">Property3</config-property>
+                <check-valid-connection-sql>string</check-valid-connection-sql>
+                <validate-on-match>true</validate-on-match>
+                <background-validation>true</background-validation>
+                <background-validation-millis>200</background-validation-millis>
+                <use-fast-fail>false</use-fast-fail>
+                <stale-connection-checker class-name="token">
+                    <config-property name="token">token</config-property>
                 </stale-connection-checker>
-                <exception-sorter class-name="someClass4">
-                    <config-property name="name">Property4</config-property>
+                <exception-sorter class-name="token">
+                    <config-property name="token">token</config-property>
                 </exception-sorter>
             </validation>
             <timeout>
                 <set-tx-query-timeout>true</set-tx-query-timeout>
-                <blocking-timeout-millis>20000</blocking-timeout-millis>
-                <idle-timeout-minutes>4</idle-timeout-minutes>
-                <query-timeout>
-                    120
-                </query-timeout>
-                <use-try-lock>
-                    100
-                </use-try-lock>
-                <allocation-retry>
-                    2
-                </allocation-retry>
-                <allocation-retry-wait-millis>
-                    3000
-                </allocation-retry-wait-millis>
+                <blocking-timeout-millis>200</blocking-timeout-millis>
+                <idle-timeout-minutes>200</idle-timeout-minutes>
+                <query-timeout>200</query-timeout>
+                <use-try-lock>200</use-try-lock>
+                <allocation-retry>200</allocation-retry>
+                <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
             </timeout>
             <statement>
-                <track-statements>nowarn</track-statements>
-                <prepared-statement-cache-size>30</prepared-statement-cache-size>
+                <track-statements>false</track-statements>
+                <prepared-statement-cache-size>200</prepared-statement-cache-size>
                 <share-prepared-statements>true</share-prepared-statements>
-
             </statement>
         </datasource>
-        <xa-datasource jndi-name="java:jboss/xa-datasources/complexXaDs" pool-name="complexXaDs_Pool"
-                       use-java-context="true" spy="false" use-ccm="true" connectable="false" statistics-enabled="true">
-            <xa-datasource-property name="URL">
-                jdbc:h2:mem:test
-            </xa-datasource-property>
+        <xa-datasource jndi-name="java:/token" pool-name="xa-token"
+                       use-java-context="true" spy="false" use-ccm="true" connectable="false" statistics-enabled="true" tracking="true">
             <xa-datasource-class>
                 org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource
             </xa-datasource-class>
@@ -152,24 +117,11 @@
 
             </xa-pool>
             <security>
-                <user-name>
-                    sa
-                </user-name>
-                <password>
-                    sa
-                </password>
-                <reauth-plugin class-name="someClass1">
-                    <config-property name="name">Property1</config-property>
-                </reauth-plugin>
+                <credential-reference store="test-store" type="org.wildfly.Foo" clear-text="123456"/>
             </security>
             <recovery no-recovery="false">
                 <recover-credential>
-                    <user-name>
-                        sa
-                    </user-name>
-                    <password>
-                        sa
-                    </password>
+                    <credential-reference store="test-store" type="org.wildfly.Foo" clear-text="123456"/>
                 </recover-credential>
                 <recover-plugin class-name="someClass5">
                     <config-property name="name">Property5</config-property>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/empty-resourceadapters.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/empty-resourceadapters.xml
@@ -1,1 +1,1 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0" />
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0" />

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled-6_0-reject.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled-6_0-reject.xml
@@ -1,0 +1,104 @@
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
+  <!--Optional:-->
+  <resource-adapters>
+    <!--1 or more repetitions:-->
+    <resource-adapter id="myRA" statistics-enabled="true">
+      <!--Optional:-->
+      <module id="moduleID" slot="main"/>
+      <!--Optional:-->
+      <bootstrap-context>bootstrapContext</bootstrap-context>
+      <bean-validation-groups>
+        <!--1 or more repetitions:-->
+        <bean-validation-group>group</bean-validation-group>
+      </bean-validation-groups>
+      <!--Optional:-->
+      <transaction-support>NoTransaction</transaction-support>
+        <workmanager>
+            <security>
+                <mapping-required>true</mapping-required>
+                <elytron-security-domain>ApplicationDomain</elytron-security-domain>
+            </security>
+        </workmanager>
+        <!--Zero or more repetitions:-->
+      <config-property name="config1">value</config-property>
+      <!--Optional:-->
+      <connection-definitions>
+        <!--1 or more repetitions:-->
+        <connection-definition use-ccm="true" sharable="false" enlistment="true" class-name="token" jndi-name="java:jboss/cf/PoolName"
+                               enabled="true" use-java-context="true" pool-name="poolName" connectable="true" tracking="true"
+                               enlistment-trace="true" mcp="org.ironjacamar.myClass">
+          <!--You have a CHOICE of the next 2 items at this level-->
+          <!--Optional:-->
+          <pool>
+            <!--Optional:-->
+            <min-pool-size>200</min-pool-size>
+            <!--Optional:-->
+            <initial-pool-size>200</initial-pool-size>
+            <!--Optional:-->
+            <max-pool-size>200</max-pool-size>
+            <!--Optional:-->
+            <prefill>true</prefill>
+            <!--Optional:-->
+            <use-strict-min>true</use-strict-min>
+            <!--Optional:-->
+            <flush-strategy>FailingConnectionOnly</flush-strategy>
+          </pool>
+          <!--Optional:-->
+          <security>
+            <!--You have a CHOICE of the next 3 items at this level-->
+            <!--Optional:-->
+            <elytron-enabled>true</elytron-enabled>
+            <authentication-context-and-application>SomeAuthenticationContext</authentication-context-and-application>
+          </security>
+          <!--Optional:-->
+          <timeout>
+            <!--Optional:-->
+            <blocking-timeout-millis>200</blocking-timeout-millis>
+            <!--Optional:-->
+            <idle-timeout-minutes>200</idle-timeout-minutes>
+            <!--Optional:-->
+            <allocation-retry>200</allocation-retry>
+            <!--Optional:-->
+            <allocation-retry-wait-millis>200</allocation-retry-wait-millis>
+            <!--Optional:-->
+            <xa-resource-timeout>200</xa-resource-timeout>
+          </timeout>
+          <!--Optional:-->
+          <validation>
+            <!--Optional:-->
+            <background-validation>false</background-validation>
+            <!--Optional:-->
+            <background-validation-millis>200</background-validation-millis>
+            <!--Optional:-->
+            <use-fast-fail>false</use-fast-fail>
+          </validation>
+          <!--Optional:-->
+          <recovery no-recovery="false">
+            <!--Optional:-->
+            <recover-credential>
+              <!--Optional:-->
+              <user-name>userName</user-name>
+              <!--Optional:-->
+              <credential-reference store="teststore" alias="myalias" clear-text="mypass"/>
+              <!--Optional:-->
+              <elytron-enabled>true</elytron-enabled>
+              <authentication-context>AnotherAuthenticationContext</authentication-context>
+            </recover-credential>
+            <!--Optional:-->
+            <recover-plugin class-name="aClass">
+              <config-property name="config3">value</config-property>
+            </recover-plugin>
+          </recovery>
+        </connection-definition>
+      </connection-definitions>
+      <!--Optional:-->
+      <admin-objects>
+        <!--1 or more repetitions:-->
+        <admin-object class-name="aClass" jndi-name="java:jboss/ao/anotherPool" enabled="true" use-java-context="true" pool-name="anotherPool">
+          <!--Zero or more repetitions:-->
+          <config-property name="config4">value</config-property>
+        </admin-object>
+      </admin-objects>
+    </resource-adapter>
+  </resource-adapters>
+</subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
@@ -81,8 +81,6 @@
               <!--Optional:-->
               <user-name>userName</user-name>
               <!--Optional:-->
-              <password>pwd</password>
-              <!--Optional:-->
               <credential-reference store="teststore" alias="myalias"/>
               <!--Optional:-->
               <elytron-enabled>true</elytron-enabled>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-elytron-enabled.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool-expression.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-pool.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression2.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool-expression2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/resourceadapters/resource-adapters-xapool.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
   <!--Optional:-->
   <resource-adapters>
     <!--1 or more repetitions:-->

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceDefinition.java
@@ -343,6 +343,10 @@ abstract class AbstractDataSourceDefinition extends PersistentResourceDefinition
                 writeHandler = AbstractDataSourceOperations.CONNECTION_POOL_WRITE_OPERATION;
             }
 
+            if (attributeDefinition == CREDENTIAL_REFERENCE) {
+                writeHandler = AbstractDataSourceOperations.CREDENTIAL_REFERENCE_WRITE_OPERATION;
+            }
+
             resourceRegistration.registerReadWriteAttribute(attributeDefinition, null, writeHandler);
         }
 

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AbstractDataSourceOperations.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceBuilder;
@@ -68,6 +69,7 @@ class AbstractDataSourceOperations {
 
     static final OperationStepHandler CONNECTION_POOL_WRITE_OPERATION = new ConnectionPoolAttributeWriter(AbstractDataSourceDefinition.CONNECTION_POOL_ATTRIBUTE.getValueTypes());
 
+    static final OperationStepHandler CREDENTIAL_REFERENCE_WRITE_OPERATION = new CredentialReferenceWriteAttributeHandler(AbstractDataSourceDefinition.CREDENTIAL_REFERENCE);
     // --- //
 
     static final OperationStepHandler FLUSH_ALL_OPERATION = new FlushOperation(AgroalDataSource.FlushMode.ALL);

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalExtension.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalExtension.java
@@ -45,7 +45,7 @@ public class AgroalExtension implements Extension {
 
     public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append(SUBSYSTEM_NAME);
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(2, 0, 0);
 
     private static final String RESOURCE_NAME = AgroalExtension.class.getPackage().getName() + ".LocalDescriptions";
 
@@ -60,6 +60,7 @@ public class AgroalExtension implements Extension {
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, AgroalNamespace.AGROAL_1_0.getUriString(), AgroalSubsystemParser_1_0.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, AgroalNamespace.AGROAL_2_0.getUriString(), AgroalSubsystemParser_2_0.INSTANCE);
     }
 
     @Override
@@ -68,6 +69,6 @@ public class AgroalExtension implements Extension {
         ManagementResourceRegistration registration = subsystem.registerSubsystemModel(AgroalSubsystemDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        subsystem.registerXMLElementWriter(AgroalSubsystemParser_1_0.INSTANCE);
+        subsystem.registerXMLElementWriter(AgroalSubsystemParser_2_0.INSTANCE);
     }
 }

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalNamespace.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalNamespace.java
@@ -33,9 +33,11 @@ enum AgroalNamespace {
 
     UNKNOWN(null), // must be first
 
-    AGROAL_1_0("urn:jboss:domain:datasources-agroal:1.0");
+    AGROAL_1_0("urn:jboss:domain:datasources-agroal:1.0"),
 
-    public static final AgroalNamespace CURRENT = AGROAL_1_0;
+    AGROAL_2_0("urn:jboss:domain:datasources-agroal:2.0");
+
+    public static final AgroalNamespace CURRENT = AGROAL_2_0;
 
     private static final Map<String, AgroalNamespace> MAP;
 

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalSubsystemParser_2_0.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalSubsystemParser_2_0.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.datasources.agroal;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+/**
+ * The subsystem parser and marshaller, that reads the model to and from it's xml persistent representation
+ *
+ * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
+ */
+class AgroalSubsystemParser_2_0 extends PersistentResourceXMLParser {
+
+    static final AgroalSubsystemParser_2_0 INSTANCE = new AgroalSubsystemParser_2_0();
+
+    private static final PersistentResourceXMLDescription XML_DESCRIPTION;
+
+    static {
+        PersistentResourceXMLBuilder subsystemXMLBuilder = builder(AgroalSubsystemDefinition.INSTANCE.getPathElement(), AgroalNamespace.AGROAL_2_0.getUriString());
+
+        PersistentResourceXMLBuilder datasourceXMLBuilder = builder(DataSourceDefinition.INSTANCE.getPathElement());
+        for (AttributeDefinition attributeDefinition : DataSourceDefinition.ATTRIBUTES) {
+            datasourceXMLBuilder.addAttribute(attributeDefinition);
+        }
+        subsystemXMLBuilder.addChild(datasourceXMLBuilder);
+
+        PersistentResourceXMLBuilder xaDatasourceXMLBuilder = builder(XADataSourceDefinition.INSTANCE.getPathElement());
+        for (AttributeDefinition attributeDefinition : XADataSourceDefinition.ATTRIBUTES) {
+            xaDatasourceXMLBuilder.addAttribute(attributeDefinition);
+        }
+        subsystemXMLBuilder.addChild(xaDatasourceXMLBuilder);
+
+        PersistentResourceXMLBuilder driverXMLBuilder = PersistentResourceXMLDescription.builder(DriverDefinition.INSTANCE.getPathElement());
+        driverXMLBuilder.setXmlWrapperElement(DriverDefinition.DRIVERS_ELEMENT_NAME);
+        for (AttributeDefinition attributeDefinition : DriverDefinition.ATTRIBUTES) {
+            driverXMLBuilder.addAttribute(attributeDefinition);
+        }
+        subsystemXMLBuilder.addChild(driverXMLBuilder);
+
+        XML_DESCRIPTION = subsystemXMLBuilder.build();
+    }
+
+    private AgroalSubsystemParser_2_0() {
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return XML_DESCRIPTION;
+    }
+}

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalTransformers.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/AgroalTransformers.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.datasources.agroal;
+
+import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
+import static org.jboss.as.controller.security.CredentialReference.CLEAR_TEXT;
+import static org.jboss.as.controller.security.CredentialReference.STORE;
+import static org.wildfly.extension.datasources.agroal.AbstractDataSourceDefinition.CONNECTION_FACTORY_ATTRIBUTE;
+import static org.wildfly.extension.datasources.agroal.AbstractDataSourceDefinition.CREDENTIAL_REFERENCE;
+
+import java.util.Map;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
+
+public class AgroalTransformers implements ExtensionTransformerRegistration {
+
+    static final ModelVersion AGROAL_1_0 = ModelVersion.create(1, 0, 0);
+    static final ModelVersion AGROAL_2_0 = ModelVersion.create(2, 0, 0);
+
+    @Override
+    public String getSubsystemName() {
+        return AgroalExtension.SUBSYSTEM_NAME;
+    }
+
+    @Override
+    public void registerTransformers(SubsystemTransformerRegistration registration) {
+        ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
+
+        // 2.0.0 (WildFly 18) to 1.0.0 (WildFly 17)
+        from2(chainedBuilder);
+
+        chainedBuilder.buildAndRegister(registration, new ModelVersion[] { AGROAL_1_0 });
+
+    }
+
+    private static void from2(ChainedTransformationDescriptionBuilder chainedBuilder) {
+        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(AGROAL_2_0, AGROAL_1_0);
+
+        ResourceTransformationDescriptionBuilder datasourceBuilder = builder.addChildResource(PathElement.pathElement("datasource"));
+        datasourceBuilder
+                .getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CONNECTION_FACTORY_ATTRIBUTE)
+                .end();
+        ResourceTransformationDescriptionBuilder xaDatasourceBuilder = builder.addChildResource(PathElement.pathElement("xa-datasource"));
+        xaDatasourceBuilder
+                .getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, CONNECTION_FACTORY_ATTRIBUTE)
+                .end();
+    }
+
+    private static final RejectAttributeChecker REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT = new RejectAttributeChecker.DefaultRejectAttributeChecker() {
+
+        @Override
+        public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
+            return ROOT_LOGGER.invalidAttributeValue(CLEAR_TEXT).getMessage();
+        }
+
+        @Override
+        protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
+            if (attributeValue.isDefined()) {
+                if (attributeValue.hasDefined(CREDENTIAL_REFERENCE.getName())) {
+                    ModelNode credentialReference = attributeValue.get(CREDENTIAL_REFERENCE.getName());
+                    String store = null;
+                    String secret = null;
+                    if (credentialReference.hasDefined(STORE)) {
+                        store = credentialReference.get(STORE).asString();
+                    }
+                    if (credentialReference.hasDefined(CLEAR_TEXT)) {
+                        secret = credentialReference.get(CLEAR_TEXT).asString();
+                    }
+                    return store != null && secret != null;
+                }
+            }
+            return false;
+        }
+    };
+}

--- a/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
+++ b/datasources-agroal/src/main/java/org/wildfly/extension/datasources/agroal/DataSourceOperations.java
@@ -21,6 +21,10 @@
  */
 package org.wildfly.extension.datasources.agroal;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
+import static org.wildfly.extension.datasources.agroal.AbstractDataSourceDefinition.CREDENTIAL_REFERENCE;
+
 import javax.transaction.TransactionSynchronizationRegistry;
 
 import io.agroal.api.configuration.supplier.AgroalConnectionFactoryConfigurationSupplier;
@@ -32,6 +36,7 @@ import org.jboss.as.controller.CapabilityServiceBuilder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
@@ -57,6 +62,11 @@ class DataSourceOperations {
 
         private DataSourceAdd() {
             super(DataSourceDefinition.ATTRIBUTES);
+        }
+
+        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws  OperationFailedException {
+            super.populateModel(context, operation, resource);
+            handleCredentialReferenceUpdate(context, resource.getModel());
         }
 
         @Override
@@ -92,6 +102,11 @@ class DataSourceOperations {
             AbstractDataSourceOperations.setupElytronSecurity(context, factoryModel, dataSourceService, serviceBuilder);
 
             serviceBuilder.install();
+        }
+
+        @Override
+        protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+            rollbackCredentialStoreUpdate(CREDENTIAL_REFERENCE, context, resource);
         }
     }
 

--- a/datasources-agroal/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/datasources-agroal/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,22 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2019, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+org.wildfly.extension.datasources.agroal.AgroalTransformers

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
@@ -21,10 +21,10 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:1.0"
-           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem" type="subsystemType"/>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
@@ -21,10 +21,10 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:2.0"
-           xmlns="urn:jboss:domain:datasources-agroal:2.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns="urn:jboss:domain:datasources-agroal:2.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="subsystemType"/>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_2_0.xsd
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:2.0"
+           xmlns="urn:jboss:domain:datasources-agroal:2.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           elementFormDefault="qualified" version="1.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+    <xs:element name="subsystem" type="subsystemType"/>
+
+    <xs:complexType name="subsystemType">
+        <xs:annotation>
+            <xs:documentation><![CDATA[ The configuration of the agroal subsystem ]]></xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="datasource" type="datasourceType">
+                    <xs:annotation>
+                        <xs:documentation><![CDATA[ A datasource ]]></xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="xa-datasource" type="xaDatasourceType">
+                    <xs:annotation>
+                        <xs:documentation><![CDATA[ A XA datasource ]]></xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="drivers" type="driversType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ List of available JDBC drivers ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- common datasource attributes -->
+
+    <xs:attributeGroup name="common-datasourceAttributes">
+        <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Name for the datasource (used for management) ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="jndi-name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ JNDI name for the datasource ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Enable statistics for this datasource ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <!-- datasource -->
+
+    <xs:complexType name="datasourceType">
+        <xs:all>
+            <xs:element name="connection-factory" type="connectionFactoryType">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Configuration for the connection factory ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="connection-pool" type="connectionPoolType">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Configuration for the connection pool ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="jta" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Enable JTA integration ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connectable" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Enable CMR (Commit Markable Resource) functionality on this datasource ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attributeGroup ref="common-datasourceAttributes"/>
+    </xs:complexType>
+
+    <!-- xa-datasource -->
+
+    <xs:complexType name="xaDatasourceType">
+        <xs:all>
+            <xs:element name="connection-factory" type="connectionFactoryType">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Configuration for the connection factory ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="connection-pool" type="connectionPoolType">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Configuration for the connection pool ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attributeGroup ref="common-datasourceAttributes"/>
+    </xs:complexType>
+
+    <!-- connection-factory -->
+
+    <xs:complexType name="connectionFactoryType">
+        <xs:all>
+            <xs:element name="connection-properties" type="connectionPropertiesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Properties for the JDBC driver ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Access to credentials defined through CredentialStorage. Alternative to username / password. ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="driver" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Unique reference to the JDBC driver ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ JDBC driver connection URL (e.g. "jdbc:h2:tcp://localhost:1234") ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transaction-isolation" type="transactionIsolationType">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Set the java.sql.Connection transaction isolation level to use ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="new-connection-sql" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ SQL statement to be executed on a connection after creation ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Username to use for basic authentication with the database ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="password" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Password to use for basic authentication with the database ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-context" type="xs:token">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Reference to a authentication context in Elytron. Alternative to username / password. ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="transactionIsolationType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[ Define constants used as the possible transaction isolation levels in transaction-isolation type ]>
+                <![CDATA[ Include: NONE, READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="READ_UNCOMMITTED"/>
+            <xs:enumeration value="READ_COMMITTED"/>
+            <xs:enumeration value="REPEATABLE_READ"/>
+            <xs:enumeration value="SERIALIZABLE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- connection-factory features -->
+
+    <xs:complexType name="connectionPropertiesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="connectionPropertyType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[ Properties to be passed to the JDBC driver when creating a connection ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="connectionPropertyType">
+        <xs:attribute name="name" type="xs:token" use="required"/>
+        <xs:attribute name="value" type="xs:token" use="required"/>
+    </xs:complexType>
+
+    <!-- connection-pool -->
+
+    <xs:complexType name="connectionPoolType">
+        <xs:attribute name="max-size" type="xs:nonNegativeInteger" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Maximum number of connections in the pool ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="min-size" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Minimum number of connections the pool should hold ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-size" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Initial number of connections the pool should hold ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="blocking-timeout" type="xs:nonNegativeInteger" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Maximum time in milliseconds to block while waiting for a connection before throwing an exception ]]>
+                    <![CDATA[ This will never throw an exception if creating a new connection takes an inordinately long period of time ]]>
+                    <![CDATA[ Default is 0 meaning that a call will wait indefinitely ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="background-validation" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Time in milliseconds between background validation runs ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="leak-detection" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Time in milliseconds a connection has to be held before a leak warning ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="idle-removal" type="xs:nonNegativeInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Time in minutes a connection has to be idle before it can be removed ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- drivers -->
+
+    <xs:complexType name="driversType">
+        <xs:sequence>
+            <xs:element name="driver" type="driverType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation><![CDATA[ Reference to a JDBC driver class ]]></xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="driverType">
+        <xs:attribute name="name" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Symbolic name of this JDBC driver (used to reference this driver) ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:token" use="required">
+            <xs:annotation>
+                <xs:documentation><![CDATA[ Name of module providing this driver ]]></xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="class" type="xs:token">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Fully qualified name of the connection provider class (either java.sql.Driver class (e.g. "org.h2.Driver"), javax.sql.DataSource or javax.sql.XADataSource) ]]>
+                    <![CDATA[ If this property is not set, the subsystem will try to load the driver using ServiceLoader ]]>
+                    <![CDATA[ XADataSource is required for xa-datasource ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/AgroalTransformersTestCase.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.datasources.agroal;
+
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_2_0;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.extension.datasources.agroal.AgroalTransformers.AGROAL_1_0;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+public class AgroalTransformersTestCase extends AbstractSubsystemBaseTest {
+    public AgroalTransformersTestCase() {
+        super(AgroalExtension.SUBSYSTEM_NAME, new AgroalExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("agroal_2_0-transformers.xml");
+    }
+
+    protected String getSubsystemXml(final String subsystemFile) throws IOException {
+        return readResource(subsystemFile);
+    }
+
+    @Test
+    public void testTransformerEAP720() throws Exception {
+        testTransformation(EAP_7_2_0, AGROAL_1_0);
+    }
+
+    @Test
+    public void testRejectingTransformersEAP_7_2_0() throws Exception {
+        PathAddress address = PathAddress.pathAddress(ModelDescriptionConstants.SUBSYSTEM, AgroalExtension.SUBSYSTEM_NAME);
+        testRejectingTransformers(EAP_7_2_0, AGROAL_1_0, "agroal_2_0-reject.xml", new FailedOperationTransformationConfig()
+                .addFailedAttribute(address.append(PathElement.pathElement("datasource", "datasource1")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(address.append(PathElement.pathElement("xa-datasource", "datasource2")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+        );
+    }
+
+    private KernelServices buildKernelServices(ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {
+        return this.buildKernelServices(this.getSubsystemXml(), controllerVersion, version, mavenResourceURLs);
+    }
+
+    private KernelServices buildKernelServices(String xml, ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {
+        KernelServicesBuilder builder = this.createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(xml);
+
+        builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
+                .addMavenResourceURL(mavenResourceURLs)
+                .skipReverseControllerCheck()
+                .dontPersistXml();
+
+        KernelServices services = builder.build();
+        assertTrue(ModelTestControllerVersion.MASTER + " boot failed", services.isSuccessfulBoot());
+        assertTrue(controllerVersion.getMavenGavVersion() + " boot failed", services.getLegacyServices(version).isSuccessfulBoot());
+        return services;
+    }
+
+    private static String getGav(final ModelTestControllerVersion controller){
+        if (controller.isEap()) {
+            return "org.jboss.eap:wildfly-datasources-agroal:" + controller.getMavenGavVersion();
+        }
+        return "org.wildfly:wildfly-datasources-agroal:" + controller.getMavenGavVersion();
+    }
+
+    private void testTransformation(final ModelTestControllerVersion controller, ModelVersion version) throws Exception {
+        KernelServices services = this.buildKernelServices(controller, version, getGav(controller));
+        checkSubsystemModelTransformation(services, version, null, false);
+        ModelNode transformed = services.readTransformedModel(version);
+        assertNotNull(transformed);
+    }
+
+    private void testRejectingTransformers(ModelTestControllerVersion controllerVersion, ModelVersion version, final String subsystemXmlFile, final FailedOperationTransformationConfig config) throws Exception {
+        KernelServicesBuilder builder = this.createKernelServicesBuilder(createAdditionalInitialization());
+        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, version)
+                .addMavenResourceURL(getGav(controllerVersion))
+                .dontPersistXml();
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        assertTrue(mainServices.getLegacyServices(version).isSuccessfulBoot());
+
+        List<ModelNode> ops = builder.parseXmlResource(subsystemXmlFile);
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version, ops, config);
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        // Create a AdditionalInitialization.MANAGEMENT variant that has all the external capabilities used by the various configs used in this test class
+        return AdditionalInitialization.withCapabilities(
+                AbstractDataSourceDefinition.AUTHENTICATION_CONTEXT_CAPABILITY + ".secure-context",
+                CredentialReference.CREDENTIAL_STORE_CAPABILITY + ".test-store"
+        );
+    }
+
+    @Override
+    public void testSchema() throws Exception {
+        //
+    }
+}

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemBaseParsingTestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemBaseParsingTestCase.java
@@ -45,6 +45,6 @@ public class SubsystemBaseParsingTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-agroal_1_0.xsd";
+        return "schema/wildfly-agroal_2_0.xsd";
     }
 }

--- a/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemFullParsing10TestCase.java
+++ b/datasources-agroal/src/test/java/org/wildfly/extension/datasources/agroal/SubsystemFullParsing10TestCase.java
@@ -38,9 +38,9 @@ import static org.jboss.as.subsystem.test.AdditionalInitialization.MANAGEMENT;
  *
  * @author <a href="lbarreiro@redhat.com">Luis Barreiro</a>
  */
-public class SubsystemFullParsingTestCase extends AbstractSubsystemTest {
+public class SubsystemFullParsing10TestCase extends AbstractSubsystemTest {
 
-    public SubsystemFullParsingTestCase() {
+    public SubsystemFullParsing10TestCase() {
         super(AgroalExtension.SUBSYSTEM_NAME, new AgroalExtension());
     }
 
@@ -56,8 +56,8 @@ public class SubsystemFullParsingTestCase extends AbstractSubsystemTest {
      * Tests that the xml is parsed into the correct operations
      */
     @Test
-    public void testParseSubsystem() throws Exception {
-        parseXmlResource("agroal_2_0-full.xml");
+    public void testParse_1_0_Subsystem() throws Exception {
+        parseXmlResource("agroal_1_0-full.xml");
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-full.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-full.xml
@@ -1,0 +1,33 @@
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
+    <datasource name="sample" jndi-name="java:jboss/datasources/ExampleDS" jta="false" connectable="true" statistics-enabled="true">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" transaction-isolation="SERIALIZABLE" new-connection-sql="SELECT 1" username="sa" password="sa">
+            <connection-properties>
+                <property name="someProperty" value="someValue"/>
+                <property name="sneakySecond" value="veryFunny"/>
+            </connection-properties>
+        </connection-factory>
+        <connection-pool max-size="30" min-size="10" initial-size="20" blocking-timeout="1000" background-validation="6000" leak-detection="5000" idle-removal="5"/>
+    </datasource>
+    <datasource name="minimal" jndi-name="java:jboss/datasources/MinimalDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701"/>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <datasource name="elytron" jndi-name="java:jboss/datasources/ElytronDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" authentication-context="secure-context">
+            <credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential" />
+        </connection-factory>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <xa-datasource name="sample-xa" jndi-name="java:jboss/datasources/ExampleXADS" statistics-enabled="true">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" transaction-isolation="REPEATABLE_READ" new-connection-sql="SELECT 1" username="sa" password="sa">
+            <connection-properties>
+                <property name="anotherProperty" value="anotherValue"/>
+            </connection-properties>
+        </connection-factory>
+        <connection-pool initial-size="5" min-size="1" max-size="10" blocking-timeout="2000" background-validation="8000" leak-detection="7000" idle-removal="7"/>
+    </xa-datasource>
+    <drivers>
+        <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>
+        <driver name="h2-xa" module="com.h2database.h2" class="org.h2.jdbcx.JdbcDataSource"/>
+    </drivers>
+</subsystem>

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-reject.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-reject.xml
@@ -1,0 +1,25 @@
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
+    <datasource name="datasource1" jndi-name="java:jboss/datasources/ElytronDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" authentication-context="secure-context">
+            <credential-reference store="test-store" clear-text="pass" type="org.wildfly.security.credential.PasswordCredential" />
+        </connection-factory>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <datasource name="minimal" jndi-name="java:jboss/datasources/MinimalDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701"/>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <xa-datasource name="datasource2" jndi-name="java:jboss/datasources/ExampleXADS" statistics-enabled="true">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" transaction-isolation="REPEATABLE_READ" new-connection-sql="SELECT 1" authentication-context="secure-context">
+            <credential-reference store="test-store" clear-text="xa-pass" type="org.wildfly.security.credential.PasswordCredential" />
+            <connection-properties>
+                <property name="anotherProperty" value="anotherValue"/>
+            </connection-properties>
+        </connection-factory>
+        <connection-pool initial-size="5" min-size="1" max-size="10" blocking-timeout="2000" background-validation="8000" leak-detection="7000" idle-removal="7"/>
+    </xa-datasource>
+    <drivers>
+        <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>
+        <driver name="h2-xa" module="com.h2database.h2" class="org.h2.jdbcx.JdbcDataSource"/>
+    </drivers>
+</subsystem>

--- a/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-transformers.xml
+++ b/datasources-agroal/src/test/resources/org/wildfly/extension/datasources/agroal/agroal_2_0-transformers.xml
@@ -1,0 +1,33 @@
+<subsystem xmlns="urn:jboss:domain:datasources-agroal:2.0">
+    <datasource name="sample" jndi-name="java:jboss/datasources/ExampleDS" jta="false" connectable="true" statistics-enabled="true">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" transaction-isolation="SERIALIZABLE" new-connection-sql="SELECT 1" username="sa" password="sa">
+            <connection-properties>
+                <property name="someProperty" value="someValue"/>
+                <property name="sneakySecond" value="veryFunny"/>
+            </connection-properties>
+        </connection-factory>
+        <connection-pool max-size="30" min-size="10" initial-size="20" blocking-timeout="1000" background-validation="6000" leak-detection="5000" idle-removal="5"/>
+    </datasource>
+    <datasource name="minimal" jndi-name="java:jboss/datasources/MinimalDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701"/>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <datasource name="elytron" jndi-name="java:jboss/datasources/ElytronDS">
+        <connection-factory driver="h2" url="jdbc:h2:tcp://localhost:1701" authentication-context="secure-context">
+            <credential-reference store="test-store" alias="another" type="org.wildfly.security.credential.PasswordCredential" />
+        </connection-factory>
+        <connection-pool max-size="30"/>
+    </datasource>
+    <xa-datasource name="sample-xa" jndi-name="java:jboss/datasources/ExampleXADS" statistics-enabled="true">
+        <connection-factory driver="h2-xa" url="jdbc:h2:tcp://localhost:1702" transaction-isolation="REPEATABLE_READ" new-connection-sql="SELECT 1" username="sa" password="sa">
+            <connection-properties>
+                <property name="anotherProperty" value="anotherValue"/>
+            </connection-properties>
+        </connection-factory>
+        <connection-pool initial-size="5" min-size="1" max-size="10" blocking-timeout="2000" background-validation="8000" leak-detection="7000" idle-removal="7"/>
+    </xa-datasource>
+    <drivers>
+        <driver name="h2" module="com.h2database.h2" class="org.h2.Driver"/>
+        <driver name="h2-xa" module="com.h2database.h2" class="org.h2.jdbcx.JdbcDataSource"/>
+    </drivers>
+</subsystem>

--- a/dist-legacy/pom.xml
+++ b/dist-legacy/pom.xml
@@ -183,6 +183,10 @@
                             <!-- Parameters to test cases. -->
                             <systemPropertyVariables combine.children="append">
                                 <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
+                                <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                                <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                                <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                                <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/dist-legacy/pom.xml
+++ b/dist-legacy/pom.xml
@@ -183,10 +183,6 @@
                             <!-- Parameters to test cases. -->
                             <systemPropertyVariables combine.children="append">
                                 <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
-                                <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
-                                <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
-                                <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
-                                <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -169,6 +169,10 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
+                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -169,10 +169,6 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
-                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
-                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
-                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
-                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
+++ b/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
@@ -189,6 +189,68 @@ To reference a credential from the previously defined credential store the follo
 {"outcome" => "success"}
 ----
 
+The above command assumes that the referenced credential already exists in the previously defined credential store.
+The next section will describe how credentials can automatically be added to the previously defined credential store.
+
+=== Automatic Updates of Credential Stores
+
+Instead of needing to add a credential to a previously defined credential store in order to reference it from a `credential-reference`,
+it is possible to have the credential get added automatically to the previously defined credential store by specifying both
+the `store` and `clear-text` attributes for the `credential-reference`. In particular, when adding a new `credential-reference`
+with both the `store` and `clear-text` attributes specified:
+
+* If the `alias` attribute is also specified, then one of the following will then occur:
+** If the previously defined credential store does not contain an entry for the given alias, a new entry will be added
+to the credential store to hold the clear text password that was specified. The `clear-text` attribute will then be
+removed from the management model.
+** If the credential store does contain an entry for the given alias, the existing credential will be replaced with the
+clear text password that was specified. The `clear-text` attribute will then be removed from the management model.
+* If the `alias` attribute is not specified, an alias will be generated and a new entry will be added to the credential
+store to hold the clear text password that was specified. The `clear-text` attribute will then be removed from the
+management model.
+
+As an example, the following CLI command will result in a new entry being added to the previously defined credential
+store, `mycredstore`, with alias `myNewAlias` and credential `myNewPassword`:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/key-store=exampleKS:add(relative-to=jboss.server.config.dir, path=example.keystore, type=JCEKS, credential-reference={store=mycredstore, alias=myNewAlias, clear-text=myNewPassword})
+{
+    "outcome" => "success",
+    "result" => {"credential-store-update" => {
+        "status" => "new-entry-added",
+        "new-alias" => "myNewAlias"
+    }}
+}
+----
+
+When updating an existing `credential-reference` that contains both the `alias` and `store` attributes to also specify
+the `clear-text` attribute:
+
+* The existing credential in the previously defined credential store will be replaced with the clear text password that
+was specified. The `clear-text` attribute will then be removed from the management model.
+
+As an example, the following CLI command will result in updating the credential for the `myNewAlias` entry that was just
+added to the previously defined credential store:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/key-store=exampleKS:write-attribute(name=credential-reference.clear-text,value=myUpdatedPassword)
+{
+    "outcome" => "success",
+    "result" => {"credential-store-update" => {"status" => "existing-entry-updated"}},
+    "response-headers" => {
+        "operation-requires-reload" => true,
+        "process-state" => "reload-required"
+    }
+}
+----
+
+NOTE: If an operation that includes a ```credential-reference``` parameter fails for any reason,
+      no automatic credential store update will take place, i.e., any credential store that was
+      specified via the ```credential-reference``` attribute will contain the same contents as it
+      did before the operation was executed.
+
 === wildfly-config.xml
 
 If you are making use of the `wildfly-config.xml` descriptor it is also possible to define a credential store within this descriptor to obtain credentials without requiring them to be in-lined within the configuration.

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -162,6 +162,10 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
+                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -162,10 +162,6 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
-                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
-                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
-                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
-                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailExtension.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailExtension.java
@@ -60,9 +60,10 @@ public class MailExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_1_2.getUriString(), MailSubsystemParser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_2_0.getUriString(), MailSubsystemParser2_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_3_0.getUriString(), MailSubsystemParser3_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_4_0.getUriString(), MailSubsystemParser4_0::new);
     }
 
-    static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(3, 0, 0);
+    static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(4, 0, 0);
 
 
     @Override
@@ -72,7 +73,7 @@ public class MailExtension implements Extension {
         final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(MailSubsystemResource.INSTANCE);
         subsystemRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        subsystem.registerXMLElementWriter(new MailSubsystemParser3_0());
+        subsystem.registerXMLElementWriter(new MailSubsystemParser4_0());
     }
 
 }

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailServerAdd.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailServerAdd.java
@@ -22,11 +22,15 @@
 
 package org.jboss.as.mail.extension;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentResourceAddHandler;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
@@ -57,6 +61,19 @@ class MailServerAdd extends RestartParentResourceAddHandler {
         for (AttributeDefinition def : attributes) {
             def.validateAndSet(operation, model);
         }
+    }
+
+    @Override
+    protected void updateModel(OperationContext context, ModelNode operation) throws OperationFailedException {
+        final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
+        populateModel(operation, resource.getModel());
+        handleCredentialReferenceUpdate(context, resource.getModel());
+        recordCapabilitiesAndRequirements(context, operation, resource);
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+        rollbackCredentialStoreUpdate(MailServerDefinition.CREDENTIAL_REFERENCE, context, resource);
     }
 
     @Override

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSessionAdd.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.mail.extension;
 
+import static org.jboss.as.controller.security.CredentialReference.KEY_DELIMITER;
 import static org.jboss.as.mail.extension.MailServerDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME;
 import static org.jboss.as.mail.extension.MailSessionDefinition.ATTRIBUTES;
 import static org.jboss.as.mail.extension.MailSessionDefinition.SESSION_CAPABILITY;
@@ -101,10 +102,11 @@ class MailSessionAdd extends AbstractAddStepHandler {
                 }
             }
             ModelNode value = MailServerDefinition.CREDENTIAL_REFERENCE.resolveModelAttribute(context, filteredModelNode);
+            String keySuffix = modelFilter[0] + KEY_DELIMITER + modelFilter[1];
             if (value.isDefined()) {
                 serverConfig.getCredentialSourceSupplierInjector()
                         .inject(
-                                CredentialReference.getCredentialSourceSupplier(context, MailServerDefinition.CREDENTIAL_REFERENCE, filteredModelNode, serviceBuilder));
+                                CredentialReference.getCredentialSourceSupplier(context, MailServerDefinition.CREDENTIAL_REFERENCE, filteredModelNode, serviceBuilder, keySuffix));
             }
         }
     }

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser4_0.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser4_0.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2013, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.jboss.as.mail.extension;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+/**
+ * @author Tomaz Cerar (c) 2017 Red Hat Inc.
+ */
+class MailSubsystemParser4_0 extends PersistentResourceXMLParser {
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return builder(MailSubsystemResource.INSTANCE.getPathElement(), Namespace.MAIL_4_0.getUriString())
+                .addChild(
+                        builder(MailSessionDefinition.INSTANCE.getPathElement())
+                                .addAttributes(MailSessionDefinition.DEBUG, MailSessionDefinition.JNDI_NAME, MailSessionDefinition.FROM)
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_SMTP.getPathElement())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD, MailServerDefinition.CREDENTIAL_REFERENCE)
+                                                .setXmlElementName(MailSubsystemModel.SMTP_SERVER)
+
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_POP3.getPathElement())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD, MailServerDefinition.CREDENTIAL_REFERENCE)
+                                                .setXmlElementName(MailSubsystemModel.POP3_SERVER)
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_IMAP.getPathElement())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD, MailServerDefinition.CREDENTIAL_REFERENCE)
+                                                .setXmlElementName(MailSubsystemModel.IMAP_SERVER)
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_CUSTOM.getPathElement())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF_OPTIONAL, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD, MailServerDefinition.CREDENTIAL_REFERENCE, MailServerDefinition.PROPERTIES)
+                                                .setXmlElementName(MailSubsystemModel.CUSTOM_SERVER)
+                                )
+                )
+                .build();
+    }
+}

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailTransformers.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailTransformers.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.mail.extension;
 
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
 import static org.jboss.as.mail.extension.MailExtension.CURRENT_MODEL_VERSION;
 import static org.jboss.as.mail.extension.MailExtension.MAIL_SESSION_PATH;
 import static org.jboss.as.mail.extension.MailSubsystemModel.CUSTOM_SERVER_PATH;
@@ -42,6 +43,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 public class MailTransformers implements ExtensionTransformerRegistration {
     static final ModelVersion MODEL_VERSION_EAP6X = ModelVersion.create(1, 3, 0); //EAP6.2,6.3 & 6.4 have version 1.3.0
     static final ModelVersion MODEL_VERSION_EAP70 = ModelVersion.create(2, 0, 0);
+    static final ModelVersion MODEL_VERSION_EAP71 = ModelVersion.create(3, 0, 0);
 
     @Override
     public String getSubsystemName() {
@@ -52,8 +54,19 @@ public class MailTransformers implements ExtensionTransformerRegistration {
     public void registerTransformers(SubsystemTransformerRegistration subsystem) {
         ChainedTransformationDescriptionBuilder chained = ResourceTransformationDescriptionBuilder.Factory.createChainedSubystemInstance(CURRENT_MODEL_VERSION);
 
+        ResourceTransformationDescriptionBuilder builder71 = chained.createBuilder(CURRENT_MODEL_VERSION, MODEL_VERSION_EAP71);
+        ResourceTransformationDescriptionBuilder sessionBuilder71 = builder71.addChildResource(MAIL_SESSION_PATH);
+        sessionBuilder71.addChildResource(PathElement.pathElement(SERVER_TYPE))
+                .getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, MailServerDefinition.CREDENTIAL_REFERENCE)
+                .end();
+        sessionBuilder71.addChildResource(CUSTOM_SERVER_PATH)
+                .getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, MailServerDefinition.CREDENTIAL_REFERENCE)
+                .end();
 
-        ResourceTransformationDescriptionBuilder builder70 = chained.createBuilder(CURRENT_MODEL_VERSION, MODEL_VERSION_EAP70);
+
+        ResourceTransformationDescriptionBuilder builder70 = chained.createBuilder(MODEL_VERSION_EAP71, MODEL_VERSION_EAP70);
         ResourceTransformationDescriptionBuilder sessionBuilder70 = builder70.addChildResource(MAIL_SESSION_PATH);
         sessionBuilder70.addChildResource(PathElement.pathElement(SERVER_TYPE))
                     .getAttributeBuilder()
@@ -70,6 +83,6 @@ public class MailTransformers implements ExtensionTransformerRegistration {
         chained.createBuilder(MODEL_VERSION_EAP70, MODEL_VERSION_EAP6X);
 
 
-        chained.buildAndRegister(subsystem, new ModelVersion[]{MODEL_VERSION_EAP70, MODEL_VERSION_EAP6X});
+        chained.buildAndRegister(subsystem, new ModelVersion[]{MODEL_VERSION_EAP71, MODEL_VERSION_EAP70, MODEL_VERSION_EAP6X});
     }
 }

--- a/mail/src/main/java/org/jboss/as/mail/extension/Namespace.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/Namespace.java
@@ -36,12 +36,13 @@ enum Namespace {
     MAIL_1_1("urn:jboss:domain:mail:1.1"),
     MAIL_1_2("urn:jboss:domain:mail:1.2"),
     MAIL_2_0("urn:jboss:domain:mail:2.0"),
-    MAIL_3_0("urn:jboss:domain:mail:3.0");
+    MAIL_3_0("urn:jboss:domain:mail:3.0"),
+    MAIL_4_0("urn:jboss:domain:mail:4.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = MAIL_3_0;
+    public static final Namespace CURRENT = MAIL_4_0;
 
     private final String name;
 

--- a/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
@@ -26,13 +26,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:3.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            targetNamespace="urn:jboss:domain:mail:3.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <!-- The mail subsystem root element -->
     <xs:element name="subsystem" type="mail-subsystemType"/>

--- a/mail/src/main/resources/schema/wildfly-mail_4_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_4_0.xsd
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:mail:4.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           targetNamespace="urn:jboss:domain:mail:4.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+    <!-- The mail subsystem root element -->
+    <xs:element name="subsystem" type="mail-subsystemType"/>
+    <xs:complexType name="mail-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the mail subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="mail-session" type="mail-sessionType"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="mail-sessionType">
+        <xs:sequence>
+            <xs:element name="smtp-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="pop3-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="imap-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="custom-server" type="custom-server-type" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="jndi-name" use="required" type="xs:string"/>
+        <xs:attribute name="debug" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       enables debuging of mail session
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="from" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                            sets mail.from attribute
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="server-type" mixed="true">
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="outbound-socket-binding-ref" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Reference to the outbound-socket-binding element in the socket-binding-group that should
+                    be used for configuring the client socket used to communicate with the mail server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of ssl for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tls" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of tls for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string" use="optional"/>
+        <xs:attribute name="password" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="property-type">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+
+
+    <xs:complexType name="custom-server-type" mixed="true">
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="property" type="property-type" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="outbound-socket-binding-ref" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Reference to the outbound-socket-binding element in the socket-binding-group that should
+                    be used for configuring the client socket used to communicate with the mail server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of ssl for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tls" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of tls for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string" use="optional"/>
+        <xs:attribute name="password" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/mail/src/main/resources/schema/wildfly-mail_4_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_4_0.xsd
@@ -26,13 +26,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:4.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:mail:4.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <!-- The mail subsystem root element -->
     <xs:element name="subsystem" type="mail-subsystemType"/>

--- a/mail/src/main/resources/subsystem-templates/mail.xml
+++ b/mail/src/main/resources/subsystem-templates/mail.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.mail</extension-module>
-   <subsystem xmlns="urn:jboss:domain:mail:3.0">
+   <subsystem xmlns="urn:jboss:domain:mail:4.0">
        <mail-session name="default" jndi-name="java:jboss/mail/Default">
            <smtp-server outbound-socket-binding-ref="mail-smtp"/>
        </mail-session>

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem40TestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem40TestCase.java
@@ -39,19 +39,32 @@ import org.junit.Test;
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
-public class MailSubsystem30TestCase extends MailSubsystemTestBase {
-    public MailSubsystem30TestCase() {
+public class MailSubsystem40TestCase extends MailSubsystemTestBase {
+    public MailSubsystem40TestCase() {
         super(MailExtension.SUBSYSTEM_NAME, new MailExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_3_0.xml");
+        return readResource("subsystem_4_0.xml");
     }
 
     @Override
-    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
-        return super.standardSubsystemTest(configId, false);
+    protected String getSubsystemXsdPath() throws Exception {
+        return "schema/wildfly-mail_4_0.xsd";
+    }
+
+    @Override
+    protected String[] getSubsystemTemplatePaths() throws IOException {
+        return new String[]{
+                "/subsystem-templates/mail.xml"
+        };
+    }
+
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 
     @Test

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailTransformersTestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailTransformersTestCase.java
@@ -57,7 +57,7 @@ public class MailTransformersTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("mail_3_0-transformers.xml");
+        return readResource("mail_4_0-transformers.xml");
     }
 
     @Test
@@ -124,7 +124,7 @@ public class MailTransformersTestCase extends AbstractSubsystemBaseTest {
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(targetVersion).isSuccessfulBoot());
 
-        List<ModelNode> ops = builder.parseXmlResource("mail_3_0-reject.xml");
+        List<ModelNode> ops = builder.parseXmlResource("mail_4_0-reject.xml");
         PathAddress sessionAddress = PathAddress.pathAddress(MailExtension.SUBSYSTEM_PATH).append(MailExtension.MAIL_SESSION_PATH);
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, targetVersion, ops, new FailedOperationTransformationConfig()
                         .addFailedAttribute(sessionAddress.append("server"),

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailTransformersTestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailTransformersTestCase.java
@@ -25,8 +25,10 @@ package org.jboss.as.mail.extension;
 import static org.jboss.as.mail.extension.MailServerDefinition.CREDENTIAL_REFERENCE;
 import static org.jboss.as.mail.extension.MailTransformers.MODEL_VERSION_EAP6X;
 import static org.jboss.as.mail.extension.MailTransformers.MODEL_VERSION_EAP70;
+import static org.jboss.as.mail.extension.MailTransformers.MODEL_VERSION_EAP71;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_4_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_0_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_1_0;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -35,6 +37,7 @@ import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -58,6 +61,11 @@ public class MailTransformersTestCase extends AbstractSubsystemBaseTest {
     @Override
     protected String getSubsystemXml() throws IOException {
         return readResource("mail_4_0-transformers.xml");
+    }
+
+    @Test
+    public void testTransformerEAP710() throws Exception {
+        testTransformation(EAP_7_1_0, MODEL_VERSION_EAP71);
     }
 
     @Test
@@ -103,16 +111,53 @@ public class MailTransformersTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testRejectingTransformersEAP_7_1_0() throws Exception {
+        PathAddress sessionAddress = PathAddress.pathAddress(MailExtension.SUBSYSTEM_PATH);
+        testRejectingTransformers(EAP_7_1_0, MODEL_VERSION_EAP71, new FailedOperationTransformationConfig()
+                .addFailedAttribute(sessionAddress.append(PathElement.pathElement(MailSubsystemModel.MAIL_SESSION, "serverWithCredentialReference")).append(PathElement.pathElement(MailSubsystemModel.SERVER_TYPE, "imap")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(sessionAddress.append(PathElement.pathElement(MailSubsystemModel.MAIL_SESSION, "serverWithCredentialReference")).append(PathElement.pathElement(MailSubsystemModel.SERVER_TYPE, "smtp")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(sessionAddress.append(PathElement.pathElement(MailSubsystemModel.MAIL_SESSION, "serverWithCredentialReference")).append(PathElement.pathElement(MailSubsystemModel.SERVER_TYPE, "pop3")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(sessionAddress.append(PathElement.pathElement(MailSubsystemModel.MAIL_SESSION, "customWithCredentialReference")).append(PathElement.pathElement(MailSubsystemModel.CUSTOM, "pop3")),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+        );
+    }
+
+    @Test
     public void testRejectingTransformersEAP_7_0_0() throws Exception {
-        testRejectingTransformers(EAP_7_0_0, MODEL_VERSION_EAP70);
+        PathAddress sessionAddress = PathAddress.pathAddress(MailExtension.SUBSYSTEM_PATH).append(MailExtension.MAIL_SESSION_PATH);
+        testRejectingTransformers(EAP_7_0_0, MODEL_VERSION_EAP70, new FailedOperationTransformationConfig()
+                .addFailedAttribute(sessionAddress.append("server"),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(
+                                CREDENTIAL_REFERENCE
+                        )
+                ).addFailedAttribute(sessionAddress.append("custom"),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(
+                                CREDENTIAL_REFERENCE
+                        )
+                )
+        );
     }
 
     @Test
     public void testRejectingTransformersEAP_6_4_0() throws Exception {
-        testRejectingTransformers(EAP_6_4_0, MODEL_VERSION_EAP6X);
+        PathAddress sessionAddress = PathAddress.pathAddress(MailExtension.SUBSYSTEM_PATH).append(MailExtension.MAIL_SESSION_PATH);
+        testRejectingTransformers(EAP_6_4_0, MODEL_VERSION_EAP6X, new FailedOperationTransformationConfig()
+                .addFailedAttribute(sessionAddress.append("server"),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(
+                                CREDENTIAL_REFERENCE
+                        )
+                ).addFailedAttribute(sessionAddress.append("custom"),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(
+                                CREDENTIAL_REFERENCE
+                        )
+                )
+        );
     }
 
-    private void testRejectingTransformers(ModelTestControllerVersion controllerVersion, ModelVersion targetVersion) throws Exception {
+    private void testRejectingTransformers(ModelTestControllerVersion controllerVersion, ModelVersion targetVersion, final FailedOperationTransformationConfig config) throws Exception {
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, targetVersion)
@@ -125,18 +170,7 @@ public class MailTransformersTestCase extends AbstractSubsystemBaseTest {
         assertTrue(mainServices.getLegacyServices(targetVersion).isSuccessfulBoot());
 
         List<ModelNode> ops = builder.parseXmlResource("mail_4_0-reject.xml");
-        PathAddress sessionAddress = PathAddress.pathAddress(MailExtension.SUBSYSTEM_PATH).append(MailExtension.MAIL_SESSION_PATH);
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, targetVersion, ops, new FailedOperationTransformationConfig()
-                        .addFailedAttribute(sessionAddress.append("server"),
-                                new FailedOperationTransformationConfig.NewAttributesConfig(
-                                        CREDENTIAL_REFERENCE
-                                )
-                        ).addFailedAttribute(sessionAddress.append("custom"),
-                            new FailedOperationTransformationConfig.NewAttributesConfig(
-                                        CREDENTIAL_REFERENCE
-                                )
-                        )
-                );
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, targetVersion, ops, config);
     }
 
     @Override

--- a/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-reject.xml
+++ b/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-reject.xml
@@ -22,7 +22,7 @@
   ~
   -->
 
-<subsystem xmlns="urn:jboss:domain:mail:3.0">
+<subsystem xmlns="urn:jboss:domain:mail:4.0">
     <mail-session name="defaultMail" jndi-name="java:/Mail" from="user dot name at domain dot tld">
         <smtp-server outbound-socket-binding-ref="mail-smtp" tls="true" username="${exp.name:nobody}">
             <credential-reference clear-text="pass"/>

--- a/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-reject.xml
+++ b/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-reject.xml
@@ -50,4 +50,21 @@
             <property name="custom_prop" value="some-custom-prop-value"/>
         </custom-server>
     </mail-session>
+    <mail-session name="customWithCredentialReference" debug="true" jndi-name="java:jboss/mail/Custom2">
+        <custom-server name="pop3" outbound-socket-binding-ref="mail-pop3" username="user1">
+            <credential-reference store="store" clear-text="user1-pass"/>
+            <property name="custom_prop" value="some-custom-prop-value"/>
+        </custom-server>
+    </mail-session>
+    <mail-session name="serverWithCredentialReference" jndi-name="java:/Mail" from="user dot name at domain dot tld">
+        <smtp-server outbound-socket-binding-ref="mail-smtp" tls="true" username="${exp.name:nobody}">
+            <credential-reference store="store" clear-text="pass"/>
+        </smtp-server>
+        <pop3-server outbound-socket-binding-ref="mail-pop3">
+            <credential-reference store="store" clear-text="different-pass"/>
+        </pop3-server>
+        <imap-server outbound-socket-binding-ref="mail-imap" username="${exp.name:nobody}">
+            <credential-reference store="store" clear-text="different-pass"/>
+        </imap-server>
+    </mail-session>
 </subsystem>

--- a/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-transformers.xml
+++ b/mail/src/test/resources/org/jboss/as/mail/extension/mail_4_0-transformers.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:mail:3.0">
+<subsystem xmlns="urn:jboss:domain:mail:4.0">
     <mail-session name="defaultMail" jndi-name="java:/Mail" from="user dot name at domain dot tld">
         <smtp-server outbound-socket-binding-ref="mail-smtp" tls="true" username="${exp.name:nobody}" />
         <pop3-server outbound-socket-binding-ref="mail-pop3"/>

--- a/mail/src/test/resources/org/jboss/as/mail/extension/subsystem_4_0.xml
+++ b/mail/src/test/resources/org/jboss/as/mail/extension/subsystem_4_0.xml
@@ -1,0 +1,53 @@
+<!--
+  ~
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~
+  -->
+
+<subsystem xmlns="urn:jboss:domain:mail:4.0">
+    <mail-session name="defaultMail" jndi-name="java:/Mail" from="user dot name at domain dot tld">
+        <smtp-server outbound-socket-binding-ref="mail-smtp" tls="true" username="${exp.name:nobody}">
+            <credential-reference clear-text="pass"/>
+        </smtp-server>
+        <pop3-server outbound-socket-binding-ref="mail-pop3"/>
+        <imap-server outbound-socket-binding-ref="mail-imap" username="${exp.name:nobody}">
+            <credential-reference clear-text="different-pass"/>
+        </imap-server>
+    </mail-session>
+    <mail-session name="default2" debug="true" jndi-name="java:jboss/mail/Default">
+        <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+    </mail-session>
+    <mail-session name="custom" debug="true" jndi-name="java:jboss/mail/Custom">
+        <custom-server name="smtp" username="username" password="password">
+            <property name="host" value="mail.example.com"/>
+        </custom-server>
+        <custom-server name="pop3" outbound-socket-binding-ref="mail-pop3">
+            <property name="custom_prop" value="some-custom-prop-value"/>
+            <property name="some.fully.qualified.property" value="fully-qualified-prop-name"/>
+        </custom-server>
+    </mail-session>
+    <mail-session name="custom2" debug="true" jndi-name="java:jboss/mail/Custom2">
+        <custom-server name="pop3" outbound-socket-binding-ref="mail-pop3" username="user1">
+            <credential-reference clear-text="user1-pass"/>
+            <property name="custom_prop" value="some-custom-prop-value"/>
+        </custom-server>
+    </mail-session>
+</subsystem>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
@@ -22,7 +22,10 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
 import static org.wildfly.extension.messaging.activemq.BridgeDefinition.ATTRIBUTES;
+import static org.wildfly.extension.messaging.activemq.BridgeDefinition.CREDENTIAL_REFERENCE;
 import static org.wildfly.extension.messaging.activemq.BridgeDefinition.DISCOVERY_GROUP_NAME;
 import static org.wildfly.extension.messaging.activemq.BridgeDefinition.FORWARDING_ADDRESS;
 import static org.wildfly.extension.messaging.activemq.BridgeDefinition.INITIAL_CONNECT_ATTEMPTS;
@@ -46,6 +49,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -63,6 +67,12 @@ public class BridgeAdd extends AbstractAddStepHandler {
 
     private BridgeAdd() {
         super(ATTRIBUTES);
+    }
+
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws  OperationFailedException {
+        super.populateModel(context, operation, resource);
+        handleCredentialReferenceUpdate(context, resource.getModel());
     }
 
     @Override
@@ -88,6 +98,11 @@ public class BridgeAdd extends AbstractAddStepHandler {
         }
         // else the initial subsystem install is not complete; MessagingSubsystemAdd will add a
         // handler that calls addBridgeConfigs
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+        rollbackCredentialStoreUpdate(CREDENTIAL_REFERENCE, context, resource);
     }
 
     static BridgeConfiguration createBridgeConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeDefinition.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -205,9 +206,14 @@ public class BridgeDefinition extends PersistentResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration registry) {
         ReloadRequiredWriteAttributeHandler reloadRequiredWriteAttributeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+        CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(CREDENTIAL_REFERENCE);
         for (AttributeDefinition attr : ATTRIBUTES) {
             if (!attr.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME)) {
-                registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+                if (attr.equals(CREDENTIAL_REFERENCE)) {
+                    registry.registerReadWriteAttribute(attr, null, credentialReferenceWriteAttributeHandler);
+                } else {
+                    registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+                }
             }
         }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -100,13 +100,20 @@ import org.wildfly.extension.messaging.activemq.jms.ExternalPooledConnectionFact
  * Domain extension that integrates Apache ActiveMQ 6.
  *
  * <dl>
- * <dt><strong>Current</strong> - WildFly 19</dt>
+ * <dt><strong>Current</strong> - WildFly 20</dt>
  *   <dd>
  *     <ul>
- *       <li>XML namespace: urn:jboss:domain:messaging-activemq:9.0
- *       <li>Management model: 9.0.0
+ *       <li>XML namespace: urn:jboss:domain:messaging-activemq:10.0
+ *       <li>Management model: 10.0.0
  *     </ul>
  *   </dd>
+ * <dt>WildFly 19</dt>
+ *  *   <dd>
+ *  *     <ul>
+ *  *       <li>XML namespace: urn:jboss:domain:messaging-activemq:9.0
+ *  *       <li>Management model: 9.0.0
+ *  *     </ul>
+ *  *   </dd>
  * <dt>WildFly 18</dt>
  *   <dd>
  *     <ul>
@@ -220,6 +227,7 @@ public class MessagingExtension implements Extension {
 
     static final String RESOURCE_NAME = MessagingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
+    protected static final ModelVersion VERSION_10_0_0 = ModelVersion.create(10, 0, 0);
     protected static final ModelVersion VERSION_9_0_0 = ModelVersion.create(9, 0, 0);
     protected static final ModelVersion VERSION_8_0_0 = ModelVersion.create(8, 0, 0);
     protected static final ModelVersion VERSION_7_0_0 = ModelVersion.create(7, 0, 0);
@@ -229,9 +237,9 @@ public class MessagingExtension implements Extension {
     protected static final ModelVersion VERSION_3_0_0 = ModelVersion.create(3, 0, 0);
     protected static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
     protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
-    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_9_0_0;
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_10_0_0;
 
-    private static final MessagingSubsystemParser_9_0 CURRENT_PARSER = new MessagingSubsystemParser_9_0();
+    private static final MessagingSubsystemParser_10_0 CURRENT_PARSER = new MessagingSubsystemParser_10_0();
 
     // ARTEMIS-2273 introduced audit logging at a info level which is rather verbose. We need to use static loggers
     // to ensure the log levels are set to WARN and there is a strong reference to the loggers. This hack will likely
@@ -342,6 +350,7 @@ public class MessagingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_6_0.NAMESPACE, MessagingSubsystemParser_6_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_7_0.NAMESPACE, MessagingSubsystemParser_7_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_8_0.NAMESPACE, MessagingSubsystemParser_8_0::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_9_0.NAMESPACE, CURRENT_PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_9_0.NAMESPACE, MessagingSubsystemParser_9_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_10_0.NAMESPACE, CURRENT_PARSER);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_10_0.java
@@ -1,0 +1,678 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.messaging.activemq;
+
+import static org.jboss.as.controller.PathElement.pathElement;
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
+import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationMasterDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationSlaveDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreMasterDefinition;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreSlaveDefinition;
+import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
+import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
+import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
+
+/**
+ * Parser and Marshaller for messaging-activemq's {@link #NAMESPACE}.
+ *
+ * <em>All resources and attributes must be listed explicitly and not through any collections.</em>
+ * This ensures that if the resource definitions change in later version (e.g. a new attribute is added),
+ * this will have no impact on parsing this specific version of the subsystem.
+ *
+ * @author Paul Ferraro
+ */
+public class MessagingSubsystemParser_10_0 extends PersistentResourceXMLParser {
+
+    static final String NAMESPACE = "urn:jboss:domain:messaging-activemq:10.0";
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+
+        final PersistentResourceXMLBuilder jgroupDiscoveryGroup = builder(JGroupsDiscoveryGroupDefinition.PATH)
+                .addAttributes(
+                        DiscoveryGroupDefinition.JGROUPS_CHANNEL_FACTORY,
+                        DiscoveryGroupDefinition.JGROUPS_CHANNEL,
+                        CommonAttributes.JGROUPS_CLUSTER,
+                        DiscoveryGroupDefinition.REFRESH_TIMEOUT,
+                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT);
+
+        final PersistentResourceXMLBuilder socketDiscoveryGroup = builder(SocketDiscoveryGroupDefinition.PATH)
+                .addAttributes(
+                        CommonAttributes.SOCKET_BINDING,
+                        DiscoveryGroupDefinition.REFRESH_TIMEOUT,
+                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT);
+
+        final PersistentResourceXMLBuilder remoteConnector = builder(pathElement(REMOTE_CONNECTOR))
+                .addAttributes(
+                        RemoteTransportDefinition.SOCKET_BINDING,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder httpConnector = builder(MessagingExtension.HTTP_CONNECTOR_PATH)
+                .addAttributes(
+                        HTTPConnectorDefinition.SOCKET_BINDING,
+                        HTTPConnectorDefinition.ENDPOINT,
+                        HTTPConnectorDefinition.SERVER_NAME,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder invmConnector = builder(pathElement(IN_VM_CONNECTOR))
+                .addAttributes(
+                        InVMTransportDefinition.SERVER_ID,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder connector = builder(pathElement(CONNECTOR))
+                .addAttributes(
+                        GenericTransportDefinition.SOCKET_BINDING,
+                        CommonAttributes.FACTORY_CLASS,
+                        CommonAttributes.PARAMS);
+
+        return builder(MessagingExtension.SUBSYSTEM_PATH, NAMESPACE)
+                .addAttributes(
+                        MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_THREAD_POOL_MAX_SIZE,
+                        MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_SCHEDULED_THREAD_POOL_MAX_SIZE)
+                .addChild(httpConnector)
+                .addChild(remoteConnector)
+                .addChild(invmConnector)
+                .addChild(connector)
+                .addChild(jgroupDiscoveryGroup)
+                .addChild(socketDiscoveryGroup)
+                .addChild(builder(MessagingExtension.CONNECTION_FACTORY_PATH)
+                        .addAttributes(
+                                CommonAttributes.HA,
+                                ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
+                                ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                                ConnectionFactoryAttributes.Common.CONNECTORS,
+                                ConnectionFactoryAttributes.Common.ENTRIES,
+                                ConnectionFactoryAttributes.External.ENABLE_AMQ1_PREFIX,
+                                ConnectionFactoryAttributes.Common.USE_TOPOLOGY
+                        ))
+                .addChild(createPooledConnectionFactory(true))
+                .addChild(builder(MessagingExtension.EXTERNAL_JMS_QUEUE_PATH)
+                        .addAttributes(
+                                ConnectionFactoryAttributes.Common.ENTRIES
+                        ))
+                .addChild(builder(MessagingExtension.EXTERNAL_JMS_TOPIC_PATH)
+                        .addAttributes(
+                                ConnectionFactoryAttributes.Common.ENTRIES
+                        ))
+                .addChild(
+                        builder(MessagingExtension.SERVER_PATH)
+                                .addAttributes(// no attribute groups
+                                        ServerDefinition.PERSISTENCE_ENABLED,
+                                        ServerDefinition.PERSIST_ID_CACHE,
+                                        ServerDefinition.PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY,
+                                        ServerDefinition.ID_CACHE_SIZE,
+                                        ServerDefinition.PAGE_MAX_CONCURRENT_IO,
+                                        ServerDefinition.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                        ServerDefinition.THREAD_POOL_MAX_SIZE,
+                                        ServerDefinition.WILD_CARD_ROUTING_ENABLED,
+                                        ServerDefinition.CONNECTION_TTL_OVERRIDE,
+                                        ServerDefinition.ASYNC_CONNECTION_EXECUTION_ENABLED,
+                                        // security
+                                        ServerDefinition.SECURITY_ENABLED,
+                                        ServerDefinition.SECURITY_DOMAIN,
+                                        ServerDefinition.ELYTRON_DOMAIN,
+                                        ServerDefinition.SECURITY_INVALIDATION_INTERVAL,
+                                        ServerDefinition.OVERRIDE_IN_VM_SECURITY,
+                                        // cluster
+                                        ServerDefinition.CLUSTER_USER,
+                                        ServerDefinition.CLUSTER_PASSWORD,
+                                        ServerDefinition.CREDENTIAL_REFERENCE,
+                                        // management
+                                        ServerDefinition.MANAGEMENT_ADDRESS,
+                                        ServerDefinition.MANAGEMENT_NOTIFICATION_ADDRESS,
+                                        ServerDefinition.JMX_MANAGEMENT_ENABLED,
+                                        ServerDefinition.JMX_DOMAIN,
+                                        // journal
+                                        ServerDefinition.JOURNAL_TYPE,
+                                        ServerDefinition.JOURNAL_BUFFER_TIMEOUT,
+                                        ServerDefinition.JOURNAL_BUFFER_SIZE,
+                                        ServerDefinition.JOURNAL_SYNC_TRANSACTIONAL,
+                                        ServerDefinition.JOURNAL_SYNC_NON_TRANSACTIONAL,
+                                        ServerDefinition.LOG_JOURNAL_WRITE_RATE,
+                                        ServerDefinition.JOURNAL_FILE_SIZE,
+                                        ServerDefinition.JOURNAL_MIN_FILES,
+                                        ServerDefinition.JOURNAL_POOL_FILES,
+                                        ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT,
+                                        ServerDefinition.JOURNAL_COMPACT_PERCENTAGE,
+                                        ServerDefinition.JOURNAL_COMPACT_MIN_FILES,
+                                        ServerDefinition.JOURNAL_MAX_IO,
+                                        ServerDefinition.CREATE_BINDINGS_DIR,
+                                        ServerDefinition.CREATE_JOURNAL_DIR,
+                                        ServerDefinition.JOURNAL_DATASOURCE,
+                                        ServerDefinition.JOURNAL_MESSAGES_TABLE,
+                                        ServerDefinition.JOURNAL_BINDINGS_TABLE,
+                                        ServerDefinition.JOURNAL_JMS_BINDINGS_TABLE,
+                                        ServerDefinition.JOURNAL_LARGE_MESSAGES_TABLE,
+                                        ServerDefinition.JOURNAL_PAGE_STORE_TABLE,
+                                        ServerDefinition.JOURNAL_NODE_MANAGER_STORE_TABLE,
+                                        ServerDefinition.JOURNAL_DATABASE,
+                                        ServerDefinition.JOURNAL_JDBC_LOCK_EXPIRATION,
+                                        ServerDefinition.JOURNAL_JDBC_LOCK_RENEW_PERIOD,
+                                        ServerDefinition.JOURNAL_JDBC_NETWORK_TIMEOUT,
+                                        ServerDefinition.GLOBAL_MAX_DISK_USAGE,
+                                        ServerDefinition.DISK_SCAN_PERIOD,
+                                        ServerDefinition.GLOBAL_MAX_MEMORY_SIZE,
+                                        // statistics
+                                        ServerDefinition.STATISTICS_ENABLED,
+                                        ServerDefinition.MESSAGE_COUNTER_SAMPLE_PERIOD,
+                                        ServerDefinition.MESSAGE_COUNTER_MAX_DAY_HISTORY,
+                                        // transaction
+                                        ServerDefinition.TRANSACTION_TIMEOUT,
+                                        ServerDefinition.TRANSACTION_TIMEOUT_SCAN_PERIOD,
+                                        // message expiry
+                                        ServerDefinition.MESSAGE_EXPIRY_SCAN_PERIOD,
+                                        ServerDefinition.MESSAGE_EXPIRY_THREAD_PRIORITY,
+                                        // debug
+                                        ServerDefinition.PERF_BLAST_PAGES,
+                                        ServerDefinition.RUN_SYNC_SPEED_TEST,
+                                        ServerDefinition.SERVER_DUMP_INTERVAL,
+                                        ServerDefinition.MEMORY_MEASURE_INTERVAL,
+                                        ServerDefinition.MEMORY_WARNING_THRESHOLD,
+                                        CommonAttributes.INCOMING_INTERCEPTORS,
+                                        CommonAttributes.OUTGOING_INTERCEPTORS)
+                                .addChild(
+                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(ReplicationMasterDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.CLUSTER_NAME,
+                                                        HAAttributes.GROUP_NAME,
+                                                        HAAttributes.CHECK_FOR_LIVE_SERVER,
+                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT))
+                                .addChild(
+                                        builder(ReplicationSlaveDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.CLUSTER_NAME,
+                                                        HAAttributes.GROUP_NAME,
+                                                        HAAttributes.ALLOW_FAILBACK,
+                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT,
+                                                        HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE,
+                                                        HAAttributes.RESTART_BACKUP,
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.REQUEST_BACKUP,
+                                                        HAAttributes.BACKUP_REQUEST_RETRIES,
+                                                        HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL,
+                                                        HAAttributes.MAX_BACKUPS,
+                                                        HAAttributes.BACKUP_PORT_OFFSET,
+                                                        HAAttributes.EXCLUDED_CONNECTORS)
+                                                .addChild(
+                                                        builder(ReplicationMasterDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.CLUSTER_NAME,
+                                                                        HAAttributes.GROUP_NAME,
+                                                                        HAAttributes.CHECK_FOR_LIVE_SERVER,
+                                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT))
+                                                .addChild(
+                                                        builder(ReplicationSlaveDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.CLUSTER_NAME,
+                                                                        HAAttributes.GROUP_NAME,
+                                                                        HAAttributes.ALLOW_FAILBACK,
+                                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT,
+                                                                        HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE,
+                                                                        HAAttributes.RESTART_BACKUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
+                                .addChild(
+                                        builder(SharedStoreMasterDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
+                                .addChild(
+                                        builder(SharedStoreSlaveDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.ALLOW_FAILBACK,
+                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
+                                                        HAAttributes.RESTART_BACKUP,
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.REQUEST_BACKUP,
+                                                        HAAttributes.BACKUP_REQUEST_RETRIES,
+                                                        HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL,
+                                                        HAAttributes.MAX_BACKUPS,
+                                                        HAAttributes.BACKUP_PORT_OFFSET)
+                                                .addChild(
+                                                        builder(SharedStoreMasterDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
+                                                .addChild(
+                                                        builder(SharedStoreSlaveDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.ALLOW_FAILBACK,
+                                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
+                                                                        HAAttributes.RESTART_BACKUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
+                                .addChild(
+                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(MessagingExtension.QUEUE_PATH)
+                                                .addAttributes(QueueDefinition.ADDRESS,
+                                                        CommonAttributes.DURABLE,
+                                                        CommonAttributes.FILTER,
+                                                        QueueDefinition.ROUTING_TYPE))
+                                .addChild(
+                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                                .addChild(
+                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        SecurityRoleDefinition.SEND,
+                                                                        SecurityRoleDefinition.CONSUME,
+                                                                        SecurityRoleDefinition.CREATE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.DELETE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.MANAGE)))
+                                .addChild(
+                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        CommonAttributes.DEAD_LETTER_ADDRESS,
+                                                        CommonAttributes.EXPIRY_ADDRESS,
+                                                        AddressSettingDefinition.EXPIRY_DELAY,
+                                                        AddressSettingDefinition.REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.REDELIVERY_MULTIPLIER,
+                                                        AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS,
+                                                        AddressSettingDefinition.MAX_REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.MAX_SIZE_BYTES,
+                                                        AddressSettingDefinition.PAGE_SIZE_BYTES,
+                                                        AddressSettingDefinition.PAGE_MAX_CACHE_SIZE,
+                                                        AddressSettingDefinition.ADDRESS_FULL_MESSAGE_POLICY,
+                                                        AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT,
+                                                        AddressSettingDefinition.LAST_VALUE_QUEUE,
+                                                        AddressSettingDefinition.REDISTRIBUTION_DELAY,
+                                                        AddressSettingDefinition.SEND_TO_DLA_ON_NO_ROUTE,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_CHECK_PERIOD,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_POLICY,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD,
+                                                        AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES,
+                                                        AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES,
+                                                        AddressSettingDefinition.AUTO_CREATE_QUEUES,
+                                                        AddressSettingDefinition.AUTO_DELETE_QUEUES,
+                                                        AddressSettingDefinition.AUTO_CREATE_ADDRESSES,
+                                                        AddressSettingDefinition.AUTO_DELETE_ADDRESSES))
+                                .addChild(httpConnector)
+                                .addChild(remoteConnector)
+                                .addChild(invmConnector)
+                                .addChild(connector)
+                                .addChild(
+                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HTTPAcceptorDefinition.HTTP_LISTENER,
+                                                        HTTPAcceptorDefinition.UPGRADE_LEGACY,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(REMOTE_ACCEPTOR))
+                                                .addAttributes(
+                                                        RemoteTransportDefinition.SOCKET_BINDING,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(IN_VM_ACCEPTOR))
+                                                .addAttributes(
+                                                        InVMTransportDefinition.SERVER_ID,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(ACCEPTOR))
+                                                .addAttributes(
+                                                        GenericTransportDefinition.SOCKET_BINDING,
+                                                        CommonAttributes.FACTORY_CLASS,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(MessagingExtension.JGROUPS_BROADCAST_GROUP_PATH)
+                                                .addAttributes(
+                                                        BroadcastGroupDefinition.JGROUPS_CHANNEL_FACTORY,
+                                                        BroadcastGroupDefinition.JGROUPS_CHANNEL,
+                                                        CommonAttributes.JGROUPS_CLUSTER,
+                                                        BroadcastGroupDefinition.BROADCAST_PERIOD,
+                                                        BroadcastGroupDefinition.CONNECTOR_REFS))
+                                .addChild(
+                                        builder(MessagingExtension.SOCKET_BROADCAST_GROUP_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.SOCKET_BINDING,
+                                                        BroadcastGroupDefinition.BROADCAST_PERIOD,
+                                                        BroadcastGroupDefinition.CONNECTOR_REFS))
+                                .addChild(jgroupDiscoveryGroup)
+                                .addChild(socketDiscoveryGroup)
+                                .addChild(
+                                        builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
+                                                .addAttributes(
+                                                        ClusterConnectionDefinition.ADDRESS,
+                                                        ClusterConnectionDefinition.CONNECTOR_NAME,
+                                                        ClusterConnectionDefinition.CHECK_PERIOD,
+                                                        ClusterConnectionDefinition.CONNECTION_TTL,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
+                                                        ClusterConnectionDefinition.MAX_RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        ClusterConnectionDefinition.RECONNECT_ATTEMPTS,
+                                                        ClusterConnectionDefinition.USE_DUPLICATE_DETECTION,
+                                                        ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE,
+                                                        ClusterConnectionDefinition.MAX_HOPS,
+                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
+                                                        ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE,
+                                                        ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS,
+                                                        ClusterConnectionDefinition.NOTIFICATION_INTERVAL,
+                                                        ClusterConnectionDefinition.CONNECTOR_REFS,
+                                                        ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
+                                                        ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
+                                .addChild(
+                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        GroupingHandlerDefinition.TYPE,
+                                                        GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
+                                                        GroupingHandlerDefinition.TIMEOUT,
+                                                        GroupingHandlerDefinition.GROUP_TIMEOUT,
+                                                        GroupingHandlerDefinition.REAPER_PERIOD))
+                                .addChild(
+                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        DivertDefinition.ROUTING_NAME,
+                                                        DivertDefinition.ADDRESS,
+                                                        DivertDefinition.FORWARDING_ADDRESS,
+                                                        CommonAttributes.FILTER,
+                                                        CommonAttributes.TRANSFORMER_CLASS_NAME,
+                                                        DivertDefinition.EXCLUSIVE))
+                                .addChild(
+                                        builder(MessagingExtension.BRIDGE_PATH)
+                                                .addAttributes(
+                                                        BridgeDefinition.QUEUE_NAME,
+                                                        BridgeDefinition.FORWARDING_ADDRESS,
+                                                        CommonAttributes.HA,
+                                                        CommonAttributes.FILTER,
+                                                        CommonAttributes.TRANSFORMER_CLASS_NAME,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CHECK_PERIOD,
+                                                        CommonAttributes.CONNECTION_TTL,
+                                                        CommonAttributes.RETRY_INTERVAL,
+                                                        CommonAttributes.RETRY_INTERVAL_MULTIPLIER,
+                                                        CommonAttributes.MAX_RETRY_INTERVAL,
+                                                        BridgeDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        BridgeDefinition.RECONNECT_ATTEMPTS,
+                                                        BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE,
+                                                        BridgeDefinition.USE_DUPLICATE_DETECTION,
+                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
+                                                        BridgeDefinition.PRODUCER_WINDOW_SIZE,
+                                                        BridgeDefinition.USER,
+                                                        BridgeDefinition.PASSWORD,
+                                                        BridgeDefinition.CREDENTIAL_REFERENCE,
+                                                        BridgeDefinition.CONNECTOR_REFS,
+                                                        BridgeDefinition.DISCOVERY_GROUP_NAME))
+                                .addChild(
+                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        CommonAttributes.FACTORY_CLASS,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(MessagingExtension.JMS_QUEUE_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.DESTINATION_ENTRIES,
+                                                        CommonAttributes.SELECTOR,
+                                                        CommonAttributes.DURABLE,
+                                                        CommonAttributes.LEGACY_ENTRIES))
+                                .addChild(
+                                        builder(MessagingExtension.JMS_TOPIC_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.DESTINATION_ENTRIES,
+                                                        CommonAttributes.LEGACY_ENTRIES))
+                                .addChild(
+                                        builder(MessagingExtension.CONNECTION_FACTORY_PATH)
+                                                .addAttributes(
+                                                        ConnectionFactoryAttributes.Common.ENTRIES,
+                                                        // common
+                                                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                                                        ConnectionFactoryAttributes.Common.CONNECTORS,
+                                                        CommonAttributes.HA,
+                                                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
+                                                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
+                                                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CLIENT_ID,
+                                                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
+                                                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND,
+                                                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
+                                                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
+                                                        CommonAttributes.MAX_RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
+                                                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                                                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
+                                                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                                                        ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
+                                                        ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
+                                                        ConnectionFactoryAttributes.Common.INITIAL_MESSAGE_PACKET_SIZE,
+                                                        ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
+                                                        ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
+                                .addChild(
+                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        LegacyConnectionFactoryDefinition.ENTRIES,
+                                                        LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
+                                                        LegacyConnectionFactoryDefinition.CONNECTORS,
+                                                        LegacyConnectionFactoryDefinition.AUTO_GROUP,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_ACKNOWLEDGE,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_DURABLE_SEND,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_NON_DURABLE_SEND,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        LegacyConnectionFactoryDefinition.CACHE_LARGE_MESSAGE_CLIENT,
+                                                        LegacyConnectionFactoryDefinition.CLIENT_FAILURE_CHECK_PERIOD,
+                                                        CommonAttributes.CLIENT_ID,
+                                                        LegacyConnectionFactoryDefinition.COMPRESS_LARGE_MESSAGES,
+                                                        LegacyConnectionFactoryDefinition.CONFIRMATION_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                                                        LegacyConnectionFactoryDefinition.CONNECTION_TTL,
+                                                        LegacyConnectionFactoryDefinition.CONSUMER_MAX_RATE,
+                                                        LegacyConnectionFactoryDefinition.CONSUMER_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.DUPS_OK_BATCH_SIZE,
+                                                        LegacyConnectionFactoryDefinition.FACTORY_TYPE,
+                                                        LegacyConnectionFactoryDefinition.FAILOVER_ON_INITIAL_CONNECTION,
+                                                        LegacyConnectionFactoryDefinition.GROUP_ID,
+                                                        LegacyConnectionFactoryDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        LegacyConnectionFactoryDefinition.INITIAL_MESSAGE_PACKET_SIZE,
+                                                        LegacyConnectionFactoryDefinition.HA,
+                                                        LegacyConnectionFactoryDefinition.MAX_RETRY_INTERVAL,
+                                                        LegacyConnectionFactoryDefinition.MIN_LARGE_MESSAGE_SIZE,
+                                                        LegacyConnectionFactoryDefinition.PRE_ACKNOWLEDGE,
+                                                        LegacyConnectionFactoryDefinition.PRODUCER_MAX_RATE,
+                                                        LegacyConnectionFactoryDefinition.PRODUCER_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.RECONNECT_ATTEMPTS,
+                                                        LegacyConnectionFactoryDefinition.RETRY_INTERVAL,
+                                                        LegacyConnectionFactoryDefinition.RETRY_INTERVAL_MULTIPLIER,
+                                                        LegacyConnectionFactoryDefinition.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                                        LegacyConnectionFactoryDefinition.THREAD_POOL_MAX_SIZE,
+                                                        LegacyConnectionFactoryDefinition.TRANSACTION_BATCH_SIZE,
+                                                        LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
+                                .addChild(createPooledConnectionFactory(false)))
+                .addChild(
+                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                                .addAttributes(
+                                        JMSBridgeDefinition.MODULE,
+                                        JMSBridgeDefinition.QUALITY_OF_SERVICE,
+                                        JMSBridgeDefinition.FAILURE_RETRY_INTERVAL,
+                                        JMSBridgeDefinition.MAX_RETRIES,
+                                        JMSBridgeDefinition.MAX_BATCH_SIZE,
+                                        JMSBridgeDefinition.MAX_BATCH_TIME,
+                                        CommonAttributes.SELECTOR,
+                                        JMSBridgeDefinition.SUBSCRIPTION_NAME,
+                                        CommonAttributes.CLIENT_ID,
+                                        JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER,
+                                        JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY,
+                                        JMSBridgeDefinition.SOURCE_DESTINATION,
+                                        JMSBridgeDefinition.SOURCE_USER,
+                                        JMSBridgeDefinition.SOURCE_PASSWORD,
+                                        JMSBridgeDefinition.SOURCE_CREDENTIAL_REFERENCE,
+                                        JMSBridgeDefinition.TARGET_CONNECTION_FACTORY,
+                                        JMSBridgeDefinition.TARGET_DESTINATION,
+                                        JMSBridgeDefinition.TARGET_USER,
+                                        JMSBridgeDefinition.TARGET_PASSWORD,
+                                        JMSBridgeDefinition.TARGET_CREDENTIAL_REFERENCE,
+                                        JMSBridgeDefinition.SOURCE_CONTEXT,
+                                        JMSBridgeDefinition.TARGET_CONTEXT))
+                .build();
+    }
+
+    private PersistentResourceXMLBuilder createPooledConnectionFactory(boolean external) {
+        PersistentResourceXMLBuilder builder = builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
+                .addAttributes(
+                        ConnectionFactoryAttributes.Common.ENTRIES,
+                        // common
+                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                        ConnectionFactoryAttributes.Common.CONNECTORS,
+                        CommonAttributes.HA,
+                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
+                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
+                        CommonAttributes.CALL_TIMEOUT,
+                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
+                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
+                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
+                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
+                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
+                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                        CommonAttributes.CLIENT_ID,
+                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
+                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND,
+                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
+                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
+                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
+                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
+                        CommonAttributes.MAX_RETRY_INTERVAL,
+                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
+                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
+                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
+                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
+                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                        ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
+                        ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
+                        ConnectionFactoryAttributes.Common.USE_TOPOLOGY,
+                        // pooled
+                        // inbound config
+                        ConnectionFactoryAttributes.Pooled.USE_JNDI,
+                        ConnectionFactoryAttributes.Pooled.JNDI_PARAMS,
+                        ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS,
+                        ConnectionFactoryAttributes.Pooled.USE_LOCAL_TX,
+                        ConnectionFactoryAttributes.Pooled.SETUP_ATTEMPTS,
+                        ConnectionFactoryAttributes.Pooled.SETUP_INTERVAL,
+                        // outbound config
+                        ConnectionFactoryAttributes.Pooled.ALLOW_LOCAL_TRANSACTIONS,
+                        ConnectionFactoryAttributes.Pooled.TRANSACTION,
+                        ConnectionFactoryAttributes.Pooled.USER,
+                        ConnectionFactoryAttributes.Pooled.PASSWORD,
+                        ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE,
+                        ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE,
+                        ConnectionFactoryAttributes.Pooled.USE_AUTO_RECOVERY,
+                        ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE,
+                        ConnectionFactoryAttributes.Pooled.MANAGED_CONNECTION_POOL,
+                        ConnectionFactoryAttributes.Pooled.ENLISTMENT_TRACE,
+                        ConnectionFactoryAttributes.Common.INITIAL_MESSAGE_PACKET_SIZE,
+                        ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS,
+                        ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED);
+        if (external) {
+            builder.addAttributes(ConnectionFactoryAttributes.External.ENABLE_AMQ1_PREFIX);
+        }
+        return builder;
+    }
+
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
 import static org.jboss.as.controller.transform.description.RejectAttributeChecker.DEFINED;
 import static org.jboss.as.controller.transform.description.RejectAttributeChecker.UNDEFINED;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
@@ -86,6 +87,27 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
     }
 
     private static void registerTransformers_WF_20(ResourceTransformationDescriptionBuilder subsystem) {
+        ResourceTransformationDescriptionBuilder server = subsystem.addChildResource(MessagingExtension.SERVER_PATH);
+        server.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, ServerDefinition.CREDENTIAL_REFERENCE.getName())
+                .end();
+        ResourceTransformationDescriptionBuilder bridge = server.addChildResource(MessagingExtension.BRIDGE_PATH);
+        bridge.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, BridgeDefinition.CREDENTIAL_REFERENCE.getName())
+                .end();
+
+        ResourceTransformationDescriptionBuilder jmsBridge = subsystem.addChildResource(MessagingExtension.JMS_BRIDGE_PATH);
+        jmsBridge.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, JMSBridgeDefinition.SOURCE_CREDENTIAL_REFERENCE.getName())
+                .end();
+        jmsBridge.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, JMSBridgeDefinition.TARGET_CREDENTIAL_REFERENCE.getName())
+                .end();
+
+        ResourceTransformationDescriptionBuilder pooledConnectionFactory = server.addChildResource(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH);
+        pooledConnectionFactory.getAttributeBuilder()
+                .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE)
+                .end();
     }
 
     private static void registerTransformers_WF_19(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -69,6 +69,7 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
     public void registerTransformers(SubsystemTransformerRegistration registration) {
         ChainedTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
 
+        registerTransformers_WF_20(builder.createBuilder(MessagingExtension.VERSION_10_0_0, MessagingExtension.VERSION_9_0_0));
         registerTransformers_WF_19(builder.createBuilder(MessagingExtension.VERSION_9_0_0, MessagingExtension.VERSION_8_0_0));
         registerTransformers_WF_18(builder.createBuilder(MessagingExtension.VERSION_8_0_0, MessagingExtension.VERSION_7_0_0));
         registerTransformers_WF_17(builder.createBuilder(MessagingExtension.VERSION_7_0_0, MessagingExtension.VERSION_6_0_0));
@@ -81,7 +82,10 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
         builder.buildAndRegister(registration, new ModelVersion[] { MessagingExtension.VERSION_1_0_0, MessagingExtension.VERSION_2_0_0,
             MessagingExtension.VERSION_3_0_0, MessagingExtension.VERSION_4_0_0, MessagingExtension.VERSION_5_0_0,
             MessagingExtension.VERSION_6_0_0, MessagingExtension.VERSION_7_0_0, MessagingExtension.VERSION_8_0_0,
-            MessagingExtension.VERSION_9_0_0});
+            MessagingExtension.VERSION_9_0_0, MessagingExtension.VERSION_10_0_0});
+    }
+
+    private static void registerTransformers_WF_20(ResourceTransformationDescriptionBuilder subsystem) {
     }
 
     private static void registerTransformers_WF_19(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.messaging.activemq.jms;
 
+import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
+import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.LOCAL;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.LOCAL_TX;
@@ -29,6 +31,7 @@ import static org.wildfly.extension.messaging.activemq.CommonAttributes.NONE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.NO_TX;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.XA_TX;
 import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttribute.getDefinitions;
+import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +64,12 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
 
     private PooledConnectionFactoryAdd() {
         super(getDefinitions(PooledConnectionFactoryDefinition.ATTRIBUTES));
+    }
+
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws  OperationFailedException {
+        super.populateModel(context, operation, resource);
+        handleCredentialReferenceUpdate(context, resource.getModel());
     }
 
     @Override
@@ -128,6 +137,11 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
 
             installStatistics(context, name);
         }
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, final ModelNode operation, final Resource resource) {
+        rollbackCredentialStoreUpdate(CREDENTIAL_REFERENCE, context, resource);
     }
 
     static String getTxSupport(final ModelNode resolvedModel) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryDefinition.java
@@ -25,6 +25,7 @@ package org.wildfly.extension.messaging.activemq.jms;
 import static java.lang.System.arraycopy;
 import static org.wildfly.extension.messaging.activemq.AbstractTransportDefinition.CONNECTOR_CAPABILITY_NAME;
 import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttribute.getDefinitions;
+import static org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -48,6 +49,7 @@ import org.jboss.as.controller.capability.DynamicNameMappers;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.wildfly.extension.messaging.activemq.AbstractTransportDefinition;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
@@ -152,12 +154,17 @@ public class PooledConnectionFactoryDefinition extends PersistentResourceDefinit
     public void registerAttributes(ManagementResourceRegistration registry) {
         Collection<AttributeDefinition> definitions = getAttributes();
         ReloadRequiredWriteAttributeHandler reloadRequiredWriteAttributeHandler = new ReloadRequiredWriteAttributeHandler(definitions);
+        CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(CREDENTIAL_REFERENCE);
         for (AttributeDefinition attr : definitions) {
             if (!attr.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME)) {
                 if (deployed) {
                     registry.registerReadOnlyAttribute(attr, PooledConnectionFactoryConfigurationRuntimeHandler.INSTANCE);
                 } else {
-                    registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+                    if (attr.equals(CREDENTIAL_REFERENCE)) {
+                        registry.registerReadWriteAttribute(attr, null, credentialReferenceWriteAttributeHandler);
+                    } else {
+                        registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+                    }
                 }
             }
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -55,6 +55,7 @@ import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.InfiniteOrPositiveValidators;
@@ -264,8 +265,13 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration registry) {
         ReloadRequiredWriteAttributeHandler reloadRequiredWriteAttributeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+        CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(SOURCE_CREDENTIAL_REFERENCE, TARGET_CREDENTIAL_REFERENCE);
         for (AttributeDefinition attr : ATTRIBUTES) {
-            registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+            if (attr.equals(SOURCE_CREDENTIAL_REFERENCE) || attr.equals(TARGET_CREDENTIAL_REFERENCE)) {
+                registry.registerReadWriteAttribute(attr, null, credentialReferenceWriteAttributeHandler);
+            } else {
+                registry.registerReadWriteAttribute(attr, null, reloadRequiredWriteAttributeHandler);
+            }
         }
         for (AttributeDefinition attr : READONLY_ATTRIBUTES) {
             registry.registerReadOnlyAttribute(attr, JMSBridgeHandler.INSTANCE);

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_10_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_10_0.xsd
@@ -24,13 +24,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:messaging-activemq:10.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:messaging-activemq:10.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="9.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem">
         <xs:complexType>

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_10_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_10_0.xsd
@@ -1,0 +1,996 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:messaging-activemq:10.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           targetNamespace="urn:jboss:domain:messaging-activemq:10.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="9.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="0" name="global-client">
+                    <xs:complexType>
+                        <xs:attribute name="thread-pool-max-size" type="xs:int" />
+                        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="http-connector" type="http-connectorType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="remote-connector" type="remote-connectorType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="in-vm-connector" minOccurs="0" maxOccurs="unbounded" type="in-vm-connectorType" />
+                <xs:element name="connector" minOccurs="0" maxOccurs="unbounded" type="connectorType" />
+                <xs:element name="jgroups-discovery-group" type="jgroups-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="socket-discovery-group" type="socket-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="connection-factory" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="ha" type="xs:boolean" use="optional" />
+                        <xs:attribute name="factory-type" type="connectionFactoryType" use="optional"/>
+                        <xs:attribute name="discovery-group" type="xs:string" use="optional"/>
+                        <xs:attribute name="connectors" type="xs:string" use="optional"/>
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                        <xs:attribute name="enable-amq1-prefix" type="xs:boolean" use="optional" />
+                        <xs:attribute name="use-topology-for-load-balancing" type="xs:boolean" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="pooled-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="inbound-config" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="use-jndi" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="jndi-params" type="xs:string" use="optional" />
+                                    <xs:attribute name="rebalance-connections" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="use-local-tx" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="setup-attempts" type="xs:int" use="optional" />
+                                    <xs:attribute name="setup-interval" type="xs:long" use="optional" />
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="outbound-config" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="allow-local-transactions" type="xs:boolean" use="optional" />
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Credential to be used by the configuration.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+
+                        <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                        <xs:attribute name="transaction" use="optional">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="xa"/>
+                                    <xs:enumeration value="local"/>
+                                    <xs:enumeration value="none"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="user" type="xs:string" use="optional" />
+                        <xs:attribute name="password" type="xs:string" use="optional" />
+                        <xs:attribute name="min-pool-size" type="xs:int" use="optional" />
+                        <xs:attribute name="use-auto-recovery" type="xs:boolean" use="optional" />
+                        <xs:attribute name="max-pool-size" type="xs:int" use="optional" />
+                        <xs:attribute name="managed-connection-pool" type="xs:string" use="optional" />
+                        <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional" />
+                        <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                        <xs:attribute name="statistics-enabled" type="xs:boolean" use="optional" />
+                        <xs:attribute name="enable-amq1-prefix" type="xs:boolean" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="external-jms-queue" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="external-jms-topic" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="server" type="serverType" />
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="serverType">
+        <xs:sequence>
+
+            <xs:element name="incoming-interceptors" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="outgoing-interceptors" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <!-- server attribute groups -->
+            <xs:element name="security" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="enabled" type="xs:boolean" />
+                    <xs:attribute name="domain" type="xs:string" />
+                    <xs:attribute name="elytron-domain" type="xs:string"/>
+                    <xs:attribute name="invalidation-interval" type="xs:long" />
+                    <xs:attribute name="override-in-vm-security" type="xs:boolean" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="cluster" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="user" type="xs:string" />
+                    <xs:attribute name="password" type="xs:string" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="management" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="address" type="xs:string" />
+                    <xs:attribute name="notification-address" type="xs:string" />
+                    <xs:attribute name="jmx-enabled" type="xs:boolean" />
+                    <xs:attribute name="jmx-domain" type="xs:string" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="journal" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="type">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="ASYNCIO"/>
+                                <xs:enumeration value="NIO"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="buffer-timeout" type="xs:long" />
+                    <xs:attribute name="buffer-size" type="xs:long" />
+                    <xs:attribute name="sync-transactional" type="xs:boolean" />
+                    <xs:attribute name="sync-non-transactional" type="xs:boolean" />
+                    <xs:attribute name="log-write-rate" type="xs:boolean" />
+                    <xs:attribute name="file-size" type="xs:long" />
+                    <xs:attribute name="min-files" type="xs:int" />
+                    <xs:attribute name="pool-files" type="xs:int" />
+                    <xs:attribute name="file-open-timeout" type="xs:int" />
+                    <xs:attribute name="compact-percentage" type="xs:int" />
+                    <xs:attribute name="compact-min-files" type="xs:int" />
+                    <xs:attribute name="max-io" type="xs:int" />
+                    <xs:attribute name="create-bindings-dir" type="xs:boolean" />
+                    <xs:attribute name="create-journal-dir" type="xs:boolean" />
+                    <xs:attribute name="datasource" type="xs:string" />
+                    <xs:attribute name="database" type="xs:string" />
+                    <xs:attribute name="messages-table" type="xs:string" />
+                    <xs:attribute name="bindings-table" type="xs:string" />
+                    <xs:attribute name="jms-bindings-table" type="xs:string" />
+                    <xs:attribute name="large-messages-table" type="xs:string" />
+                    <xs:attribute name="node-manager-store-table" type="xs:string" />
+                    <xs:attribute name="page-store-table" type="xs:string" />
+                    <xs:attribute name="jdbc-lock-expiration" type="xs:int" />
+                    <xs:attribute name="jdbc-lock-renew-period" type="xs:int" />
+                    <xs:attribute name="jdbc-network-timeout" type="xs:int" />
+                    <xs:attribute name="global-max-memory-size" type="xs:long" />
+                    <xs:attribute name="global-max-disk-usage" type="xs:int" />
+                    <xs:attribute name="disk-scan-period" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="statistics" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="enabled" type="xs:boolean" />
+                    <xs:attribute name="message-counter-sample-period" type="xs:long" />
+                    <xs:attribute name="message-counter-max-day-history" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="transaction" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="timeout" type="xs:long" />
+                    <xs:attribute name="scan-period" type="xs:long" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="message-expiry" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="scan-period" type="xs:long" />
+                    <xs:attribute name="thread-priority" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="debug" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="perf-blast-pages" type="xs:int" />
+                    <xs:attribute name="run-sync-speed-test" type="xs:boolean" />
+                    <xs:attribute name="server-dump-interval" type="xs:long" />
+                    <xs:attribute name="memory-measure-interval" type="xs:long" />
+                    <xs:attribute name="memory-warning-threshold" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+            <!-- end of server attribute groups -->
+
+            <xs:choice>
+                <xs:element name="live-only" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="replication-master" minOccurs="0" maxOccurs="1" type="replication-masterType" />
+                <xs:element name="replication-slave" minOccurs="0" maxOccurs="1" type="replication-slaveType" />
+                <xs:element name="replication-colocated" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="master" minOccurs="0" maxOccurs="1" type="replication-masterType" />
+                            <xs:element name="slave" minOccurs="0" maxOccurs="1" type="replication-slaveType" />
+                        </xs:sequence>
+
+                        <xs:attributeGroup ref="ha-policy-colocated-attributeGroup" />
+                        <xs:attribute name="excluded-connectors" type="xs:string" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="shared-store-master" minOccurs="0" maxOccurs="1" type="shared-store-masterType" />
+                <xs:element name="shared-store-slave" minOccurs="0" maxOccurs="1"  type="shared-store-slaveType" />
+                <xs:element name="shared-store-colocated" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="master" minOccurs="0" maxOccurs="1" type="shared-store-masterType" />
+                            <xs:element name="slave" minOccurs="0" maxOccurs="1" type="shared-store-slaveType" />
+                        </xs:sequence>
+
+                        <xs:attributeGroup ref="ha-policy-colocated-attributeGroup" />
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+
+            <xs:element name="bindings-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="journal-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="large-messages-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="paging-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+
+            <xs:element name="queue" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+
+                    <xs:attribute name="address" type="xs:string" use="optional" />
+                    <xs:attribute name="filter" type="xs:string" use="optional" />
+                    <xs:attribute name="durable" type="xs:boolean" use="optional" />
+                    <xs:attribute name="routing-type" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="MULTICAST"/>
+                                <xs:enumeration value="ANYCAST"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="security-setting" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="role" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required" />
+
+                                <xs:attribute name="send" type="xs:string" use="optional" />
+                                <xs:attribute name="consume" type="xs:string" use="optional" />
+                                <xs:attribute name="create-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="delete-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="create-non-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="delete-non-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="manage" type="xs:string" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="address-setting" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+
+                    <xs:attribute name="dead-letter-address" type="xs:string" use="optional" />
+                    <xs:attribute name="expiry-address" type="xs:string" use="optional" />
+                    <xs:attribute name="expiry-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="redelivery-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="redelivery-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="max-delivery-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="max-redelivery-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="max-size-bytes" type="xs:long" use="optional" />
+                    <xs:attribute name="page-size-bytes" type="xs:int" use="optional" />
+                    <xs:attribute name="page-max-cache-size" type="xs:int" use="optional" />
+                    <xs:attribute name="address-full-policy" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="DROP"/>
+                                <xs:enumeration value="PAGE"/>
+                                <xs:enumeration value="BLOCK"/>
+                                <xs:enumeration value="FAIL"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="message-counter-history-day-limit" type="xs:int" use="optional" />
+                    <xs:attribute name="last-value-queue" type="xs:boolean" use="optional" />
+                    <xs:attribute name="redistribution-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="send-to-dla-on-no-route" type="xs:boolean" use="optional" />
+                    <xs:attribute name="slow-consumer-check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="slow-consumer-policy" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="KILL"/>
+                                <xs:enumeration value="NOTIFY"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="slow-consumer-threshold" type="xs:long" use="optional" />
+                    <xs:attribute name="auto-create-jms-queues" type="xs:boolean">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use auto-create-queues and auto-create-addresses instead.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="auto-delete-jms-queues" type="xs:boolean">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use auto-delete-queues and auto-delete-addresses instead.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="auto-create-queues" type="xs:boolean" />
+                    <xs:attribute name="auto-delete-queues" type="xs:boolean" />
+                    <xs:attribute name="auto-create-addresses" type="xs:boolean" />
+                    <xs:attribute name="auto-delete-addresses" type="xs:boolean" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="http-connector" minOccurs="0" maxOccurs="unbounded" type="http-connectorType" />
+
+            <xs:element name="remote-connector" minOccurs="0" maxOccurs="unbounded" type="remote-connectorType" />
+
+            <xs:element name="in-vm-connector" minOccurs="0" maxOccurs="unbounded" type="in-vm-connectorType" />
+
+            <xs:element name="connector" minOccurs="0" maxOccurs="unbounded" type="connectorType" />
+
+            <xs:element name="http-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="upgrade-legacy" type="xs:boolean" use="optional" />
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="http-listener" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="remote-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="socket-binding" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="in-vm-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="server-id" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="factory-class" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+
+            <xs:element name="jgroups-broadcast-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="jgroups-stack" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>Deprecated. Use jgroups-channel instead.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="jgroups-channel" type="xs:string" use="optional" />
+                    <xs:attribute name="jgroups-cluster" type="xs:string" use="optional" />
+                    <xs:attribute name="broadcast-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="socket-broadcast-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="socket-binding" type="xs:string" use="required" />
+                    <xs:attribute name="broadcast-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="jgroups-discovery-group" type="jgroups-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="socket-discovery-group" type="socket-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="cluster-connection" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="address" type="xs:string" use="required" />
+                    <xs:attribute name="connector-name" type="xs:string" use="required" />
+
+                    <xs:attribute name="check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="use-duplicate-detection" type="xs:boolean" use="optional" />
+                    <xs:attribute name="message-load-balancing-type" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="OFF"/>
+                                <xs:enumeration value="STRICT"/>
+                                <xs:enumeration value="ON_DEMAND"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="max-hops" type="xs:int" use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="notification-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="notification-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="static-connectors" type="stringList" use="optional" />
+                    <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional" />
+                    <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="grouping-handler" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="type" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="LOCAL"/>
+                                <xs:enumeration value="REMOTE"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="address" type="xs:string" use="required" />
+
+                    <xs:attribute name="timeout" type="xs:int" use="optional" />
+                    <xs:attribute name="group-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="reaper-period" type="xs:long" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="divert" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="address" type="xs:string" use="required" />
+                    <xs:attribute name="forwarding-address" type="xs:string" use="required" />
+
+                    <xs:attribute name="routing-name" type="xs:string"  use="optional" />
+                    <xs:attribute name="filter" type="xs:string" use="optional" />
+                    <xs:attribute name="transformer-class-name" type="xs:string" use="optional" />
+                    <xs:attribute name="exclusive" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="bridge" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="queue-name" type="xs:string" use="required" />
+
+                    <xs:attribute name="forwarding-address" type="xs:string" use="optional" />
+                    <xs:attribute name="ha" type="xs:boolean"  use="optional" />
+                    <xs:attribute name="filter" type="xs:string"  use="optional" />
+                    <xs:attribute name="transformer-class-name" type="xs:string"  use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="check-period" type="xs:long"  use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long"  use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long"  use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double"  use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long"  use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int"  use="optional" />
+                    <xs:attribute name="reconnect-attempts-on-same-node" type="xs:int"  use="optional" />
+                    <xs:attribute name="use-duplicate-detection" type="xs:boolean"  use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int"  use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="user" type="xs:string"  use="optional" />
+                    <xs:attribute name="password" type="xs:string"  use="optional" />
+                    <xs:attribute name="static-connectors" type="stringList"  use="optional" />
+                    <xs:attribute name="discovery-group" type="xs:string"  use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="connector-service" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="factory-class" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="jms-queue" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attribute name="selector" type="xs:string" use="optional" />
+                    <xs:attribute name="durable" type="xs:string" use="optional" />
+                    <xs:attribute name="legacy-entries" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="jms-topic" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+                    <xs:attribute name="legacy-entries" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                    <xs:attribute name="factory-type" type="connectionFactoryType" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="legacy-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+
+                    <xs:attribute name="auto-group" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-acknowledge" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-durable-send" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-non-durable-send" type="xs:boolean" use="optional" />
+                    <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="cache-large-message-client" type="xs:boolean" use="optional" />
+                    <xs:attribute name="client-failure-check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="client-id" type="xs:string" use="optional" />
+                    <xs:attribute name="compress-large-messages" type="xs:boolean" use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="connection-load-balancing-policy-class-name" type="xs:string" use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+                    <xs:attribute name="consumer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="consumer-max-rate" type="xs:int" use="optional" />
+                    <xs:attribute name="dups-ok-batch-size" type="xs:int" use="optional" />
+                    <xs:attribute name="factory-type" type="connectionFactoryType" use="optional" />
+                    <xs:attribute name="failover-on-initial-connection" type="xs:boolean" use="optional" />
+                    <xs:attribute name="group-id" type="xs:string" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="initial-message-packet-size" type="xs:int" use="optional" />
+                    <xs:attribute name="ha" type="xs:boolean" use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="pre-acknowledge" type="xs:boolean" use="optional" />
+                    <xs:attribute name="producer-max-rate" type="xs:int" use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+                    <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+                    <xs:attribute name="transaction-batch-size" type="xs:int" use="optional" />
+                    <xs:attribute name="use-global-pools" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="pooled-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="inbound-config" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="use-jndi" type="xs:boolean" use="optional" />
+                                <xs:attribute name="jndi-params" type="xs:string" use="optional" />
+                                <xs:attribute name="rebalance-connections" type="xs:boolean" use="optional" />
+                                <xs:attribute name="use-local-tx" type="xs:boolean" use="optional" />
+                                <xs:attribute name="setup-attempts" type="xs:int" use="optional" />
+                                <xs:attribute name="setup-interval" type="xs:long" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="outbound-config" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="allow-local-transactions" type="xs:boolean" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                    <xs:attribute name="transaction" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="xa"/>
+                                <xs:enumeration value="local"/>
+                                <xs:enumeration value="none"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                    <xs:attribute name="min-pool-size" type="xs:int" use="optional" />
+                    <xs:attribute name="use-auto-recovery" type="xs:boolean" use="optional" />
+                    <xs:attribute name="max-pool-size" type="xs:int" use="optional" />
+                    <xs:attribute name="managed-connection-pool" type="xs:string" use="optional" />
+                    <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="statistics-enabled" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" use="required" />
+
+        <xs:attribute name="persistence-enabled" type="xs:boolean" use="optional" />
+        <xs:attribute name="persist-id-cache" type="xs:boolean" use="optional" />
+        <xs:attribute name="persist-delivery-count-before-delivery" type="xs:boolean" use="optional" />
+        <xs:attribute name="id-cache-size" type="xs:int" use="optional" />
+        <xs:attribute name="page-max-concurrent-io" type="xs:int" use="optional" />
+        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="wild-card-routing-enabled" type="xs:boolean" use="optional" />
+        <xs:attribute name="connection-ttl-override" type="xs:long" use="optional" />
+        <xs:attribute name="async-connection-execution-enabled" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:simpleType name="stringList">
+        <xs:restriction base="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ A list of string separated by whitespaces. ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="classType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="module" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="scale-downType">
+        <xs:attribute name="enabled" type="xs:boolean" use="required" />
+        <xs:attribute name="cluster-name" type="xs:string" use="required" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+        <xs:attribute name="connectors" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="replication-masterType">
+        <xs:attribute name="cluster-name" type="xs:string" use="optional" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="check-for-live-server" type="xs:boolean" use="optional" />
+        <xs:attribute name="initial-replication-sync-timeout" type="xs:long" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="replication-slaveType">
+        <xs:sequence>
+            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+        </xs:sequence>
+
+        <xs:attribute name="cluster-name" type="xs:string" use="optional" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="allow-failback" type="xs:boolean" use="optional" />
+        <xs:attribute name="initial-replication-sync-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="restart-backup" type="xs:boolean" use="optional" />
+        <xs:attribute name="max-saved-replicated-journal-size" type="xs:int" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="shared-store-masterType">
+        <xs:attribute name="failover-on-server-shutdown" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="shared-store-slaveType">
+        <xs:sequence>
+            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+        </xs:sequence>
+
+        <xs:attribute name="allow-failback" type="xs:boolean" use="optional" />
+        <xs:attribute name="failover-on-server-shutdown" type="xs:boolean" use="optional" />
+        <xs:attribute name="restart-backup" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:attributeGroup name="ha-policy-colocated-attributeGroup">
+        <xs:attribute name="request-backup" type="xs:boolean" use="optional" />
+        <xs:attribute name="backup-request-retries" type="xs:int" use="optional" />
+        <xs:attribute name="backup-request-retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="max-backups" type="xs:int" use="optional" />
+        <xs:attribute name="backup-port-offset" type="xs:int" use="optional" />
+    </xs:attributeGroup>
+
+    <xs:complexType name="directoryType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                A directory location configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem pathname where the directory should be
+                located.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" />
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="value" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:attributeGroup name="common-connection-factory-attributeGroup">
+        <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+        <xs:attribute name="connectors" type="xs:string" use="optional" />
+        <xs:attribute name="ha" type="xs:boolean" use="optional" />
+        <xs:attribute name="client-failure-check-period" type="xs:long" use="optional" />
+        <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+        <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="consumer-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="consumer-max-rate" type="xs:int" use="optional" />
+        <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="producer-max-rate" type="xs:int" use="optional" />
+        <xs:attribute name="protocol-manager-factory" type="xs:string" use="optional" />
+        <xs:attribute name="compress-large-messages" type="xs:boolean" use="optional" />
+        <xs:attribute name="cache-large-message-client" type="xs:boolean" use="optional" />
+        <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+        <xs:attribute name="client-id" type="xs:string" use="optional" />
+        <xs:attribute name="dups-ok-batch-size" type="xs:int" use="optional" />
+        <xs:attribute name="transaction-batch-size" type="xs:int" use="optional" />
+        <xs:attribute name="block-on-acknowledge" type="xs:boolean" use="optional" />
+        <xs:attribute name="block-on-non-durable-send" type="xs:boolean" use="optional" />
+        <xs:attribute name="block-on-durable-send" type="xs:boolean" use="optional" />
+        <xs:attribute name="auto-group" type="xs:boolean" use="optional" />
+        <xs:attribute name="pre-acknowledge" type="xs:boolean" use="optional" />
+        <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+        <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+        <xs:attribute name="failover-on-initial-connection" type="xs:boolean" use="optional" />
+        <xs:attribute name="connection-load-balancing-policy-class-name" type="xs:string" use="optional" />
+        <xs:attribute name="use-global-pools" type="xs:boolean" use="optional" />
+        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="group-id" type="xs:string" use="optional" />
+        <xs:attribute name="deserialization-white-list" type="stringList" use="optional" />
+        <xs:attribute name="deserialization-black-list" type="stringList" use="optional" />
+        <xs:attribute name="initial-message-packet-size" type="xs:int" use="optional" />
+        <xs:attribute name="use-topology-for-load-balancing" type="xs:boolean" use="optional" />
+    </xs:attributeGroup>
+
+    <xs:simpleType name="connectionFactoryType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="GENERIC"/>
+            <xs:enumeration value="TOPIC"/>
+            <xs:enumeration value="QUEUE"/>
+            <xs:enumeration value="XA_GENERIC"/>
+            <xs:enumeration value="XA_QUEUE"/>
+            <xs:enumeration value="XA_TOPIC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="socket-discovery-groupType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string"  use="required" />
+        <xs:attribute name="refresh-timeout" type="xs:long" />
+        <xs:attribute name="initial-wait-timeout" type="xs:long" />
+    </xs:complexType>
+
+    <xs:complexType name="jgroups-discovery-groupType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="jgroups-stack" type="xs:string" >
+            <xs:annotation>
+                <xs:documentation>Deprecated. Use jgroups-channel instead.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="jgroups-channel" type="xs:string" />
+        <xs:attribute name="jgroups-cluster" type="xs:string" />
+        <xs:attribute name="refresh-timeout" type="xs:long" />
+        <xs:attribute name="initial-wait-timeout" type="xs:long" />
+    </xs:complexType>
+
+    <xs:complexType name="remote-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="http-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string" use="required" />
+        <xs:attribute name="endpoint" type="xs:string" use="required" />
+        <xs:attribute name="server-name" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="in-vm-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="server-id" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="factory-class" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="jms-bridgeType">
+        <xs:sequence>
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="source-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="source-credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration to connect to the source destination.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="target" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="target-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="target-credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration to connect to the target destination.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="module" type="xs:string" use="required" />
+
+        <xs:attribute name="quality-of-service" use="optional" default="AT_MOST_ONCE">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="AT_MOST_ONCE"/>
+                    <xs:enumeration value="DUPLICATES_OK"/>
+                    <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="failure-retry-interval" type="xs:long" use="optional" default="5000" />
+        <xs:attribute name="max-retries" type="xs:int" use="optional" default="-1"/>
+        <xs:attribute name="max-batch-size" type="xs:int" use="optional" default="1"/>
+        <xs:attribute name="max-batch-time" type="xs:long" use="optional" default="-1"/>
+        <xs:attribute name="selector" type="xs:string" use="optional" />
+        <xs:attribute name="subscription-name" type="xs:string" use="optional" />
+        <xs:attribute name="client-id" type="xs:string" use="optional" />
+        <xs:attribute name="add-messageID-in-header" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="contextType">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="value" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
@@ -24,13 +24,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:messaging-activemq:9.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            targetNamespace="urn:jboss:domain:messaging-activemq:9.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="9.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem">
         <xs:complexType>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
@@ -3,7 +3,7 @@
 <config>
     <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
     <extension-module>org.wildfly.extension.messaging-activemq</extension-module>
-    <subsystem xmlns="urn:jboss:domain:messaging-activemq:9.0">
+    <subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
         <server name="default"
                 persistence-enabled="true">
             <cluster password="${jboss.messaging.cluster.password:CHANGE ME!!}" />

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
     <extension-module>org.wildfly.extension.messaging-activemq</extension-module>
-    <subsystem xmlns="urn:jboss:domain:messaging-activemq:9.0">
+    <subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
 
         <server name="default">
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_10_0_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_10_0_TestCase.java
@@ -231,6 +231,16 @@ public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemB
         PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM_PATH);
 
         FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
+        if (messagingVersion.compareTo(MessagingExtension.VERSION_10_0_0) > 0) {
+            config.addFailedAttribute(subsystemAddress.append(pathElement(SERVER, "server1")),
+                    FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            config.addFailedAttribute(subsystemAddress.append(pathElement(SERVER, "server2")).append(BRIDGE_PATH),
+                    FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            config.addFailedAttribute(subsystemAddress.append(pathElement(SERVER, "server3")).append(POOLED_CONNECTION_FACTORY_PATH),
+                    FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            config.addFailedAttribute(subsystemAddress.append(pathElement(JMS_BRIDGE, "bridge-with-credential-reference")),
+                    FailedOperationTransformationConfig.REJECTED_RESOURCE);
+        }
         if (messagingVersion.compareTo(MessagingExtension.VERSION_9_0_0) > 0) {
             config.addFailedAttribute(subsystemAddress.append(pathElement(SERVER, "server1")),
                     FailedOperationTransformationConfig.REJECTED_RESOURCE);

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0.xml
@@ -1,0 +1,704 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <global-client thread-pool-max-size="${global.client.thread-pool-max-size:32}"
+                   scheduled-thread-pool-max-size="${global.client.scheduled.thread-pool-max-size:54}" />
+
+    <http-connector name="client-http"
+                    socket-binding="http"
+                    endpoint="http"
+                    server-name="=foo">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </http-connector>
+
+    <remote-connector name="client-netty-throughput"
+                      socket-binding="messaging-throughput">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </remote-connector>
+
+    <in-vm-connector name="in-vm-client"
+                     server-id="${my.server-id:0}"/>
+
+    <connector name="myconnector-client"
+               factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+        <param name="host" value="192.168.1.2"/>
+        <param name="port" value="5445"/>
+        <param name="key-store-path" value="path/to/server.jks"/>
+        <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+    </connector>
+
+    <jgroups-discovery-group name="client-discovery-group-2"
+                     jgroups-channel="ee"
+                     jgroups-cluster="activemq-cluster"
+                     refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                     initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+    <socket-discovery-group name="client-discovery-group-1"
+                     socket-binding="group-t-binding"/>
+
+    <connection-factory name="InVmConnectionFactory"
+                        connectors="in-vm client"
+                        entries="${connection-factory.entries.entry:java:/ClientConnectionFactory}"
+                        enable-amq1-prefix="true"
+                        use-topology-for-load-balancing="true" />
+
+    <connection-factory name="RemoteClientConnectionFactory"
+                        factory-type="XA_QUEUE"
+                        connectors="client-http client-netty-throughput"
+                        entries="RemoteClientConnectionFactory java:/global/jms/RemoteClientConnectionFactory" />
+
+    <connection-factory name="otherClientConnectionFactory"
+                        discovery-group="client-discovery-group-1"
+                        ha="${ha:true}"
+                        entries="otherClientConnectionFactory"
+                        use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="hornetq-ra-local"
+                               transaction="local"
+                               user="alice"
+                               password="alicepassword"
+                               use-auto-recovery="${use.auto.recovery:true}"
+                               connectors="in-vm-client"
+                               entries="java:/JmsLocal"
+                               enable-amq1-prefix="true"
+                               use-topology-for-load-balancing="true" />
+
+    <pooled-connection-factory name="activemq-ra-none"
+                               transaction="none"
+                               user="alice"
+                               password="alicepassword"
+                               connectors="in-vm-client"
+                               entries="java:/JmsNone"
+                               use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="activemq-ra"
+                               transaction="${transaction:xa}"
+                               user="${user:alice}"
+                               password="${password:alicepassword}"
+                               min-pool-size="${min.pool.size:42}"
+                               max-pool-size="${max.pool.size:242}"
+                               managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                               enlistment-trace="${enlistment.trace:false}"
+                               initial-message-packet-size="${initial.message.packet.size:9876}"
+                               initial-connect-attempts="${initial.connect.attempts:5432}"
+                               connectors="in-vm-client"
+                               entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                               ha="${ha:true}"
+                               client-failure-check-period="${client.failure.check.period:12345}"
+                               connection-ttl="${connection.ttl:6789}"
+                               call-timeout="${call.timeout:123}"
+                               call-failover-timeout="${call.failover.timeout:456}"
+                               consumer-window-size="${consumer.window.size:456}"
+                               consumer-max-rate="${consumer.max.rate:789}"
+                               confirmation-window-size="${confirmation.window.size:-1}"
+                               producer-window-size="${producer.window.size:-1}"
+                               producer-max-rate="${producer.max.rate:1024}"
+                               protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                               compress-large-messages="${compress.large.messages:true}"
+                               cache-large-message-client="${cache.large.message.client:false}"
+                               min-large-message-size="${min.large.message.size:2048}"
+                               client-id="${client.id:myClientID}"
+                               dups-ok-batch-size="${dups.ok.batch.size:256}"
+                               transaction-batch-size="${transaction.batch.size:512}"
+                               block-on-acknowledge="${block.on.acknowledge:false}"
+                               block-on-non-durable-send="${block.on.non.durable.send:false}"
+                               block-on-durable-send="${block.on.durable.send:false}"
+                               auto-group="${auto.group:true}"
+                               pre-acknowledge="${pre.acknowledge:true}"
+                               retry-interval="${retry.interval:500}"
+                               retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                               max-retry-interval="${max.retry.interval:10000}"
+                               reconnect-attempts="${reconnect.attempts:2}"
+                               failover-on-initial-connection="${failover.on.initial.connection:true}"
+                               connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                               use-global-pools="${use.global.pools:true}"
+                               scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                               thread-pool-max-size="${thread.pool.max.size:48}"
+                               group-id="${group.id:myGroup}"
+                               deserialization-black-list="org.foo.Bar org.foo.Baz"
+                               deserialization-white-list="org.bar.Bar org.baz.Baz"
+                               statistics-enabled="${pcf.statistics-enabled:true}">
+        <inbound-config
+            use-jndi="${use.jndi:false}"
+            jndi-params="${jndi.params:whatever}"
+            rebalance-connections="${inbound.rebalance-connections:true}"
+            use-local-tx="${use.local.tx:true}"
+            setup-attempts="${setup-attempts:123}"
+            setup-interval="${setup-interval:456}" />
+        <outbound-config
+            allow-local-transactions="${allow.local.transactions:true}" />
+    </pooled-connection-factory>
+
+    <pooled-connection-factory name="pcf-with-credential-reference"
+                               entries="java:/JmsLocal2"
+                               connectors="in-vm-client"
+                               user="foo">
+        <credential-reference clear-text="passwordOut!"/>
+    </pooled-connection-factory>
+
+    <external-jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/client-test}"/>
+    <external-jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/client-test2"/>
+    <external-jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/client-test}"/>
+
+    <server name="default"
+            persistence-enabled="${persistence.enabled:false}"
+            persist-id-cache="${persist.id.cache:false}"
+            persist-delivery-count-before-delivery="${persist.delivery.count.before.delivery:true}"
+            id-cache-size="${id.cache.size:102030}"
+            page-max-concurrent-io="${page.max.concurrent.io:10}"
+            scheduled-thread-pool-max-size="${messaging.scheduled.thread.pool.max.size:6}"
+            thread-pool-max-size="${messaging.thread.pool.max.size:5}"
+            wild-card-routing-enabled="${wild.card.routing.enabled:false}"
+            connection-ttl-override="${connection.ttl.override:5432}"
+            async-connection-execution-enabled="${async.connection.execution.enabled:false}">
+
+        <incoming-interceptors>
+            <class name="org.foo.incoming.myInterceptor" module="org.foo" />
+            <class name="org.bar.incoming.myOtherInterceptor" module="org.bar" />
+        </incoming-interceptors>
+
+        <outgoing-interceptors>
+            <class name="org.foo.outgoing.myInterceptor" module="org.foo" />
+            <class name="org.bar.outgoing.myOtherInterceptor" module="org.bar" />
+        </outgoing-interceptors>
+
+        <security
+            enabled="${security.enabled:false}"
+            elytron-domain="elytronDomain"
+            invalidation-interval="${security.invalidation.interval:1234}"
+            override-in-vm-security="${override.in-vm.security:false}"/>
+
+        <cluster
+            user="${messaging.cluster.user.name}"
+            password="${messaging.cluster.user.password}"/>
+
+        <management
+            address="${management.address:my.management.address}"
+            notification-address="${management.notification.address:my.management.notif.address}"
+            jmx-enabled="${jmx.management.enabled:false}"
+            jmx-domain="${jmx.domain:my.jmx.domain}"/>
+
+        <journal
+                type="${journal.type:NIO}"
+                buffer-timeout="${journal.buffer.timeout:1357}"
+                buffer-size="${journal.buffer.size:2468}"
+                sync-transactional="${journal.sync.transactional:false}"
+                sync-non-transactional="${journal.sync.non.transactional:true}"
+                log-write-rate="${log.journal.write.rate:true}"
+                file-size="${journal.file.size:102400}"
+                min-files="${journal.min.files:2}"
+                pool-files="${journal.pool.files:5}"
+                compact-percentage="${journal.compact.percentage:83}"
+                file-open-timeout="${journal.file.open.timeout:7}"
+                compact-min-files="${journal.compact.min.files:2}"
+                max-io="${journal.max.io:50}"
+                create-bindings-dir="${create.bindings.dir:false}"
+                create-journal-dir="${create.journal.dir:true}"
+                datasource="fooDS"
+                database="mysql"
+                jdbc-lock-expiration="${journal.jdbc.lock.expiration:891}"
+                jdbc-lock-renew-period="${journal.jdbc.lock.renew.period:892}"
+                jdbc-network-timeout="${journal.jdbc.network.timeout:4567}"
+                messages-table="${journal.message.table:MESSAGES}"
+                bindings-table="${journal.bindings.table:BINDINGS}"
+                jms-bindings-table="${journal.jms.bindings.table:JMS_BINDINGS}"
+                large-messages-table="${journal.large-messages.table:LARGE_MESSAGES}"
+                page-store-table="${journal.page-store.table:PAGE_STORE}"
+                node-manager-store-table="${journal.node-manager-store-table:NODE_MANAGER_STORE}" />
+
+        <statistics
+            enabled="${statistics.enabled:true}"
+            message-counter-sample-period="${message.counter.sample.period:7654}"
+            message-counter-max-day-history="${message.counter.max.day.history:23}"/>
+
+        <transaction
+            timeout="${transaction.timeout:4321}"
+            scan-period="${transaction.timeout.scan.period:5432}"/>
+
+        <message-expiry
+            scan-period="${message.expiry.scan.period:7654}"
+            thread-priority="${message.expiry.thread.priority:7}"/>
+
+        <debug
+            perf-blast-pages="${perf.blast.pages:70}"
+            run-sync-speed-test="${run.sync.speed.test:false}"
+            server-dump-interval="${server.dump.interval:8642}"
+            memory-warning-threshold="${memory.warning.threshold:1024}"
+            memory-measure-interval="${memory.measure.interval:2048}"/>
+
+        <bindings-directory path="${my.bindings.dir:test}" relative-to="test"/>
+        <journal-directory path="${my.journal.dir:test}" relative-to="test"/>
+        <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test"/>
+        <paging-directory path="${my.paging.dir:test}" relative-to="test"/>
+
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+
+        <queue name="coreQueueB" address="addressB"
+               routing-type="ANYCAST" />
+
+        <security-setting name="#">
+            <role name="guest"
+                  send="true"
+                  consume="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"/>
+            <role name="admin"
+                  send="true"
+                  consume="true"
+                  create-durable-queue="true"
+                  delete-durable-queue="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"
+                  manage="true"/>
+        </security-setting>
+
+        <address-setting name="#"
+                         dead-letter-address="${dead.letter.address:jms.queue.DLQ}"
+                         expiry-address="${expiry.address:jms.queue.ExpiryQueue}"
+                         expiry-delay="${expiry.delay:12345}"
+                         redelivery-delay="${redelivery.delay:0}"
+                         redelivery-multiplier="${redelivery.multiplier:1.0}"
+                         max-delivery-attempts="${max.delivery.attempts:5}"
+                         max-redelivery-delay="${max.redelivery.delay:234}"
+                         max-size-bytes="${max.size.bytes:10485760}"
+                         page-size-bytes="${page.size.bytes:10485760}"
+                         page-max-cache-size="${page.max.cache.size:7}"
+                         address-full-policy="${address.full.policy:BLOCK}"
+                         message-counter-history-day-limit="${message.counter.history.day.limit:10}"
+                         last-value-queue="${last.value.queue:false}"
+                         redistribution-delay="${redistribution.delay:0}"
+                         send-to-dla-on-no-route="${send.to.dla.on.no.route:false}"
+                         slow-consumer-check-period="${slow.consumer.check.period:123}"
+                         slow-consumer-policy="${slow.consumer.policy:KILL}"
+                         slow-consumer-threshold="${slow.consumer.threshold:456}"
+                         auto-create-jms-queues="${auto.create.jms.queue:true}"
+                         auto-delete-jms-queues="${auto.delete.jms.queue:true}"
+                         auto-create-queues="${auto.create.queues:true}"
+                         auto-delete-queues="${auto.delete.queues:true}"
+                         auto-create-addresses="${auto.create.addresses:true}"
+                         auto-delete-addresses="${auto.delete.addresses:true}" />
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http"
+                        server-name="=foo">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+        <remote-connector name="netty"
+                          socket-binding="messaging"/>
+        <remote-connector name="netty-throughput"
+                          socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <connector name="myconnector"
+                   factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="host" value="192.168.1.2"/>
+            <param name="port" value="5445"/>
+            <param name="key-store-path" value="path/to/server.jks"/>
+            <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+        </connector>
+
+        <http-acceptor name="http"
+                       http-listener="default"
+                       upgrade-legacy="${upgrade.legacy:true}">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-acceptor>
+        <remote-acceptor name="netty"
+                         socket-binding="messaging"/>
+        <remote-acceptor name="netty-throughput"
+                         socket-binding="messaging-throughput">
+            <param name="batch-delay" value="50"/>
+            <param name="direct-deliver" value="false"/>
+        </remote-acceptor>
+        <in-vm-acceptor name="in-vm"
+                        server-id="${my.server-id:0}"/>
+        <acceptor name="myacceptor"
+                  factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="batchDelay" value="${batch.delay:50}"/>
+        </acceptor>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         broadcast-period="${broadcast.group.period:1234}"
+                         connectors="http netty"/>
+
+        <socket-broadcast-group name="groupS"
+                         socket-binding="group-s-binding"
+                         connectors="in-vm"/>
+
+        <jgroups-discovery-group name="groupU"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                         initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+        <socket-discovery-group name="groupT"
+                         socket-binding="group-t-binding"/>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            check-period="${check.period:2345}"
+                            connection-ttl="${connection.ttl:1234}"
+                            min-large-message-size="${min.large.message.size:10245}"
+                            call-timeout="${call.timeout:3456}"
+                            call-failover-timeout="${call.failover.timeout:7890}"
+                            retry-interval="${retry.interval:987}"
+                            retry-interval-multiplier="${retry.interval.multiplier:3.0}"
+                            max-retry-interval="${max.retry.interval:3600}"
+                            reconnect-attempts="${reconnect.attempts:-1}"
+                            use-duplicate-detection="${use.duplicate.detection:true}"
+                            message-load-balancing-type="${message.load.balancing.type:STRICT}"
+                            max-hops="${max.hops:7}"
+                            confirmation-window-size="${confirmation.windows.size:459}"
+                            producer-window-size="${producer.windows.size:5678}"
+                            notification-attempts="${notification.attempts:2}"
+                            notification-interval="${notification.interval:1}"
+                            static-connectors="in-vm netty" />
+        <cluster-connection name="cc2"
+                            address="cc2-address"
+                            connector-name="netty"
+                            static-connectors="in-vm netty"
+                            allow-direct-connections-only="true" />
+        <cluster-connection name="cc3"
+                            address="cc3-address"
+                            connector-name="netty"
+                            discovery-group="groupC"/>
+        <cluster-connection name="cc4"
+                            address="cc4-address"
+                            connector-name="netty-throughput"
+                            static-connectors="in-vm netty" />
+
+        <grouping-handler name="grouping-handler"
+                          type="${grouping.type:LOCAL}"
+                          address="${address:handler-address}"
+                          timeout="${timeout:5000}"
+                          group-timeout="${group-timeout:1234}"
+                          reaper-period="${reaper-period:5678}" />
+
+        <divert name="testDivert1"
+                routing-name="${routing.name:routing}"
+                address="${address:address1}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                filter="${filter:afilter}"
+                transformer-class-name="org.jboss.test.Transformer"
+                exclusive="${exclusive:true}"/>
+        <divert name="testDivert2"
+                address="address2"
+                forwarding-address="forwardingaddress2"/>
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                ha="${ha:true}"
+                filter="${filter:afilter}"
+                transformer-class-name="foo.bar"
+                min-large-message-size="${min.large.message.size:10240}"
+                check-period="${check.period:666}"
+                connection-ttl="${connection.tt:36000}"
+                retry-interval="${retry.interval:750}"
+                retry-interval-multiplier="${retry.interval.multiplier:2}"
+                max-retry-interval="${max.retry.interval:3000}"
+                reconnect-attempts="${reconnect-attempts:3}"
+                reconnect-attempts-on-same-node="${reconnect-attempts-on-same-node:5}"
+                use-duplicate-detection="${use.duplicate.detection:true}"
+                confirmation-window-size="${confirmation.window.size:350}"
+                producer-window-size="${producer.windows.size:5678}"
+                user="${user:Brian}"
+                password="${password:secret}"
+                static-connectors="in-vm netty" />
+        <bridge name="bridge2"
+                queue-name="coreQueueB"
+                discovery-group="groupC" />
+
+        <connector-service name="b"
+                           factory-class="bar.foo">
+            <param name="foo"
+                   value="${connector.value:bar}"/>
+            <param name="bar"
+                   value="2"/>
+        </connector-service>
+
+
+        <jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/test}"
+                   selector="${selector:color='red'}"
+                   durable="${durable:true}" />
+        <jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/test2"
+                   legacy-entries="java:/global/queue/legacy/test java:/global/queue/legacy/test2" />
+        <jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/test}"
+                   legacy-entries="${jms-topic.entry:topic/legacy/test}" />
+
+        <connection-factory name="InVmConnectionFactory"
+                            connectors="in-vm netty"
+                            entries="${connection-factory.entries.entry:java:/ConnectionFactory}"
+                            use-topology-for-load-balancing="true" />
+        <connection-factory name="RemoteConnectionFactory"
+                            factory-type="XA_QUEUE"
+                            client-id="testClient"
+                            connectors="http netty"
+                            entries="RemoteConnectionFactory java:/global/jms/RemoteConnectionFactory"
+                            use-topology-for-load-balancing="false" />
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            ha="${ha:true}"
+                            client-failure-check-period="${client.failure.check.period:12345}"
+                            connection-ttl="${connection.ttl:56789}"
+                            call-timeout="${call.timeout:123}"
+                            call-failover-timeout="${call.failover.timeout:456}"
+                            consumer-window-size="${consumer.window.size:456}"
+                            consumer-max-rate="${consumer.max.rate:789}"
+                            confirmation-window-size="${confirmation.window.size:-1}"
+                            producer-window-size="${producer.window.size:-1}"
+                            producer-max-rate="${producer.max.rate:1024}"
+                            protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                            compress-large-messages="${compress.large.messages:true}"
+                            cache-large-message-client="${cache.large.message.client:false}"
+                            min-large-message-size="${min.large.message.size:2048}"
+                            client-id="${client.id:myClientID}"
+                            dups-ok-batch-size="${dups.ok.batch.size:256}"
+                            transaction-batch-size="${transaction.batch.size:512}"
+                            block-on-acknowledge="${block.on.acknowledge:false}"
+                            block-on-non-durable-send="${block.on.non.durable.send:false}"
+                            block-on-durable-send="${block.on.durable.send:false}"
+                            auto-group="${auto.group:true}"
+                            pre-acknowledge="${pre.acknowledge:true}"
+                            retry-interval="${retry.interval:500}"
+                            retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                            max-retry-interval="${max.retry.interval:10000}"
+                            reconnect-attempts="${reconnect.attempts:2}"
+                            failover-on-initial-connection="${failover.on.initial.connection:true}"
+                            connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                            use-global-pools="${use.global.pools:true}"
+                            scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                            thread-pool-max-size="${thread.pool.max.size:48}"
+                            group-id="${group.id:myGroup}"
+                            deserialization-black-list="org.foo.Bar org.foo.Baz"
+                            deserialization-white-list="org.bar.Bar org.baz.Baz"
+                            initial-message-packet-size="${initial.message.packet.size:456}" />
+        <legacy-connection-factory name="legacyConnectionFactory-discovery"
+                                   entries="legacy/RemoteConnectionFactory java:/global/jms/legacy/RemoteConnectionFactory"
+                                   discovery-group="groupT"
+                                   auto-group="${auto.group:true}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   call-timeout="${call.timeout:123}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   client-id="${client.id:myClientID}"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                                   connection-ttl="${connection.ttl:56789}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   factory-type="${legacy.connection.factory.factory-type:XA_QUEUE}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   group-id="${group.id:myGroup}"
+                                   ha="${legacy.connection.factory.ha:true}"
+                                   initial-connect-attempts="${initial.connect.attemps:123}"
+                                   initial-message-packet-size="${initial.message.packet.size:456}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   use-global-pools="${use.global.pools:true}" />
+        <legacy-connection-factory name="legacyConnectionFactory-connectors"
+                                   entries="legacy/RemoteConnectionFactory2 java:/global/jms/legacy/RemoteConnectionFactory2"
+                                   connectors="netty http" />
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"
+                                   use-topology-for-load-balancing="true" />
+        <pooled-connection-factory name="activemq-ra-none"
+                                   transaction="none"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsNone"
+                                   use-topology-for-load-balancing="false" />
+        <pooled-connection-factory name="activemq-ra"
+                                   transaction="${transaction:xa}"
+                                   user="${user:alice}"
+                                   password="${password:alicepassword}"
+                                   min-pool-size="${min.pool.size:42}"
+                                   max-pool-size="${max.pool.size:242}"
+                                   managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                                   enlistment-trace="${enlistment.trace:false}"
+                                   initial-message-packet-size="${initial.message.packet.size:9876}"
+                                   initial-connect-attempts="${initial.connect.attempts:5432}"
+                                   connectors="in-vm netty"
+                                   entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                                   ha="${ha:true}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   connection-ttl="${connection.ttl:6789}"
+                                   call-timeout="${call.timeout:123}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   client-id="${client.id:myClientID}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   auto-group="${auto.group:true}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                                   use-global-pools="${use.global.pools:true}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   group-id="${group.id:myGroup}"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz"
+                                   statistics-enabled="${pcf.statistics-enabled:true}">
+            <inbound-config
+                use-jndi="${use.jndi:false}"
+                jndi-params="${jndi.params:whatever}"
+                rebalance-connections="${inbound.rebalance-connections:true}"
+                use-local-tx="${use.local.tx:true}"
+                setup-attempts="${setup-attempts:123}"
+                setup-interval="${setup-interval:456}" />
+            <outbound-config
+                allow-local-transactions="${allow.local.transactions:true}" />
+        </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
+    </server>
+
+    <server name="empty"/>
+
+    <jms-bridge name="default"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser"
+                password="myPassword"/>
+
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser"
+                password="myPassword"/>
+    </jms-bridge>
+
+    <jms-bridge name="another-bridge"
+                module="org.another.mq.broker"
+                quality-of-service="ONCE_AND_ONLY_ONCE"
+                failure-retry-interval="-1"
+                max-retries="-1"
+                max-batch-size="1"
+                max-batch-time="-1"
+                selector="${selector:color='red'}"
+                subscription-name="${subscription.name:mySubscription}"
+                client-id="${client.id:myClientID}"
+                add-messageID-in-header="${add.messageID.in.header:true}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/sourceTopic"
+                user="myUser"
+                password="myPassword">
+            <source-context>
+                <property name="java.naming.factory.initial"
+                          value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property name="java.naming.provider.url"
+                          value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property name="java.naming.factory.url.pkgs"
+                          value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+            </source-context>
+        </source>
+        <target connection-factory="anotherAS7/jms/cf/targetCF"
+                destination="anotherAS7/jms/queue/targetQueue"
+                user="${userInExpression:user}"
+                password="${passwordInExpression:password}">
+            <target-context>
+                <property name="java.naming.factory.initial"
+                          value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property name="java.naming.provider.url"
+                          value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property name="java.naming.factory.url.pkgs"
+                          value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+            </target-context>
+        </target>
+    </jms-bridge>
+
+    <jms-bridge name="bridge-with-credential-reference"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser">
+            <source-credential-reference clear-text="passwordOut!"/>
+        </source>
+
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser">
+            <target-credential-reference alias="bob" store="jms-bridge-store" />
+        </target>
+    </jms-bridge>
+
+    <jms-bridge name="default-bridge"
+                module="org.default.mq.broker"
+                selector="${selector:color='red'}"
+                subscription-name="${subscription.name:mySubscription}"
+                client-id="${client.id:myClientID}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/sourceTopic"
+                user="myUser"
+                password="myPassword">
+        </source>
+        <target connection-factory="anotherAS7/jms/cf/targetCF"
+                destination="anotherAS7/jms/queue/targetQueue"
+                user="${userInExpression:user}"
+                password="${passwordInExpression:password}">
+        </target>
+    </jms-bridge>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_ha-policy.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_ha-policy.xml
@@ -1,0 +1,92 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <server name="ha-policy-live-only-scale-down-discovery-group">
+        <live-only>
+            <scale-down enabled="${scale-down.enabled:true}"
+                        cluster-name="${scale-down.cluster-name:mycluster}"
+                        group-name="${scale-down.group-name:mygroup}"
+                        discovery-group="groupC"/>
+        </live-only>
+    </server>
+    <server name="ha-policy-live-only-scale-down-connectors">
+        <live-only>
+            <scale-down enabled="${scale-down.enabled:true}"
+                        cluster-name="${scale-down.cluster-name:mycluster}"
+                        group-name="${scale-down.group-name:mygroup}"
+                        connectors="netty in-vm"/>
+        </live-only>
+    </server>
+    <server name="ha-policy-replication-master">
+        <replication-master
+                cluster-name="${replication-master.cluster-name:mycluster}"
+                group-name="${replication-master.cluster-name:mygroup}"
+                check-for-live-server="${replication-master.check-for-live-server:false}"
+                initial-replication-sync-timeout="${replication-master.initial-replication-sync-timeout:1234}"/>
+    </server>
+    <server name="ha-policy-replication-slave">
+        <replication-slave
+                cluster-name="${replication-slave.cluster-name:mycluster}"
+                group-name="${replication-slave.cluster-name:mygroup}"
+                allow-failback="${replication-slave.allow-failback:true}"
+                initial-replication-sync-timeout="${replication-master.initial-replication-sync-timeout:1234}"
+                restart-backup="${replication-slave.restart-backup:true}"
+                max-saved-replicated-journal-size="${replication-slave.max-saved-replicated-journal-size:24}">
+            <scale-down enabled="${replication-slave-scale-down.enabled:true}"
+                        cluster-name="${replication-slave-scale-down.cluster-name:mycluster}"
+                        group-name="${replication-slave-scale-down.group-name:mygroup}"
+                        connectors="netty"/>
+        </replication-slave>
+    </server>
+    <server name="ha-policy-replication-colocated">
+        <replication-colocated request-backup="${replication-colocated.request-backup:false}"
+                               backup-request-retries="${replication-colocated.backup-request-retries:-1}"
+                               backup-request-retry-interval="${replication-colocated.backup-request-retry-interval:5098}"
+                               max-backups="${replication-colocated.max-backups:5}"
+                               backup-port-offset="${replication-colocated.backup-port-offset:500}"
+                               excluded-connectors="netty">
+            <master cluster-name="${replication-colocated-master.cluster-name:mycluster}"
+                    group-name="${replication-colocated-master.cluster-name:mygroup}"
+                    check-for-live-server="${replication-colocated-master.check-for-live-server:false}" />
+            <slave cluster-name="${replication-colocated-slave.cluster-name:mycluster}"
+                   group-name="${replication-colocated-slave.cluster-name:mygroup}"
+                   allow-failback="${replication-colocated-slave.allow-failback:true}"
+                   initial-replication-sync-timeout="${replication-colocated-slave.initial-replication-sync-timeout:1234}"
+                   restart-backup="${replication-colocated-slave.restart-backup:true}"
+                   max-saved-replicated-journal-size="${replication-colocated-slave.max-saved-replicated-journal-size:24}">
+                <scale-down enabled="${replication-colocated-slave-scale-down.enabled:true}"
+                            cluster-name="${replication-colocated-slave-scale-down.cluster-name:mycluster}"
+                            group-name="${replication-colocated-slave-scale-down.group-name:mygroup}"
+                            connectors="netty"/>
+            </slave>
+        </replication-colocated>
+    </server>
+    <server name="ha-policy-shared-store-master">
+        <shared-store-master failover-on-server-shutdown="${shared-store-master.failover-on-server-shutdown:true}" />
+    </server>
+    <server name="ha-policy-shared-store-slave">
+        <shared-store-slave allow-failback="${shared-store-slave.allow-failback:false}"
+                            failover-on-server-shutdown="${shared-store-slave.failover-on-server-shutdown:true}"
+                            restart-backup="${shared-store-slave.restart-backup:false}">
+            <scale-down enabled="${shared-store-slave-scale-down.enabled:true}"
+                        cluster-name="${shared-store-slave-scale-down.cluster-name:mycluster}"
+                        group-name="${shared-store-slave-slave-scale-down.group-name:mygroup}"
+                        connectors="netty" />
+        </shared-store-slave>
+    </server>
+    <server name="ha-policy-shared-store-colocated">
+        <shared-store-colocated request-backup="${shared-store-colocated.request-backup:false}"
+                                backup-request-retries="${shared-store-colocated.backup-request-retries:-1}"
+                                backup-request-retry-interval="${shared-store-colocated.backup-request-retry-interval:5098}"
+                                max-backups="${shared-store-colocated.max-backups:5}"
+                                backup-port-offset="${shared-store-colocated.backup-port-offset:500}">
+            <master failover-on-server-shutdown="${shared-store-colocated-master.failover-on-server-shutdown:true}" />
+            <slave allow-failback="${shared-store-colocated-slave.allow-failback:false}"
+                   failover-on-server-shutdown="${shared-store-colocated-slave.failover-on-server-shutdown:true}"
+                   restart-backup="${shared-store-colocated-slave.restart-backup:false}">
+                <scale-down enabled="${shared-store-colocated-slave-scale-down.enabled:true}"
+                            cluster-name="${shared-store-colocated-slave-scale-down.cluster-name:mycluster}"
+                            group-name="${shared-store-colocated-slave-slave-scale-down.group-name:mygroup}"
+                            connectors="netty" />
+            </slave>
+        </shared-store-colocated>
+    </server>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_reject_transform.xml
@@ -1,0 +1,222 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <global-client thread-pool-max-size="${global.client.thread-pool-max-size:32}"
+                   scheduled-thread-pool-max-size="${global.client.scheduled.thread-pool-max-size:54}" />
+
+    <http-connector name="client-http"
+                    socket-binding="http"
+                    endpoint="http"
+                    server-name="=foo">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </http-connector>
+
+    <remote-connector name="client-netty-throughput"
+                      socket-binding="messaging-throughput">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </remote-connector>
+
+    <in-vm-connector name="in-vm-client"
+                     server-id="${my.server-id:0}"/>
+
+    <connector name="myconnector-client"
+               factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+        <param name="host" value="192.168.1.2"/>
+        <param name="port" value="5445"/>
+        <param name="key-store-path" value="path/to/server.jks"/>
+        <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+    </connector>
+
+    <socket-discovery-group name="client-discovery-group-1"
+                     socket-binding="group-t-binding"/>
+
+    <connection-factory name="InVmConnectionFactory"
+                        connectors="in-vm-client"
+                        entries="${connection-factory.entries.entry:java:/ClientConnectionFactory}"
+                        enable-amq1-prefix="false"
+                        use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm-client"
+                                   entries="java:/JmsLocal"
+                                   enable-amq1-prefix="false"/>
+
+    <external-jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/client-test}"/>
+    <external-jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/client-test2"/>
+    <external-jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/client-test}"/>
+
+    <server name="default">
+
+        <security elytron-domain="elytronDomain"/>
+        <cluster user="testuser">
+            <credential-reference store="cs1" alias="testuser"/>
+        </cluster>
+        <journal datasource="fooDS"
+                 database="mysql"
+                 jdbc-lock-expiration="891"
+                 jdbc-lock-renew-period="892"
+                 jdbc-network-timeout="4567"
+                 messages-table="MY_MESSAGES"
+                 bindings-table="MY_BINDINGS"
+                 jms-bindings-table="MY_JMS_BINDINGS"
+                 large-messages-table="MY_LARGE_MESSAGES"
+                 node-manager-store-table="MY_NODE_MANAGER_STORE"
+                 page-store-table="MY_PAGE_STORE"
+                 global-max-disk-usage="70"
+                 global-max-memory-size="100000"
+                 disk-scan-period="10000"
+                 file-open-timeout="7"/>
+
+        <replication-colocated>
+            <master />
+        </replication-colocated>
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"
+               routing-type="ANYCAST" />
+
+        <queue name="coreQueueB" address="addressB" routing-type="ANYCAST" />
+
+        <address-setting name="#"
+                         auto-create-queues="true"
+                         auto-delete-queues="true"
+                         auto-create-addresses="false"
+                         auto-delete-addresses="false" />
+
+        <remote-connector name="netty"
+                                           socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+
+        <in-vm-connector name="in-vm"
+                                          server-id="${my.server-id:0}"/>
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http"
+                        server-name="=foo">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            producer-window-size="${producer.windows.size:5678}"
+                            static-connectors="in-vm netty" />
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}">
+            <credential-reference clear-text="secret1"/>
+        </bridge>
+        <bridge name="bridge2"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}"
+                password="${password:secret}">
+        </bridge>
+
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            deserialization-black-list="org.foo.Bar org.foo.Baz"
+                            deserialization-white-list="org.bar.Bar org.baz.Baz"
+                            initial-message-packet-size="${initial.message.packet.size:12345}"/>
+
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"
+                                   statistics-enabled="true"
+                                   use-topology-for-load-balancing="false">
+            <inbound-config
+                    rebalance-connections="true" />
+            <outbound-config
+                    allow-local-transactions="true" />
+
+        </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         connectors="http"/>
+
+        <jgroups-discovery-group name="groupU"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"/>
+    </server>
+    <server name="server1">
+        <security elytron-domain="elytronDomain"/>
+        <cluster user="testuser">
+            <credential-reference store="cs1" alias="testuser" clear-text="clusterpass"/>
+        </cluster>
+    </server>
+    <server name="server2">
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+        <bridge name="bridge2"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}">
+            <credential-reference store="cs1" clear-text="bridgepass"/>
+        </bridge>
+    </server>
+    <server name="server3">
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz">
+            <credential-reference store="cs1" clear-text="pooledpass"/>
+        </pooled-connection-factory>
+    </server>
+    <jms-bridge name="bridge-with-credential-reference"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser">
+            <source-credential-reference store="cs1" clear-text="sourcepass"/>
+        </source>
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser">
+            <target-credential-reference alias="bob" store="jms-bridge-store" clear-text="targetpass"/>
+        </target>
+    </jms-bridge>
+    <server name="other">
+        <replication-master />
+    </server>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_10_0_transform.xml
@@ -1,0 +1,416 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <server name="default"
+            persistence-enabled="${persistence.enabled:false}"
+            persist-id-cache="${persist.id.cache:false}"
+            persist-delivery-count-before-delivery="${persist.delivery.count.before.delivery:true}"
+            id-cache-size="${id.cache.size:102030}"
+            page-max-concurrent-io="${page.max.concurrent.io:10}"
+            scheduled-thread-pool-max-size="${messaging.scheduled.thread.pool.max.size:6}"
+            thread-pool-max-size="${messaging.thread.pool.max.size:5}"
+            wild-card-routing-enabled="${wild.card.routing.enabled:false}"
+            connection-ttl-override="${connection.ttl.override:5432}"
+            async-connection-execution-enabled="${async.connection.execution.enabled:false}">
+
+        <security
+                enabled="${security.enabled:false}"
+                domain="someDomain"
+                invalidation-interval="${security.invalidation.interval:1234}"
+                override-in-vm-security="${override.in-vm.security:false}"/>
+
+        <cluster
+                user="${messaging.cluster.user.name:myClusterUser}"
+                password="${messaging.cluster.user.password:myClusterPassword}"/>
+
+        <management
+                address="${management.address:my.management.address}"
+                notification-address="${management.notification.address:my.management.notif.address}"
+                jmx-enabled="${jmx.management.enabled:false}"
+                jmx-domain="${jmx.domain:my.jmx.domain}"/>
+
+        <journal
+                type="${journal.type:NIO}"
+                buffer-timeout="${journal.buffer.timeout:1357}"
+                buffer-size="${journal.buffer.size:2468}"
+                sync-transactional="${journal.sync.transactional:false}"
+                sync-non-transactional="${journal.sync.non.transactional:true}"
+                log-write-rate="${log.journal.write.rate:true}"
+                file-size="${journal.file.size:102400}"
+                min-files="${journal.min.files:2}"
+                pool-files="${journal.pool.files:5}"
+                compact-percentage="${journal.compact.percentage:83}"
+                compact-min-files="${journal.compact.min.files:2}"
+                max-io="${journal.max.io:50}"
+                create-bindings-dir="${create.bindings.dir:false}"
+                create-journal-dir="${create.journal.dir:true}"
+                global-max-disk-usage="100"
+                disk-scan-period="5000"
+                global-max-memory-size="-1"/>
+
+        <statistics
+                enabled="${statistics.enabled:true}"
+                message-counter-sample-period="${message.counter.sample.period:7654}"
+                message-counter-max-day-history="${message.counter.max.day.history:23}"/>
+
+        <transaction
+                timeout="${transaction.timeout:4321}"
+                scan-period="${transaction.timeout.scan.period:5432}"/>
+
+        <message-expiry
+                scan-period="${message.expiry.scan.period:7654}"
+                thread-priority="${message.expiry.thread.priority:7}"/>
+
+        <debug
+                perf-blast-pages="${perf.blast.pages:70}"
+                run-sync-speed-test="${run.sync.speed.test:false}"
+                server-dump-interval="${server.dump.interval:8642}"
+                memory-warning-threshold="${memory.warning.threshold:1024}"
+                memory-measure-interval="${memory.measure.interval:2048}"/>
+
+        <bindings-directory path="${my.bindings.dir:test}" relative-to="test"/>
+        <journal-directory path="${my.journal.dir:test}" relative-to="test"/>
+        <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test"/>
+        <paging-directory path="${my.paging.dir:test}" relative-to="test"/>
+
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+
+        <queue name="coreQueueB"
+               address="addressB"/>
+
+        <security-setting name="#">
+            <role name="guest"
+                  send="true"
+                  consume="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"/>
+            <role name="admin"
+                  send="true"
+                  consume="true"
+                  create-durable-queue="true"
+                  delete-durable-queue="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"
+                  manage="true"/>
+        </security-setting>
+
+        <address-setting name="#"
+                         dead-letter-address="${dead.letter.address:jms.queue.DLQ}"
+                         expiry-address="${expiry.address:jms.queue.ExpiryQueue}"
+                         expiry-delay="${expiry.delay:12345}"
+                         redelivery-delay="${redelivery.delay:0}"
+                         redelivery-multiplier="${redelivery.multiplier:1.0}"
+                         max-delivery-attempts="${max.delivery.attempts:5}"
+                         max-redelivery-delay="${max.redelivery.delay:234}"
+                         max-size-bytes="${max.size.bytes:10485760}"
+                         page-size-bytes="${page.size.bytes:10485760}"
+                         page-max-cache-size="${page.max.cache.size:7}"
+                         address-full-policy="${address.full.policy:BLOCK}"
+                         message-counter-history-day-limit="${message.counter.history.day.limit:10}"
+                         last-value-queue="${last.value.queue:false}"
+                         redistribution-delay="${redistribution.delay:0}"
+                         send-to-dla-on-no-route="${send.to.dla.on.no.route:false}"
+                         slow-consumer-check-period="${slow.consumer.check.period:123}"
+                         slow-consumer-policy="${slow.consumer.policy:KILL}"
+                         slow-consumer-threshold="${slow.consumer.threshold:456}"
+                         auto-create-jms-queues="${auto.create.jms.queue:true}"
+                         auto-delete-jms-queues="${auto.delete.jms.queue:true}"
+                         auto-create-queues="false"
+                         auto-delete-queues="false"
+                         auto-create-addresses="true"
+                         auto-delete-addresses="true"/>
+
+        <address-setting name="test"
+                         page-size-bytes="100"/>
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+        <remote-connector name="netty"
+                          socket-binding="messaging"/>
+        <remote-connector name="netty-throughput"
+                          socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <connector name="myconnector"
+                   factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="host" value="192.168.1.2"/>
+            <param name="port" value="5445"/>
+            <param name="key-store-path" value="path/to/server.jks"/>
+            <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+        </connector>
+
+        <http-acceptor name="http"
+                       http-listener="default"
+                       upgrade-legacy="${upgrade.legacy:true}">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-acceptor>
+        <remote-acceptor name="netty"
+                         socket-binding="messaging"/>
+        <remote-acceptor name="netty-throughput"
+                         socket-binding="messaging-throughput">
+            <param name="batch-delay" value="50"/>
+            <param name="direct-deliver" value="false"/>
+        </remote-acceptor>
+        <in-vm-acceptor name="in-vm"
+                        server-id="${my.server-id:0}"/>
+        <acceptor name="myacceptor"
+                  factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="batchDelay" value="${batch.delay:50}"/>
+        </acceptor>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-cluster="activemq-cluster"
+                         broadcast-period="${broadcast.group.period:1234}"
+                         connectors="http netty"/>
+        <jgroups-discovery-group name="groupU"
+                         jgroups-cluster="activemq-cluster"
+                         refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                         initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            check-period="${check.period:2345}"
+                            connection-ttl="${connection.ttl:1234}"
+                            min-large-message-size="${min.large.message.size:10245}"
+                            call-timeout="${call.timeout:3456}"
+                            call-failover-timeout="${call.failover.timeout:7890}"
+                            retry-interval="${retry.interval:987}"
+                            retry-interval-multiplier="${retry.interval.multiplier:3.0}"
+                            max-retry-interval="${max.retry.interval:3600}"
+                            reconnect-attempts="${reconnect.attempts:-1}"
+                            use-duplicate-detection="${use.duplicate.detection:true}"
+                            message-load-balancing-type="${message.load.balancing.type:STRICT}"
+                            max-hops="${max.hops:7}"
+                            confirmation-window-size="${confirmation.windows.size:459}"
+                            producer-window-size="-1"
+                            notification-attempts="${notification.attempts:2}"
+                            notification-interval="${notification.interval:1}"
+                            static-connectors="in-vm netty" />
+        <cluster-connection name="cc2"
+                            address="cc2-address"
+                            connector-name="netty"
+                            static-connectors="in-vm netty"
+                            allow-direct-connections-only="true" />
+        <cluster-connection name="cc3"
+                            address="cc3-address"
+                            connector-name="netty"
+                            discovery-group="groupC"/>
+        <cluster-connection name="cc4"
+                            address="cc4-address"
+                            connector-name="netty-throughput"
+                            static-connectors="in-vm netty" />
+
+        <grouping-handler name="grouping-handler"
+                          type="${grouping.type:LOCAL}"
+                          address="${address:handler-address}"
+                          timeout="${timeout:5000}"
+                          group-timeout="${group-timeout:1234}"
+                          reaper-period="${reaper-period:5678}" />
+
+        <divert name="testDivert1"
+                routing-name="${routing.name:routing}"
+                address="${address:address1}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                filter="${filter:afilter}"
+                transformer-class-name="org.jboss.test.Transformer"
+                exclusive="${exclusive:true}"/>
+        <divert name="testDivert2"
+                address="address2"
+                forwarding-address="forwardingaddress2"/>
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                ha="${ha:true}"
+                filter="${filter:afilter}"
+                transformer-class-name="foo.bar"
+                min-large-message-size="${min.large.message.size:10240}"
+                check-period="${check.period:666}"
+                connection-ttl="${connection.tt:36000}"
+                retry-interval="${retry.interval:750}"
+                retry-interval-multiplier="${retry.interval.multiplier:2}"
+                max-retry-interval="${max.retry.interval:3000}"
+                reconnect-attempts="${reconnect-attempts:3}"
+                reconnect-attempts-on-same-node="${reconnect-attempts-on-same-node:5}"
+                use-duplicate-detection="${use.duplicate.detection:true}"
+                confirmation-window-size="${confirmation.window.size:350}"
+                producer-window-size="-1"
+                user="${user:Brian}"
+                password="${password:secret}"
+                static-connectors="in-vm netty" />
+        <bridge name="bridge2"
+                queue-name="coreQueueB"
+                discovery-group="groupC" />
+        <jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/test}"
+                   selector="${selector:color='red'}"
+                   durable="${durable:true}" />
+        <jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/test2"
+                   legacy-entries="java:/global/queue/legacy/test java:/global/queue/legacy/test2" />
+        <jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/test}"
+                   legacy-entries="${jms-topic.entry:topic/legacy/test}" />
+
+        <connection-factory name="InVmConnectionFactory"
+                            connectors="in-vm netty"
+                            entries="${connection-factory.entries.entry:java:/ConnectionFactory}" />
+        <connection-factory name="RemoteConnectionFactory"
+                            factory-type="XA_QUEUE"
+                            client-id="testClient"
+                            connectors="http netty"
+                            entries="RemoteConnectionFactory java:/global/jms/RemoteConnectionFactory" />
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            ha="${ha:true}"
+                            client-failure-check-period="${client.failure.check.period:12345}"
+                            connection-ttl="${connection.ttl:56789}"
+                            call-timeout="${call.timeout:123}"
+                            call-failover-timeout="${call.failover.timeout:456}"
+                            consumer-window-size="${consumer.window.size:456}"
+                            consumer-max-rate="${consumer.max.rate:789}"
+                            confirmation-window-size="${confirmation.window.size:-1}"
+                            producer-window-size="${producer.window.size:-1}"
+                            producer-max-rate="${producer.max.rate:1024}"
+                            protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                            compress-large-messages="${compress.large.messages:true}"
+                            cache-large-message-client="${cache.large.message.client:false}"
+                            min-large-message-size="${min.large.message.size:2048}"
+                            client-id="${client.id:myClientID}"
+                            dups-ok-batch-size="${dups.ok.batch.size:256}"
+                            transaction-batch-size="${transaction.batch.size:512}"
+                            block-on-acknowledge="${block.on.acknowledge:false}"
+                            block-on-non-durable-send="${block.on.non.durable.send:false}"
+                            block-on-durable-send="${block.on.durable.send:false}"
+                            auto-group="${auto.group:true}"
+                            pre-acknowledge="${pre.acknowledge:true}"
+                            retry-interval="${retry.interval:500}"
+                            retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                            max-retry-interval="${max.retry.interval:10000}"
+                            reconnect-attempts="${reconnect.attempts:2}"
+                            failover-on-initial-connection="${failover.on.initial.connection:true}"
+                            connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                            use-global-pools="${use.global.pools:true}"
+                            scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                            thread-pool-max-size="${thread.pool.max.size:48}"
+                            group-id="${group.id:myGroup}"
+                            use-topology-for-load-balancing="true" />
+        <legacy-connection-factory name="legacyConnectionFactory-discovery"
+                                   entries="legacy/RemoteConnectionFactory java:/global/jms/legacy/RemoteConnectionFactory"
+                                   discovery-group="groupT"
+                                   auto-group="${auto.group:true}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   call-timeout="${call.timeout:123}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   client-id="${client.id:myClientID}"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                                   connection-ttl="${connection.ttl:56789}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   factory-type="${legacy.connection.factory.factory-type:XA_QUEUE}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   group-id="${group.id:myGroup}"
+                                   ha="${legacy.connection.factory.ha:true}"
+                                   initial-connect-attempts="${initial.connect.attemps:123}"
+                                   initial-message-packet-size="${initial.message.packet.size:456}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   use-global-pools="${use.global.pools:true}" />
+        <legacy-connection-factory name="legacyConnectionFactory-connectors"
+                                   entries="legacy/RemoteConnectionFactory2 java:/global/jms/legacy/RemoteConnectionFactory2"
+                                   connectors="netty http" />
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"/>
+        <pooled-connection-factory name="activemq-ra-none"
+                                   transaction="none"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsNone"/>
+        <pooled-connection-factory name="activemq-ra"
+                                   transaction="${transaction:xa}"
+                                   user="${user:alice}"
+                                   password="${password:alicepassword}"
+                                   min-pool-size="${min.pool.size:42}"
+                                   max-pool-size="${max.pool.size:242}"
+                                   managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                                   enlistment-trace="${enlistment.trace:false}"
+                                   initial-message-packet-size="${initial.message.packet.size:9876}"
+                                   initial-connect-attempts="${initial.connect.attempts:5432}"
+                                   connectors="in-vm netty"
+                                   entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                                   ha="${ha:true}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   connection-ttl="${connection.ttl:6789}"
+                                   call-timeout="${call.timeout:123}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   client-id="${client.id:myClientID}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   auto-group="${auto.group:true}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                                   use-global-pools="${use.global.pools:true}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   group-id="${group.id:myGroup}"
+                                   statistics-enabled="false"
+                                   use-topology-for-load-balancing="true">
+            <inbound-config
+                    use-jndi="${use.jndi:false}"
+                    jndi-params="${jndi.params:whatever}"
+                    rebalance-connections="false"
+                    use-local-tx="${use.local.tx:true}"
+                    setup-attempts="${setup-attempts:123}"
+                    setup-interval="${setup-interval:456}" />
+            <outbound-config
+                    allow-local-transactions="false" />
+        </pooled-connection-factory>
+    </server>
+</subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/basic-attributes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/basic-attributes.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS" enabled="true" statistics-enabled="true">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/complex-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2" major-version="1" minor-version="4">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/empty-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/empty-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/pool-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/pool-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/statement-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/statement-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/timeout-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/timeout-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/validation-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/validation-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-driver-classes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-driver-classes.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-ds-classes-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-ds-classes-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-xa-ds-classes-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-2-xa-ds-classes-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="name" module="com.h2database.h2">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-wait-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-alloc-retry-wait-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-blckg-timeout-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-blckg-timeout-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-empty-name-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver name="" module="com.h2database.h2" major-version="1">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-flush-strategy-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-flush-strategy-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-idle-mins-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-idle-mins-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-less-min-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-less-min-pool-size-propertiy.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-max-pool-size-propertiy.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-min-pool-size-propertiy.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-min-pool-size-propertiy.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-xa-ds-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-no-xa-ds-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <!-- there is no xa-datasource-property -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-stmt-cache-size-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-stmt-cache-size-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-transaction-isolation-type.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-transaction-isolation-type.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-trck-stmt-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-trck-stmt-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-validation-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-validation-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <datasource jndi-name="java:jboss/datasources/DS"
                     pool-name="DS">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-wo-name-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <drivers>
             <driver module="com.h2database.h2" major-version="1">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-2-security-domains.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-2-security-domains.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-bogus-driver.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-bogus-driver.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-res-timeout-property.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/wrong-xa-res-timeout-property.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-basic-attributes.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-basic-attributes.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS" enabled="true">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-bool-pres-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-default-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-default-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-false-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-false-bool-pres-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-true-bool-pres-properties.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/metrics/data-sources/xa-true-bool-pres-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:datasources:5.0">
+<subsystem xmlns="urn:jboss:domain:datasources:6.0">
     <datasources>
         <xa-datasource jndi-name="java:jboss/datasources/DS" pool-name="DS">
             <xa-datasource-property name="DatabaseName">mydb</xa-datasource-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/basic.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/basic.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="basic">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/double.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/double.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="double">
             <config-property name="name">overRA</config-property>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/inflow.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/inflow.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="inflow2">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/mod-2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/mod-2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="mod2">
             <module slot="main" id="org.jboss.ironjacamar.ra16out1"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/multi.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/multi.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="multi">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/pure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/pure.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter>
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/second.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/second.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:resource-adapters:5.0">
+<subsystem xmlns="urn:jboss:domain:resource-adapters:6.0">
     <resource-adapters>
         <resource-adapter id="second">
             <module slot="main" id="org.jboss.ironjacamar.ra16out"/>

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ApplicationSecurityDomainSingleSignOnDefinition.java
@@ -22,32 +22,21 @@
 
 package org.wildfly.extension.undertow;
 
-import static org.jboss.as.controller.security.CredentialReference.handleCredentialReferenceUpdate;
-import static org.jboss.as.controller.security.CredentialReference.rollbackCredentialStoreUpdate;
-
+import java.util.EnumSet;
 import java.util.function.UnaryOperator;
 
-import org.jboss.as.clustering.controller.AddStepHandlerDescriptor;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.CommonUnaryRequirement;
-import org.jboss.as.clustering.controller.ReloadRequiredAddStepHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.clustering.controller.UnaryCapabilityNameResolver;
 import org.jboss.as.clustering.controller.ReloadRequiredResourceRegistration;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.WriteAttributeStepHandler;
-import org.jboss.as.clustering.controller.WriteAttributeStepHandlerDescriptor;
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.controller.security.CredentialReferenceWriteAttributeHandler;
-import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -97,68 +86,11 @@ public class ApplicationSecurityDomainSingleSignOnDefinition extends SingleSignO
     @Override
     public void registerOperations(ManagementResourceRegistration registration) {
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(Attribute.class)
+                .addAttributes(EnumSet.complementOf(EnumSet.of(Attribute.CREDENTIAL)))
+                .addAttribute(Attribute.CREDENTIAL, new CredentialReferenceWriteAttributeHandler(Attribute.CREDENTIAL.getDefinition()))
                 .addAttributes(SingleSignOnDefinition.Attribute.class)
                 .addCapabilities(Capability.class)
                 ;
-        new UndertowResourceRegistration(descriptor).register(registration);
+        new ReloadRequiredResourceRegistration(descriptor).register(registration);
     }
-
-    private static class UndertowResourceRegistration extends ReloadRequiredResourceRegistration {
-
-        public UndertowResourceRegistration(AddStepHandlerDescriptor descriptor) {
-            super(descriptor, new UndertowAddStepHandler(descriptor), new ReloadRequiredRemoveStepHandler(descriptor), new UndertowWriteAttributeStepHandler(descriptor));
-        }
-    }
-
-    private static class UndertowAddStepHandler extends ReloadRequiredAddStepHandler {
-
-        public UndertowAddStepHandler(AddStepHandlerDescriptor descriptor) {
-            super(descriptor);
-        }
-
-        @Override
-        protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-            super.populateModel(context, operation, resource);
-            handleCredentialReferenceUpdate(context, resource.getModel());
-        }
-
-        @Override
-        protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
-            rollbackCredentialStoreUpdate(Attribute.CREDENTIAL.getDefinition(), context, resource);
-            super.rollbackRuntime(context, operation, resource);
-        }
-    }
-
-    private static class UndertowWriteAttributeStepHandler extends WriteAttributeStepHandler {
-
-        private final WriteAttributeStepHandlerDescriptor descriptor;
-
-        public UndertowWriteAttributeStepHandler(WriteAttributeStepHandlerDescriptor descriptor) {
-            super(descriptor, null);
-            this.descriptor = descriptor;
-        }
-
-        @Override
-        public void register(ManagementResourceRegistration registration) {
-            CredentialReferenceWriteAttributeHandler credentialReferenceWriteAttributeHandler = new CredentialReferenceWriteAttributeHandler(Attribute.CREDENTIAL.getDefinition());
-            for (AttributeDefinition attribute : descriptor.getAttributes()) {
-                if (attribute.equals(Attribute.CREDENTIAL)) {
-                    registration.registerReadWriteAttribute(attribute, null, credentialReferenceWriteAttributeHandler);
-                } else {
-                    registration.registerReadWriteAttribute(attribute, null, this);
-                }
-            }
-        }
-
-        @Override
-        protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode resolvedValue, Void handback) throws OperationFailedException {
-            if (attributeName.equals(Attribute.CREDENTIAL.getName())) {
-                rollbackCredentialStoreUpdate(Attribute.CREDENTIAL.getDefinition(), context, resolvedValue);
-            }
-            super.revertUpdateToRuntime(context, operation, attributeName, valueToRestore, resolvedValue, handback);
-        }
-
-    }
-
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
@@ -46,12 +46,13 @@ enum Namespace {
     UNDERTOW_8_0("urn:jboss:domain:undertow:8.0"),
     UNDERTOW_9_0("urn:jboss:domain:undertow:9.0"),
     UNDERTOW_10_0("urn:jboss:domain:undertow:10.0"),
+    UNDERTOW_11_0("urn:jboss:domain:undertow:11.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = UNDERTOW_10_0;
+    public static final Namespace CURRENT = UNDERTOW_11_0;
 
     private final String name;
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
@@ -79,7 +79,7 @@ public class UndertowExtension implements Extension {
     static final AccessConstraintDefinition LISTENER_CONSTRAINT = new SensitiveTargetAccessConstraintDefinition(
                     new SensitivityClassification(SUBSYSTEM_NAME, "web-connector", false, false, false));
 
-    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(10, 0, 0);
+    private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(11, 0, 0);
 
 
     public static StandardResourceDescriptionResolver getResolver(final String... keyPrefix) {
@@ -105,6 +105,7 @@ public class UndertowExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_8_0.getUriString(), UndertowSubsystemParser_8_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_9_0.getUriString(), UndertowSubsystemParser_9_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_10_0.getUriString(), UndertowSubsystemParser_10_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_11_0.getUriString(), UndertowSubsystemParser_11_0::new);
     }
 
     @Override
@@ -117,7 +118,7 @@ public class UndertowExtension implements Extension {
         deployments.registerSubModel(DeploymentServletDefinition.INSTANCE);
         deployments.registerSubModel(DeploymentWebSocketDefinition.INSTANCE);
 
-        subsystem.registerXMLElementWriter(UndertowSubsystemParser_10_0::new);
+        subsystem.registerXMLElementWriter(UndertowSubsystemParser_11_0::new);
     }
 
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_11_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_11_0.java
@@ -1,0 +1,443 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.as.controller.operations.common.Util;
+import org.wildfly.extension.undertow.filters.CustomFilterDefinition;
+import org.wildfly.extension.undertow.filters.ErrorPageDefinition;
+import org.wildfly.extension.undertow.filters.ExpressionFilterDefinition;
+import org.wildfly.extension.undertow.filters.FilterDefinitions;
+import org.wildfly.extension.undertow.filters.FilterRefDefinition;
+import org.wildfly.extension.undertow.filters.GzipFilter;
+import org.wildfly.extension.undertow.filters.ModClusterDefinition;
+import org.wildfly.extension.undertow.filters.NoAffinityResourceDefinition;
+import org.wildfly.extension.undertow.filters.RankedAffinityResourceDefinition;
+import org.wildfly.extension.undertow.filters.RequestLimitHandler;
+import org.wildfly.extension.undertow.filters.ResponseHeaderFilter;
+import org.wildfly.extension.undertow.filters.RewriteFilterDefinition;
+import org.wildfly.extension.undertow.filters.SingleAffinityResourceDefinition;
+import org.wildfly.extension.undertow.handlers.FileHandler;
+import org.wildfly.extension.undertow.handlers.HandlerDefinitions;
+import org.wildfly.extension.undertow.handlers.ReverseProxyHandler;
+import org.wildfly.extension.undertow.handlers.ReverseProxyHandlerHost;
+
+/**
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
+ * @author Radoslav Husar
+ */
+public class UndertowSubsystemParser_11_0 extends PersistentResourceXMLParser {
+    private final PersistentResourceXMLDescription xmlDescription;
+
+    UndertowSubsystemParser_11_0() {
+        xmlDescription = builder(UndertowRootDefinition.INSTANCE.getPathElement(), Namespace.UNDERTOW_11_0.getUriString())
+                .addAttributes(
+                        UndertowRootDefinition.DEFAULT_SERVER,
+                        UndertowRootDefinition.DEFAULT_VIRTUAL_HOST,
+                        UndertowRootDefinition.DEFAULT_SERVLET_CONTAINER,
+                        UndertowRootDefinition.INSTANCE_ID,
+                        UndertowRootDefinition.DEFAULT_SECURITY_DOMAIN,
+                        UndertowRootDefinition.STATISTICS_ENABLED)
+                .addChild(
+                        builder(ByteBufferPoolDefinition.INSTANCE.getPathElement())
+                                .addAttributes(ByteBufferPoolDefinition.DIRECT, ByteBufferPoolDefinition.BUFFER_SIZE, ByteBufferPoolDefinition.MAX_POOL_SIZE, ByteBufferPoolDefinition.THREAD_LOCAL_CACHE_SIZE, ByteBufferPoolDefinition.LEAK_DETECTION_PERCENT)
+                )
+                .addChild(
+                        builder(BufferCacheDefinition.INSTANCE.getPathElement())
+                                .addAttributes(BufferCacheDefinition.BUFFER_SIZE, BufferCacheDefinition.BUFFERS_PER_REGION, BufferCacheDefinition.MAX_REGIONS)
+                )
+                .addChild(builder(ServerDefinition.INSTANCE.getPathElement())
+                                .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
+                                .addChild(
+                                        listenerBuilder(AjpListenerResourceDefinition.INSTANCE)
+                                                // xsd ajp-listener-type
+                                                .addAttributes(AjpListenerResourceDefinition.SCHEME,
+                                                        ListenerResourceDefinition.REDIRECT_SOCKET,
+                                                        AjpListenerResourceDefinition.MAX_AJP_PACKET_SIZE)
+                                )
+                                .addChild(
+                                        listenerBuilder(HttpListenerResourceDefinition.INSTANCE)
+                                                // xsd http-listener-type
+                                                .addAttributes(
+                                                        HttpListenerResourceDefinition.CERTIFICATE_FORWARDING,
+                                                        ListenerResourceDefinition.REDIRECT_SOCKET,
+                                                        HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING,
+                                                        HttpListenerResourceDefinition.ENABLE_HTTP2,
+                                                        HttpListenerResourceDefinition.HTTP2_ENABLE_PUSH,
+                                                        HttpListenerResourceDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_FRAME_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                                        HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11,
+                                                        HttpListenerResourceDefinition.PROXY_PROTOCOL)
+                                ).addChild(
+                                        listenerBuilder(HttpsListenerResourceDefinition.INSTANCE)
+                                                // xsd https-listener-type
+                                                .setMarshallDefaultValues(true)
+                                                .addAttributes(
+                                                        HttpsListenerResourceDefinition.SSL_CONTEXT,
+                                                        HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING,
+                                                        HttpListenerResourceDefinition.CERTIFICATE_FORWARDING,
+                                                        HttpsListenerResourceDefinition.SECURITY_REALM,
+                                                        HttpsListenerResourceDefinition.VERIFY_CLIENT,
+                                                        HttpsListenerResourceDefinition.ENABLED_CIPHER_SUITES,
+                                                        HttpsListenerResourceDefinition.ENABLED_PROTOCOLS,
+                                                        HttpsListenerResourceDefinition.ENABLE_HTTP2,
+                                                        HttpsListenerResourceDefinition.ENABLE_SPDY,
+                                                        HttpsListenerResourceDefinition.SSL_SESSION_CACHE_SIZE,
+                                                        HttpsListenerResourceDefinition.SSL_SESSION_TIMEOUT,
+                                                        HttpListenerResourceDefinition.HTTP2_ENABLE_PUSH,
+                                                        HttpListenerResourceDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_FRAME_SIZE,
+                                                        HttpListenerResourceDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                                        HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11,
+                                                        HttpListenerResourceDefinition.PROXY_PROTOCOL)
+                                ).addChild(
+                                        builder(HostDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(HostDefinition.ALIAS,
+                                                        HostDefinition.DEFAULT_WEB_MODULE,
+                                                        HostDefinition.DEFAULT_RESPONSE_CODE,
+                                                        HostDefinition.DISABLE_CONSOLE_REDIRECT,
+                                                        HostDefinition.QUEUE_REQUESTS_ON_START)
+                                                .addChild(
+                                                        builder(LocationDefinition.INSTANCE.getPathElement())
+                                                                .addAttributes(LocationDefinition.HANDLER)
+                                                                .addChild(filterRefBuilder())
+                                                ).addChild(
+                                                builder(AccessLogDefinition.INSTANCE.getPathElement())
+                                                        .addAttributes(
+                                                                AccessLogDefinition.PATTERN,
+                                                                AccessLogDefinition.WORKER,
+                                                                AccessLogDefinition.DIRECTORY,
+                                                                AccessLogDefinition.RELATIVE_TO,
+                                                                AccessLogDefinition.PREFIX,
+                                                                AccessLogDefinition.SUFFIX,
+                                                                AccessLogDefinition.ROTATE,
+                                                                AccessLogDefinition.USE_SERVER_LOG,
+                                                                AccessLogDefinition.EXTENDED,
+                                                                AccessLogDefinition.PREDICATE)
+                                        ).addChild(
+                                                builder(ConsoleAccessLogDefinition.INSTANCE.getPathElement())
+                                                    .addAttributes(
+                                                            ExchangeAttributeDefinitions.ATTRIBUTES,
+                                                            ConsoleAccessLogDefinition.INCLUDE_HOST_NAME,
+                                                            AccessLogDefinition.PATTERN,
+                                                            AccessLogDefinition.WORKER,
+                                                            ConsoleAccessLogDefinition.METADATA,
+                                                            AccessLogDefinition.PREDICATE
+                                                    )
+                                        ).addChild(filterRefBuilder())
+                                                .addChild(
+                                                    builder(UndertowExtension.PATH_SSO)
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.DOMAIN.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.PATH.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.HTTP_ONLY.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.SECURE.getDefinition())
+                                                        .addAttribute(SingleSignOnDefinition.Attribute.COOKIE_NAME.getDefinition())
+                                        ).addChild(builder(HttpInvokerDefinition.INSTANCE.getPathElement())
+                                            .addAttributes(HttpInvokerDefinition.PATH, HttpInvokerDefinition.HTTP_AUTHENTICATION_FACTORY, HttpInvokerDefinition.SECURITY_REALM))
+                                        )
+                )
+                .addChild(
+                        builder(ServletContainerDefinition.INSTANCE.getPathElement())
+                                .addAttribute(ServletContainerDefinition.ALLOW_NON_STANDARD_WRAPPERS)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_BUFFER_CACHE)
+                                .addAttribute(ServletContainerDefinition.STACK_TRACE_ON_ERROR)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_ENCODING)
+                                .addAttribute(ServletContainerDefinition.USE_LISTENER_ENCODING)
+                                .addAttribute(ServletContainerDefinition.IGNORE_FLUSH)
+                                .addAttribute(ServletContainerDefinition.EAGER_FILTER_INIT)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_SESSION_TIMEOUT)
+                                .addAttribute(ServletContainerDefinition.DISABLE_CACHING_FOR_SECURED_PAGES)
+                                .addAttribute(ServletContainerDefinition.DIRECTORY_LISTING)
+                                .addAttribute(ServletContainerDefinition.PROACTIVE_AUTHENTICATION)
+                                .addAttribute(ServletContainerDefinition.SESSION_ID_LENGTH)
+                                .addAttribute(ServletContainerDefinition.MAX_SESSIONS)
+                                .addAttribute(ServletContainerDefinition.DISABLE_FILE_WATCH_SERVICE)
+                                .addAttribute(ServletContainerDefinition.DISABLE_SESSION_ID_REUSE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_METADATA_SIZE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_MAX_FILE_SIZE)
+                                .addAttribute(ServletContainerDefinition.FILE_CACHE_TIME_TO_LIVE)
+                                .addAttribute(ServletContainerDefinition.DEFAULT_COOKIE_VERSION)
+                                .addAttribute(ServletContainerDefinition.PRESERVE_PATH_ON_FORWARD)
+                                .addChild(
+                                        builder(JspDefinition.INSTANCE.getPathElement())
+                                                .setXmlElementName(Constants.JSP_CONFIG)
+                                                .addAttributes(
+                                                        JspDefinition.DISABLED,
+                                                        JspDefinition.DEVELOPMENT,
+                                                        JspDefinition.KEEP_GENERATED,
+                                                        JspDefinition.TRIM_SPACES,
+                                                        JspDefinition.TAG_POOLING,
+                                                        JspDefinition.MAPPED_FILE,
+                                                        JspDefinition.CHECK_INTERVAL,
+                                                        JspDefinition.MODIFICATION_TEST_INTERVAL,
+                                                        JspDefinition.RECOMPILE_ON_FAIL,
+                                                        JspDefinition.SMAP,
+                                                        JspDefinition.DUMP_SMAP,
+                                                        JspDefinition.GENERATE_STRINGS_AS_CHAR_ARRAYS,
+                                                        JspDefinition.ERROR_ON_USE_BEAN_INVALID_CLASS_ATTRIBUTE,
+                                                        JspDefinition.SCRATCH_DIR,
+                                                        JspDefinition.SOURCE_VM,
+                                                        JspDefinition.TARGET_VM,
+                                                        JspDefinition.JAVA_ENCODING,
+                                                        JspDefinition.X_POWERED_BY,
+                                                        JspDefinition.DISPLAY_SOURCE_FRAGMENT,
+                                                        JspDefinition.OPTIMIZE_SCRIPTLETS)
+                                )
+                                .addChild(
+                                        builder(SessionCookieDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        SessionCookieDefinition.NAME,
+                                                        SessionCookieDefinition.DOMAIN,
+                                                        SessionCookieDefinition.COMMENT,
+                                                        SessionCookieDefinition.HTTP_ONLY,
+                                                        SessionCookieDefinition.SECURE,
+                                                        SessionCookieDefinition.MAX_AGE
+                                                )
+                                )
+                                .addChild(
+                                        builder(PersistentSessionsDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PersistentSessionsDefinition.PATH,
+                                                        PersistentSessionsDefinition.RELATIVE_TO
+                                                )
+                                )
+                                .addChild(
+                                        builder(WebsocketsDefinition.INSTANCE.getPathElement())
+                                                .setMarshallDefaultValues(true)
+                                                .addAttributes(
+                                                        WebsocketsDefinition.WORKER,
+                                                        WebsocketsDefinition.BUFFER_POOL,
+                                                        WebsocketsDefinition.DISPATCH_TO_WORKER,
+                                                        WebsocketsDefinition.PER_MESSAGE_DEFLATE,
+                                                        WebsocketsDefinition.DEFLATER_LEVEL
+                                                )
+                                )
+                                .addChild(builder(MimeMappingDefinition.INSTANCE.getPathElement())
+                                        .setXmlWrapperElement("mime-mappings")
+                                        .addAttributes(
+                                                MimeMappingDefinition.VALUE
+                                        ))
+                                .addChild(builder(WelcomeFileDefinition.INSTANCE.getPathElement()).setXmlWrapperElement("welcome-files"))
+                                .addChild(builder(CrawlerSessionManagementDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(CrawlerSessionManagementDefinition.USER_AGENTS, CrawlerSessionManagementDefinition.SESSION_TIMEOUT))
+                )
+                .addChild(
+                        builder(HandlerDefinitions.INSTANCE.getPathElement())
+                                .setXmlElementName(Constants.HANDLERS)
+                                .setNoAddOperation(true)
+                                .addChild(
+                                        builder(FileHandler.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        FileHandler.PATH,
+                                                        FileHandler.CACHE_BUFFER_SIZE,
+                                                        FileHandler.CACHE_BUFFERS,
+                                                        FileHandler.DIRECTORY_LISTING,
+                                                        FileHandler.FOLLOW_SYMLINK,
+                                                        FileHandler.SAFE_SYMLINK_PATHS,
+                                                        FileHandler.CASE_SENSITIVE
+                                                )
+                                )
+                                .addChild(
+                                        builder(ReverseProxyHandler.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        ReverseProxyHandler.CONNECTIONS_PER_THREAD,
+                                                        ReverseProxyHandler.SESSION_COOKIE_NAMES,
+                                                        ReverseProxyHandler.PROBLEM_SERVER_RETRY,
+                                                        ReverseProxyHandler.MAX_REQUEST_TIME,
+                                                        ReverseProxyHandler.REQUEST_QUEUE_SIZE,
+                                                        ReverseProxyHandler.CACHED_CONNECTIONS_PER_THREAD,
+                                                        ReverseProxyHandler.CONNECTION_IDLE_TIMEOUT,
+                                                        ReverseProxyHandler.MAX_RETRIES)
+                                                .addChild(builder(ReverseProxyHandlerHost.INSTANCE.getPathElement())
+                                                        .setXmlElementName(Constants.HOST)
+                                                        .addAttributes(
+                                                                ReverseProxyHandlerHost.OUTBOUND_SOCKET_BINDING,
+                                                                ReverseProxyHandlerHost.SCHEME,
+                                                                ReverseProxyHandlerHost.PATH,
+                                                                ReverseProxyHandlerHost.INSTANCE_ID,
+                                                                ReverseProxyHandlerHost.SSL_CONTEXT,
+                                                                ReverseProxyHandlerHost.SECURITY_REALM,
+                                                                ReverseProxyHandlerHost.ENABLE_HTTP2))
+                                )
+
+
+                )
+                .addChild(
+                        builder(FilterDefinitions.INSTANCE.getPathElement())
+                                .setXmlElementName(Constants.FILTERS)
+                                .setNoAddOperation(true)
+                                .addChild(
+                                        builder(RequestLimitHandler.INSTANCE.getPathElement())
+                                                .addAttributes(RequestLimitHandler.MAX_CONCURRENT_REQUESTS, RequestLimitHandler.QUEUE_SIZE)
+                                ).addChild(
+                                builder(ResponseHeaderFilter.INSTANCE.getPathElement())
+                                        .addAttributes(ResponseHeaderFilter.NAME, ResponseHeaderFilter.VALUE)
+                        ).addChild(
+                                builder(GzipFilter.INSTANCE.getPathElement())
+                        ).addChild(
+                                builder(ErrorPageDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(ErrorPageDefinition.CODE, ErrorPageDefinition.PATH)
+                        ).addChild(
+                                builder(ModClusterDefinition.INSTANCE.getPathElement())
+                                .addAttributes(
+                                        ModClusterDefinition.MANAGEMENT_SOCKET_BINDING,
+                                        ModClusterDefinition.ADVERTISE_SOCKET_BINDING,
+                                        ModClusterDefinition.SECURITY_KEY,
+                                        ModClusterDefinition.ADVERTISE_PROTOCOL,
+                                        ModClusterDefinition.ADVERTISE_PATH,
+                                        ModClusterDefinition.ADVERTISE_FREQUENCY,
+                                        ModClusterDefinition.FAILOVER_STRATEGY,
+                                        ModClusterDefinition.HEALTH_CHECK_INTERVAL,
+                                        ModClusterDefinition.BROKEN_NODE_TIMEOUT,
+                                        ModClusterDefinition.WORKER,
+                                        ModClusterDefinition.MAX_REQUEST_TIME,
+                                        ModClusterDefinition.MANAGEMENT_ACCESS_PREDICATE,
+                                        ModClusterDefinition.CONNECTIONS_PER_THREAD,
+                                        ModClusterDefinition.CACHED_CONNECTIONS_PER_THREAD,
+                                        ModClusterDefinition.CONNECTION_IDLE_TIMEOUT,
+                                        ModClusterDefinition.REQUEST_QUEUE_SIZE,
+                                        ModClusterDefinition.SSL_CONTEXT,
+                                        ModClusterDefinition.SECURITY_REALM,
+                                        ModClusterDefinition.USE_ALIAS,
+                                        ModClusterDefinition.ENABLE_HTTP2,
+                                        ModClusterDefinition.MAX_AJP_PACKET_SIZE,
+                                        ModClusterDefinition.HTTP2_ENABLE_PUSH,
+                                        ModClusterDefinition.HTTP2_HEADER_TABLE_SIZE,
+                                        ModClusterDefinition.HTTP2_INITIAL_WINDOW_SIZE,
+                                        ModClusterDefinition.HTTP2_MAX_CONCURRENT_STREAMS,
+                                        ModClusterDefinition.HTTP2_MAX_FRAME_SIZE,
+                                        ModClusterDefinition.HTTP2_MAX_HEADER_LIST_SIZE,
+                                        ModClusterDefinition.MAX_RETRIES)
+                                        .addChild(
+                                                builder(NoAffinityResourceDefinition.PATH).setXmlElementName(Constants.NO_AFFINITY)
+                                        )
+                                        .addChild(
+                                                builder(SingleAffinityResourceDefinition.PATH).setXmlElementName(Constants.SINGLE_AFFINITY)
+                                        )
+                                        .addChild(
+                                                builder(RankedAffinityResourceDefinition.PATH).setXmlElementName(Constants.RANKED_AFFINITY)
+                                                        .addAttribute(RankedAffinityResourceDefinition.Attribute.DELIMITER.getDefinition())
+                                        )
+                        ).addChild(
+                                builder(CustomFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(CustomFilterDefinition.CLASS_NAME, CustomFilterDefinition.MODULE, CustomFilterDefinition.PARAMETERS)
+                                        .setXmlElementName("filter")
+                        ).addChild(
+                                builder(ExpressionFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(ExpressionFilterDefinition.EXPRESSION, ExpressionFilterDefinition.MODULE)
+                        ).addChild(
+                                builder(RewriteFilterDefinition.INSTANCE.getPathElement())
+                                        .addAttributes(RewriteFilterDefinition.TARGET, RewriteFilterDefinition.REDIRECT)
+                        )
+
+                )
+                .addChild(
+                        builder(ApplicationSecurityDomainDefinition.INSTANCE.getPathElement())
+                            .setXmlWrapperElement(Constants.APPLICATION_SECURITY_DOMAINS)
+                            .addAttribute(ApplicationSecurityDomainDefinition.HTTP_AUTHENTICATION_FACTORY)
+                            .addAttribute(ApplicationSecurityDomainDefinition.OVERRIDE_DEPLOYMENT_CONFIG)
+                            .addAttribute(ApplicationSecurityDomainDefinition.SECURITY_DOMAIN)
+                            .addAttribute(ApplicationSecurityDomainDefinition.ENABLE_JACC)
+                            .addAttribute(ApplicationSecurityDomainDefinition.ENABLE_JASPI)
+                            .addAttribute(ApplicationSecurityDomainDefinition.INTEGRATED_JASPI)
+                            .addChild(builder(UndertowExtension.PATH_SSO)
+                                    .addAttribute(SingleSignOnDefinition.Attribute.DOMAIN.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.PATH.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.HTTP_ONLY.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.SECURE.getDefinition())
+                                    .addAttribute(SingleSignOnDefinition.Attribute.COOKIE_NAME.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.KEY_STORE.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.KEY_ALIAS.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.SSL_CONTEXT.getDefinition())
+                                    .addAttribute(ApplicationSecurityDomainSingleSignOnDefinition.Attribute.CREDENTIAL.getDefinition(), AttributeParser.OBJECT_PARSER, AttributeMarshaller.ATTRIBUTE_OBJECT)
+                            )
+                )
+                 //here to make sure we always add filters & handlers path to mgmt model
+                .setAdditionalOperationsGenerator((address, addOperation, operations) -> {
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_FILTERS)));
+                        operations.add(Util.createAddOperation(address.append(UndertowExtension.PATH_HANDLERS)));
+                })
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return xmlDescription;
+    }
+
+    /** Registers attributes common across listener types */
+    private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder listenerBuilder(PersistentResourceDefinition resource) {
+        return builder(resource.getPathElement())
+                // xsd socket-optionsType
+                .addAttributes(
+                        ListenerResourceDefinition.RECEIVE_BUFFER,
+                        ListenerResourceDefinition.SEND_BUFFER,
+                        ListenerResourceDefinition.BACKLOG,
+                        ListenerResourceDefinition.KEEP_ALIVE,
+                        ListenerResourceDefinition.READ_TIMEOUT,
+                        ListenerResourceDefinition.WRITE_TIMEOUT,
+                        ListenerResourceDefinition.MAX_CONNECTIONS)
+                // xsd listener-type
+                .addAttributes(
+                        ListenerResourceDefinition.SOCKET_BINDING,
+                        ListenerResourceDefinition.WORKER,
+                        ListenerResourceDefinition.BUFFER_POOL,
+                        ListenerResourceDefinition.ENABLED,
+                        ListenerResourceDefinition.RESOLVE_PEER_ADDRESS,
+                        ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                        ListenerResourceDefinition.BUFFER_PIPELINED_DATA,
+                        ListenerResourceDefinition.MAX_HEADER_SIZE,
+                        ListenerResourceDefinition.MAX_PARAMETERS,
+                        ListenerResourceDefinition.MAX_HEADERS,
+                        ListenerResourceDefinition.MAX_COOKIES,
+                        ListenerResourceDefinition.ALLOW_ENCODED_SLASH,
+                        ListenerResourceDefinition.DECODE_URL,
+                        ListenerResourceDefinition.URL_CHARSET,
+                        ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE,
+                        ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE,
+                        ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                        ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE,
+                        ListenerResourceDefinition.NO_REQUEST_TIMEOUT,
+                        ListenerResourceDefinition.REQUEST_PARSE_TIMEOUT,
+                        ListenerResourceDefinition.DISALLOWED_METHODS,
+                        ListenerResourceDefinition.SECURE,
+                        ListenerResourceDefinition.RFC6265_COOKIE_VALIDATION,
+                        ListenerResourceDefinition.ALLOW_UNESCAPED_CHARACTERS_IN_URL);
+    }
+
+    private static PersistentResourceXMLDescription.PersistentResourceXMLBuilder filterRefBuilder() {
+        return builder(FilterRefDefinition.INSTANCE.getPathElement())
+                .addAttributes(FilterRefDefinition.PREDICATE, FilterRefDefinition.PRIORITY);
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.undertow;
 
+import static org.jboss.as.controller.security.CredentialReference.REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT;
 import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.ENABLE_JASPI;
 import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.INTEGRATED_JASPI;
 import static org.wildfly.extension.undertow.ApplicationSecurityDomainDefinition.SECURITY_DOMAIN;
@@ -81,6 +82,7 @@ public class UndertowTransformers implements ExtensionTransformerRegistration {
     private static ModelVersion MODEL_VERSION_EAP7_1_0 = ModelVersion.create(4, 0, 0);
     private static ModelVersion MODEL_VERSION_EAP7_2_0 = ModelVersion.create(7, 0, 0);
     private static final ModelVersion MODEL_VERSION_WILDFLY_16 = ModelVersion.create(8, 0, 0);
+    private static final ModelVersion MODEL_VERSION_WILDFLY_18 = ModelVersion.create(10, 0, 0);
 
     @Override
     public String getSubsystemName() {
@@ -92,12 +94,21 @@ public class UndertowTransformers implements ExtensionTransformerRegistration {
 
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(subsystemRegistration.getCurrentSubsystemVersion());
 
-        registerTransformersWildFly16(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), MODEL_VERSION_WILDFLY_16));
+        registerTransformersWildFly18(chainedBuilder.createBuilder(subsystemRegistration.getCurrentSubsystemVersion(), MODEL_VERSION_WILDFLY_18));
+        registerTransformersWildFly16(chainedBuilder.createBuilder(MODEL_VERSION_WILDFLY_18, MODEL_VERSION_WILDFLY_16));
         registerTransformers_EAP_7_2_0(chainedBuilder.createBuilder(MODEL_VERSION_WILDFLY_16, MODEL_VERSION_EAP7_2_0));
         registerTransformers_EAP_7_1_0(chainedBuilder.createBuilder(MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0));
         registerTransformers_EAP_7_0_0(chainedBuilder.createBuilder(MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0));
 
-        chainedBuilder.buildAndRegister(subsystemRegistration, new ModelVersion[]{MODEL_VERSION_WILDFLY_16, MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0});
+        chainedBuilder.buildAndRegister(subsystemRegistration, new ModelVersion[]{MODEL_VERSION_WILDFLY_18, MODEL_VERSION_WILDFLY_16, MODEL_VERSION_EAP7_2_0, MODEL_VERSION_EAP7_1_0, MODEL_VERSION_EAP7_0_0});
+    }
+
+    private static void registerTransformersWildFly18(ResourceTransformationDescriptionBuilder subsystemBuilder) {
+        subsystemBuilder.addChildResource(UndertowExtension.PATH_APPLICATION_SECURITY_DOMAIN)
+                .addChildResource(UndertowExtension.PATH_SSO)
+                .getAttributeBuilder()
+                    .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, ApplicationSecurityDomainSingleSignOnDefinition.Attribute.CREDENTIAL.getName())
+                .end();
     }
 
     private static void registerTransformersWildFly16(ResourceTransformationDescriptionBuilder subsystemBuilder) {

--- a/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
@@ -19,12 +19,12 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:undertow:11.0"
            targetNamespace="urn:jboss:domain:undertow:11.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
     
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
     <!-- The undertow subsystem root element -->
     <xs:element name="subsystem" type="undertow-subsystemType"/>
 

--- a/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2019 Red Hat, Inc.
+  ~ Copyright 2020 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:jboss:domain:undertow:10.0"
-           targetNamespace="urn:jboss:domain:undertow:10.0"
+           xmlns="urn:jboss:domain:undertow:11.0"
+           targetNamespace="urn:jboss:domain:undertow:11.0"
            xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
-
+    
     <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
     <!-- The undertow subsystem root element -->
     <xs:element name="subsystem" type="undertow-subsystemType"/>

--- a/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow-load-balancer.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:10.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+    <subsystem xmlns="urn:jboss:domain:undertow:11.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"  />

--- a/undertow/src/main/resources/subsystem-templates/undertow.xml
+++ b/undertow/src/main/resources/subsystem-templates/undertow.xml
@@ -24,7 +24,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:10.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
+    <subsystem xmlns="urn:jboss:domain:undertow:11.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other" statistics-enabled="${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}">
         <buffer-cache name="default" />
         <server name="default-server">
             <?AJP?>

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem110TestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem110TestCase.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2019, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -28,19 +28,19 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.junit.Test;
 
-public class UndertowSubsystem100TestCase extends AbstractUndertowSubsystemTestCase {
+public class UndertowSubsystem110TestCase extends AbstractUndertowSubsystemTestCase {
 
     private final String virtualHostName = "some-server";
     private final int flag = 1;
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("undertow-10.0.xml");
+        return readResource("undertow-11.0.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-undertow_10_0.xsd";
+        return "schema/wildfly-undertow_11_0.xsd";
     }
 
     @Override
@@ -48,9 +48,10 @@ public class UndertowSubsystem100TestCase extends AbstractUndertowSubsystemTestC
         return new String[] { "/subsystem-templates/undertow.xml" };
     }
 
+    @Test
     @Override
-    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
-        return super.standardSubsystemTest(configId, false);
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 
     @Test

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
@@ -179,6 +179,8 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 ALLOW_UNESCAPED_CHARACTERS_IN_URL))
                 .addFailedAttribute(hostAddress.append(PathElement.pathElement(Constants.SETTING, "console-access-log")), FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                .addFailedAttribute(subsystemAddress.append(UndertowExtension.PATH_APPLICATION_SECURITY_DOMAIN).append(UndertowExtension.PATH_SSO),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
         );
     }
 
@@ -197,6 +199,8 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
                          new FailedOperationTransformationConfig.NewAttributesConfig(
                                  ServletContainerDefinition.PRESERVE_PATH_ON_FORWARD
                          ))
+                .addFailedAttribute(subsystemAddress.append(UndertowExtension.PATH_APPLICATION_SECURITY_DOMAIN).append(UndertowExtension.PATH_SSO),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
         );
     }
 

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-11.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-11.0.xml
@@ -1,6 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2017, Red Hat, Inc., and individual contributors
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,18 +21,19 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:undertow:11.0" default-server="some-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+   <byte-buffer-pool name="test" thread-local-cache-size="45" buffer-size="1000" direct="false" leak-detection-percent="50" max-pool-size="1000"/>
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
-   <byte-buffer-pool name="test-buffers" buffer-size="1000" leak-detection-percent="0" direct="true" max-pool-size="10" thread-local-cache-size="1" />
    <server default-host="other-host" name="some-server" servlet-container="myContainer">
-      <ajp-listener disallowed-methods="FOO TRACE" max-parameters="5000" name="ajp-connector" no-request-timeout="10000" receive-buffer="5000" redirect-socket="ajps" request-parse-timeout="2000" resolve-peer-address="true" secure="true" send-buffer="50000" socket-binding="ajp" tcp-backlog="500" tcp-keep-alive="true" allow-unescaped-characters-in-url="true" rfc6265-cookie-validation="true"/>
-      <http-listener always-set-keep-alive="${prop.smth:false}" certificate-forwarding="true" name="default" proxy-address-forwarding="${prop.smth:false}" redirect-socket="ajp" resolve-peer-address="true" socket-binding="http" proxy-protocol="true" require-host-http11="true"  allow-unescaped-characters-in-url="true" rfc6265-cookie-validation="true"/>
+      <ajp-listener disallowed-methods="FOO TRACE" allow-unescaped-characters-in-url="true" max-parameters="5000" name="ajp-connector" no-request-timeout="10000" receive-buffer="5000" redirect-socket="ajps" request-parse-timeout="2000" resolve-peer-address="true" secure="true" send-buffer="50000" socket-binding="ajp" tcp-backlog="500" tcp-keep-alive="true" max-ajp-packet-size="10000"/>
+      <http-listener always-set-keep-alive="${prop.smth:false}" certificate-forwarding="true" name="default" proxy-address-forwarding="${prop.smth:false}" redirect-socket="ajp" resolve-peer-address="true" socket-binding="http" proxy-protocol="true"/>
       <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="second" redirect-socket="https-non-default" require-host-http11="true" socket-binding="http-2" url-charset="windows-1250"/>
       <http-listener max-cookies="100" max-headers="30" max-parameters="30" max-post-size="100000" name="no-redirect" socket-binding="http-3" url-charset="windows-1250" worker="non-default"/>
-      <https-listener disallowed-methods="" max-buffered-request-size="50000"  allow-unescaped-characters-in-url="true"  max-connections="100" name="https" record-request-start-time="true" require-host-http11="true" resolve-peer-address="true" security-realm="UndertowRealm" socket-binding="https-non-default" verify-client="REQUESTED" rfc6265-cookie-validation="true" proxy-protocol="true" proxy-address-forwarding="true"/>
-      <https-listener certificate-forwarding="true" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" name="https-2" proxy-address-forwarding="true" read-timeout="-1" security-realm="UndertowRealm" socket-binding="https-2" write-timeout="-1"/>
-      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-4" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-4" security-realm="UndertowRealm"/>
-      <host alias="localhost,some.host" default-response-code="503" default-web-module="something.war" name="default-virtual-host" queue-requests-on-start="false" >
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https" record-request-start-time="true" require-host-http11="true" resolve-peer-address="true" security-realm="UndertowRealm" socket-binding="https-non-default" verify-client="REQUESTED"/>
+      <https-listener certificate-forwarding="true" allow-unescaped-characters-in-url="true" enabled-cipher-suites="ALL:!MD5:!DHA" enabled-protocols="SSLv3, TLSv1.2" name="https-2" proxy-address-forwarding="true" read-timeout="-1" security-realm="UndertowRealm" socket-binding="https-2" write-timeout="-1"/>
+      <https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-3" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-3" ssl-context="TestContext" rfc6265-cookie-validation="true" proxy-protocol="true"/>
+      <!--<https-listener disallowed-methods="" max-buffered-request-size="50000" max-connections="100" name="https-4" record-request-start-time="true" resolve-peer-address="true" socket-binding="https-4" />--> <!-- this one must fail-->
+      <host alias="localhost,some.host" default-response-code="503" default-web-module="something.war" name="default-virtual-host">
          <location handler="welcome-content" name="/">
             <filter-ref name="limit-connections"/>
             <filter-ref name="headers" priority="${some.priority:10}"/>
@@ -40,28 +41,28 @@
             <filter-ref name="static-gzip" predicate="path-suffix('.js')"/>
          </location>
          <access-log directory="${jboss.server.server.dir}" pattern="REQ %{i,test-header}" predicate="not path-suffix(*.css)" prefix="access" rotate="false"/>
-         <console-access-log predicate="not path-suffix(*.css)">
+         <console-access-log predicate="not path-suffix(*.css)" worker="default">
             <attributes>
+               <authentication-type/>
                <date-time date-format="yyyy-MM-dd'T'HH:mm:ss" key="timestamp"/>
                <query-parameter>
                   <name value="test"/>
-                  <name value="foo"/>
                </query-parameter>
-               <response-code/>
-               <response-header key-prefix="responseHeader">
+               <request-header key-prefix="requestHeader">
                   <name value="Content-Type"/>
                   <name value="Content-Encoding"/>
-               </response-header>
+               </request-header>
+               <response-code/>
                <response-time time-unit="MICROSECONDS"/>
             </attributes>
             <metadata>
                <property name="@version" value="1"/>
-               <property name="qualifiedHost" value="${jboss.qualified.host.name:unknown}"/>
+               <property name="host" value="${jboss.host.name:localhost}"/>
             </metadata>
          </console-access-log>
          <single-sign-on cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" path="/path" secure="true"/>
       </host>
-      <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host">
+      <host alias="www.mysite.com,${prop.value:default-alias}" default-response-code="501" default-web-module="something-else.war" disable-console-redirect="true" name="other-host" queue-requests-on-start="false">
          <location handler="welcome-content" name="/">
             <filter-ref name="limit-connections"/>
             <filter-ref name="headers"/>
@@ -73,7 +74,7 @@
          <http-invoker http-authentication-factory="factory" path="services"/>
       </host>
    </server>
-   <servlet-container default-buffer-cache="extra" default-encoding="utf-8" default-session-timeout="100" directory-listing="true" eager-filter-initialization="true" ignore-flush="true" name="myContainer" proactive-authentication="${prop.pro:false}" use-listener-encoding="${prop.foo:false}" disable-session-id-reuse="${prop.foo:true}" disable-file-watch-service="${prop.foo:true}" file-cache-metadata-size="${prop.foo:50}" file-cache-max-file-size="${prop.foo:5000}" file-cache-time-to-live="${prop.foo:1000}"  default-cookie-version="${prop.foo:1}" preserve-path-on-forward="true">
+   <servlet-container default-buffer-cache="extra" default-encoding="utf-8" default-session-timeout="100" directory-listing="true" eager-filter-initialization="true" ignore-flush="true" name="myContainer" proactive-authentication="${prop.pro:false}" use-listener-encoding="${prop.foo:false}"  disable-session-id-reuse="${prop.foo:true}" disable-file-watch-service="${prop.foo:true}" file-cache-metadata-size="50" file-cache-max-file-size="5000" file-cache-time-to-live="1000"  default-cookie-version="1" preserve-path-on-forward="false">
       <jsp-config check-interval="${prop.check-interval:20}" disabled="${prop.disabled:false}" display-source-fragment="${prop.display-source-fragment:true}" dump-smap="${prop.dump-smap:true}" error-on-use-bean-invalid-class-attribute="${prop.error-on-use-bean-invalid-class-attribute:true}" generate-strings-as-char-arrays="${prop.generate-strings-as-char-arrays:true}" java-encoding="${prop.java-encoding:utf-8}" keep-generated="${prop.keep-generated:true}" mapped-file="${prop.mapped-file:true}" modification-test-interval="${prop.modification-test-interval:1000}" optimize-scriptlets="${prop.optimise-scriptlets:true}" recompile-on-fail="${prop.recompile-on-fail:true}" scratch-dir="${prop.scratch-dir:/some/dir}" smap="${prop.smap:true}" source-vm="${prop.source-vm:1.7}" tag-pooling="${prop.tag-pooling:true}" target-vm="${prop.target-vm:1.7}" trim-spaces="${prop.trim-spaces:true}" x-powered-by="${prop.x-powered-by:true}"/>
       <session-cookie comment="session cookie" domain="example.com" http-only="true" max-age="1000" name="MYSESSIONCOOKIE" secure="true"/>
       <websockets deflater-level="0" dispatch-to-worker="false" per-message-deflate="false"/>
@@ -88,8 +89,8 @@
    <handlers>
       <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
       <reverse-proxy connection-idle-timeout="60" connections-per-thread="30" max-retries="10" name="reverse-proxy">
-         <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" security-realm="UndertowRealm" />
-         <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" security-realm="UndertowRealm" />
+         <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
+         <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
       </reverse-proxy>
    </handlers>
    <filters>
@@ -97,19 +98,25 @@
       <response-header header-name="MY_HEADER" header-value="someValue" name="headers"/>
       <gzip name="static-gzip"/>
       <error-page code="404" name="404-handler" path="/opt/data/404.html"/>
-      <mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp" advertise-socket-binding="advertise-socket-binding"
-                   name="mod-cluster" broken-node-timeout="1000" cached-connections-per-thread="10" connection-idle-timeout="10"
-                   health-check-interval="600" management-access-predicate="method[GET]" management-socket-binding="test3" max-request-time="1000"
-                   failover-strategy="DETERMINISTIC" max-retries="10" security-key="password" security-realm="UndertowRealm" />
+      <mod-cluster advertise-frequency="1000" advertise-path="/foo" advertise-protocol="ajp"
+                   advertise-socket-binding="advertise-socket-binding" broken-node-timeout="1000"
+                   cached-connections-per-thread="10" connection-idle-timeout="10"
+                   failover-strategy="DETERMINISTIC" health-check-interval="600"
+                   management-access-predicate="method[GET]" management-socket-binding="test3"
+                   max-request-time="1000" max-retries="10" name="mod-cluster"
+                   security-key="password" ssl-context="TestContext" max-ajp-packet-size="10000">
+         <ranked-affinity delimiter="."/>
+      </mod-cluster>
       <filter class-name="io.undertow.server.handlers.HttpTraceHandler" module="io.undertow.core" name="custom-filter"/>
       <expression-filter expression="dump-request" name="requestDumper"/>
       <rewrite name="redirects" redirect="true" target="'/foo/'"/>
    </filters>
    <application-security-domains>
-      <application-security-domain enable-jacc="true" http-authentication-factory="elytron-factory" name="other" override-deployment-config="true">
+      <application-security-domain enable-jacc="true" http-authentication-factory="elytron-factory" name="other" override-deployment-config="true" enable-jaspi="false" integrated-jaspi="false">
          <single-sign-on client-ssl-context="my-ssl-context" cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" key-alias="my-key-alias" key-store="my-key-store" path="/path" secure="true">
             <credential-reference alias="my-credential-alias" store="my-credential-store" type="password"/>
          </single-sign-on>
       </application-security-domain>
+      <application-security-domain security-domain="elytron-domain" name="domain-ref" />
    </application-security-domains>
 </subsystem>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:10.0" default-server="default-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
+<subsystem xmlns="urn:jboss:domain:undertow:11.0" default-server="default-server" default-servlet-container="myContainer" default-virtual-host="default-virtual-host" instance-id="some-id" statistics-enabled="true">
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="default"/>
    <buffer-cache buffer-size="1025" buffers-per-region="1054" max-regions="15" name="extra"/>
    <server default-host="other-host" name="default-server" servlet-container="myContainer">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-reject.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-reject.xml
@@ -108,7 +108,7 @@
    <application-security-domains>
       <application-security-domain enable-jacc="true" http-authentication-factory="elytron-factory" name="other" override-deployment-config="true">
          <single-sign-on client-ssl-context="my-ssl-context" cookie-name="SSOID" domain="${prop.domain:myDomain}" http-only="true" key-alias="my-key-alias" key-store="my-key-store" path="/path" secure="true">
-            <credential-reference alias="my-credential-alias" store="my-credential-store" type="password"/>
+            <credential-reference alias="my-credential-alias" store="my-credential-store" clear-text="my-password" type="password"/>
          </single-sign-on>
       </application-security-domain>
    </application-security-domains>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12218

Just FYI for reviewers, there are two commits in this PR for each of the sub-task JIRAs below - one commit is for the model and schema bump and the second commit updates the new schema to reference the "urn:wildfly:credential-reference:1.1" namespace.

Sub-task JIRAs:
https://issues.redhat.com/browse/WFLY-13363 (jgroups)
https://issues.redhat.com/browse/WFLY-13364 (datasources)
https://issues.redhat.com/browse/WFLY-13365 (resource-adapters)
https://issues.redhat.com/browse/WFLY-13366 (agroal)
https://issues.redhat.com/browse/WFLY-13367 (mail)
https://issues.redhat.com/browse/WFLY-13368 (messaging-activemq)
https://issues.redhat.com/browse/WFLY-13369 (undertow)

This PR also includes https://github.com/wildfly/wildfly/pull/13204 and reverts https://github.com/wildfly/wildfly/pull/13204/commits/56d2394985036f5a5b75aa352a6e533fb1d4f1c1.