### PR TITLE
WFLY-12694 Update jackson-databind to 2.9.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
         <version.antlr>2.7.7</version.antlr>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.9.10</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson-databind>2.9.10.1</version.com.fasterxml.jackson-databind>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>
@@ -1254,7 +1255,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}</version>
+                <version>${version.com.fasterxml.jackson-databind}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Update jackson-databind to 2.9.10.1
https://issues.jboss.org/browse/WFLY-12694

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted

Only jackson-databind has 2.9.10.1, other jackson-* still on 2.9.10