### PR TITLE
[WFLY-12526] Ensure isUserInRole uses a PrivilegedAction as the deployments ProtectionDomain is not relevant.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/JbossAuthorizationManager.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/JbossAuthorizationManager.java
@@ -96,7 +96,7 @@ public class JbossAuthorizationManager implements AuthorizationManager {
             //    callerSubject = getSubjectFromRequestPrincipal(principal);
             //}
 
-            authzDecision = helper.hasRole(roleName, account.getPrincipal(), servletName, getPrincipalRoles(account),
+            authzDecision = SecurityActions.hasRole(helper, roleName, account.getPrincipal(), servletName, getPrincipalRoles(account),
                     PolicyContext.getContextID(), callerSubject, new ArrayList<String>(account.getRoles()));
         }
         boolean finalDecision = baseDecision && authzDecision;

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/SecurityActions.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/SecurityActions.java
@@ -23,7 +23,9 @@
 package org.wildfly.extension.undertow.security;
 
 import java.security.AccessController;
+import java.security.Principal;
 import java.security.PrivilegedAction;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,6 +34,7 @@ import org.jboss.security.SecurityContext;
 import org.jboss.security.SecurityContextAssociation;
 import org.jboss.security.SecurityContextFactory;
 import org.jboss.security.SecurityRolesAssociation;
+import org.jboss.security.javaee.AbstractWebAuthorizationHelper;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -238,4 +241,17 @@ class SecurityActions {
             return subject;
         }
     }
+
+    static boolean hasRole(AbstractWebAuthorizationHelper helper, String roleName, Principal principal, String servletName, Set<Principal> principalRoles, String contextID, Subject callerSubject, List<String> roles) {
+        if (WildFlySecurityManager.isChecking()) {
+            return doPrivileged(new PrivilegedAction<Boolean>() {
+                public Boolean run() {
+                    return helper.hasRole(roleName, principal, servletName, principalRoles, contextID, callerSubject, roles);
+                }
+            });
+        } else {
+            return helper.hasRole(roleName, principal, servletName, principalRoles, contextID, callerSubject, roles);
+        }
+    }
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12526

Reviewing the call stack in the Jira issue the deployment's ProtectionDomain should be dropped as not revevant for the ongoing call.