### PR TITLE
[WFLY-12560 Convert code to use the ServerReload methods that take Ma…

### DIFF
--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/AbstractVerifyHibernate51CompatibilityTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/AbstractVerifyHibernate51CompatibilityTestCase.java
@@ -490,7 +490,7 @@ public abstract class AbstractVerifyHibernate51CompatibilityTestCase {
         public void tearDown(ManagementClient managementClient, String s) throws Exception {
             ModelNode op = Operations.createRemoveOperation(PROP_ADDR_ENABLETRANSFORMER);
             managementClient.getControllerClient().execute(op);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
     }
 }

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase.java
@@ -80,14 +80,14 @@ public class VerifyHibernate51CompatibilityPropertyEnabledTransformerTestCase
             ModelNode op = Operations.createAddOperation(PROP_ADDR);
             op.get("value").set("true");
             managementClient.getControllerClient().execute(op);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         @Override
         public void tearDown(ManagementClient managementClient, String s) throws Exception {
             ModelNode op = Operations.createRemoveOperation(PROP_ADDR);
             managementClient.getControllerClient().execute(op);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/analyzer/transactiontimeout/TransactionTimeoutSetupStep.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/analyzer/transactiontimeout/TransactionTimeoutSetupStep.java
@@ -43,7 +43,7 @@ class TransactionTimeoutSetupStep extends SnapshotRestoreSetupTask {
     public void doSetup(ManagementClient managementClient, String serverId) throws Exception {
         setTimeout(managementClient, 5);
 
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private void setTimeout(ManagementClient managementClient, int timeout) throws IOException, MgmtOperationException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/transaction/SingleThreadedBatchSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/transaction/SingleThreadedBatchSetup.java
@@ -55,6 +55,6 @@ class SingleThreadedBatchSetup extends SnapshotRestoreSetupTask {
 
         ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/SaslLegacyMechanismConfigurationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/SaslLegacyMechanismConfigurationTestCase.java
@@ -36,7 +36,7 @@ import org.jboss.as.test.integration.ejb.security.authorization.SaslLegacyMechan
 import org.jboss.as.test.integration.ejb.security.authorization.SaslLegacyMechanismBeanRemote;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -304,7 +304,7 @@ public class SaslLegacyMechanismConfigurationTestCase extends AbstractCliTestBas
          ModelNode response = execute(compositeOperation, mcc);
          Assert.assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
 
-         ServerReload.reloadIfRequired(managementClient.getControllerClient());
+         ServerReload.reloadIfRequired(managementClient);
       }
 
       private ModelNode addSaslMechanisms() throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaMgmtBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/JcaMgmtBase.java
@@ -52,7 +52,7 @@ public class JcaMgmtBase extends ContainerResourceMgmtTestBase {
      * @throws Exception
      */
     public void reload() throws Exception {
-        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient(), 50000);
+        ServerReload.executeReloadAndWaitForCompletion(getManagementClient(), 50000);
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/classloading/AbstractDataSourceClassloadingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/classloading/AbstractDataSourceClassloadingTestCase.java
@@ -70,7 +70,7 @@ public abstract class AbstractDataSourceClassloadingTestCase {
             setupModule();
             setupDriver(managementClient, classNamePropertyName, driverClass);
             setupDs(managementClient, "TestDS", false);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 50000);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
         }
 
         @Override
@@ -80,7 +80,7 @@ public abstract class AbstractDataSourceClassloadingTestCase {
             if (testModuleRoot.exists()) {
                 deleteRecursively(testModuleRoot);
             }
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 50000);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
         }
 
         private void setupModule() throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCaseSetup.java
@@ -187,7 +187,7 @@ public abstract class AbstractModuleDeploymentTestCaseSetup extends AbstractMgmt
             removeModule(defaultPath, true);
         }
         if (reloadRequired) {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
         for (Path p : toRemove) {
             deleteRecursively(p);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/TracerEnableTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/TracerEnableTestCase.java
@@ -101,7 +101,7 @@ public class TracerEnableTestCase {
             operation.get("enabled").set("true");
             ManagementOperations.executeOperation(managementClient.getControllerClient(), operation);
 
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 30_000);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, 30_000);
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/doctype/DoctypeDeclTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/doctype/DoctypeDeclTestCase.java
@@ -147,13 +147,13 @@ public class DoctypeDeclTestCase {
         final ModelNode address = Operations.createAddress(ClientConstants.SUBSYSTEM, "jsf");
         final ModelNode op = Operations.createWriteAttributeOperation(address, "disallow-doctype-decl", value);
         ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private void undefineDisallowDoctypeDeclAttributeAndReload() throws Exception {
         final ModelNode address = Operations.createAddress(ClientConstants.SUBSYSTEM, "jsf");
         final ModelNode op = Operations.createUndefineAttributeOperation(address, "disallow-doctype-decl");
         ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
@@ -148,7 +148,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
 
         logger.trace("Restarting server.");
 
-        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(getManagementClient());
 
         // wait until the connector is available on the new port
         final String testUrl = new URL("http", testHost, TEST_PORT + 1, "/").toString();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/console/WebConsoleRedirectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/console/WebConsoleRedirectionTestCase.java
@@ -31,7 +31,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,14 +49,14 @@ public class WebConsoleRedirectionTestCase {
 
     @Test
     public void testRedirectionInAdminMode() throws Exception {
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+        ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
         try {
             final HttpURLConnection connection = getConnection();
             assertEquals(HttpURLConnection.HTTP_MOVED_TEMP, connection.getResponseCode());
             String location = connection.getHeaderFields().get(Headers.LOCATION_STRING).get(0);
             assertEquals("/consoleerror/noConsoleForAdminModeError.html", location);
         } finally {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), false);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, false);
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notclosinginjectedcontext/NotClosingInjectedContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/notclosinginjectedcontext/NotClosingInjectedContextTestCase.java
@@ -223,7 +223,7 @@ public class NotClosingInjectedContextTestCase {
             operation.get("value").set("true");
             client.getControllerClient().execute(operation);
 
-            ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient(), TimeoutUtil.adjust(50000));
+            ServerReload.executeReloadAndWaitForCompletion(client, TimeoutUtil.adjust(50000));
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java
@@ -100,7 +100,7 @@ public class DiscoveryGroupExternalMessagingDeploymentTestCase {
                 logger.info("[WFCI-32] Disable on Windows+IPv6 until CI environment is fixed");
                 return;
             }
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.createJmsQueue(QUEUE_NAME, "/queue/" + QUEUE_NAME);
             ops.createJmsTopic(TOPIC_NAME, "/topic/" + TOPIC_NAME);
@@ -124,7 +124,7 @@ public class DiscoveryGroupExternalMessagingDeploymentTestCase {
             op.get("entries").add(QUEUE_LOOKUP);
             op.get("entries").add("/topic/myAwesomeClientQueue");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
@@ -83,7 +83,7 @@ public class ExternalMessagingDeploymentRemoteTestCase {
 
         @Override
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.createJmsQueue(QUEUE_NAME, "/queue/" + QUEUE_NAME);
             ops.createJmsTopic(TOPIC_NAME, "/topic/" + TOPIC_NAME);
@@ -105,7 +105,7 @@ public class ExternalMessagingDeploymentRemoteTestCase {
             op.get("entries").add(QUEUE_LOOKUP);
             op.get("entries").add("/queue/myAwesomeClientQueue");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentTestCase.java
@@ -80,7 +80,7 @@ public class ExternalMessagingDeploymentTestCase {
 
         @Override
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.createJmsQueue(QUEUE_NAME, "/queue/" + QUEUE_NAME);
             ops.createJmsTopic(TOPIC_NAME, "/topic/" + TOPIC_NAME);
@@ -100,7 +100,7 @@ public class ExternalMessagingDeploymentTestCase {
             op.get("entries").add(QUEUE_LOOKUP);
             op.get("entries").add("/queue/myAwesomeClientQueue");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSQueueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSQueueTestCase.java
@@ -73,7 +73,7 @@ public class SendToExternalJMSQueueTestCase {
 
         @Override
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.addExternalHttpConnector("http-test-connector", "http", "http-acceptor");
             ops.createJmsQueue("myAwesomeQueue", "/queue/myAwesomeQueue");
@@ -90,7 +90,7 @@ public class SendToExternalJMSQueueTestCase {
             op.get("entries").add(QUEUE_LOOKUP);
             op.get("entries").add("/queue/myAwesomeClientQueue");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSTopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/SendToExternalJMSTopicTestCase.java
@@ -71,7 +71,7 @@ public class SendToExternalJMSTopicTestCase {
 
         @Override
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.addExternalHttpConnector("http-test-connector", "http", "http-acceptor");
             ops.createJmsTopic("myAwesomeTopic", "/topic/myAwesomeTopic");
@@ -88,7 +88,7 @@ public class SendToExternalJMSTopicTestCase {
             op.get("entries").add("java:jboss/exported/topic/myAwesomeClientTopic");
             op.get("entries").add("/topic/myAwesomeClientTopic");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryClientMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryClientMappingTestCase.java
@@ -74,7 +74,7 @@ public class ConnectionFactoryClientMappingTestCase {
             attr.get("connectors").add("http-test-connector");
             ops.addJmsConnectionFactory("TestConnectionFactory", CONNECTION_FACTORY_JNDI_NAME, attr);
 
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode clientMapping(String destAddr, String destPort) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryManagementTestCase.java
@@ -115,7 +115,7 @@ public class ConnectionFactoryManagementTestCase extends ContainerResourceMgmtTe
             jmsOperations.removeJmsConnectionFactory(CF_NAME);
             managementClient.getControllerClient().execute( Operations.createRemoveOperation(address));
         }
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private static ModelNode execute(ModelControllerClient client, ModelNode operation) throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ConnectionFactoryManagementTestCase.java
@@ -48,7 +48,7 @@ import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -91,12 +91,12 @@ public class ConnectionFactoryManagementTestCase extends ContainerResourceMgmtTe
         }
 
         jmsOperations.removeJmsConnectionFactory(CF_NAME);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     @Test
     public void testRemoveReferencedConnector() throws Exception {
-        JMSOperations jmsOperations = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
+        JMSOperations jmsOperations = JMSOperationsProvider.getInstance(managementClient);
         ModelNode address = jmsOperations.getServerAddress().add("in-vm-connector", "in-vm-test");
         ModelNode addOp = Operations.createAddOperation(address);
         addOp.get("server-id").set(0);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExportImportJournalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExportImportJournalTestCase.java
@@ -137,13 +137,13 @@ public class ExportImportJournalTestCase {
         sendMessage(remoteContext, jmsQueueLookup, text);
 
         // reload in admin-only mode
-        executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+        executeReloadAndWaitForCompletion(managementClient, true);
 
         // export the journal (must be performed in admin-only mode)
         String dumpFilePath = exportJournal();
 
         // reload in normal mode
-        executeReloadAndWaitForCompletion(managementClient.getControllerClient(), false);
+        executeReloadAndWaitForCompletion(managementClient, false);
 
         // remove all messages
         removeAllMessagesFromQueue(jmsQueueName);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryClientMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryClientMappingTestCase.java
@@ -69,7 +69,7 @@ public class ExternalConnectionFactoryClientMappingTestCase {
             attr.get("connectors").add("http-test-connector");
             ops.addJmsExternalConnectionFactory("TestConnectionFactory", CONNECTION_FACTORY_JNDI_NAME, attr);
 
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode clientMapping(String destAddr, String destPort) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalConnectionFactoryManagementTestCase.java
@@ -50,7 +50,7 @@ import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jgroups.util.StackType;
 import org.jgroups.util.Util;
@@ -110,7 +110,7 @@ public class ExternalConnectionFactoryManagementTestCase extends ContainerResour
             jmsOperations.removeJmsExternalConnectionFactory(CF_NAME);
             jmsOperations.removeExternalHttpConnector(CONNECTOR_NAME);
         }
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class ExternalConnectionFactoryManagementTestCase extends ContainerResour
 
         op = Operations.createRemoveOperation(invmConnectorAddress);
         execute(managementClient.getControllerClient(), op);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private static ModelNode execute(final ModelControllerClient client, final ModelNode op) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalPooledConnectionFactoryStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/ExternalPooledConnectionFactoryStatisticsTestCase.java
@@ -67,7 +67,7 @@ public class ExternalPooledConnectionFactoryStatisticsTestCase {
 
         @Override
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), true);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient, true);
             JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
             ops.addExternalHttpConnector("http-test-connector", "http", "http-acceptor");
             ModelNode attr = new ModelNode();
@@ -79,7 +79,7 @@ public class ExternalPooledConnectionFactoryStatisticsTestCase {
             op.get("entries").add("java:/JmsXA java:jboss/DefaultJMSConnectionFactory");
             op.get("connectors").add("http-test-connector");
             execute(managementClient, op, true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {
@@ -163,7 +163,7 @@ public class ExternalPooledConnectionFactoryStatisticsTestCase {
     private void enableStatistics() throws IOException {
         ModelNode op = Operations.createWriteAttributeOperation(getPooledConnectionFactoryAddress(), STATISTICS_ENABLED, true);
         execute(op, true);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private int readStatistic(String name) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/PooledConnectionFactoryStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/PooledConnectionFactoryStatisticsTestCase.java
@@ -118,7 +118,7 @@ public class PooledConnectionFactoryStatisticsTestCase {
         op.get(NAME).set(STATISTICS_ENABLED);
         op.get(VALUE).set(true);
         execute(op, true);
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     private int readStatistic(String name) throws IOException {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/JMSThreadPoolMetricsSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/metrics/JMSThreadPoolMetricsSetup.java
@@ -27,7 +27,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 
@@ -62,7 +62,7 @@ class JMSThreadPoolMetricsSetup implements ServerSetupTask {
         op.get("value").set(connectors);
         client.getControllerClient().execute(op);
 
-        ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(client);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mod_cluster/ModClusterSubsystemTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/mod_cluster/ModClusterSubsystemTestCase.java
@@ -80,7 +80,7 @@ public class ModClusterSubsystemTestCase {
             Assert.assertEquals("Adding mod_cluster subsystem failed! " + response.toJSONString(false), SUCCESS, outcome);
 
             // We need to reload the server here since the add operation leaves the server in 'reload-required' state
-            ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
             // Test subsystem remove
             request = ctx.buildRequest("/subsystem=modcluster:remove");
@@ -102,7 +102,7 @@ public class ModClusterSubsystemTestCase {
 
             // Remove leaves the server in 'reload-required' state, we need to reload the server in order not to leave running services
             // around for subsequent tests
-            ServerReload.executeReloadAndWaitForCompletion(controllerClient);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         } finally {
             ctx.terminateSession();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
@@ -128,7 +128,7 @@ public class SecurityAuditingTestCase extends AnnSBTest {
             executeOperations(updates);
 
             if (System.getProperty("elytron") != null) {
-                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 50000);
+                ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
             }
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/authentication/ResponseHeaderAuthenticationServerSetupTask.java
@@ -2,8 +2,8 @@ package org.jboss.as.test.integration.web.headers.authentication;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
@@ -78,7 +78,7 @@ public class ResponseHeaderAuthenticationServerSetupTask extends SnapshotRestore
 
         this.createKeyStore();
 
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeAtRootTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeAtRootTestCase.java
@@ -114,7 +114,7 @@ public class DefaultResponseCodeAtRootTestCase extends ContainerResourceMgmtTest
             operation.get("address").add("location","/");
             cob.addStep(operation);
             executeOperation(cob.build().getOperation());
-            executeReloadAndWaitForCompletion(getModelControllerClient());
+            executeReloadAndWaitForCompletion(getManagementClient());
             deployer.deploy("test");
             HttpGet httpget = null;
             HttpResponse response = null;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeTestCase.java
@@ -94,7 +94,7 @@ public class DefaultResponseCodeTestCase extends ContainerResourceMgmtTestBase {
             operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "remove");
             operation.get("address").add("location","/");
             executeOperation(operation);
-            executeReloadAndWaitForCompletion(getModelControllerClient());
+            executeReloadAndWaitForCompletion(getManagementClient());
             HttpGet httpget = new HttpGet(url.toString() + URL_PATTERN);
             HttpResponse response = this.httpclient.execute(httpget);
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/RewriteLocationByDeplomentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/RewriteLocationByDeplomentTestCase.java
@@ -61,7 +61,7 @@ public class RewriteLocationByDeplomentTestCase extends ContainerResourceMgmtTes
             op.get("handler").set("welcome-content");
             executeOperation(op);
 
-            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(getManagementClient());
             response = getResponse("/test");
             Assert.assertEquals(200, response.getStatusLine().getStatusCode());
             Assert.assertTrue("Expected to receive welcome page, but content length is 0",

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/runas/ServletRunAsTestCase.java
@@ -232,7 +232,7 @@ public class ServletRunAsTestCase {
                 + Utils.encodeQueryParam(CallProtectedEjbServlet.FILE_PARAM, INCORRECT_ROLE_AND_STOP_SERVER.getAbsolutePath()));
         Utils.makeCall(servletUrl.toURI(), HTTP_OK);
 
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 50000);
+        ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
     }
 
     /**

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
@@ -38,8 +38,8 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
@@ -75,7 +75,7 @@ public class PreservePathTestCase {
 
       CoreUtils.applyUpdate(setPreservePathOp, managementClient.getControllerClient());
 
-      ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+      ServerReload.executeReloadAndWaitForCompletion(managementClient);
    }
 
    @After
@@ -88,7 +88,7 @@ public class PreservePathTestCase {
       ModelNode setPreservePathOp = createOpNode("subsystem=undertow/servlet-container=default", UNDEFINE_ATTRIBUTE_OPERATION);
       setPreservePathOp.get("name").set("preserve-path-on-forward");
       CoreUtils.applyUpdate(setPreservePathOp, managementClient.getControllerClient());
-      ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+      ServerReload.executeReloadAndWaitForCompletion(managementClient);
    }
 
    @Deployment
@@ -171,6 +171,6 @@ public class PreservePathTestCase {
 
       CoreUtils.applyUpdate(setPreservePathOp, managementClient.getControllerClient());
 
-      ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+      ServerReload.executeReloadAndWaitForCompletion(managementClient);
    }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/agroal/AgroalDatasourceTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/agroal/AgroalDatasourceTestBase.java
@@ -78,7 +78,7 @@ public abstract class AgroalDatasourceTestBase extends ContainerResourceMgmtTest
         }
 
         // Reload before continuing
-        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient(), TimeoutUtil.adjust(50000));
+        ServerReload.executeReloadAndWaitForCompletion(getManagementClient(), TimeoutUtil.adjust(50000));
     }
 
     @After

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/AbstractEarOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/AbstractEarOpenTracingTestCase.java
@@ -57,7 +57,7 @@ public abstract class AbstractEarOpenTracingTestCase {
     public void testEarServicesUseDifferentTracersAfterReload() throws Exception {
         //TODO the tracer instance is same after reload as before it - check whether this is correct or no
         testHttpInvokation();
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
         testHttpInvokation();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/MultiWarOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/MultiWarOpenTracingTestCase.java
@@ -89,7 +89,7 @@ public class MultiWarOpenTracingTestCase {
     @Test
     public void testMultipleWarServicesUseDifferentTracersAfterReload() throws Exception {
         testHttpInvokation();
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
         testHttpInvokation();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/OnOffOpenTracingTestCase.java
@@ -101,12 +101,12 @@ public class OnOffOpenTracingTestCase {
         serverSnapshot.close();
     }
 
-    private void opentracingSubsystem(String operationName, ModelControllerClient client) throws Exception {
+    private void opentracingSubsystem(String operationName, ManagementClient client) throws Exception {
         final String OT_SUBSYSTEM_NAME = "microprofile-opentracing-smallrye";
 
         // remove the OpenTracing subsystem
         ModelNode operation = createOpNode("subsystem=" + OT_SUBSYSTEM_NAME, operationName);
-        Utils.applyUpdate(operation, client);
+        Utils.applyUpdate(operation, client.getControllerClient());
 
         executeReloadAndWaitForCompletion(client, 100000);
     }
@@ -121,7 +121,7 @@ public class OnOffOpenTracingTestCase {
 
         Utils.applyUpdate(operation, client);
 
-        executeReloadAndWaitForCompletion(client, 100000);
+        executeReloadAndWaitForCompletion(managementClient, 100000);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class OnOffOpenTracingTestCase {
         Assert.assertTrue(response.contains("Tracer instance is: JaegerTracer"));
 
         // Remove OpenTracing subsystem to disable it.
-        opentracingSubsystem(ModelDescriptionConstants.REMOVE, managementClient.getControllerClient());
+        opentracingSubsystem(ModelDescriptionConstants.REMOVE, managementClient);
 
         try {
             // Perform request to the deployment on server where OpenTracing is disabled. Deployment must not have a Tracer instance available.
@@ -150,7 +150,7 @@ public class OnOffOpenTracingTestCase {
                     response.matches("(?s).*java\\.lang\\.NoClassDefFoundError: L*io.opentracing.Tracer.*"));
             // really dots because openjdk uses '/' whereas ibmjdk uses '.'      ---^        ---^
         } finally {
-            opentracingSubsystem(ModelDescriptionConstants.ADD, managementClient.getControllerClient());
+            opentracingSubsystem(ModelDescriptionConstants.ADD, managementClient);
         }
 
         // And again perform request to the deployment on the server where OpenTracing is enabled.

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/shared/NonDistributableSharedSessionTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/shared/NonDistributableSharedSessionTestCase.java
@@ -106,7 +106,7 @@ public class NonDistributableSharedSessionTestCase {
             }
 
             // A distributable web application preserves its web sessions across server restarts, a non-distributable web application does not.
-            ServerReload.executeReloadAndWaitForCompletion(this.managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(this.managementClient);
 
             expected = 1;
             try (CloseableHttpResponse response = client.execute(new HttpGet(uri1))) {

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/batch/BatchSubsystemSecurityTestCase.java
@@ -373,7 +373,7 @@ public class BatchSubsystemSecurityTestCase {
             final ModelNode result = managementClient.getControllerClient().execute(setOp);
             Assert.assertTrue(result.get("outcome").asString().equals("success"));
 
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
     }

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/IIOPTransactionPropagationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/client/IIOPTransactionPropagationTestCase.java
@@ -43,7 +43,7 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -191,7 +191,7 @@ public class IIOPTransactionPropagationTestCase {
             }
 
             if (isNeedReload) {
-                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 40000);
+                ServerReload.executeReloadAndWaitForCompletion(managementClient, 40000);
             }
         }
 
@@ -213,7 +213,7 @@ public class IIOPTransactionPropagationTestCase {
             }
 
             if (isNeedReload) {
-                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 40000);
+                ServerReload.executeReloadAndWaitForCompletion(managementClient, 40000);
             }
         }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLRealmSetupTool.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLRealmSetupTool.java
@@ -194,7 +194,7 @@ public class SSLRealmSetupTool {
         ModelNode result = managementClient.getControllerClient().execute(operation);
         log.infof("remove HTTPS connector", result);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
         // restore https connector to previous state
         operation = new ModelNode();
@@ -207,7 +207,7 @@ public class SSLRealmSetupTool {
         operation.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         result = managementClient.getControllerClient().execute(operation);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
         // Removing security realm
         ModelNode secRealmAddress = getSecurityRealmsAddress();

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/AbstractTestsuite.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/connectionlistener/AbstractTestsuite.java
@@ -186,7 +186,7 @@ public abstract class AbstractTestsuite {
             operation.get("value").set("true");
             executeOperation(operation);
 
-            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient(), 50000);
+            ServerReload.executeReloadAndWaitForCompletion(getManagementClient(), 50000);
 
             return address;
         }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/AbstractCertificateLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/AbstractCertificateLoginModuleTestCase.java
@@ -201,7 +201,7 @@ public abstract class AbstractCertificateLoginModuleTestCase {
             operation.get("keystore-password").set(SecurityTestConstants.KEYSTORE_PASSWORD);
             Utils.applyUpdate(operation, client);
 
-            executeReloadAndWaitForCompletion(client, 100000);
+            executeReloadAndWaitForCompletion(managementClient, 100000);
 
             operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=https2" , ADD);
             operation.get(PORT).set(Integer.toString(HTTPS_PORT));

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
@@ -116,7 +116,7 @@ public class CertificateRolesLoginModuleTestCase extends AbstractCertificateLogi
         SecurityDomainsSetup.INSTANCE.setup(managementClient, CONTAINER);
 
         LOGGER.trace("*** reloading server");
-        executeReloadAndWaitForCompletion(client, 100000);
+        executeReloadAndWaitForCompletion(managementClient, 100000);
         deployer.deploy(APP_NAME);
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
@@ -126,7 +126,7 @@ public class DatabaseCertLoginModuleTestCase extends AbstractCertificateLoginMod
         SecurityDomainsSetup.INSTANCE.setup(managementClient, CONTAINER);
 
         LOGGER.trace("*** reloading server");
-        executeReloadAndWaitForCompletion(client, 100000);
+        executeReloadAndWaitForCompletion(managementClient, 100000);
         deployer.deploy(APP_NAME);
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
@@ -111,7 +111,7 @@ public class ReloadRequiringChangesTestCase {
             //change wsdl-host to "foo-host" and reload
             final String hostname = "foo-host";
             setWsdlHost(client, hostname);
-            ServerReload.executeReloadAndWaitForCompletion(client);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
             //change wsdl-host to "bar-host" and verify deployment still uses "foo-host"
             setWsdlHost(client, "bar-host");
@@ -143,7 +143,7 @@ public class ReloadRequiringChangesTestCase {
             //change wsdl-host to "my-host" and reload
             final String hostname = "my-host";
             setWsdlHost(client, hostname);
-            ServerReload.executeReloadAndWaitForCompletion(client);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
             //undefine wsdl-host and verify deployment still uses "foo-host"
             setWsdlHost(client, null);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
@@ -101,7 +101,7 @@ public class ReloadWSDLPublisherTestCase {
         Service service = Service.create(wsdlURL, serviceName);
         EndpointIface proxy = service.getPort(EndpointIface.class);
         Assert.assertEquals("Hello World!", proxy.helloString("World"));
-        executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 100000);
+        executeReloadAndWaitForCompletion(managementClient, 100000);
         checkWsdl(wsdlURL);
         serviceName = new QName("http://jbossws.org/basic", "POJOService");
         service = Service.create(wsdlURL, serviceName);

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/elytron/seccontext/AbstractSecurityContextPropagationTestBase.java
@@ -89,9 +89,9 @@ import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.SecurityTestConstants;
 import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -756,8 +756,7 @@ public abstract class AbstractSecurityContextPropagationTestBase {
         }
 
         private void reload() {
-            ModelNode operation = Util.createOperation("reload", null);
-            ServerReload.executeReloadAndWaitForCompletion(client, operation, (int) SECONDS.toMillis(90), host,
+            ServerReload.executeReloadAndWaitForCompletion(client, (int) SECONDS.toMillis(90), false, host,
                     getManagementPort());
         }
 

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/custompermissions/AbstractCustomPermissionServerSetup.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/custompermissions/AbstractCustomPermissionServerSetup.java
@@ -64,7 +64,7 @@ public abstract class AbstractCustomPermissionServerSetup implements ServerSetup
             operation.get("value").set(Arrays.asList(customPermission));
 
             ManagementOperations.executeOperation(managementClient.getControllerClient(), operation);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
     }
 
@@ -110,7 +110,7 @@ public abstract class AbstractCustomPermissionServerSetup implements ServerSetup
             operation.get("value").set(backupList);
 
             ManagementOperations.executeOperation(managementClient.getControllerClient(), operation);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
     }
 

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/ReloadableCliTestBase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/ReloadableCliTestBase.java
@@ -80,7 +80,7 @@ public abstract class ReloadableCliTestBase extends AbstractCliTestBase {
      * Executes server reload command and waits for completion.
      */
     protected void reloadServer() {
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
     /**

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/RemoveDeploymentPermissionsServerSetupTask.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/RemoveDeploymentPermissionsServerSetupTask.java
@@ -98,11 +98,9 @@ public class RemoveDeploymentPermissionsServerSetupTask implements ServerSetupTa
 
     /**
      * Provide reload operation on the server
-     *
-     * @throws Exception
      */
-    private static void reload(final ManagementClient managementClient) throws Exception {
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+    private static void reload(final ManagementClient managementClient) {
+        ServerReload.executeReloadAndWaitForCompletion(managementClient);
     }
 
 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/NoBrokerMessagingTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/NoBrokerMessagingTestCase.java
@@ -69,7 +69,7 @@ public class NoBrokerMessagingTestCase {
         public void doSetup(org.jboss.as.arquillian.container.ManagementClient managementClient, String s) throws Exception {
             execute(managementClient, Operations.createUndefineAttributeOperation(PathAddress.parseCLIStyleAddress("/subsystem=ee/service=default-bindings").toModelNode(), "jms-connection-factory"), true);
             execute(managementClient, Operations.createRemoveOperation(PathAddress.parseCLIStyleAddress("/subsystem=messaging-activemq/server=default").toModelNode()), true);
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         private ModelNode execute(final org.jboss.as.arquillian.container.ManagementClient managementClient, final ModelNode op, final boolean expectSuccess) throws IOException {

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/handlers/RequestDumpingHandlerTestCase.java
@@ -145,7 +145,7 @@ public class RequestDumpingHandlerTestCase {
             operation.get("socket-binding").set(HTTPS);
             operation.get("security-realm").set(HTTPS_REALM);
             Utils.applyUpdate(operation, managementClient.getControllerClient());
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         @Override

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebTestsSecurityDomainSetup.java
@@ -46,8 +46,8 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.security.Constants;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.wildfly.test.security.common.elytron.PropertyFileBasedDomain;
@@ -160,7 +160,7 @@ public class WebTestsSecurityDomainSetup extends AbstractSecurityDomainSetup {
                 domainMapper.remove(cli);
                 ps.remove(cli);
                 cli.close();
-                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+                ServerReload.executeReloadAndWaitForCompletion(managementClient);
             } catch (Exception e) {
                 throw new RuntimeException("Cleaning up for Elytron based security domain failed.", e);
             }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/cert/WebCERTTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/cert/WebCERTTestsSecurityDomainSetup.java
@@ -165,7 +165,7 @@ public class WebCERTTestsSecurityDomainSetup extends AbstractSecurityRealmsServe
 
             log.debug("end of the domain creation");
 
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         } catch (Exception e) {
             log.error("Failed to setup domain creation.", e);
         }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -31,14 +31,13 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.ws.authentication.policy.resources.EchoService;
 import org.jboss.as.test.integration.ws.authentication.policy.resources.EchoServiceRemote;
 import org.jboss.as.test.integration.ws.authentication.policy.resources.PicketLinkSTSService;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -293,8 +292,7 @@ public class AuthenticationPolicyContextTestCase {
     }
 
     private void reload() {
-        ModelNode operation = Util.createOperation("reload", null);
-        ServerReload.executeReloadAndWaitForCompletion(modelControllerClient, operation, (int) SECONDS.toMillis(90), HOST,
+        ServerReload.executeReloadAndWaitForCompletion(modelControllerClient, (int) SECONDS.toMillis(90), false, HOST,
                 getManagementPort());
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractDataSourceServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractDataSourceServerSetupTask.java
@@ -97,7 +97,7 @@ public abstract class AbstractDataSourceServerSetupTask extends SnapshotRestoreS
             updates.add(enableNode);
         }
         CoreUtils.applyUpdates(updates, managementClient.getControllerClient());
-        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), 50000);
+        ServerReload.executeReloadAndWaitForCompletion(managementClient, 50000);
     }
 
     // Protected methods -----------------------------------------------------

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSnapshot.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ServerSnapshot.java
@@ -53,7 +53,7 @@ public class ServerSnapshot {
             return new AutoCloseable() {
                 @Override
                 public void close() throws Exception {
-                    ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient(), fileName);
+                    ServerReload.executeReloadAndWaitForCompletion(client, fileName);
 
                     ModelNode node = new ModelNode();
                     node.get(ModelDescriptionConstants.OP).set("write-config");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/interceptor/serverside/AbstractServerInterceptorsSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/interceptor/serverside/AbstractServerInterceptorsSetupTask.java
@@ -122,7 +122,7 @@ public abstract class AbstractServerInterceptorsSetupTask {
             }
             modifyServerInterceptors(interceptorModules, managementClient);
             // reload in order to apply server-interceptors changes
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
 
         @Override
@@ -132,7 +132,7 @@ public abstract class AbstractServerInterceptorsSetupTask {
             }
             revertServerInterceptors(managementClient);
             // reload in order to apply server-interceptors changes
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+            ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
     }
 }


### PR DESCRIPTION
…nagementClient. Deprecate the ModelControllerClient variants. Improve ServerReload javadoc.

https://issues.jboss.org/browse/WFLY-12560

Besides being a code cleanup, this is a further attempt to avoid intermittent failures in multinode tests, which we are still seeing.