### PR TITLE
[WFLY-12651] ModuleClassLoaderLocator created for every request when using default module

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
@@ -127,7 +127,6 @@ import org.wildfly.clustering.infinispan.spi.service.TemplateConfigurationServic
  */
 class SecurityDomainAdd extends AbstractAddStepHandler {
 
-    private static final String DEFAULT_MODULE = "org.picketbox";
     private static final String LEGACY_CACHE_NAME = "auth-cache";
 
     static final SecurityDomainAdd INSTANCE = new SecurityDomainAdd();
@@ -254,8 +253,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 mappingInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                mappingInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
 
@@ -281,8 +278,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 identityTrustInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                identityTrustInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
         applicationPolicy.setIdentityTrustInfo(identityTrustInfo);
@@ -305,8 +300,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = MappingProviderModuleDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 auditInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                auditInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
         applicationPolicy.setAuditInfo(auditInfo);
@@ -332,8 +325,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 aclInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                aclInfo.addJBossModuleName(DEFAULT_MODULE);
             }
 
         }
@@ -360,8 +351,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 authzInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                authzInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
 
@@ -418,8 +407,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, authModule);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 authenticationInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                authenticationInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
         applicationPolicy.setAuthenticationInfo(authenticationInfo);
@@ -476,8 +463,6 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
             ModelNode moduleName = LoginModuleResourceDefinition.MODULE.resolveModelAttribute(context, module);
             if (moduleName.isDefined() && !moduleName.asString().isEmpty()) {
                 authInfo.addJBossModuleName(moduleName.asString());
-            } else {
-                authInfo.addJBossModuleName(DEFAULT_MODULE);
             }
         }
     }

--- a/security/subsystem/src/main/java/org/jboss/as/security/deployment/SecurityDependencyProcessor.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/deployment/SecurityDependencyProcessor.java
@@ -23,6 +23,7 @@
 package org.jboss.as.security.deployment;
 
 import org.jboss.as.security.ModuleName;
+import org.jboss.as.security.plugins.ModuleClassLoaderLocator;
 import org.jboss.as.security.remoting.RemotingLoginModule;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -35,6 +36,8 @@ import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.filter.PathFilters;
+import org.jboss.security.plugins.ClassLoaderLocator;
+import org.jboss.security.plugins.ClassLoaderLocatorFactory;
 
 /**
  * Adds a security subsystem dependency to deployments
@@ -70,6 +73,10 @@ public class SecurityDependencyProcessor implements DeploymentUnitProcessor {
 
     /** {@inheritDoc} */
     public void undeploy(DeploymentUnit context) {
+        ClassLoaderLocator locator = ClassLoaderLocatorFactory.get();
+        if (locator instanceof ModuleClassLoaderLocator) {
+            ((ModuleClassLoaderLocator)locator).clearCache();
+        }
     }
 
 }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12651

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

When `jboss-module-name`s are defined for the login module, no matter default module(`org.picketbox`) is used or not, each `ModuleClassLoaderLocator.get(List<String> modules)` call(on each request) will create a new `ModuleClassLoaderLocator.CombinedClassLoader` instance.

The proposed fix is to introduce a cache in `ModuleClassLoaderLocator` for each specified ModuleClassLoaders and current context ClassLoader combination to avoid to create new instance on each request.

The cache won't be cleaned in the JVM, but there should not be much combinations, so the cache won't be big.

