### PR TITLE
Ignore DynamicJNDIContextEJBInvocationTestCase

### DIFF
--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/scoped/context/DynamicJNDIContextEJBInvocationTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +52,7 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
  */
 @RunWith(Arquillian.class)
 @ServerSetup(PassivationConfigurationSetup.class)
+@Ignore("WFLY-12512")
 public class DynamicJNDIContextEJBInvocationTestCase {
 
     private static final Logger logger = Logger.getLogger(DynamicJNDIContextEJBInvocationTestCase.class);


### PR DESCRIPTION
Ignores frequently intermittently failing tests. JIRA to sort the problem is WFLY-12512.