### PR TITLE
[WFLY-12733] EJB Timers: Forcing refresh timers in a database-data-store in a clustered environment

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -61,6 +61,7 @@ import org.jboss.as.ejb3.context.CurrentInvocationContext;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.subsystem.deployment.TimerServiceResource;
 import org.jboss.as.ejb3.timerservice.persistence.TimerPersistence;
+import org.jboss.as.ejb3.timerservice.persistence.database.DatabaseTimerPersistence;
 import org.jboss.as.ejb3.timerservice.spi.ScheduleTimer;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
 import org.jboss.invocation.InterceptorContext;
@@ -942,6 +943,18 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         synchronized (this.scheduledTimerFutures) {
             return this.scheduledTimerFutures.containsKey(tid);
         }
+    }
+
+    /**
+     * Force refresh timer when it is working with Database persistence.
+     */
+    public boolean refreshTimers(){
+        TimerPersistence timerPersistence = this.timerPersistence.getValue();
+        if(DatabaseTimerPersistence.class.isInstance(timerPersistence)){
+            return ((DatabaseTimerPersistence)timerPersistence).refreshTimers();
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
The EJB Timer has a way to persist timers in a database using datasources. It is described [here|https://docs.jboss.org/author/display/WFLY10/EJB3+Clustered+Database+Timers]. The database-data-store has an attribute called refresh-interval that define a time in milliseconds to refresh the timers reading the timers from database. Look this sample of configuration.

```
                    <data-stores>
                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
                        <database-data-store name="clustered-store" datasource-jndi-name="java:/jdbc/MyDataSource" partition="timer" refresh-interval="60000" allow-execution="true"/>
                    </data-stores>
```

This pull request add a method in TimerServiceImpl to force a refresh programmatically.