### PR TITLE
WFLY-12768 Extract microprofile-metrics galleon layer from observability

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -119,8 +119,10 @@ Basic layers:
 * _datasources_: Support for datasources.
 * _ee-security_: Support for Jakarta EE Security API
 * _jaxrs_: Support for jaxrs. Depends on _web-server_ (layer defined in the WildFly servlet feature-pack).
-* _jms-activemq_: Support for connections to a remote jms broker. 
+* _jms-activemq_: Support for connections to a remote jms broker.
 * _jpa_: Support for jpa (latest WildFly supported hibernate release).
+* _microprofile-config_: Support for MicroProfile Config.
+* _microprofile-metrics_: Support for MicroProfile Metrics.
 * _observability_: Support for microprofile monitoring and configuration features (config, health, metrics, open-tracing).
 * _open-tracing_: Support for microprofile open-tracing. This layer is an optional dependency of _observability_ layer.
 * _resource-adapters_: Support for deployment of JCA adapters.

--- a/galleon-pack/src/main/resources/feature_groups/metrics.xml
+++ b/galleon-pack/src/main/resources/feature_groups/metrics.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="metrics" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.microprofile-metrics-smallrye">
-      <param name="security-enabled" value="false"/>
-      <param name="exposed-subsystems" value="[*]" />
-      <param name="prefix" value="${wildfly.metrics.prefix:wildfly}" />
+        <param name="security-enabled" value="false"/>
+        <param name="exposed-subsystems" value="[*]"/>
+        <param name="prefix" value="${wildfly.metrics.prefix:wildfly}"/>
     </feature>
 </feature-group-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/microprofile-metrics/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/microprofile-metrics/layer-spec.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2019, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-metrics">
+    <dependencies>
+        <layer name="microprofile-config"/>
+    </dependencies>
+    <feature-group name="metrics"/>
+</layer-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -2,8 +2,8 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
         <layer name="microprofile-config"/>
+        <layer name="microprofile-metrics"/>
         <layer name="open-tracing" optional="true"/>
     </dependencies>
     <feature-group name="health"/>
-    <feature-group name="metrics"/>
 </layer-spec>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2087,6 +2087,58 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>microprofile-metrics-provisioning</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <install-dir>${layers.install.dir}/microprofile-metrics</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>org.wildfly.core</groupId>
+                                    <artifactId>wildfly-core-galleon-pack</artifactId>
+                                    <version>${version.org.wildfly.core}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <transitive>true</transitive>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-servlet-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                                <feature-pack>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>wildfly-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                            </feature-packs>
+                            <configurations>
+                                <config>
+                                    <model>standalone</model>
+                                    <name>standalone.xml</name>
+                                    <layers>
+                                        <layer>microprofile-metrics</layer>
+                                    </layers>
+                                </config>
+                            </configurations>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>observability-provisioning</id>
                         <goals>
                             <goal>provision</goal>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-12768

Not everyone who requires metrics also requires health; e.g. the fault tolerance unfortunately (atm) requires config and metrics, but not health.

