### PR TITLE
WFLY-12629 MicroProfile capability names are mangled "org.wildlfy..."

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileSubsystemDefinition.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileSubsystemDefinition.java
@@ -37,7 +37,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  * @author <a href="mailto:tcerar@redhat.com">Tomaz Cerar</a>
  */
 class MicroProfileSubsystemDefinition extends PersistentResourceDefinition {
-    static final String CONFIG_CAPABILITY_NAME = "org.wildlfy.microprofile.config";
+    static final String CONFIG_CAPABILITY_NAME = "org.wildfly.microprofile.config";
 
     static final RuntimeCapability<Void> CONFIG_CAPABILITY =
             RuntimeCapability.Builder.of(CONFIG_CAPABILITY_NAME)

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
@@ -42,7 +42,7 @@ import org.jboss.msc.service.ServiceName;
  */
 public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDefinition {
 
-    static final String HEALTH_REPORTER_CAPABILITY = "org.wildlfy.microprofile.health.reporter";
+    static final String HEALTH_REPORTER_CAPABILITY = "org.wildfly.microprofile.health.reporter";
 
     static final RuntimeCapability<Void> HEALTH_REPORTER_RUNTIME_CAPABILITY =
             RuntimeCapability.Builder.of(HEALTH_REPORTER_CAPABILITY, HealthReporter.class)

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemDefinition.java
@@ -41,11 +41,11 @@ import org.jboss.msc.service.ServiceName;
  */
 public class MicroProfileMetricsSubsystemDefinition extends PersistentResourceDefinition {
 
-    static final String METRICS_COLLECTOR_CAPABILITY = "org.wildlfy.extension.microprofile.metrics.wildfly-collector";
+    static final String METRICS_COLLECTOR_CAPABILITY = "org.wildfly.extension.microprofile.metrics.wildfly-collector";
 
     static final String CLIENT_FACTORY_CAPABILITY ="org.wildfly.management.model-controller-client-factory";
     static final String MANAGEMENT_EXECUTOR ="org.wildfly.management.executor";
-    static final String MP_CONFIG = "org.wildlfy.microprofile.config";
+    static final String MP_CONFIG = "org.wildfly.microprofile.config";
     static final RuntimeCapability<Void> METRICS_COLLECTOR_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(METRICS_COLLECTOR_CAPABILITY, MetricsCollectorService.class)
             .addRequirements(CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR, MP_CONFIG)
             .build();


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-12629


Namely:

org.wildlfy.microprofile.config
org.wildlfy.microprofile.health.reporter
org.wildlfy.extension.microprofile.metrics.wildfly-collector

Lets fix these up before we properly support this since WF 19. Also these aren't even documented in https://github.com/wildfly/wildfly-capabilities