### PR TITLE
[WFLY-12732] Upgrade WildFly Core 11.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.17.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12732

---


## Release Notes - WildFly Core - Version 11.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4716'>WFCORE-4716</a>] -         Upgrade Byteman to 4.0.8
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4721'>WFCORE-4721</a>] -         Upgrade test and build dependencies
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4732'>WFCORE-4732</a>] -         Upgrade wildfly-server-provisioning-maven-plugin from 1.2.12 to 1.2.13
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4734'>WFCORE-4734</a>] -         Upgrade jackson-databind test dependency to 2.9.10.1
</li>
</ul>
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4688'>WFCORE-4688</a>] -         &#39;-Xlog:gc&#39; option is not supported on OpenJDK11 + OpenJ9
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4717'>WFCORE-4717</a>] -         Add missing phases for EE Security subsystem
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4720'>WFCORE-4720</a>] -         SetupAction does not specify whether the dependencies method can return null
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4723'>WFCORE-4723</a>] -         SyslogAuditLogTestCase Test Failures
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4726'>WFCORE-4726</a>] -         Exclude javax.inject:javax.inject from org.apache.maven:maven-resolver-provider dependency
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4419'>WFCORE-4419</a>] -         Remove deprecated ParseUtil methods
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4449'>WFCORE-4449</a>] -         Remove unused MultistepUtil methods
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4713'>WFCORE-4713</a>] -         Migrate controller module to new MSC API
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4727'>WFCORE-4727</a>] -         Clean out no longer needed AbstractControllerService and ModelTestControllerService constructors
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4728'>WFCORE-4728</a>] -         Ban javax.inject:javax.inject by maven-enforcer-plugin 
</li>
</ul>
                                    