### PR TITLE
WFLY-12699 add test that reproduces stack overflow and remove use of COMPUTE_FRAMES to avoid (ASM) recomputing stackmap frames.

### DIFF
--- a/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
+++ b/jpa/hibernate-transformer/src/main/java/org/jboss/as/hibernate/Hibernate51CompatibilityTransformer.java
@@ -18,7 +18,6 @@
 
 package org.jboss.as.hibernate;
 
-import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 
@@ -96,7 +95,7 @@ public class Hibernate51CompatibilityTransformer implements ClassFileTransformer
         final TransformedState transformedState = new TransformedState();
         final ClassReader classReader = new ClassReader(classfileBuffer);
 
-        final ClassWriter classWriter = new ClassWriter(classReader, COMPUTE_FRAMES) {
+        final ClassWriter classWriter = new ClassWriter(classReader, 0) {
 
             // Pass the classloader in so org.objectweb.asm.ClassWriter.getCommonSuperClass() uses the app classloader
             // instead of ASM classloader, for loading super classes.

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/AbstractVerifyHibernate51CompatibilityTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/AbstractVerifyHibernate51CompatibilityTestCase.java
@@ -109,6 +109,7 @@ public abstract class AbstractVerifyHibernate51CompatibilityTestCase {
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "entities.jar");
         lib.addClasses(Student.class);
         lib.addClass(IntegerType.class);
+        lib.addClass(StackOverFlowTestClass.class);
         lib.addClass(IntegerUserVersionType.class);
         lib.addClass(BooleanSingleColumnType.class);
         lib.addClass(BooleanAbstractStandardBasicType.class);
@@ -436,6 +437,13 @@ public abstract class AbstractVerifyHibernate51CompatibilityTestCase {
         } finally {
             sfsb.cleanup();
         }
+    }
+
+    @Test
+    public void testJDBCResourceBundle() {
+        // WFLY-12699 stack overflow occurs when StackOverFlowTestClass class is loaded into memory + transformed
+        // by the Hibernate51CompatibilityTransformer
+        StackOverFlowTestClass.class.getName();
     }
 
     @Test

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StackOverFlowTestClass.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/transformer/StackOverFlowTestClass.java
@@ -1,0 +1,20 @@
+package org.jboss.as.test.compat.jpa.hibernate.transformer;
+
+public class StackOverFlowTestClass {
+    // commenting this method out avoids stackoverflow
+    public static String test(String aKey) {
+    // commenting out the try/catch avoids stackoverflow
+        try {
+            StackOverFlowTestClass vAnchorBundle = getNothing();
+            if (vAnchorBundle != null)
+                return aKey;
+        } catch (Exception e3) {
+        }
+        return aKey;
+    }
+
+    // commenting out the call to this method also avoids stackoverflow
+    public static StackOverFlowTestClass getNothing() {
+        return null;
+    }
+}


### PR DESCRIPTION
[WFLY-12699](https://issues.jboss.org/browse/WFLY-12699)
Address reported stack overflow that occurred when ASM recomputes stackmap frames with the StackOverFlowTestClass.  There are two ways to address the issue, one is to avoid using COMPUTE_FRAMES, which I don't think we really needed for the [WFLY-11991](https://issues.jboss.org/browse/WFLY-11991) change.  

With this pull request, we are switching back to passing zero flag to new ASM ClassWriter which gets us:
> with new ClassWriter(0) nothing is automatically computed. You
> have to compute yourself the frames and the local variables and operand
> stack sizes.

We previously were passing COMPUTE_FRAMES to ASM ClassWriter, which got us:
> with new ClassWriter(ClassWriter.COMPUTE_FRAMES) everything is
> computed automatically. You don’t have to call visitFrame, but you
> must still call visitMaxs (arguments will be ignored and recomputed).

To be complete, the other option (which we haven't used) is pass COMPUTE_MAXS to ASM ClassWriter, which does:

> with new ClassWriter(ClassWriter.COMPUTE_MAXS) the sizes of the
> local variables and operand stack parts are computed for you. You must
> still call visitMaxs, but you can use any arguments: they will be ignored
> and recomputed. With this option you still have to compute the frames
> yourself.

So, the reason why we previously switched to COMPUTE_FRAMES, was so the Hibernate transformer could add additional variables and bytecode instructions which we were doing but we optimized a bit to avoid the need for the additional variables and bytecode instructions, which resulted in the previous [WFLY-11991](https://issues.jboss.org/browse/WFLY-11991) change.  I think that the previous change could of removed the COMPUTE_FRAMES after the reworking/optimizing but that was overlooked.

The other way to solve the stack overflow bug is to keep COMPUTE_FRAMES and implement the ClassWriter#getCommonSuperClass method, which I started hacking on via [WFLY-12699_stackoverflow_save](https://github.com/scottmarlow/wildfly/commits/WFLY-12699_stackoverflow_save), however, it is not complete (would need more logic to deal with comparing super types and classloading). [WFLY-12699 mentions some links to examples of other projects that have implemented the getCommonSuperClass solution](https://issues.jboss.org/browse/WFLY-12699).