### PR TITLE
[WFLY-12819] Upgrade WildFly Core 11.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12819

---


## Release Notes - WildFly Core - Version 11.0.0.Beta3
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4295'>WFCORE-4295</a>] -         Upgrade jboss-vfs to 3.2.15.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4711'>WFCORE-4711</a>] -         Upgrade XNIO to 3.7.7.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4738'>WFCORE-4738</a>] -         Upgrade Galleon from 4.0.4.Final to 4.1.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4741'>WFCORE-4741</a>] -         Upgrade Undertow to 2.0.28.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4751'>WFCORE-4751</a>] -         Upgrade WildFly Elytron to 1.11.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4752'>WFCORE-4752</a>] -         Upgrade Elytron Web to 1.7.0.CR2
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4753'>WFCORE-4753</a>] -         Upgrade JBoss Modules from 1.9.1.Final to 1.9.2.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4756'>WFCORE-4756</a>] -         Upgrade jboss-logging-tools from 2.2.0.Final to 2.2.1.Final
</li>
</ul>
                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4475'>WFCORE-4475</a>] -         jboss-deployment-structure.xml with fails to parse when annotations=true on a sub-deployment module
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4596'>WFCORE-4596</a>] -         Write lock is acquired reading patching resource using include-runtime
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4733'>WFCORE-4733</a>] -         Server stops after switching from &#39;local&#39; DC to &#39;remote&#39; DC
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4745'>WFCORE-4745</a>] -         Fix logging test suite to work in all environments
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4626'>WFCORE-4626</a>] -         Expose ExternalModuleService as WildFly capability
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4744'>WFCORE-4744</a>] -         Undertow DUPs use ad hoc phase priorities
</li>
</ul>
                                    