### PR TITLE
[WFLY-12523] Move from javax.validation:validation-api:2.0.1 to jakar…

### DIFF
--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -42,8 +42,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
           <groupId>org.hibernate.validator</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -140,8 +140,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -283,14 +283,14 @@
         <version.jakarta.inject.jakarta.inject-api>1.0</version.jakarta.inject.jakarta.inject-api>
         <version.jakarta.json.jakarta-json-api>1.1.6</version.jakarta.json.jakarta-json-api>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
+        <version.jakarta.persistence>2.2.3</version.jakarta.persistence>
         <version.jakarta.security.enterprise>1.0.1</version.jakarta.security.enterprise>
+        <version.jakarta.validation>2.0.2</version.jakarta.validation>
         <version.javax.activation>1.1.1</version.javax.activation>
         <version.javax.enterprise>2.0.2</version.javax.enterprise>
         <version.javax.json.bind.api>1.0</version.javax.json.bind.api>
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.6.2</version.javax.mail>
-        <version.jakarta.persistence>2.2.3</version.jakarta.persistence>
-        <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.3.GA</version.jboss.jaxbintros>
         <version.joda-time>2.9.7</version.joda-time>
@@ -1740,6 +1740,12 @@
             </dependency>
 
             <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${version.jakarta.validation}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>javax.activation</groupId>
                 <artifactId>activation</artifactId>
                 <version>${version.javax.activation}</version>
@@ -1805,12 +1811,6 @@
                 <groupId>javax.jws</groupId>
                 <artifactId>jsr181-api</artifactId>
                 <version>${version.javax.jws.jsr181-api}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${version.javax.validation}</version>
             </dependency>
 
             <dependency>
@@ -5713,6 +5713,14 @@
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${version.org.hibernate.validator}</version>
+                <exclusions>
+                    <!-- TODO remove this exclusion once this supports Jakarta Validation -->
+                    <!-- Superceded by jakarta.validation:jakarta.validation-api -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -6280,6 +6288,12 @@
                         <groupId>org.jboss.spec.javax.transaction</groupId>
                         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                     </exclusion>
+                    <!-- TODO remove this exclusion once this supports Jakarta Validation -->
+                    <!-- Superceded by jakarta.validation:jakarta.validation-api -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -6635,6 +6649,12 @@
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging</artifactId>
                     </exclusion>
+                    <!-- TODO remove this exclusion once this supports Jakarta Validation -->
+                    <!-- Superceded by jakarta.validation:jakarta.validation-api -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -6806,6 +6826,12 @@
                     <exclusion>
                         <groupId>javax.annotation</groupId>
                         <artifactId>jsr250-api</artifactId>
+                    </exclusion>
+                    <!-- TODO remove this exclusion once this supports Jakarta Validation -->
+                    <!-- Superceded by jakarta.validation:jakarta.validation-api -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -8576,6 +8602,7 @@
                                             <exclude>javax.persistence:persistence-api</exclude>
                                             <exclude>javax.servlet:servlet-api</exclude>
                                             <exclude>javax.transaction:jta</exclude>
+                                            <exclude>javax.validation:validation-api</exclude>
 					    <exclude>javax.xml:jaxrpc-api</exclude>
                                             <exclude>javax.xml.soap:saaj-api</exclude>
                                             <exclude>javax.xml.stream:stax-api</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <version.org.hibernate>5.3.11.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.5.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.16.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.17.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>9.4.16.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -130,8 +130,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -35,6 +35,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
       <licenses>
@@ -84,17 +95,6 @@
         <license>
           <name>GNU General Public License v2.0 only, with Classpath exception</name>
           <url>http://openjdk.java.net/legal/gplv2+ce.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
           <distribution>repo</distribution>
         </license>
       </licenses>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -24,7 +24,7 @@
 
 <module xmlns="urn:jboss:module:1.7" name="javax.validation.api">
     <resources>
-        <artifact name="${javax.validation:validation-api}"/>
+        <artifact name="${jakarta.validation:jakarta.validation-api}"/>
     </resources>
 
     <dependencies>

--- a/servlet-galleon-pack/pom.xml
+++ b/servlet-galleon-pack/pom.xml
@@ -137,8 +137,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -147,8 +147,8 @@
       <artifactId>jboss-annotations-api_1.3_spec</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.management.j2ee</groupId>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -116,8 +116,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Required for artemis-commons, just needs to be on the class path -->


### PR DESCRIPTION
…ta.validation:jakarta.validation-api:2.0.2

https://issues.jboss.org/browse/WFLY-12523

Also, related upgrade of Hibernate Validator to 6.0.17:

https://issues.jboss.org/browse/WFLY-12533

@gsmet FYI