### PR TITLE
Make ServiceLoader module dependencies on org.wildfly.clustering.web.…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
@@ -41,6 +41,6 @@
         <module name="org.wildfly.clustering.server" services="import"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.singleton"/>
-        <module name="org.wildfly.clustering.web.infinispan" services="import"/>
+        <module name="org.wildfly.clustering.web.infinispan" services="import" optional="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
@@ -45,7 +45,7 @@
         <module name="org.wildfly.clustering.marshalling.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.api"/>
-        <module name="org.wildfly.clustering.web.infinispan" services="import"/>
+        <module name="org.wildfly.clustering.web.infinispan" services="import" optional="true"/>
         <module name="org.wildfly.clustering.web.undertow" services="import"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
@@ -52,7 +52,7 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.api"/>
         <module name="org.wildfly.clustering.web.container"/>
-        <module name="org.wildfly.clustering.web.infinispan" services="import"/>
+        <module name="org.wildfly.clustering.web.infinispan" services="import" optional="true"/>
         <module name="org.wildfly.clustering.web.spi"/>
         <module name="org.wildfly.extension.undertow"/>
         <module name="org.wildfly.security.elytron-private"/>


### PR DESCRIPTION
…infinispan optional to avoid requiring infinispan subsystem

Currently just for CI test. @pferraro FYI.

When running tests of a Galleon-trimmed server using the web-server and datasources layers, SharedSessionTestCase would fail as InfinispanLegacySessionManagementProviderFactory was getting discovered and would wire in infinispan service deps, but the config did not have the infinispan subsystem.

The only module that has compile-time deps on clustering/web/infinispan is clustering/web/extension so the other deps are for service loading and should be optional.