### PR TITLE
WFLY-12689 WebNonTxEmCloserAction#dependencies() should return an emp…

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/interceptor/WebNonTxEmCloserAction.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/interceptor/WebNonTxEmCloserAction.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.jpa.interceptor;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -55,6 +56,6 @@ public class WebNonTxEmCloserAction implements SetupAction {
 
     @Override
     public Set<ServiceName> dependencies() {
-        return null;
+        return Collections.emptySet();
     }
 }


### PR DESCRIPTION
…ty set instead of null

When a web application contains both MBean (jboss-service.xml) and
persistence-unit (persistence.xml), this causes NullPointerException and
the WAR deployment fails.

JIRA: https://issues.jboss.org/browse/WFLY-12689
