### PR TITLE
WFLY-12741 Eliminate redundant buffer allocation/copying when marshalling session attributes and EJB instances

### DIFF
--- a/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/ByteBufferOutputStream.java
+++ b/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/ByteBufferOutputStream.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.marshalling.jboss;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * A specialized ByteArrayOutputStream that exposes the internal buffer.
+ * @author Paul Ferraro
+ */
+public final class ByteBufferOutputStream extends ByteArrayOutputStream {
+
+    public ByteBufferOutputStream() {
+        super();
+    }
+
+    public ByteBufferOutputStream(int size) {
+        super(size);
+    }
+
+    /**
+     * Returns the internal buffer of this output stream.
+     * @return the internal byte buffer.
+     */
+    public ByteBuffer getBuffer() {
+        return ByteBuffer.wrap(this.buf, 0, this.count);
+    }
+}

--- a/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/HashableMarshalledValue.java
+++ b/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/HashableMarshalledValue.java
@@ -25,6 +25,7 @@ package org.wildfly.clustering.marshalling.jboss;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
 
 /**
  * Like {@link SimpleMarshalledValue}, but also serializes the underlying object's hash code,
@@ -41,8 +42,8 @@ public class HashableMarshalledValue<T> extends SimpleMarshalledValue<T> {
         this.hashCode = (object != null ) ? object.hashCode() : 0;
     }
 
-    HashableMarshalledValue(byte[] bytes, int hashCode) {
-        super(bytes);
+    HashableMarshalledValue(ByteBuffer buffer, int hashCode) {
+        super(buffer);
         this.hashCode = hashCode;
     }
 

--- a/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/HashableMarshalledValueExternalizer.java
+++ b/clustering/marshalling/jboss/src/main/java/org/wildfly/clustering/marshalling/jboss/HashableMarshalledValueExternalizer.java
@@ -47,7 +47,7 @@ public class HashableMarshalledValueExternalizer<T> implements Externalizer<Hash
     public HashableMarshalledValue<T> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
         SimpleMarshalledValue<T> value = this.externalizer.readObject(input);
         int hashCode = input.readInt();
-        return new HashableMarshalledValue<>(value.getBytes(), hashCode);
+        return new HashableMarshalledValue<>(value.getBuffer(), hashCode);
     }
 
     @SuppressWarnings("unchecked")

--- a/clustering/marshalling/jboss/src/test/java/org/wildfly/clustering/marshalling/jboss/SimpleMarshalledValueFactoryTestCase.java
+++ b/clustering/marshalling/jboss/src/test/java/org/wildfly/clustering/marshalling/jboss/SimpleMarshalledValueFactoryTestCase.java
@@ -90,7 +90,7 @@ public class SimpleMarshalledValueFactoryTestCase {
 
         mv = this.factory.createMarshalledValue(null);
         assertNull(mv.peek());
-        assertNull(mv.getBytes());
+        assertNull(mv.getBuffer());
         assertNull(mv.get(this.context));
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12741