### PR TITLE
[WFLY-12580] Explicitly disable the inheritance of Galleon configurations from transitive feature pack

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -86,12 +86,14 @@
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
                                     <version>${version.org.wildfly.core}</version>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <transitive>true</transitive>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                     <version>${project.version}</version>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -97,12 +97,14 @@
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
                                     <version>${version.org.wildfly.core}</version>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <transitive>true</transitive>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>wildfly-servlet-galleon-pack</artifactId>
                                     <version>${project.version}</version>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/galleon-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
+++ b/galleon-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" name="standalone-load-balancer.xml" model="standalone">
+    <layers>
+        <include name="management"/>
+        <include name="logging"/>
+        <include name="undertow-load-balancer"/>
+    </layers>
+    <feature-group name="standalone-security-realms"/>
+    <feature-group name="management-legacy-security"/>
+</config>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -59,6 +59,7 @@
     <config name="standalone-ha.xml" model="standalone"/>
     <config name="standalone-full.xml" model="standalone"/>
     <config name="standalone-full-ha.xml" model="standalone"/>
+    <config name="standalone-load-balancer.xml" model="standalone"/>
     <config name="domain.xml" model="domain"/>
     <config name="host.xml" model="host"/>
     <config name="host-master.xml" model="host"/>

--- a/servlet-build/pom.xml
+++ b/servlet-build/pom.xml
@@ -87,6 +87,7 @@
                                     <excluded-packages>
                                         <name>docs.schema</name>
                                     </excluded-packages>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>

--- a/servlet-dist/pom.xml
+++ b/servlet-dist/pom.xml
@@ -88,6 +88,7 @@
                                     <groupId>org.wildfly.core</groupId>
                                     <artifactId>wildfly-core-galleon-pack</artifactId>
                                     <version>${version.org.wildfly.core}</version>
+                                    <inheritConfigs>false</inheritConfigs>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Jira issue: https://issues.jboss.org/browse/WFLY-12580