### PR TITLE
WFLY-12646 Upgrade JGroups to 4.1.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <version.org.jboss.ws.cxf>5.3.0.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>3.2.3.Final</version.org.jboss.ws.spi>
-        <version.org.jgroups>4.1.4.Final</version.org.jgroups>
+        <version.org.jgroups>4.1.6.Final</version.org.jgroups>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
         <version.org.jgroups.azure>1.2.1.Final</version.org.jgroups.azure>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12646