### PR TITLE
[WFLY-11930] Allow Java EE Subsystem to enable/disable descriptor bas…

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Application_Deployment_Configuration.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EE_Application_Deployment_Configuration.adoc
@@ -106,6 +106,14 @@ shipped with WildFly.
   <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
 ----
 
+When enabled, properties can be replaced in the following deployment descriptors:
+
+* ejb-jar.xml
+* persistence.xml
+* application.xml
+* web.xml
+* permissions.xml
+
 [[jboss-descriptor-property-replacement]]
 === JBoss Descriptor Property Replacement
 
@@ -117,6 +125,15 @@ defaults to `true`.
 ----
   <jboss-descriptor-property-replacement>false</jboss-descriptor-property-replacement>
 ----
+
+When enabled, properties can be replaced in the following deployment descriptors:
+
+* jboss-ejb3.xml
+* jboss-app.xml
+* jboss-web.xml
+* jboss-permissions.xml
+* *-jms.xml
+* *-ds.xml
 
 [[annotation-property-replacement]]
 === Annotation Property Replacement

--- a/ee/src/main/java/org/jboss/as/ee/metadata/property/PropertyResolverProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/property/PropertyResolverProcessor.java
@@ -22,11 +22,14 @@
 
 package org.jboss.as.ee.metadata.property;
 
