### PR TITLE
WFLY-12487 Include the original cause of failure, if jsf-injection module load fails

### DIFF
--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/deployment/JSFDependencyProcessor.java
@@ -153,7 +153,7 @@ public class JSFDependencyProcessor implements DeploymentUnitProcessor {
                 jsfInjectionDependency.addImportFilter(PathFilters.is("META-INF/1.2/faces-config.xml"), false);
             }
         } catch (ModuleLoadException e) {
-            throw JSFLogger.ROOT_LOGGER.jsfInjectionFailed(jsfVersion);
+            throw JSFLogger.ROOT_LOGGER.jsfInjectionFailed(jsfVersion, e);
         }
 
         moduleSpecification.addSystemDependency(jsfInjectionDependency);

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
@@ -34,6 +34,7 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -107,7 +108,7 @@ public interface JSFLogger extends BasicLogger {
     void phaseListenersConfigParseFailed(VirtualFile facesConfig);
 
     @Message(id = 16, value = "Failed to inject JSF from slot %s")
-    DeploymentUnitProcessingException jsfInjectionFailed(String slotName);
+    DeploymentUnitProcessingException jsfInjectionFailed(String slotName, @Cause Throwable cause);
 
     @LogMessage(level = DEBUG)
     @Message(id = 17, value = "JSF 1.2 classes detected. Using org.jboss.as.jsf.injection.weld.legacy.WeldApplicationFactoryLegacy.")


### PR DESCRIPTION
The commit here introduces a relatively trivial enhancement to the exception that gets thrown while processing a JSF deployment. The details of this enhancement are noted in https://issues.jboss.org/browse/WFLY-12487.

With this change, the `DeploymentUnitProcessingException` will now include the original cause of the jsf-injection module load failure, if and when that happens.