### PR TITLE
[WFLY-12478] Upgrade WildFly Core from 10.0.0.Beta5 to 10.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12478

---

# Release Notes - WildFly Core - Version 10.0.0.Beta6
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4637'>WFCORE-4637</a>] -         Upgrade JBoss / Jakarta JACC to 2.0.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4638'>WFCORE-4638</a>] -         Upgrade WildFly Elytron to 1.10.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4639'>WFCORE-4639</a>] -         Upgrade Elytron Web to 1.6.0.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4641'>WFCORE-4641</a>] -         Upgrade Undertow to 2.0.26.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4644'>WFCORE-4644</a>] -         Upgrade JBoss / Jakarta JACC to 2.0.0.CR3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4375'>WFCORE-4375</a>] -          Provide ability to easily apply certain JBoss module libraries to all deployments running in a server
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4624'>WFCORE-4624</a>] -         Perist interfaces and socket-bindings in alphabetical order
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4625'>WFCORE-4625</a>] -         Expose a util method for standard marshalling of xml element content
</li>
</ul>
                                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4227'>WFCORE-4227</a>] -         Add the ability for the CLI SSL security commands to be able to obtain a server certificate from Let&#39;s Encrypt
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4336'>WFCORE-4336</a>] -         Create a Custom filter log to allow remove/filtering of exceptions
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4617'>WFCORE-4617</a>] -         jboss-cli.sh does not error on invalid options such as --controler
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4633'>WFCORE-4633</a>] -         StandaloneScriptTestCase fails on IBM JDK8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4636'>WFCORE-4636</a>] -         Logging&#39;s CommonAttributes NAME and MODULE should use setFlags(Flag.RESTART_ALL_SERVICES)
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4643'>WFCORE-4643</a>] -         The secure-management layer is missing the /core-service=management/access=identity resource
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4368'>WFCORE-4368</a>] -         Remove the org.apache.commons:commons-lang3 exclusion from elytron-tool
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4591'>WFCORE-4591</a>] -         Bump logging schema and model versions
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4640'>WFCORE-4640</a>] -         Add a DUP to the Elytron subsystem that adds the  &#39;javax.security.auth.message.api&#39; and &#39;javax.security.jacc.api&#39; modules to the deployment
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4642'>WFCORE-4642</a>] -         Add ability to run chunks of the integration testsuite against Galleon-slimmed server
</li>
</ul>
                                    