### PR TITLE
[WFLY-12548] Upgrade WildFly Core 10.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12548

----


## Release Notes - WildFly Core - Version 10.0.0.Beta7
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4647'>WFCORE-4647</a>] -         Upgrade WildFly Elytron to 1.10.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4651'>WFCORE-4651</a>] -         Upgrade WildFly Open SSL to 1.0.8.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4654'>WFCORE-4654</a>] -         Upgrade to JBoss / JASPI 2.0.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4658'>WFCORE-4658</a>] -         Upgrade jboss-remoting to 5.0.15.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4660'>WFCORE-4660</a>] -         Upgrade JBoss MSC to 1.4.10.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4661'>WFCORE-4661</a>] -         Upgrade the JBoss / Jakarta JASPI Fork to 2.0.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4662'>WFCORE-4662</a>] -         Upgrade JBoss / Jakarta JACC to 2.0.0.Final
</li>
</ul>
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4623'>WFCORE-4623</a>] -         Intermittent failures in IdentityOperationsTestCase
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4630'>WFCORE-4630</a>] -         Move to jakarta.inject:jakarta.inject-api
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4648'>WFCORE-4648</a>] -         Migrate javax.json to jakarta.json
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4657'>WFCORE-4657</a>] -         Upgrade jboss-jboss-interceptors-api_spec from 2.0.0.CR2 to 2.0.0.Final
</li>
</ul>
                                    