### PR TITLE
[WFLY-12621] upgraded Hibernate to 5.3.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0.1</version.org.glassfish.soteria>
         <version.org.harmcrest>1.3</version.org.harmcrest>
-        <version.org.hibernate>5.3.12.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.13.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.17.Final</version.org.hibernate.validator>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12621

# Changes in 5.3.13.Final (October 8th, 2019)

https://hibernate.atlassian.net/projects/HHH/versions/31792/tab/release-report-all-issues

* Bug
    * [HHH-13586] - ClassCastException when using a single region name for both entity and query results
    * [HHH-13645] - StatsNamedContainer#getOrCompute throws NullPointerException when computed value is null

* Improvement
    * [HHH-13130] - Provide Gradle-based bytecode enhancement as a task separate from the compileJava task
