### PR TITLE
[WFLY-12479]: Upgrade Apache Artemis from 2.8.1 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.3.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.8.1</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.9.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.0</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.3.2</version.org.apache.cxf>
@@ -307,7 +307,7 @@
         <version.org.apache.myfaces.core>2.3.1</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.1.1</version.org.apache.neethi>
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
-        <version.org.apache.qpid.proton>0.32.0</version.org.apache.qpid.proton>
+        <version.org.apache.qpid.proton>0.33.1</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.3</version.org.apache.santuario>
         <version.org.apache.thrift>0.12.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.0</version.org.apache.velocity>
@@ -2023,6 +2023,10 @@
                 <artifactId>artemis-server</artifactId>
                 <version>${version.org.apache.activemq.artemis}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>io.micrometer</groupId>
+                        <artifactId>micrometer-core</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>io.netty</groupId>
                         <artifactId>netty-buffer</artifactId>


### PR DESCRIPTION
* Upgrade Apache Artemis to 2.9.0

Jira: https://issues.jboss.org/browse/WFLY-12479