### PR TITLE
[18.0.x][WFLY-12714] Upgrade Hibernate Validator to 6.0.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
         <version.org.hibernate>5.3.12.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.17.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.18.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>9.4.16.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12714
Upstream: https://github.com/wildfly/wildfly/pull/12745
