### PR TITLE
[WFLY-12427] Add missing dependencies for smallrye-health

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
@@ -33,9 +33,12 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="org.eclipse.microprofile.config.api" />
         <module name="org.eclipse.microprofile.health.api"/>
         <module name="javax.enterprise.api" />
         <module name="javax.annotation.api" />
         <module name="javax.json.api" />
+        <module name="org.jboss.logging" />
+        <module name="io.smallrye.config" services="import"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
@@ -43,6 +43,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
         <module name="org.eclipse.microprofile.health.api"/>
+        <module name="org.wildfly.extension.microprofile.config-smallrye" />
         <module name="org.jboss.as.weld.common" />
         <module name="javax.enterprise.api" />
         <module name="javax.annotation.api" />

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingWithWeldProbeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/EarOpenTracingWithWeldProbeTestCase.java
@@ -51,7 +51,12 @@ public class EarOpenTracingWithWeldProbeTestCase extends AbstractEarOpenTracingT
         + "xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee\n"
         + "http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd\">\n<context-param>\n"
         + "<param-name>org.jboss.weld.development</param-name>\n"
-        + "<param-value>true</param-value>\n</context-param>\n"
+        + "<param-value>true</param-value>\n"
+        // [WELD-2595] explicitely exclude SmallRyeHealthReporter CDI bean otherwise Weld fails
+        // during deployment with a WELD-001504 because this class declares a final method.
+        + "<param-name>org.jboss.weld.probe.invocationMonitor.excludeType</param-name>\n"
+        + "<param-value>io.smallrye.health.SmallRyeHealthReporter</param-value>\n"
+        + "</context-param>\n"
         + "</web-app>";
 
     private static String WELD_PROPERTIES = "org.jboss.weld.probe.allowRemoteAddress=" + System.getProperty("node0")


### PR DESCRIPTION
smallrye-health and its subsystem were missing dependencies to
org.jboss.logging.
Once logging was fixed, it showed that smallrye-health was missing a
dependency to smallrye-config to ensure that the SmallRyeHealthReporter
(that is not used by WildFly) was properly injected its
ConfigProperties.

JIRA: https://issues.jboss.org/browse/WFLY-12427