### PR TITLE
[WFLY-12647] Remove redundant 'rbac-soak' profile.

### DIFF
--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -52,51 +52,6 @@
     </modules>
 
     <profiles>
-
-        <profile>
-            <id>rbac-soak</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <properties>
-                <!-- default values usable for development -->
-                <jboss.test.rbac.soak.clients>10</jboss.test.rbac.soak.clients>
-                <jboss.test.rbac.soak.iterations>5</jboss.test.rbac.soak.iterations>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <failIfNoTests>false</failIfNoTests>
-                            <!-- parallel>none</parallel -->
-                            <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
-
-                            <!-- System properties to forked surefire JVM which runs clients. -->
-                            <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>
-
-                            <systemPropertyVariables>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <jboss.options>-ea</jboss.options>
-                                <jboss.home>${project.basedir}/target/wildfly</jboss.home>
-                                <module.path>${jboss.dist}/modules</module.path>
-                                <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
-                                <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir} ${extra.server.jvm.args}</server.jvm.args>
-                                <jboss.test.rbac.soak.clients>${jboss.test.rbac.soak.clients}</jboss.test.rbac.soak.clients>
-                                <jboss.test.rbac.soak.iterations>${jboss.test.rbac.soak.iterations}</jboss.test.rbac.soak.iterations>
-                            </systemPropertyVariables>
-                            <includes>
-                                <include>org/jboss/as/test/integration/domain/rbac/RbacSoakTest.java</include>
-                            </includes>
-                            <argLine />
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>layers.profile</id>
             <activation>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12647