### PR TITLE
WFLY-12393 The jberet-core module should not depend on the javaee.api…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -33,7 +33,10 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javaee.api"/>
+        <module name="javax.batch.api"/>
+        <module name="javax.inject.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.annotation.api"/>
         <module name="javax.transaction.api"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.marshalling"/>


### PR DESCRIPTION
… module

JIRA: https://issues.jboss.org/browse/WFLY-12393