### PR TITLE
[18.0.x][WFLY-12746] Bump clustering testsuite surefire execution timeout to …

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -42,7 +42,7 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
-        <surefire.forked.process.timeout>4500</surefire.forked.process.timeout>
+        <surefire.forked.process.timeout>5400</surefire.forked.process.timeout>
         <test-group>org/jboss/as/test/clustering/cluster</test-group>
         <!-- Needs to kept inline with what the infinispan-server-feature-pack requires -->
         <version.org.jboss.infinispan-wildfly>14.0.1.Final</version.org.jboss.infinispan-wildfly>


### PR DESCRIPTION
…5400

Issue: https://issues.jboss.org/browse/WFLY-12746
Upstream: https://github.com/wildfly/wildfly/pull/12763