### PR TITLE
[WFLY-12542] MP Metrics should require the MP Config capability.

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemAdd.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemAdd.java
@@ -28,6 +28,7 @@ import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
 import org.wildfly.extension.microprofile.config.smallrye._private.MicroProfileConfigLogger;
 import org.wildfly.extension.microprofile.config.smallrye.deployment.DependencyProcessor;
 import org.wildfly.extension.microprofile.config.smallrye.deployment.SubsystemDeploymentProcessor;
@@ -51,6 +52,11 @@ class MicroProfileConfigSubsystemAdd extends AbstractBoottimeAddStepHandler {
         MicroProfileConfigLogger.ROOT_LOGGER.activatingSubsystem();
 
         ConfigProviderService.install(context);
+
+        // Add a void service other capabilities can use to ensure MP Config is ready
+        ServiceBuilder capSvc = context.getCapabilityServiceTarget().addCapability(MicroProfileSubsystemDefinition.CONFIG_CAPABILITY);
+        capSvc.requires(ServiceNames.CONFIG_PROVIDER);
+        capSvc.install();
 
         context.addStep(new AbstractDeploymentChainStep() {
             public void execute(DeploymentProcessorTarget processorTarget) {

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemRemove.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemRemove.java
@@ -38,6 +38,7 @@ class MicroProfileConfigSubsystemRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+        context.removeService(MicroProfileSubsystemDefinition.CONFIG_CAPABILITY.getCapabilityServiceName(Void.class));
         context.removeService(ServiceNames.CONFIG_PROVIDER);
     }
 

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileSubsystemDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileSubsystemDefinition.java
@@ -41,6 +41,7 @@ class MicroProfileSubsystemDefinition extends PersistentResourceDefinition {
 
     static final RuntimeCapability<Void> CONFIG_CAPABILITY =
             RuntimeCapability.Builder.of(CONFIG_CAPABILITY_NAME)
+                    .setServiceType(Void.class)
                     .addRequirements(WELD_CAPABILITY_NAME)
                     .build();
 

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsCollectorService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsCollectorService.java
@@ -21,9 +21,9 @@
  */
 package org.wildfly.extension.microprofile.metrics;
 
-import static org.wildfly.extension.microprofile.config.smallrye.ServiceNames.CONFIG_PROVIDER;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.CLIENT_FACTORY_CAPABILITY;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.MANAGEMENT_EXECUTOR;
+import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.MP_CONFIG;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.WILDFLY_COLLECTOR_SERVICE;
 import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
 
@@ -62,7 +62,7 @@ public class MetricsCollectorService implements Service<MetricCollector> {
         ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(WILDFLY_COLLECTOR_SERVICE);
         Supplier<ModelControllerClientFactory> modelControllerClientFactory = serviceBuilder.requires(context.getCapabilityServiceName(CLIENT_FACTORY_CAPABILITY, ModelControllerClientFactory.class));
         Supplier<Executor> managementExecutor = serviceBuilder.requires(context.getCapabilityServiceName(MANAGEMENT_EXECUTOR, Executor.class));
-        serviceBuilder.requires(CONFIG_PROVIDER);
+        serviceBuilder.requires(context.getCapabilityServiceName(MP_CONFIG, null));
         MetricsCollectorService service = new MetricsCollectorService(modelControllerClientFactory, managementExecutor, exposedSubsystems, prefix);
         serviceBuilder.setInstance(service)
                 .install();

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -45,8 +45,9 @@ public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDe
 
     static final String CLIENT_FACTORY_CAPABILITY ="org.wildfly.management.model-controller-client-factory";
     static final String MANAGEMENT_EXECUTOR ="org.wildfly.management.executor";
+    static final String MP_CONFIG = "org.wildlfy.microprofile.config";
     static final RuntimeCapability<Void> METRICS_COLLECTOR_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(METRICS_COLLECTOR_CAPABILITY, MetricsCollectorService.class)
-            .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR)
+            .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR, MP_CONFIG)
             .build();
 
     public static final ServiceName WILDFLY_COLLECTOR_SERVICE = METRICS_COLLECTOR_RUNTIME_CAPABILITY.getCapabilityServiceName();


### PR DESCRIPTION
Also, if services from other capabilities depend on ConfigProviderService being started before they can use MP Config, then have the MP Config capability install a void service they can depend upon.  Have MP Metrics depend on that instead of an internal impl service of the config subsystem.

https://issues.jboss.org/browse/WFLY-12542