### PR TITLE
WFLY-12663 Upgrade jgroups-kubernetes to 1.0.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
         <version.org.jgroups.azure>1.2.1.Final</version.org.jgroups.azure>
-        <version.org.jgroups.kubernetes>1.0.12.Final</version.org.jgroups.kubernetes>
+        <version.org.jgroups.kubernetes>1.0.13.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.jvnet.staxex>1.7.8</version.org.jvnet.staxex>
         <version.org.kohsuke.metainf-services>1.7</version.org.kohsuke.metainf-services>


### PR DESCRIPTION
Resolves
https://issues.jboss.org/browse/WFLY-12663
https://issues.jboss.org/browse/WFLY-12657