### PR TITLE
WFLY-12348 JPA statistics fix (WFLY-10964) should be applied to JPA 2.1

### DIFF
--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateCollectionStatistics.java
@@ -85,13 +85,13 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
         return null;
     }
 
-    private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, String collectionName) {
+    private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
         if (entityManagerFactory == null) {
             return null;
         }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
-            return sessionFactory.getStatistics().getCollectionStatistics(collectionName);
+            return sessionFactory.getStatistics().getCollectionStatistics(pathAddress.getValue(HibernateStatistics.COLLECTION));
         }
         return null;
     }
@@ -106,7 +106,7 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     private Operation collectionUpdateCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getUpdateCount() : 0);
         }
     };
@@ -114,7 +114,7 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     private Operation collectionRemoveCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getRemoveCount() : 0);
         }
     };
@@ -122,7 +122,7 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     private Operation collectionRecreatedCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getRemoveCount() : 0);
         }
     };
@@ -130,7 +130,7 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     private Operation collectionLoadCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getLoadCount() : 0);
         }
     };
@@ -138,7 +138,7 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     private Operation collectionFetchCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            CollectionStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getFetchCount() : 0);
         }
     };

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityStatistics.java
@@ -77,13 +77,13 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
         return null;
     }
 
-    private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, String entityName) {
+    private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, PathAddress pathAddress) {
         if (entityManagerFactory == null) {
             return null;
         }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
-            return sessionFactory.getStatistics().getEntityStatistics(entityName);
+            return sessionFactory.getStatistics().getEntityStatistics(pathAddress.getValue(HibernateStatistics.ENTITY));
         }
         return null;
     }
@@ -91,7 +91,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation entityDeleteCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getDeleteCount() : 0);
         }
     };
@@ -99,7 +99,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation entityFetchCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getFetchCount() : 0);
         }
     };
@@ -107,7 +107,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation entityInsertCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getInsertCount() : 0);
         }
     };
@@ -115,7 +115,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation entityLoadCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getLoadCount() : 0);
         }
     };
@@ -123,7 +123,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation entityUpdateCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getUpdateCount() : 0);
         }
     };
@@ -131,7 +131,7 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     private Operation optimisticFailureCount = new Operation() {
         @Override
         public Object invoke(Object... args) {
-            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getStatisticName(args));
+            org.hibernate.stat.EntityStatistics statistics = getStatistics(getEntityManagerFactory(args), getPathAddress(args));
             return Long.valueOf(statistics != null ? statistics.getOptimisticFailureCount() : 0);
         }
     };


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12348
Applied same fix for Hibernate ORM 5.1.* as already applied for ORM 5.3.*