### PR TITLE
WFLY-12472 - Adding test for missing ee subsystem and fix a null pointer in clustering

### DIFF
--- a/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/deployment/DistributableWebDeploymentDependencyProcessor.java
+++ b/clustering/web/extension/src/main/java/org/wildfly/extension/clustering/web/deployment/DistributableWebDeploymentDependencyProcessor.java
@@ -62,7 +62,7 @@ public class DistributableWebDeploymentDependencyProcessor implements Deployment
         WarMetaData warMetaData = unit.getAttachment(WarMetaData.ATTACHMENT_KEY);
         SharedSessionManagerConfig sharedConfig = unit.getAttachment(SharedSessionManagerConfig.ATTACHMENT_KEY);
 
-        if (((warMetaData != null) && (warMetaData.getMergedJBossWebMetaData().getDistributable() != null)) || ((sharedConfig != null) && sharedConfig.isDistributable())) {
+        if (((warMetaData != null) && (warMetaData.getMergedJBossWebMetaData() != null && warMetaData.getMergedJBossWebMetaData().getDistributable() != null)) || ((sharedConfig != null) && sharedConfig.isDistributable())) {
             CapabilityServiceSupport support = unit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
             DistributableWebDeploymentConfiguration config = unit.getAttachment(CONFIGURATION_KEY);
 

--- a/naming/src/main/java/org/jboss/as/naming/deployment/JndiNamingDependencyProcessor.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/JndiNamingDependencyProcessor.java
@@ -22,6 +22,7 @@
 package org.jboss.as.naming.deployment;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +78,7 @@ public class JndiNamingDependencyProcessor implements DeploymentUnitProcessor {
     }
 
     private static Set<ServiceName> installComponentJndiAggregatingServices(final ServiceTarget target, final Map<ServiceName, Set<ServiceName>> mappings) {
+        if (mappings == null) return Collections.emptySet();
         final Set<ServiceName> retVal = new HashSet<>();
         ServiceBuilder sb;
         ServiceName sn;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/excludesubsystem/ExcludeEESubsystemTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/excludesubsystem/ExcludeEESubsystemTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.excludesubsystem;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests excluding subsystems via jboss-deployment-structure.xml
+ * Test for WFLY-12472
+ */
+@RunWith(Arquillian.class)
+public class ExcludeEESubsystemTestCase {
+
+    private static final Logger logger = Logger.getLogger(ExcludeEESubsystemTestCase.class);
+    private static final String EXCLUDE_SUBSYSTEM_EE = "excludeSubsystemEE";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Deployment(name = EXCLUDE_SUBSYSTEM_EE, managed = false)
+    public static Archive<?> createDeployment() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, EXCLUDE_SUBSYSTEM_EE + ".war");
+        jar.addAsManifestResource(ExcludeEESubsystemTestCase.class.getPackage(), "jboss-deployment-structure-exclude-ee.xml",
+                "jboss-deployment-structure.xml");
+        jar.addPackage(ExcludeEESubsystemTestCase.class.getPackage());
+        return jar;
+    }
+
+    // Test that simple deployment runs without ee subsystem as required by Infinispan
+    @Test
+    public void testDeploy() throws Exception {
+        deployer.deploy(EXCLUDE_SUBSYSTEM_EE);
+        deployer.undeploy(EXCLUDE_SUBSYSTEM_EE);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/excludesubsystem/jboss-deployment-structure-exclude-ee.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/excludesubsystem/jboss-deployment-structure-exclude-ee.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+    <deployment>
+        <exclude-subsystems>
+            <subsystem name="ejb3" />
+            <subsystem name="ee" />
+            <subsystem name="webservices" />
+            <subsystem name="weld" />
+            <subsystem name="messaging-activemq" />
+            <subsystem name="jpa" />
+            <subsystem name="undertow" />
+        </exclude-subsystems>
+        <exclusions>
+            <module name="javax.jms.api"></module>
+        </exclusions>
+    </deployment>
+</jboss-deployment-structure>
+


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12472

This complements existing PR https://github.com/wildfly/wildfly/pull/12573 by adding a test and fix a second NullPointerException in clustering when the subsystem is missing, that could happen in standalone infinispan.