### PR TITLE
Move some javax.* to jakarta.*

### DIFF
--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -216,12 +216,12 @@
         <!-- Required by the artemis-jms-client -->
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
 
         <dependency>

--- a/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/managedbean/processors/JavaEEDependencyProcessor.java
@@ -62,7 +62,7 @@ public class JavaEEDependencyProcessor implements DeploymentUnitProcessor {
             ModuleIdentifier.create("javax.rmi.api"),
             ModuleIdentifier.create("javax.xml.bind.api"),
             ModuleIdentifier.create("javax.api"),
-            // javax.json.bind.api (JSON-B) implementation
+            // (JSON-B) implementation
             ModuleIdentifier.create(ECLIPSE_YASSON),
             ModuleIdentifier.create(GLASSFISH_EL),
             ModuleIdentifier.create("org.glassfish.javax.enterprise.concurrent")

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-binding-provider/main/module.xml
@@ -33,7 +33,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.glassfish.javax.json"/>
+        <module name="org.glassfish.jakarta.json"/>
         <module name="javax.json.bind.api" export="true"/>
         <module name="org.eclipse.yasson"/>
         <module name="javax.api"/>

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -117,6 +117,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.json</groupId>
             <artifactId>jakarta.json-api</artifactId>
         </dependency>

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -117,8 +117,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
 
         <dependency>

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -39,8 +39,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/microprofile/metrics-smallrye/pom.xml
+++ b/microprofile/metrics-smallrye/pom.xml
@@ -39,8 +39,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
+        <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.jakarta.security.enterprise>1.0.1</version.jakarta.security.enterprise>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0.SP1</version.javax.enterprise>
@@ -327,6 +328,7 @@
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
+        <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0.1</version.org.glassfish.soteria>
@@ -1749,6 +1751,12 @@
                         <artifactId>javax.el-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${version.jakarta.json.jakarta-json-api}</version>
             </dependency>
 
             <dependency>
@@ -5343,6 +5351,13 @@
                         <artifactId>javax.enterprise.concurrent-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <!-- JSR-353 JSONP RI implementation -->
+            <dependency>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.json</artifactId>
+                <version>${version.org.glassfish.jakarta.json}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -281,10 +281,10 @@
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
+        <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
         <version.jakarta.security.enterprise>1.0.1</version.jakarta.security.enterprise>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0.SP1</version.javax.enterprise>
-        <version.javax.json.bind.api>1.0</version.javax.json.bind.api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.2</version.javax.mail>
         <version.javax.persistence>2.2</version.javax.persistence>
@@ -326,7 +326,7 @@
         <version.org.eclipse.microprofile.metrics.api>2.0.2</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
-        <version.org.eclipse.yasson>1.0.3</version.org.eclipse.yasson>
+        <version.org.eclipse.yasson>1.0.4</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>
         <version.org.glassfish.jakarta.json>1.1.6</version.org.glassfish.jakarta.json>
         <version.org.glassfish.jakarta.el>3.0.2</version.org.glassfish.jakarta.el>
@@ -1760,9 +1760,9 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.json.bind</groupId>
-                <artifactId>javax.json.bind-api</artifactId>
-                <version>${version.javax.json.bind.api}</version>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${version.jakarta.json.bind.api}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>
@@ -5249,6 +5249,11 @@
                     <exclusion>
                         <groupId>*</groupId>
                         <artifactId>*</artifactId>
+                    </exclusion>
+                    <!-- This seems to require an explicit exclusion for yasson 1.0.4 -->
+                    <exclusion>
+                        <groupId>org.glassfish</groupId>
+                        <artifactId>jakarta.json</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,7 @@
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
+        <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
         <version.jakarta.security.enterprise>1.0.1</version.jakarta.security.enterprise>
@@ -1750,7 +1751,17 @@
                         <groupId>javax.el</groupId>
                         <artifactId>javax.el-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${version.jakarta.inject.jakarta.inject-api}</version>
             </dependency>
 
             <dependency>
@@ -1885,6 +1896,10 @@
                 <artifactId>artemis-cli</artifactId>
                 <version>${version.org.apache.activemq.artemis}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.apache.commons</groupId>
                         <artifactId>commons-lang3</artifactId>
@@ -5279,6 +5294,12 @@
                 <groupId>org.eclipse.microprofile.health</groupId>
                 <artifactId>microprofile-health-api</artifactId>
                 <version>${version.org.eclipse.microprofile.health.api}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.microprofile.health</groupId>
@@ -5710,6 +5731,10 @@
                 <artifactId>hornetq-jms-client</artifactId>
                 <version>${version.org.hornetq}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.hornetq</groupId>
                         <artifactId>hornetq-journal</artifactId>
@@ -8006,6 +8031,10 @@
                 <artifactId>wildfly-arquillian-container-managed</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.jboss.sasl</groupId>
                         <artifactId>jboss-sasl</artifactId>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -145,8 +145,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -120,6 +120,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
         </dependency>
@@ -162,6 +167,11 @@
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -140,8 +140,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -62,8 +62,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -73,12 +73,12 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>javax.json.bind</groupId>
-      <artifactId>javax.json.bind-api</artifactId>
+      <groupId>jakarta.json.bind</groupId>
+      <artifactId>jakarta.json.bind-api</artifactId>
       <licenses>
         <license>
-          <name>Common Development and Distribution License 1.1</name>
-          <url>https://javaee.github.io/glassfish/LICENSE</url>
+          <name>Eclipse Public License 2.0</name>
+          <url>http://www.eclipse.org/legal/epl-2.0</url>
           <distribution>repo</distribution>
         </license>
         <license>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
@@ -21,9 +21,8 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.5" name="javax.inject.api">
+<module xmlns="urn:jboss:module:1.9" name="javax.inject.api">
     <resources>
-        <artifact name="${javax.inject:javax.inject}"/>
+        <artifact name="${jakarta.inject:jakarta.inject-api}"/>
     </resources>
 </module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<module xmlns="urn:jboss:module:1.9" name="javax.json.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <resources>
+        <artifact name="${jakarta.json:jakarta.json-api}"/>
+    </resources>
+    <dependencies>
+        <!--
+            This is required as a circular dependency because the RI does not include a META-INF/services provider file.
+            It must also be exported so that modules that depend on the API, e.g. deployments, will be able to see the
+            implementation.
+        -->
+        <module name="org.glassfish.jakarta.json" export="true"/>
+    </dependencies>
+</module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/json/bind/api/main/module.xml
@@ -16,13 +16,12 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="javax.json.bind.api">
-
+<module xmlns="urn:jboss:module:1.9" name="javax.json.bind.api">
     <properties>
         <property name="jboss.api" value="public"/>
     </properties>
     <resources>
-        <artifact name="${javax.json.bind:javax.json.bind-api}"/>
+        <artifact name="${jakarta.json.bind:jakarta.json.bind-api}"/>
     </resources>
     <dependencies>
         <module name="javax.json.api"/>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/json/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/jakarta/json/main/module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.9" name="org.glassfish.jakarta.json">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.json.api" />
+    </dependencies>
+    <resources>
+        <artifact name="${org.glassfish:jakarta.json}">
+            <filter>
+                <!-- This artifact packages both the API and the impl in the same jar,
+                     but we want to use our own API jar (see javax.json.api module).
+                     So suppress the API packages. -->
+                <exclude path="javax/*"/>
+            </filter>
+        </artifact>
+    </resources>
+</module>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2019 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module-alias xmlns="urn:jboss:module:1.9" name="org.glassfish.javax.json" target-name="org.glassfish.jakarta.json"/>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -149,8 +149,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -155,8 +155,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -126,6 +126,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.activation</groupId>
             <artifactId>activation</artifactId>
             <scope>provided</scope>
@@ -177,6 +182,11 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
 
         <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -46,8 +46,8 @@
     <!-- Export out the EE Specs and demos -->
 
     <dependency>
-      <groupId>javax.json</groupId>
-      <artifactId>javax.json-api</artifactId>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
     </dependency>
 
     <dependency>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -106,8 +106,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json.bind</groupId>
-            <artifactId>javax.json.bind-api</artifactId>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -176,6 +176,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -62,6 +62,12 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-testsuite-shared</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -124,7 +124,7 @@
         <!-- Required implementation for the org.wildfly.core:event-logger which is initialized in the subsystem tests -->
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/webservices/tests-integration/pom.xml
+++ b/webservices/tests-integration/pom.xml
@@ -43,8 +43,8 @@
 
     <dependencies>
         <dependency> <!-- Required by activemq... -->
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.ws</groupId>

--- a/weld/subsystem/pom.xml
+++ b/weld/subsystem/pom.xml
@@ -47,6 +47,11 @@
    <dependencies>
 
       <dependency>
+         <groupId>jakarta.inject</groupId>
+         <artifactId>jakarta.inject-api</artifactId>
+      </dependency>
+
+      <dependency>
          <groupId>${project.groupId}</groupId>
          <artifactId>wildfly-ee</artifactId>
       </dependency>


### PR DESCRIPTION
This includes a temporary commit to add the jakarta.json module to full. This module lives in core which for testing purposes should wait for this to be merged, then reverted once merged into core and core is released. This also pertains to the jakarta.inject dependency as well.

This includes the following as to not cause conflicts with having these separate commits:

- https://issues.jboss.org/browse/WFLY-12499
- https://issues.jboss.org/browse/WFLY-12501
- https://issues.jboss.org/browse/WFLY-12502