### PR TITLE
WFLY-12539 Do not auto-update legacy JGroup protocols in domain contr…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolRegistration.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolRegistration.java
@@ -220,8 +220,10 @@ public class ProtocolRegistration implements Registration<ManagementResourceRegi
             new GenericProtocolResourceDefinition(protocol.name(), JGroupsModel.VERSION_5_0_0, this.configurator, this.parentServiceConfiguratorFactory).register(registration);
         }
 
-        for (LegacyProtocol protocol : EnumSet.allOf(LegacyProtocol.class)) {
-            new LegacyProtocolResourceDefinition(protocol.name, protocol.targetName, protocol.deprecation, this.configurator, this.parentServiceConfiguratorFactory).register(registration);
+        if (registration.getProcessType().isServer()) { // only auto-update legacy protocols in server processes
+            for (LegacyProtocol protocol : EnumSet.allOf(LegacyProtocol.class)) {
+                new LegacyProtocolResourceDefinition(protocol.name, protocol.targetName, protocol.deprecation, this.configurator, this.parentServiceConfiguratorFactory).register(registration);
+            }
         }
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/LegacyJGroupsProtocolsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/LegacyJGroupsProtocolsTestCase.java
@@ -1,0 +1,62 @@
+package org.jboss.as.test.integration.domain;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.executeForResult;
+
+/**
+ * Verifies that legacy JGroups protocols are not auto-updated by domain controller.
+ *
+ * (DC can be controlling older EAP version slaves, which require legacy protocols.)
+ *
+ * https://issues.jboss.org/browse/WFLY-12539
+ */
+public class LegacyJGroupsProtocolsTestCase {
+
+    private static final PathAddress UDP_STACK_ADDR =
+            PathAddress.pathAddress("profile", "default").append("subsystem", "jgroups").append("stack", "udp");
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainClient masterClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        final DomainTestSupport.Configuration configuration;
+        configuration = DomainTestSupport.Configuration.create(LegacyJGroupsProtocolsTestCase.class.getSimpleName(),
+                "domain-configs/domain-standard.xml", "host-configs/host-master.xml", null);
+        testSupport = DomainTestSupport.create(configuration);
+        testSupport.start();
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        masterClient = domainMasterLifecycleUtil.getDomainClient();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() {
+        testSupport.stop();
+        domainMasterLifecycleUtil = null;
+    }
+
+    @Test
+    public void testJGroupsProtocolsNotUpdated() throws Exception {
+        ModelNode readOp = Util.createEmptyOperation(ClientConstants.READ_RESOURCE_OPERATION, UDP_STACK_ADDR);
+        readOp.get("recursive").set(true);
+        ModelNode result = executeForResult(readOp, masterClient);
+
+        // UNICAST2 defined in configuration should not be auto-updated to UNICAST3
+        ModelNode protocols = result.get("protocol");
+        Assert.assertTrue("UNICAST2 protocol is expected to be present, actual protocols: " + protocols,
+                protocols.toString().contains("UNICAST2"));
+    }
+}


### PR DESCRIPTION
…oller

Wildfly automatically updates legacy JGroup protocols to new versions, e.g. NAKACK to NAKACK2 and UNICAST2 to UNICAST3. However in domain mode we can have Wildfly DC controlling older version (e.g. EAP 6.4) slaves which only know the legacy protocol versions and thus are unable to use the updated versions. To allow for this domain configuration, legacy protocols should not be upgraded by domain controller.

https://issues.jboss.org/browse/WFLY-12539
Downstream issue: https://issues.jboss.org/browse/JBEAP-17511