### PR TITLE
[WFLY-12455] Update permission names in tests to fix failures that occur with the security manager enabled with the JBoss Jakarta JACC and JASPI upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>

--- a/pom.xml
+++ b/pom.xml
@@ -207,14 +207,14 @@
         <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.8.2</version.jacoco.plugin><!-- TODO property does not follow verion.groupId format -->
-        <version.org.jboss.galleon>4.0.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.0.4.Final</version.org.jboss.galleon>
         <version.org.jboss.universe.producer.wildfly-producers>1.0.2.Final</version.org.jboss.universe.producer.wildfly-producers>
         <version.org.jboss.universe.community-universe>1.0.2.Final</version.org.jboss.universe.community-universe>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.1.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>4.0.1.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.0.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.0.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
@@ -58,7 +58,7 @@ public class PolicyContextTestCase {
         ear.addAsModule(war);
         ear.addAsModule(jar);
 
-        ear.addAsManifestResource(createPermissionsXmlAsset(new SecurityPermission("getPolicy")), "permissions.xml");
+        ear.addAsManifestResource(createPermissionsXmlAsset(new SecurityPermission("setPolicy")), "permissions.xml");
 
         return ear;
     }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/JaspiTestBase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/jaspi/JaspiTestBase.java
@@ -41,7 +41,7 @@ abstract class JaspiTestBase {
     protected static WebArchive createDeployment(final String name) {
         final Package testPackage = ConfiguredJaspiTestCase.class.getPackage();
         final Permission[] permissions = new Permission[] {
-                    new SecurityPermission("getFactory"),
+                    new SecurityPermission("getProperty.authconfigprovider.factory"),
                     new SecurityPermission("setProperty.authconfigfactory.provider")
                 };
         return ShrinkWrap.create(WebArchive.class, name + ".war")

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -127,7 +127,7 @@ public class AuthenticationPolicyContextTestCase {
         war.addAsManifestResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/META-INF/jboss-deployment-structure.xml", "jboss-deployment-structure.xml");
         war.addAsManifestResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/META-INF/jboss-webservices.xml", "jboss-webservices.xml");
         war.addAsManifestResource(createPermissionsXmlAsset(
-                new SecurityPermission("getPolicy"),
+                new SecurityPermission("setPolicy"),
                 new RuntimePermission("org.jboss.security.getSecurityContext")
         ), "permissions.xml");
         return war;
@@ -149,7 +149,7 @@ public class AuthenticationPolicyContextTestCase {
         war.addAsManifestResource(AuthenticationPolicyContextTestCase.class.getPackage(), "resources/META-INF/jboss-webservices.xml", "jboss-webservices.xml");
         war.addAsResource(AuthenticationPolicyContextTestCase.class.getPackage(), "dummmy-ws-handler.xml", "org/jboss/as/test/integration/ws/authentication/policy/resources/dummmy-ws-handler.xml");
         war.addAsManifestResource(createPermissionsXmlAsset(
-                new SecurityPermission("getPolicy"),
+                new SecurityPermission("setPolicy"),
                 new RuntimePermission("org.jboss.security.getSecurityContext")
         ), "permissions.xml");
         return war;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12455

Core Upgrade: https://issues.jboss.org/browse/WFLY-12451
Galleon Upgrade: https://issues.jboss.org/browse/WFLY-12293