### PR TITLE
WFLY-12469 Timer ScheduleExpression default timezone should be null

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
@@ -94,7 +94,7 @@ public class ScheduleAnnotationInformationFactory extends ClassAnnotationInforma
                 timer.getScheduleExpression().second(value);
             }
         },
-        TIMEZONE("timezone", "") {
+        TIMEZONE("timezone", null) {
             protected void setString(final AutoTimer timer, final String value) {
                 timer.getScheduleExpression().timezone(value);
             }


### PR DESCRIPTION
Changed default value to null for ejb timer schedule expression timezone, to comply with the spec requirement.

JIRA: https://issues.jboss.org/browse/WFLY-12469