### PR TITLE
WFLY-12777 Stateful bean with @StatefulTimeout value -1 should not ti…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderServiceConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderServiceConfigurator.java
@@ -134,8 +134,13 @@ public class DistributableCacheFactoryBuilderServiceConfigurator<K, V extends Id
             @Override
             public Duration getTimeout() {
                 StatefulTimeoutInfo info = description.getStatefulTimeout();
+
+                // A value of -1 means the bean will never be removed due to timeout
+                if (info == null || info.getValue() < 0) {
+                    return null;
+                }
                 // TODO Once based on JDK9+, change to Duration.of(this.info.getValue(), this.info.getTimeUnit().toChronoUnit())
-                return (info != null) ? Duration.ofMillis(TimeUnit.MILLISECONDS.convert(info.getValue(), info.getTimeUnit())) : null;
+                return Duration.ofMillis(TimeUnit.MILLISECONDS.convert(info.getValue(), info.getTimeUnit()));
             }
         };
         CapabilityServiceConfigurator configurator = this.builder.getBeanManagerFactoryServiceConfigurator(context);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
@@ -65,7 +65,7 @@ public class SimpleCache<K, V extends Identifiable<K>> implements Cache<K, V>, P
         this.identifierFactory = identifierFactory;
 
         // A value of -1 means the bean will never be removed due to timeout
-        if (timeout == null || timeout.getValue() == -1) {
+        if (timeout == null || timeout.getValue() < 0) {
             this.timeout = null;
         } else {
             this.timeout = Duration.ofMillis(TimeUnit.MILLISECONDS.convert(timeout.getValue(), timeout.getTimeUnit()));

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
@@ -63,7 +63,14 @@ public class SimpleCache<K, V extends Identifiable<K>> implements Cache<K, V>, P
     public SimpleCache(StatefulObjectFactory<V> factory, IdentifierFactory<K> identifierFactory, StatefulTimeoutInfo timeout, ServerEnvironment environment) {
         this.factory = factory;
         this.identifierFactory = identifierFactory;
-        this.timeout = (timeout != null) ? Duration.ofMillis(TimeUnit.MILLISECONDS.convert(timeout.getValue(), timeout.getTimeUnit())) : null;
+
+        // A value of -1 means the bean will never be removed due to timeout
+        if (timeout == null || timeout.getValue() == -1) {
+            this.timeout = null;
+        } else {
+            this.timeout = Duration.ofMillis(TimeUnit.MILLISECONDS.convert(timeout.getValue(), timeout.getTimeUnit()));
+        }
+
         this.environment = environment;
     }
 


### PR DESCRIPTION
…meout or removed

Fixed `org.jboss.as.ejb3.cache.simple.SimpleCache` class to properly handle stateful-timeout value -1 (never timeout).

JIRA: https://issues.jboss.org/browse/WFLY-12777