### PR TITLE
[WFLY-12474] Upgrade smallrye-metrics 2.1.4

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -3021,7 +3021,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics-2.0</artifactId>
+            <artifactId>smallrye-metrics</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -632,7 +632,7 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
-      <artifactId>smallrye-metrics-2.0</artifactId>
+      <artifactId>smallrye-metrics</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/metrics/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${io.smallrye:smallrye-metrics-2.0}"/>
+        <artifact name="${io.smallrye:smallrye-metrics}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1530,7 +1530,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics-2.0</artifactId>
+            <artifactId>smallrye-metrics</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-metrics-2.0</artifactId>
+            <artifactId>smallrye-metrics</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <version.io.prometheus.simpleclient>0.6.0</version.io.prometheus.simpleclient>
         <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-metrics>1.1.0</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>2.1.4</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -322,7 +322,7 @@
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.health.api>2.0.1</version.org.eclipse.microprofile.health.api>
-        <version.org.eclipse.microprofile.metrics.api>2.0.1</version.org.eclipse.microprofile.metrics.api>
+        <version.org.eclipse.microprofile.metrics.api>2.0.2</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
@@ -1625,7 +1625,7 @@
 
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-metrics-2.0</artifactId>
+                <artifactId>smallrye-metrics</artifactId>
                 <version>${version.io.smallrye.smallrye-metrics}</version>
             </dependency>
 


### PR DESCRIPTION
* upgrade from smallrye-metrics-2.0:1.1.0 to smallrye-metrics:2.1.4.
  There was a change in the version convention but this is a micro
  update
* upgrade from microprofile-metrics:2.0.1 to 2.0.2 (micro upgrades)
* smallrye-metrics:2.1.4 incorporates fixes for WFLY-12403 and
  WFLY-12413

JIRA: https://issues.jboss.org/browse/WFLY-12474
JIRA: https://issues.jboss.org/browse/WFLY-12475
JIRA: https://issues.jboss.org/browse/WFLY-12403
JIRA: https://issues.jboss.org/browse/WFLY-12413

---

* [Release notes for smallrye-metrics:2.14](https://github.com/smallrye/smallrye-metrics/milestone/9?closed=1)
* [Diff between MicroProfile Metrics 2.0.1 and 2.0.2](https://github.com/eclipse/microprofile-metrics/compare/2.0.1...2.0.2) - no functional changes