### PR TITLE
[WFLY-12707] Explicitly skip the enforcer and checkstyle plugins wher…

### DIFF
--- a/spec-api/test/pom.xml
+++ b/spec-api/test/pom.xml
@@ -38,8 +38,16 @@
   <artifactId>wildfly-spec-api-test</artifactId>
   <name>WildFly: Validation Tests for Exported Jakarta EE Specification APIs</name>
   <description>Validation Tests for Jakarta EE Specification APIs exported by the Application Server</description>
-  <properties>
-    <!-- we want unused imports in tish case, so lets skip checkstyle-->
-    <checkstyle.skip>true</checkstyle.skip>
-  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <!-- we want unused and wildcard imports in this case, so lets skip checkstyle -->
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -48,7 +48,6 @@
              ts.copy-jbossas.groups execution assumes it's the same as jboss.dist -->
         <jboss.home>${jboss.dist}</jboss.home>
 
-        <enforcer.skip>true</enforcer.skip>
         <jbossas.ts.dir>${basedir}/..</jbossas.ts.dir>
 
         <ts.elytron.cli>../shared/enable-elytron-domain.cli</ts.elytron.cli>
@@ -201,6 +200,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <!-- This enforcer.skip property was set to true in the properties. However this doesn't work if the
+                     property is passed on the command line. Therefore we need to explicitly skip it.
+                -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -52,8 +52,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
 
-        <enforcer.skip>true</enforcer.skip>
-
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
         <version.org.hsqldb.hsqldb>2.5.0</version.org.hsqldb.hsqldb>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -45,7 +45,6 @@
         <xslt.scripts.dir>${jbossas.ts.integ.dir}/src/test/xslt</xslt.scripts.dir>
 
         <ts.skipTests>${skipTests}</ts.skipTests>
-        <enforcer.skip>true</enforcer.skip>
 
         <ts.elytron.cli>../../shared/enable-elytron.cli</ts.elytron.cli>
         <wildfly.dir>${project.build.directory}/wildfly</wildfly.dir>
@@ -309,6 +308,15 @@
 
     <build>
         <plugins>
+            <plugin>
+                <!-- This enforcer.skip property was set to true in the properties. However this doesn't work if the
+                     property is passed on the command line. Therefore we need to explicitly skip it.
+                -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <!-- General plugin configuration for all integration tests -->
 
             <!-- Resources plugin. -->

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -20,12 +20,6 @@
 
     <name>WildFly Test Suite: Shared</name>
 
-
-    <properties>
-        <!-- Arquillian dependency versions -->
-        <enforcer.skip>true</enforcer.skip>
-    </properties>
-
     <dependencyManagement>
         <dependencies>
             <!-- Not defined in the parent pom as this should only be used here -->
@@ -112,6 +106,16 @@
 
     <build>
         <plugins>
+            <plugin>
+                <!-- This enforcer.skip property was set to true in the properties. However this doesn't work if the
+                     property is passed on the command line. Therefore we need to explicitly skip it.
+                -->
+                <!-- Arquillian dependency versions -->
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
…e required instead of attempting to override the property.

https://issues.jboss.org/browse/WFLY-12707

Note we skip the enforcer plugin in all integration tests which seems a bit weird IMO. I started cleaning it up, but it's quite the web of dependencies that need to be cleaned up. If we'd prefer that approach I can take the time to fix it, however I didn't want to spend too much time and went with the simple approach first.