### PR TITLE
WFLY-12596 Hibernate bytecode transformer needs to pass classloader into ASM ClassWriter for super classes that are in a different classloader.

### DIFF
--- a/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
+++ b/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
@@ -95,7 +95,18 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
 
         final TransformedState transformedState = new TransformedState();
         final ClassReader classReader = new ClassReader(classfileBuffer);
-        final ClassWriter classWriter = new ClassWriter(classReader, COMPUTE_FRAMES);
+
+        final ClassWriter classWriter = new ClassWriter(classReader, COMPUTE_FRAMES) {
+
+            // Pass the classloader in so org.objectweb.asm.ClassWriter.getCommonSuperClass() uses the app classloader
+            // instead of ASM classloader, for loading super classes.
+            @Override
+            protected ClassLoader getClassLoader() {
+                return loader;
+            }
+
+        };
+
         PrintWriter traceAfterPrintWriter = null;
 
         try {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12596
Currently targeted for WF19 but also fine for WF18
