### PR TITLE
WFLY-12355 Upgrade jboss-batch-api_1.0_spec from 1.0.2.Final to 2.0.0…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>2.0.0.CR1</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
-        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>2.0.0.CR1</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
+        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>2.0.0.CR2</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.CR2</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>2.0.0.CR2</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>2.0.0.CR1</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>


### PR DESCRIPTION
….CR2

JIRA: https://issues.jboss.org/browse/WFLY-12355
Diff between 2.0.0.CR1 and 2.0.0.CR2: https://github.com/jboss/jboss-jakarta-batch-api_spec/compare/2.0.0.CR1...2.0.0.CR2