### PR TITLE
WFLY-12545 fix IllegalArgumentException when list-clear persist empty…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -497,9 +497,7 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> 
                     break;
                 }
                 case ALIASES: {
-                    for (String alias : reader.getListAttributeValue(i)) {
-                        CacheFactoryResourceDefinition.ALIASES.parseAndAddParameterElement(alias, operation, reader);
-                    }
+                    CacheFactoryResourceDefinition.ALIASES.getParser().parseAndSetParameter(CacheFactoryResourceDefinition.ALIASES, value, operation, reader);
                     break;
                 }
                 default: {


### PR DESCRIPTION
… aliases list for ejb cache

https://issues.jboss.org/browse/WFLY-12545
After list-clear or list-remove operations, an empty aliases list can be persisted for ejb cache, this can cause IllegalArgumentException after reload.