### PR TITLE
[WFLY-12492] Upgrade Jastow to 2.0.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <version.io.smallrye.smallrye-health>2.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-metrics>2.1.5</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
-        <version.io.undertow.jastow>2.0.7.Final</version.io.undertow.jastow>
+        <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-12492
EAP 7.2.z Jira: https://issues.jboss.org/browse/JBEAP-17541
EAP 7.3.z Jira: https://issues.jboss.org/browse/JBEAP-17542

Diff between Jastow 2.0.7 and 2.0.8.Final: https://github.com/undertow-io/jastow/compare/2.0.7.Final...2.0.8.Final
The release 2.0.8.Final includes fix for https://issues.jboss.org/browse/UNDERTOW-1589