### PR TITLE
[WFLY-12510] Update all usages of wildfly-credential-reference_1_0.xsd

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
@@ -23,12 +23,12 @@
 <xs:schema targetNamespace="urn:jboss:domain:jgroups:7.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="urn:jboss:domain:jgroups:7.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="7.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:datasources:5.0" xmlns="urn:jboss:domain:datasources:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:resource-adapters:5.0" xmlns="urn:jboss:domain:resource-adapters:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
@@ -21,10 +21,10 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:1.0"
-           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="subsystemType"/>
 

--- a/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
@@ -26,13 +26,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:3.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:mail:3.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <!-- The mail subsystem root element -->
     <xs:element name="subsystem" type="mail-subsystemType"/>

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
@@ -24,13 +24,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:messaging-activemq:9.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:messaging-activemq:9.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="9.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem">
         <xs:complexType>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12510

Update all usages of wildfly-credential-reference_1_0.xsd to the new wildfly-credential-reference_1_1.xsd version to allow the WildFly testsuite to pass with the changes for [WFCORE-4150](https://issues.jboss.org/browse/WFCORE-4150).

Depends on https://github.com/wildfly/wildfly-core/pull/3925. See https://github.com/wildfly/wildfly-core/pull/3925#issuecomment-526323865 for more details.