### PR TITLE
[WFLY-12628] Downgrade MicroProfile Heatlh 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
-        <version.org.eclipse.microprofile.health.api>2.1</version.org.eclipse.microprofile.health.api>
+        <version.org.eclipse.microprofile.health.api>2.0.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.metrics.api>2.0.2</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>


### PR DESCRIPTION
Upgrade to 2.1 was an error as smallrye-health:2.0.0 requires MP Health
2.0.1

JIRA: https://issues.jboss.org/browse/WFLY-12628