### PR TITLE
WFLY-12759 Extract microprofile-config galleon layer from observability

### DIFF
--- a/galleon-pack/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-config">
+    <dependencies>
+        <layer name="management"/>
+        <layer name="cdi"/>
+    </dependencies>
+    <feature spec="subsystem.microprofile-config-smallrye"/>
+</layer-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
-        <layer name="management"/>
-        <layer name="cdi"/>
+        <layer name="microprofile-config"/>
         <layer name="open-tracing" optional="true"/>
     </dependencies>
     <feature-group name="health"/>
     <feature-group name="metrics"/>
-    <feature spec="subsystem.microprofile-config-smallrye"/>
 </layer-spec>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2034,7 +2034,59 @@
                             </configurations>
                         </configuration>
                     </execution>
-                     <execution>
+                    <execution>
+                        <id>microprofile-config-provisioning</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <install-dir>${layers.install.dir}/microprofile-config</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                            </feature-packs>
+                            <configurations>
+                                <config>
+                                    <model>standalone</model>
+                                    <name>standalone.xml</name>
+                                    <layers>
+                                        <layer>microprofile-config</layer>
+                                    </layers>
+                                </config>
+                            </configurations>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>observability-provisioning</id>
                         <goals>
                             <goal>provision</goal>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12759

Microprofile specs like OpenAPI don't require metrics nor health, suggesting the microprofile layers should be more granular.