### PR TITLE
[WFLY-12727]: Upgrade Netty to 4.1.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
         <version.io.jaegertracing>0.34.0</version.io.jaegertracing>
-        <version.io.netty>4.1.34.Final</version.io.netty>
+        <version.io.netty>4.1.42.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>
         <version.io.opentracing.interceptors>0.0.4</version.io.opentracing.interceptors>


### PR DESCRIPTION
 * Upgrade Netty from 4.1.34.Final to 4.1.42.Final

Jira: https://issues.jboss.org/browse/WFLY-12727