### PR TITLE
[WFLY-12576] Eliminate StabilityMonitor usages to improve reliability.

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondlevelcache/InfinispanCacheDeploymentListener.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondlevelcache/InfinispanCacheDeploymentListener.java
@@ -27,17 +27,19 @@ import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 import java.security.AccessController;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Supplier;
 
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.controller.ServiceNameFactory;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.msc.service.LifecycleEvent;
+import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.StabilityMonitor;
 import org.jipijapa.cache.spi.Classification;
 import org.jipijapa.cache.spi.Wrapper;
 import org.jipijapa.event.spi.EventListener;
@@ -93,25 +95,19 @@ public class InfinispanCacheDeploymentListener implements EventListener {
                 builder.requires(ServiceNameFactory.parseServiceName(InfinispanCacheRequirement.CONFIGURATION.getName()).append(container, cache));
             }
         }
-
-        ServiceController<?> controller = builder.install();
-
-        // Ensure cache configuration services are started
-        StabilityMonitor monitor = new StabilityMonitor();
-        monitor.addController(controller);
-        try {
-            monitor.awaitStability();
-            // TODO Figure out why the awaitStability() returns prematurely while there are still dependencies starting
-            while (controller.getState() == ServiceController.State.DOWN) {
-                Thread.yield();
-                monitor.awaitStability();
+        final CountDownLatch latch = new CountDownLatch(1);
+        builder.addListener(new LifecycleListener() {
+            @Override
+            public void handleEvent(final ServiceController<?> controller, final LifecycleEvent event) {
+                if (event == LifecycleEvent.UP) {
+                    latch.countDown();
+                    controller.removeListener(this);
+                }
             }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw e;
-        } finally {
-            monitor.removeController(controller);
-        }
+        });
+        ServiceController<?> controller = builder.install();
+        // Ensure cache configuration services are started
+        latch.await();
 
         return new CacheWrapper(manager.get(), controller);
     }
