### PR TITLE
WFLY-12728 remove unneeded dependencies/dependencyManagement from jpa/hibernate5_3/pom.xml

### DIFF
--- a/jpa/hibernate5_3/pom.xml
+++ b/jpa/hibernate5_3/pom.xml
@@ -36,93 +36,6 @@
 
     <name>jipijapa Hibernate 5.3.x (JPA 2.2) integration</name>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-core</artifactId>
-                <scope>provided</scope>
-                <version>${version.org.hibernate}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-hibernate-cache-spi</artifactId>
-                <version>${version.org.infinispan}</version>
-                <scope>provided</scope>
-                <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-hibernate-cache-commons</artifactId>
-                <version>${version.org.infinispan}</version>
-                <scope>provided</scope>
-                <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-            </dependency>
-            
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-core</artifactId>
-                <version>${version.org.infinispan}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>caffeine</artifactId>
-                        <groupId>com.github.ben-manes.caffeine</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>hamcrest-core</artifactId>
-                        <groupId>org.hamcrest</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jgroups</artifactId>
-                        <groupId>org.jgroups</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jboss-logging</artifactId>
-                        <groupId>org.jboss.logging</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jboss-marshalling-osgi</artifactId>
-                        <groupId>org.jboss.marshalling</groupId>
-                    </exclusion>
-                    <!-- TODO remove this exclusion once this supports Jakarta Transactions 1.3 -->
-                    <!-- superseded by org.jboss.spec.javax.transaction:jboss-transaction-api_1.3_spec -->
-                    <exclusion>
-                        <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-                        <groupId>org.jboss.spec.javax.transaction</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                        <groupId>org.jboss.spec.javax.transaction</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>rxjava</artifactId>
-                        <groupId>io.reactivex.rxjava2</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-        </dependencies>
-    </dependencyManagement>
-        
-
     <dependencies>
         <!-- testing -->
         <dependency>
@@ -183,38 +96,18 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
             <scope>provided</scope>
-            <version>${version.org.hibernate}</version>
-            <exclusions>
-              <exclusion>
-                 <groupId>*</groupId>
-                 <artifactId>*</artifactId>
-              </exclusion>
-           </exclusions>
-
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-hibernate-cache-spi</artifactId>
             <scope>provided</scope>
-            <exclusions>
-              <exclusion>
-                 <groupId>*</groupId>
-                 <artifactId>*</artifactId>
-              </exclusion>
-           </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-hibernate-cache-commons</artifactId>
             <scope>provided</scope>
-             <exclusions>
-              <exclusion>
-                 <groupId>*</groupId>
-                 <artifactId>*</artifactId>
-              </exclusion>
-           </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12728

Minor cleanup of jpa/hibernate5_3/pom.xml, we had extra dependencies + dependencyManagement section specified that we don't need anymore (likely leftover from when we had both EE 7 + EE 8 versions of Hibernate ORM included in WildFly).