### PR TITLE
WFLY-12761 Upgrade jberet-core from 1.3.4.Final to 1.3.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
         <version.org.infinispan>9.4.16.Final</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>
         <version.org.javassist>3.23.2-GA</version.org.javassist>
-        <version.org.jberet>1.3.4.Final</version.org.jberet>
+        <version.org.jberet>1.3.5.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12761

diff between 1.3.4.Final and 1.3.5.Final:
https://github.com/jberet/jsr352/compare/1.3.4.Final...1.3.5.Final

This issue is the only change in this release:
JBERET-458 getRunningExecutions() should look in cache as fallback