### PR TITLE
[WFLY-12530] Add doPrivileged calls to access the AuthConfigFactory.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecurityContext.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecurityContext.java
@@ -21,10 +21,11 @@
  */
 package org.wildfly.extension.undertow.security.jaspi;
 
+import static org.wildfly.extension.undertow.security.jaspi.SecurityActions.getAuthConfigFactory;
+
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.message.MessageInfo;
-import javax.security.auth.message.config.AuthConfigFactory;
 import javax.security.auth.message.config.AuthConfigProvider;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -81,7 +82,7 @@ class JASPICSecurityContext extends SecurityContextImpl {
     public boolean login(final String username, final String password) {
         // if there is an AuthConfigProvider for the HttpServlet layer and appContext, this method must throw an exception.
         String appContext = this.buildAppContext();
-        AuthConfigProvider provider = AuthConfigFactory.getFactory().getConfigProvider(layer, appContext, null);
+        AuthConfigProvider provider = getAuthConfigFactory().getConfigProvider(layer, appContext, null);
         if (provider != null) {
             ServletException se = new ServletException("login is not supported by the JASPIC mechanism");
             throw new SecurityException(se);
@@ -111,7 +112,7 @@ class JASPICSecurityContext extends SecurityContextImpl {
 
         // call cleanSubject() if there is an AuthConfigProvider for the HttpServlet layer and appContext.
         String appContext = this.buildAppContext();
-        if (AuthConfigFactory.getFactory().getConfigProvider(layer, appContext, null) != null) {
+        if (getAuthConfigFactory().getConfigProvider(layer, appContext, null) != null) {
             Subject authenticatedSubject = this.getAuthenticatedSubject();
             MessageInfo messageInfo = this.buildMessageInfo();
             this.manager.cleanSubject(messageInfo, authenticatedSubject, layer, appContext, handler);
@@ -196,4 +197,6 @@ class JASPICSecurityContext extends SecurityContextImpl {
             subject = picketBoxContext.getSubjectInfo().getAuthenticatedSubject();
         return subject != null ? subject : new Subject();
     }
+
+
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/SecurityActions.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/SecurityActions.java
@@ -22,7 +22,10 @@
 
 package org.wildfly.extension.undertow.security.jaspi;
 
+import static java.security.AccessController.doPrivileged;
 import java.security.PrivilegedAction;
+
+import javax.security.auth.message.config.AuthConfigFactory;
 
 import org.jboss.security.SecurityContext;
 import org.jboss.security.SecurityContextAssociation;
@@ -36,6 +39,18 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 class SecurityActions {
 
+    private static final PrivilegedAction<AuthConfigFactory> GET_AUTH_CONFIG_FACTORY_ACTION = new PrivilegedAction<AuthConfigFactory>() {
+
+        @Override
+        public AuthConfigFactory run() {
+            return AuthConfigFactory.getFactory();
+        }
+
+    };
+
+    static AuthConfigFactory getAuthConfigFactory() {
+        return WildFlySecurityManager.isChecking() ?  doPrivileged(GET_AUTH_CONFIG_FACTORY_ACTION) : GET_AUTH_CONFIG_FACTORY_ACTION.run();
+    }
 
     /**
      * Get the current {@code SecurityContext}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12530

The stack trace is shown on the Jira issue, the JASPICSecurityContext use of AuthConfigFactory is an internal detail - the deployment is making use of standard servlet APIs so should not require these permissions to be granted.
