### PR TITLE
WFLY-12355 Upgrade jboss-batch-api_1.0_spec from 1.0.2.Final to 2.0.0…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>1.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
-        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.2.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
+        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>2.0.0.CR1</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.13.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.2.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>


### PR DESCRIPTION
….CR1

JIRA: https://issues.jboss.org/browse/WFLY-12355

Upgrades jboss batch api to version 2.0.0.CR1 of the jboss fork of jakarta batch api.
