### PR TITLE
[WFLY-12789] Upgrade WildFly HTTP Client to 1.0.18.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,7 @@
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>11.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.0.17.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.8.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.18</version.org.yaml.snakeyaml>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-12789

Release Notes:
     Release Notes - WildFly EJB HTTP Client - Version 1.0.18.Final
                                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WEJBHTTP-29'>WEJBHTTP-29</a>] -         WildFlyClientInputStream hangs on close
</li>
</ul>
                                            