### PR TITLE
WFLY-12805 Add missing dependency

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/transactions/main/module.xml
@@ -39,6 +39,7 @@
         <module name="org.jboss.as.weld.common" />
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
+        <module name="org.jboss.as.naming"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.transaction.client"/>
         <module name="javax.transaction.api"/>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFLY-12805

Add missing dependency for weld transaction.

@manovotn Please review.