### PR TITLE
[WFLY-12554][WFLY-12555] upgrade smallrye health 2.0 & MP Health 2.1

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2999,7 +2999,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-health-2.0</artifactId>
+            <artifactId>smallrye-health</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -621,7 +621,7 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
-      <artifactId>smallrye-health-2.0</artifactId>
+      <artifactId>smallrye-health</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/health/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <resources>
-        <artifact name="${io.smallrye:smallrye-health-2.0}"/>
+        <artifact name="${io.smallrye:smallrye-health}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1518,7 +1518,7 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-health-2.0</artifactId>
+            <artifactId>smallrye-health</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -56,7 +56,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-health-2.0</artifactId>
+            <artifactId>smallrye-health</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <version.io.rest-assured>3.0.0</version.io.rest-assured>
         <version.io.prometheus.simpleclient>0.6.0</version.io.prometheus.simpleclient>
         <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
-        <version.io.smallrye.smallrye-health>1.0.2</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>2.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-metrics>2.1.4</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
@@ -1702,7 +1702,7 @@
 
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-health-2.0</artifactId>
+                <artifactId>smallrye-health</artifactId>
                 <version>${version.io.smallrye.smallrye-health}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
-        <version.org.eclipse.microprofile.health.api>2.0.1</version.org.eclipse.microprofile.health.api>
+        <version.org.eclipse.microprofile.health.api>2.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.metrics.api>2.0.2</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>

--- a/testsuite/integration/microprofile-tck/health/pom.xml
+++ b/testsuite/integration/microprofile-tck/health/pom.xml
@@ -68,9 +68,9 @@
                     </dependency>
                 </dependencies>
                 <configuration>
-                    <dependenciesToScan>
-                        <dependency>org.eclipse.microprofile.health:microprofile-health-tck</dependency>
-                    </dependenciesToScan>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>tck-suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                 </configuration>
             </plugin>
         </plugins>

--- a/testsuite/integration/microprofile-tck/health/tck-suite.xml
+++ b/testsuite/integration/microprofile-tck/health/tck-suite.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-Health-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-health 2.1 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.health.tck.*">
+            </package>
+        </packages>
+        <classes>
+            <!-- Exclude this class as WildFly does not support CDI Producer for the @Health annoation WFLY-12557 -->
+            <class name="org.eclipse.microprofile.health.tck.CDIProducedProceduresTest">
+                <methods>
+                    <exclude name=".*" />
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
[WFLY-12554] Upgrade smallrye-health 2.0
smallrye/smallrye-health@smallrye-health-2.0-1.0.2...2.0.0

[WFLY-12555] Upgrade MicroProfile Health 2.1
eclipse/microprofile-health@2.0.1...2.1
 
Exclude CDIProducedProceduresTest from the microprofile-health TCK that
is not supported by WildFly (tracked by WFLY-12557)