### PR TITLE
[WFLY-12457] Single action timer is not triggered automatically after a DB outage, requires server restart

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
@@ -30,9 +30,9 @@ import javax.ejb.ScheduleExpression;
 import javax.ejb.Timer;
 import javax.ejb.TimerHandle;
 
-import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
 import org.jboss.as.ejb3.component.allowedmethods.MethodType;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
 
 /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
@@ -98,7 +98,7 @@ public interface TimerPersistence {
 
         /**
          * Invoked when a timer needs to be sync with the underlying store
-         * @param oldTimer The timer in Server memory 
+         * @param oldTimer The timer in Server memory
          * @param newtimer The timer coming from the store
          */
         void timerSync(TimerImpl oldTimer, TimerImpl newTimer);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/TimerPersistence.java
@@ -97,6 +97,13 @@ public interface TimerPersistence {
         void timerAdded(TimerImpl timer);
 
         /**
+         * Invoked when a timer needs to be sync with the underlying store
+         * @param oldTimer The timer in Server memory 
+         * @param newtimer The timer coming from the store
+         */
+        void timerSync(TimerImpl oldTimer, TimerImpl newTimer);
+
+        /**
          * Invoked when a timer is removed from the underlying store
          * @param timerId The timer
          */


### PR DESCRIPTION
added logic when in memory timer are out of sync with the store

https://issues.jboss.org/browse/WFLY-12457