### PR TITLE
[WFLY-12322] Avoid re-dispatching to the worker

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -248,7 +248,7 @@ final class AssociationImpl implements Association, AutoCloseable {
             }
         };
         // invoke the method and write out the response, possibly on a separate thread
-        execute(invocationRequest, runnable, isAsync);
+        execute(invocationRequest, runnable, isAsync, false);
         return cancellationFlag::cancel;
     }
 
@@ -286,14 +286,16 @@ final class AssociationImpl implements Association, AutoCloseable {
 
     }
 
-    private void execute(Request request, Runnable task, final boolean isAsync) {
+    private void execute(Request request, Runnable task, final boolean isAsync, boolean alwaysDispatch) {
         if (request.getProtocol().equals("local") && ! isAsync) {
             task.run();
         } else {
             if(executor != null) {
                 executor.execute(task);
-            } else {
+            } else if(isAsync || alwaysDispatch){
                 request.getRequestExecutor().execute(task);
+            } else {
+                task.run();
             }
         }
     }
@@ -363,7 +365,7 @@ final class AssociationImpl implements Association, AutoCloseable {
 
             sessionOpenRequest.convertToStateful(sessionID);
         };
-        execute(sessionOpenRequest, runnable, false);
+        execute(sessionOpenRequest, runnable, false, true);
         return ignored -> cancelled.set(true);
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBean.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ejb.async;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
 import javax.annotation.Resource;
 import javax.ejb.AsyncResult;
 import javax.ejb.Asynchronous;
@@ -85,21 +86,28 @@ public class AsyncBean implements AsyncBeanCancelRemoteInterface {
     }
 
     public Future<String> asyncRemoteCancelMethod() throws InterruptedException {
-        String result;
-        result = ctx.wasCancelCalled() ? "true" : "false";
+        try {
+            System.out.println("ASYNC REMOTE ");
+            String result;
+            result = ctx.wasCancelCalled() ? "true" : "false";
 
-        synchronizeBean.latchCountDown();
-        long end = System.currentTimeMillis() + 5000;
-        while (System.currentTimeMillis() < end) {
-            if (ctx.wasCancelCalled()) {
-                break;
+            System.out.println("DO COUNTDOWN ");
+            synchronizeBean.latchCountDown();
+            long end = System.currentTimeMillis() + 5000;
+            while (System.currentTimeMillis() < end) {
+                if (ctx.wasCancelCalled()) {
+                    break;
+                }
+                Thread.sleep(50);
             }
-            Thread.sleep(50);
-        }
-        result += ";";
+            result += ";";
 
-        result += ctx.wasCancelCalled() ? "true" : "false";
-        return new AsyncResult<String>(result);
+            result += ctx.wasCancelCalled() ? "true" : "false";
+            return new AsyncResult<String>(result);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
     }
 
     public Future<String> asyncMethodWithException(boolean isException) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBean.java
@@ -87,11 +87,11 @@ public class AsyncBean implements AsyncBeanCancelRemoteInterface {
 
     public Future<String> asyncRemoteCancelMethod() throws InterruptedException {
         try {
-            System.out.println("ASYNC REMOTE ");
+            //System.out.println("ASYNC REMOTE ");
             String result;
             result = ctx.wasCancelCalled() ? "true" : "false";
 
-            System.out.println("DO COUNTDOWN ");
+            //System.out.println("DO COUNTDOWN ");
             synchronizeBean.latchCountDown();
             long end = System.currentTimeMillis() + 5000;
             while (System.currentTimeMillis() < end) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBeanSynchronizeSingleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBeanSynchronizeSingleton.java
@@ -40,7 +40,7 @@ public class AsyncBeanSynchronizeSingleton implements AsyncBeanSynchronizeSingle
     public void reset() {
         latch = new CountDownLatch(1);
         latch2 = new CountDownLatch(1);
-        System.out.println("RESET " + latch);
+        //System.out.println("RESET " + latch);
     }
 
     public void latchCountDown() {
@@ -52,7 +52,7 @@ public class AsyncBeanSynchronizeSingleton implements AsyncBeanSynchronizeSingle
     }
 
     public void latchAwaitSeconds(int sec) throws InterruptedException {
-        System.out.println("AWAIT " + latch);
+        //System.out.println("AWAIT " + latch);
         if (!latch.await(sec, TimeUnit.SECONDS)) {
             throw new RuntimeException("Await failed");
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBeanSynchronizeSingleton.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/AsyncBeanSynchronizeSingleton.java
@@ -40,6 +40,7 @@ public class AsyncBeanSynchronizeSingleton implements AsyncBeanSynchronizeSingle
     public void reset() {
         latch = new CountDownLatch(1);
         latch2 = new CountDownLatch(1);
+        System.out.println("RESET " + latch);
     }
 
     public void latchCountDown() {
@@ -51,6 +52,7 @@ public class AsyncBeanSynchronizeSingleton implements AsyncBeanSynchronizeSingle
     }
 
     public void latchAwaitSeconds(int sec) throws InterruptedException {
+        System.out.println("AWAIT " + latch);
         if (!latch.await(sec, TimeUnit.SECONDS)) {
             throw new RuntimeException("Await failed");
         }


### PR DESCRIPTION
This follows up on #12448 with the removal of some System.out logging.