### PR TITLE
[WFLY-12691] Upgrade WildFly Core 10.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>10.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>10.0.2.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.16.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12691

---


## Release Notes - WildFly Core - Version 10.0.2.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4709'>WFCORE-4709</a>] -         Upgrade Undertow to 2.0.27.Final
</li>
</ul>
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4683'>WFCORE-4683</a>] -         User with Monitor role can stop the servers in domain mode
</li>
</ul>
                                            