### PR TITLE
[WFLY-12579] Tweak basic integration tests for OCSP to be able to run them in product branches

### DIFF
--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/certs/CommonBase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/certs/CommonBase.java
@@ -162,7 +162,7 @@ public class CommonBase {
             responseString = EntityUtils.toString(httpEntity);
         } finally {
             Assert.assertEquals(HttpStatus.SC_OK, statusCode);
-            Assert.assertTrue(responseString.contains("Welcome to WildFly"));
+            Assert.assertTrue(responseString.contains("Welcome to "));
 
             if (httpEntity != null) {
                 EntityUtils.consumeQuietly(httpEntity);


### PR DESCRIPTION
We could go even further and pass to the test the full.dist.product.slot to identify if we are in a product or community and tweak based on that value, however removing the "WildFly" from the assert should be enough.

Jira issue: https://issues.jboss.org/browse/WFLY-12579

cc: @jamezp @bstansberry