### PR TITLE
[WFLY-12675] Upgrade WildFly Core 11.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.17.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12675

---


## Release Notes - WildFly Core - Version 11.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4678'>WFCORE-4678</a>] -         Use a more recent version of guava
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4682'>WFCORE-4682</a>] -         Upgrade Jandex to 2.1.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4689'>WFCORE-4689</a>] -         Upgrade jboss-remoting to 5.0.16.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4691'>WFCORE-4691</a>] -         Upgrade XNIO to 3.7.5.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4692'>WFCORE-4692</a>] -         Upgrade WildFly Common to 1.5.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4705'>WFCORE-4705</a>] -         Upgrade WildFly Elytron 1.11.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4706'>WFCORE-4706</a>] -         Upgrade Elytron Web to 1.7.0.CR1
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4708'>WFCORE-4708</a>] -         Upgrade XNIO to 3.7.6.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4709'>WFCORE-4709</a>] -         Upgrade Undertow to 2.0.27.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4714'>WFCORE-4714</a>] -         Upgrade galleon plugins to 4.0.4.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4505'>WFCORE-4505</a>] -         use default charset for process file via jboss-cli  --properties
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4594'>WFCORE-4594</a>] -         Expose CoreProcessStateService functionality used by subsystems via a capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4595'>WFCORE-4595</a>] -         ControlledProcessState.State should expose whether a state means a running server
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4680'>WFCORE-4680</a>] -         Redact passwords in the sun.java.command logging
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4710'>WFCORE-4710</a>] -         Wrong BufferPoolMXBean name used in lookup
</li>
</ul>
                                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4681'>WFCORE-4681</a>] -         Add Phase entries for Microprofile OpenAPI Extension
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4338'>WFCORE-4338</a>] -         Race condition on PID file allows for termination of arbitrary processes by local users
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4656'>WFCORE-4656</a>] -         Write Empty ALLOWED_ORIGINS list cause ConfigurationPersistenceException on reload
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4683'>WFCORE-4683</a>] -         User with Monitor role can stop the servers in domain mode
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4684'>WFCORE-4684</a>] -         The legacy core-feature-pack doesn&#39;t install the .well-known/acme-challenge dir
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4687'>WFCORE-4687</a>] -         StandaloneScriptTestCase fails on Eclipse OpenJ9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4699'>WFCORE-4699</a>] -         preferIPv6Addresses and preferIPv4Stack System Properties are Mishandled in the Config
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4652'>WFCORE-4652</a>] -         Ignore tests that expect default configuration during Elytron testing
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4679'>WFCORE-4679</a>] -         Update the mock-server-netty dep; specify the logback dep
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4686'>WFCORE-4686</a>] -         Ensure the log manager is set for tests for Eclipse OpenJ9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4690'>WFCORE-4690</a>] -         Fix test suite tests to work with Eclipse OpenJ9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4696'>WFCORE-4696</a>] -         Bump the Elytron subsystem version
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4702'>WFCORE-4702</a>] -         Add deployment phases for MicroProfile Fault Tolerance
</li>
</ul>
                                    