### PR TITLE
[WFLY-12613] Exclude IBM J9 JVM from Byteman-based test cases

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-extension-byteman</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -418,10 +418,13 @@
             </build>
         </profile>
         <profile>
-            <!-- Selectively disable executions for tests that only work on Java 8 -->
-            <id>ts.clustering.java8</id>
+            <!-- Selectively disable executions for clustering tests that do not work on IBM JDK -->
+            <id>ts.clustering.ibm-exclusions</id>
             <activation>
-                <jdk>[1.9,)</jdk>
+                <property>
+                    <name>java.vendor</name>
+                    <value>IBM Corporation</value>
+                </property>
             </activation>
             <build>
                 <plugins>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
@@ -48,8 +48,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -83,7 +81,7 @@ import static org.junit.Assert.assertNull;
  * - shutdown A                                 // membership = {B}
  * - crash B                                    // membership = {B}
  * - start A                                    // membership = {A,B}
- * In this case, B is e member of the cluster (according to the DNR) but it has crashed.
+ * In this case, B is a member of the cluster (according to the DNR) but it has crashed.
  *
  * @author Richard Achmatowicz
  */
@@ -137,12 +135,6 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
         }
     }
 
-    @BeforeClass
-    public static void beforeClass() {
-        // restrict test to run under Java < 9 until arquillian-byteman-extension supports JDK 9
-        Assume.assumeTrue(System.getProperty("java.version").startsWith("1.8"));
-    }
-
     // Byteman rules to capture the DNR contents after each invocation
     @BMRules({
         @BMRule(name = "Set up results linkMap (SETUP)",
@@ -178,14 +170,12 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
             condition = "debug(\"returning the result\")",
             action = "return getNodeListMap();")
     })
-
     @Test
     @RunAsClient
     public void testDNRContentsAfterLastNodeToLeave() throws Exception {
+
         List<Future<?>> futures = new ArrayList<>(THREADS);
-
         LOGGER.info("\n *** Starting test case test()\n");
-
         LOGGER.info("*** Started nodes = " + getStartedNodes());
 
         ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
@@ -303,7 +293,7 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
     }
 
     /*
-     * Method to allow determing the set of started nodes so that a Byteman rule
+     * Method to allow determining the set of started nodes so that a Byteman rule
      * can keep track of them.
      */
     private Set<String> getStartedNodes() {

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -334,9 +334,9 @@
                 <jdk>[1.9,)</jdk>
             </activation>
             <properties>
-                <!-- needed for arquillian-bytenman-extension -->
+                <!-- needed for arquillian-byteman-extension -->
                 <surefire.byteman.argline>-Djdk.attach.allowAttachSelf=true</surefire.byteman.argline>
-                <surefire.byteman.args>-Djboss.modules.system.packages=org.jboss.byteman -Djdk.attach.allowAttachSelf=true</surefire.byteman.args>
+                <surefire.byteman.args>-Djboss.modules.system.packages=com.sun.tools.attach,org.jboss.byteman -Djdk.attach.allowAttachSelf=true</surefire.byteman.args>
             </properties>
             <dependencies/>
         </profile>


### PR DESCRIPTION
This PR does the following:
- upgrades version of arquillian-extension-byteman from 1.0.0 to 1.1.0
- adds in exclusion for running the Byteman-based test org.jboss.as.test.clustering.cluster.ejb.remote.byteman.LastNodeToLeaveRemoteEJBTestCase against IBM JDKs 
- corrects a parameter for setup of the profile required to run Byteman for JDK > 8 

For more details, see: https://issues.jboss.org/browse/WFLY-12613