+import java.util.function.Function;
+
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.metadata.property.CompositePropertyResolver;
+import org.jboss.metadata.property.PropertyReplacer;
 import org.jboss.metadata.property.PropertyReplacers;
 
 /**
@@ -35,14 +38,33 @@ import org.jboss.metadata.property.PropertyReplacers;
 public class PropertyResolverProcessor implements DeploymentUnitProcessor {
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        CompositePropertyResolver propertyResolver = new CompositePropertyResolver(deploymentUnit.getAttachment(Attachments.DEPLOYMENT_PROPERTY_RESOLVERS));
+
+        final CompositePropertyResolver propertyResolver = new CompositePropertyResolver(deploymentUnit.getAttachment(Attachments.DEPLOYMENT_PROPERTY_RESOLVERS));
+        final PropertyReplacer propertyReplacer = PropertyReplacers.resolvingExpressionReplacer(propertyResolver);
+        //We pass a function basically to be used by wildfly-core which does not the dependencies used to instantiate a PropertyReplacer
+        final Function<String, String> functionExpand = (value) -> propertyReplacer.replaceProperties(value);
+
+        // setup the expression expand function for spec descriptors, if property expansion is enabled for them. If it does not exist, then by default we assume they are enabled.
+        final Boolean specDescriptorPropReplacement = deploymentUnit.getAttachment(org.jboss.as.ee.structure.Attachments.SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT);
+        if (specDescriptorPropReplacement == null || specDescriptorPropReplacement) {
+            deploymentUnit.putAttachment(org.jboss.as.server.deployment.Attachments.SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION, functionExpand);
+        }
+        // setup the expression expand function for JBoss/WildFly descriptors, if property expansion is enabled for them
+        final Boolean jbossDescriptorPropReplacement = deploymentUnit.getAttachment(org.jboss.as.ee.structure.Attachments.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT);
+        if (jbossDescriptorPropReplacement == null || jbossDescriptorPropReplacement) {
+            deploymentUnit.putAttachment(org.jboss.as.server.deployment.Attachments.WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION, functionExpand);
+        }
+
         deploymentUnit.putAttachment(Attachments.FINAL_PROPERTY_RESOLVER, propertyResolver);
-        deploymentUnit.putAttachment(Attachments.FINAL_PROPERTY_REPLACER, PropertyReplacers.resolvingReplacer(propertyResolver));
+        deploymentUnit.putAttachment(Attachments.FINAL_PROPERTY_REPLACER, propertyReplacer);
     }
 
     public void undeploy(DeploymentUnit deploymentUnit) {
         deploymentUnit.removeAttachment(Attachments.FINAL_PROPERTY_REPLACER);
         deploymentUnit.removeAttachment(Attachments.FINAL_PROPERTY_RESOLVER);
         deploymentUnit.removeAttachment(Attachments.DEPLOYMENT_PROPERTY_RESOLVERS);
+
+        deploymentUnit.removeAttachment(org.jboss.as.server.deployment.Attachments.SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
+        deploymentUnit.removeAttachment(org.jboss.as.server.deployment.Attachments.WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION);
     }
 }

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -33,8 +33,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.metadata</groupId>
+            <artifactId>jboss-metadata-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-security-manager</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PermissionParserExpressionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PermissionParserExpressionsTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Permission;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import javax.xml.stream.XMLInputFactory;
+
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.module.ExpressionStreamReaderDelegate;
+import org.jboss.metadata.property.CompositePropertyResolver;
+import org.jboss.metadata.property.PropertyReplacer;
+import org.jboss.metadata.property.PropertyReplacers;
+import org.jboss.metadata.property.SimpleExpressionResolver;
+import org.jboss.metadata.property.SystemPropertyResolver;
+import org.jboss.modules.LocalModuleLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.security.PermissionFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.extension.security.manager.deployment.PermissionsParser;
+
+/**
+ * Unit test to verify that the permissions parser is able to use a property resolver to parse permissions.
+ *
+ * @author Yeray Borges
+ */
+public class PermissionParserExpressionsTestCase {
+    final List<SimpleExpressionResolver> resolvers = Arrays.asList(SystemPropertyResolver.INSTANCE);
+    final CompositePropertyResolver compositePropertyResolver = new CompositePropertyResolver(resolvers.toArray(new SimpleExpressionResolver[0]));
+    final PropertyReplacer propertyReplacer = PropertyReplacers.resolvingExpressionReplacer(compositePropertyResolver);
+    final ModuleIdentifier identifier = ModuleIdentifier.fromString("java.base");
+    final Path fileUnderTest = Paths.get("src", "test", "resources", "propertypermission", "permissions.xml");
+    final Function<String, String> functionExpand = (value) -> propertyReplacer.replaceProperties(value);
+
+    @Test
+    public void test() throws DeploymentUnitProcessingException {
+        System.setProperty("CLASS_NAME", "java.io.FilePermission");
+        System.setProperty("NAME_A", "A");
+        System.setProperty("NAME_B", "B");
+        System.setProperty("NAME_C", "C");
+        System.setProperty("ACTION_READ", "read");
+
+        File[] modulePaths = getModulePaths();
+        LocalModuleLoader ml = new LocalModuleLoader(modulePaths);
+
+        List<PermissionFactory> permissionFactories = parsePermissions(fileUnderTest, ml, identifier, functionExpand);
+        Assert.assertEquals("Unexpected number of permissions", 3, permissionFactories.size());
+        Permission permission = permissionFactories.get(0).construct();
+        Assert.assertNotNull(permission);
+
+        Assert.assertTrue("Unexpected permission class", permission instanceof FilePermission);
+        Assert.assertEquals("Unexpected permission name", permission.getName(), "A");
+        Assert.assertEquals("Unexpected permission action", permission.getActions(), "read");
+
+        permission = permissionFactories.get(1).construct();
+        Assert.assertNotNull(permission);
+
+        Assert.assertTrue("Unexpected permission class", permission instanceof FilePermission);
+        Assert.assertEquals("Unexpected permission name", permission.getName(), "B");
+        Assert.assertEquals("Unexpected permission action", permission.getActions(), "read");
+
+        permission = permissionFactories.get(2).construct();
+        Assert.assertNotNull(permission);
+
+        Assert.assertTrue("Unexpected permission class", permission instanceof FilePermission);
+        Assert.assertEquals("Unexpected permission name", permission.getName(), "C");
+        Assert.assertEquals("Unexpected permission action", permission.getActions(), "write");
+    }
+
+    private List<PermissionFactory> parsePermissions(final Path path, final ModuleLoader loader, final ModuleIdentifier identifier, final Function<String, String> exprExpandFunction)
+            throws DeploymentUnitProcessingException {
+
+        InputStream inputStream = null;
+        try {
+            inputStream = Files.newInputStream(path);
+            final XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            final ExpressionStreamReaderDelegate expressionStreamReaderDelegate = new ExpressionStreamReaderDelegate(inputFactory.createXMLStreamReader(inputStream), exprExpandFunction);
+            return PermissionsParser.parse(expressionStreamReaderDelegate, loader, identifier);
+        } catch (Exception e) {
+            throw new DeploymentUnitProcessingException(e.getMessage(), e);
+        } finally {
+            try {
+                if (inputStream != null) {
+                    inputStream.close();
+                }
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    private File[] getModulePaths() {
+        final List<File> files = new ArrayList<>();
+        String modulePath = System.getProperty("module.path");
+        if (modulePath == null) {
+            fail("module.path system property is not set");
+        }
+        final String[] modulePaths = modulePath.split(Pattern.quote(File.pathSeparator));
+        for (String path: modulePaths) {
+            files.add(Paths.get(path).normalize().toFile());
+        }
+
+        return files.toArray(new File[]{});
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PropertyPermissionExpressionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/PropertyPermissionExpressionsTestCase.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.PropertyPermission;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.ee.subsystem.EeExtension;
+import org.jboss.as.subsystem.test.SubsystemOperations;
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.testsuite.integration.secman.servlets.JSMCheckServlet;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that enabling disabling spec-descriptor-property-replacement and jboss-descriptor-property-replacement on the EE subsystem the replacement via environment
+ * properties on permissions.xml and jboss-permissions.xml is enabled and disabled.
+ *
+ * @author Yeray Borges
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+@ServerSetup(PropertyPermissionExpressionsTestCase.SystemPropertiesSetup.class)
+public class PropertyPermissionExpressionsTestCase {
+    private static final String PROPERTY_NAME = "ENVIRONMENT_PROP_NAME";
+    private static final String PROPERTY_VALUE = "java.home";
+    private static final PathAddress EE_SUBSYSTEM_PATH_ADDRESS = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EeExtension.SUBSYSTEM_NAME));
+    private static final String VERIFY_JSM_DEPLOYMENT = "verify-jsm-deployment";
+    private static final String SPEC_PRINT_PROP_SERVLET_DEPLOYMENT = "spec_print-prop-servlet_deployment";
+    private static final String JBOSS_PRINT_PROP_SERVLET_DEPLOYMENT = "jboss_print-prop-servlet_deployment";
+    private static final Asset EXPRESSIONS_PERMISSIONS_XML = PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(
+            "${"+PROPERTY_NAME+"}", "read"));
+
+    private ModelControllerClient client;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @ArquillianResource
+    private ManagementClient mgmtClient;
+
+    @Deployment(name = VERIFY_JSM_DEPLOYMENT)
+    public static Archive<?> createJavaSecManagerVerifier() {
+        return ShrinkWrap.create(WebArchive.class, "verify-jsm-enabled.war")
+                .addClass(JSMCheckServlet.class);
+    }
+
+    @Deployment(name = SPEC_PRINT_PROP_SERVLET_DEPLOYMENT, managed = false, testable = false)
+    public static Archive<?> createSpectPrintPropServlet() {
+        return ShrinkWrap.create(WebArchive.class, SPEC_PRINT_PROP_SERVLET_DEPLOYMENT + ".war")
+                .addClass(PrintSystemPropertyServlet.class)
+                .addAsManifestResource(EXPRESSIONS_PERMISSIONS_XML, "permissions.xml");
+    }
+
+    @Deployment(name = JBOSS_PRINT_PROP_SERVLET_DEPLOYMENT, managed = false, testable = false)
+    public static Archive<?> createJbossPrintPropServlet() {
+        return ShrinkWrap.create(WebArchive.class, JBOSS_PRINT_PROP_SERVLET_DEPLOYMENT + ".war")
+                .addClass(PrintSystemPropertyServlet.class)
+                .addAsManifestResource(EXPRESSIONS_PERMISSIONS_XML, "jboss-permissions.xml");
+    }
+
+    @Test
+    @InSequence(10)
+    @OperateOnDeployment(VERIFY_JSM_DEPLOYMENT)
+    public void verifyJavaSecurityManageIsEnabled(@ArquillianResource() @OperateOnDeployment(VERIFY_JSM_DEPLOYMENT) URL webAppURL) throws Exception {
+        final URI checkJSMuri = new URI(webAppURL.toExternalForm() + JSMCheckServlet.SERVLET_PATH.substring(1));
+        assertEquals("JSM should be enabled.", Boolean.toString(true), Utils.makeCall(checkJSMuri, 200));
+    }
+
+    @Test
+    @InSequence(20)
+    public void verifyExpressionsInSpecPermissions() throws Exception {
+        verifyExpressionsInPermissions("spec-descriptor-property-replacement", SPEC_PRINT_PROP_SERVLET_DEPLOYMENT);
+    }
+
+    @Test
+    @InSequence(30)
+    public void verifyExpressionsInJbossPermissions() throws Exception {
+        verifyExpressionsInPermissions("jboss-descriptor-property-replacement", JBOSS_PRINT_PROP_SERVLET_DEPLOYMENT);
+    }
+
+    private void verifyExpressionsInPermissions(String eeSubsystemConfName, String deployment) throws Exception {
+        final URI sysPropUri = new URI(TestSuiteEnvironment.getHttpUrl() + "/" + deployment + "/" + PrintSystemPropertyServlet.SERVLET_PATH.substring(1));
+        client = mgmtClient.getControllerClient();
+
+        executeOperation(client, Operations.createWriteAttributeOperation(EE_SUBSYSTEM_PATH_ADDRESS.toModelNode(), eeSubsystemConfName, true));
+        deployer.deploy(deployment);
+
+        Utils.makeCall(sysPropUri, HttpServletResponse.SC_OK);
+        deployer.undeploy(deployment);
+
+        executeOperation(client, Operations.createWriteAttributeOperation(EE_SUBSYSTEM_PATH_ADDRESS.toModelNode(), eeSubsystemConfName, false));
+        deployer.deploy(deployment);
+
+        Utils.makeCall(sysPropUri, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        deployer.undeploy(deployment);
+    }
+
+    protected static ModelNode executeOperation(ModelControllerClient client, ModelNode op) throws IOException {
+        final ModelNode result = client.execute(op);
+        Assert.assertTrue(SubsystemOperations.getFailureDescriptionAsString(result), SubsystemOperations.isSuccessfulOutcome(result));
+        return result;
+    }
+
+    static class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+        @Override
+        protected SystemProperty[] getSystemProperties() {
+            return new SystemProperty[] { new DefaultSystemProperty(PROPERTY_NAME, PROPERTY_VALUE) };
+        }
+    }
+}

--- a/testsuite/integration/secman/src/test/resources/propertypermission/permissions.xml
+++ b/testsuite/integration/secman/src/test/resources/propertypermission/permissions.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+             http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+             version="7">
+    <permission>
+        <class-name>${CLASS_NAME}</class-name>
+        <name>${NAME_A}</name>
+        <actions>${ACTION_READ}</actions>
+    </permission>
+    <permission>
+        <class-name>${CLASS_NAME}</class-name>
+        <name>${NAME_B}</name>
+        <actions>${NONEXIST:${ACTION_READ:write}}</actions>
+    </permission>
+    <permission>
+        <class-name>${CLASS_NAME}</class-name>
+        <name>${NAME_C}</name>
+        <actions>${NONEXIST:${NONEXIST:write}}</actions>
+    </permission>
+</permissions>


### PR DESCRIPTION
…ed property replacement for permissions descriptors

wildfly counterpart of https://github.com/wildfly/wildfly-core/pull/4002. It requires a wildfly-core upgrade including that PR to make this to pass.

Jira issue: https://issues.jboss.org/browse/WFLY-11930