@@ -155,21 +151,24 @@ public class InfinispanCacheDeploymentListener implements EventListener {
             if (ROOT_LOGGER.isTraceEnabled()) {
                 ROOT_LOGGER.tracef("stop second level cache by removing dependency on service '%s'", this.controller.getName().getCanonicalName());
             }
-            StabilityMonitor monitor = new StabilityMonitor();
-            monitor.addController(this.controller);
-            this.controller.setMode(ServiceController.Mode.REMOVE);
+            final CountDownLatch latch = new CountDownLatch(1);
+            controller.addListener(new LifecycleListener() {
+                @Override
+                public void handleEvent(final ServiceController<?> controller, final LifecycleEvent event) {
+                    if (event == LifecycleEvent.REMOVED) latch.countDown();
+                }
+            });
+            controller.setMode(ServiceController.Mode.REMOVE);
             try {
-                monitor.awaitStability();
-            } catch (InterruptedException e) {
+                latch.await();
+            } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
-            } finally {
-                monitor.removeController(this.controller);
             }
         }
     }
 
     private static ServiceContainer currentServiceContainer() {
-        if(System.getSecurityManager() == null) {
+        if (System.getSecurityManager() == null) {
             return CurrentServiceContainer.getServiceContainer();
         }
         return AccessController.doPrivileged(CurrentServiceContainer.GET_ACTION);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyBindingRegistry.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/WildFlyBindingRegistry.java
@@ -26,15 +26,17 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.wildfly.extension.messaging.activemq.BinderServiceUtil.installBinderService;
 import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.ROOT_LOGGER;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.Locale;
 
 import org.apache.activemq.artemis.spi.core.naming.BindingRegistry;
+import org.jboss.msc.service.LifecycleEvent;
+import org.jboss.msc.service.LifecycleListener;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.StabilityMonitor;
 
 /**
  * A {@link BindingRegistry} implementation for WildFly.
@@ -91,16 +93,24 @@ public class WildFlyBindingRegistry implements BindingRegistry {
             return;
         }
         // remove the binding service
-        bindingService.setMode(ServiceController.Mode.REMOVE);
-        final StabilityMonitor monitor = new StabilityMonitor();
-        monitor.addController(bindingService);
+        final CountDownLatch latch = new CountDownLatch(1);
+        bindingService.addListener(new LifecycleListener() {
+            @Override
+            public void handleEvent(final ServiceController<?> controller, final LifecycleEvent event) {
+                if (event == LifecycleEvent.REMOVED) {
+                    ROOT_LOGGER.unboundJndiName(bindInfo.getAbsoluteJndiName());
+                    latch.countDown();
+                }
+            }
+        });
         try {
-            monitor.awaitStability();
-            ROOT_LOGGER.unboundJndiName(bindInfo.getAbsoluteJndiName());
-        } catch (InterruptedException e) {
-            ROOT_LOGGER.failedToUnbindJndiName(name, 5, SECONDS.toString().toLowerCase(Locale.US));
+            bindingService.setMode(ServiceController.Mode.REMOVE);
         } finally {
-            monitor.removeController(bindingService);
+            try {
+                latch.await();
+            } catch (InterruptedException ie) {
+                ROOT_LOGGER.failedToUnbindJndiName(name, 5, SECONDS.toString().toLowerCase(Locale.US));
+            }
         }
     }
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainResourceDefinition.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.security;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.security.Principal;
@@ -29,6 +28,8 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
@@ -54,9 +55,10 @@ import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.LifecycleEvent;
+import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.security.CacheableManager;
 import org.jboss.security.SimplePrincipal;
 
@@ -226,19 +228,21 @@ class SecurityDomainResourceDefinition extends SimpleResourceDefinition {
      * @throws OperationFailedException if the service is not available, or the thread was interrupted.
      */
     private static void waitForService(final ServiceController<?> controller) throws OperationFailedException {
-        if (controller.getState() == ServiceController.State.UP) return;
-
-        final StabilityMonitor monitor = new StabilityMonitor();
-        monitor.addController(controller);
         try {
-            monitor.awaitStability(100, MILLISECONDS);
+            final CountDownLatch latch = new CountDownLatch(1);
+            final LifecycleListener listener = new LifecycleListener() {
+                @Override
+                public void handleEvent(ServiceController<?> controller, LifecycleEvent event) {
+                    latch.countDown();
+                    controller.removeListener(this);
+                }
+            };
+            controller.addListener(listener);
+            latch.await(100, TimeUnit.MILLISECONDS);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw SecurityLogger.ROOT_LOGGER.interruptedWaitingForSecurityDomain(controller.getName().getSimpleName());
-        } finally {
-            monitor.removeController(controller);
-        }
-
+        } catch (final Throwable ignored) {}
         if (controller.getState() != ServiceController.State.UP) {
             throw SecurityLogger.ROOT_LOGGER.requiredSecurityDomainServiceNotAvailable(controller.getName().getSimpleName());
         }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/publish/EndpointPublisherImpl.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/publish/EndpointPublisherImpl.java
@@ -23,6 +23,7 @@ package org.jboss.as.webservices.publish;
 
 import java.io.File;
 import java.security.AccessController;
+import java.util.concurrent.CountDownLatch;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -45,11 +46,13 @@ import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossServletMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.ServletMappingMetaData;
+import org.jboss.msc.service.LifecycleEvent;
+import org.jboss.msc.service.LifecycleListener;
 import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.ws.common.deployment.DeploymentAspectManagerImpl;
 import org.jboss.ws.common.deployment.EndpointHandlerDeploymentAspect;
 import org.jboss.ws.common.integration.AbstractDeploymentAspect;
@@ -70,7 +73,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * WS endpoint publisher, allows for publishing a WS endpoint on AS 7
  *
  * @author alessio.soldano@jboss.com
- * @since 12-Jul-2011
+ * @authro <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public final class EndpointPublisherImpl implements EndpointPublisher {
 
@@ -175,22 +178,28 @@ public final class EndpointPublisherImpl implements EndpointPublisher {
      * @throws Exception
      */
     protected Context doPublish(ServiceTarget target, DeploymentUnit unit) throws Exception {
-        Deployment deployment = unit.getAttachment(WSAttachmentKeys.DEPLOYMENT_KEY);
-        List<Endpoint> endpoints = deployment.getService().getEndpoints();
+        final Deployment deployment = unit.getAttachment(WSAttachmentKeys.DEPLOYMENT_KEY);
+        final List<Endpoint> endpoints = deployment.getService().getEndpoints();
         //If we're running in a Service, that will already have proper dependencies set on the installed endpoint services,
         //otherwise we need to explicitly wait for the endpoint services to be started before creating the webapp.
         if (!runningInService) {
             final ServiceRegistry registry = unit.getServiceRegistry();
-            final StabilityMonitor monitor = new StabilityMonitor();
+            final CountDownLatch latch = new CountDownLatch(endpoints.size());
+            final LifecycleListener listener = new LifecycleListener() {
+                @Override
+                public void handleEvent(final ServiceController<?> controller, final LifecycleEvent event) {
+                    if (event == LifecycleEvent.UP) {
+                        latch.countDown();
+                        controller.removeListener(this);
+                    }
+                }
+            };
+            ServiceName serviceName;
             for (Endpoint ep : endpoints) {
-                final ServiceName serviceName = EndpointService.getServiceName(unit, ep.getShortName());
-                monitor.addController(registry.getRequiredService(serviceName));
+                serviceName = EndpointService.getServiceName(unit, ep.getShortName());
+                registry.getRequiredService(serviceName).addListener(listener);
             }
-            try {
-                monitor.awaitStability();
-            } finally {
-                monitor.clear();
-            }
+            latch.await();
         }
         deployment.addAttachment(WebDeploymentController.class, startWebApp(host, unit)); //TODO simplify and use findChild later in destroy()/stopWebApp()
         return new Context(unit.getAttachment(WSAttachmentKeys.JBOSSWEB_METADATA_KEY).getContextRoot(), endpoints);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12576

Stability monitors will be deprecated in next MSC release due to their unreliability.
This PR should improve our test suite reliability.