### PR TITLE
[WFLY-12562] Upgrade WildFly Core 10.0.0.Beta9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Beta8</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.0.Beta9</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12562

--


##  Release Notes - WildFly Core - Version 10.0.0.Beta9
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4658'>WFCORE-4658</a>] -         Upgrade jboss-remoting to 5.0.15.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4663'>WFCORE-4663</a>] -         Upgrade JBoss MSC to 1.4.11.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4664'>WFCORE-4664</a>] -         Update legacy wildfly-build-tools to 1.2.12.Final
</li>
</ul>
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4659'>WFCORE-4659</a>] -         Partial revert of *not* having static default authentication context
</li>
</ul>
                                            