### PR TITLE
WFLY-12814 PreDestroy method not called by stateful beans with timeout 0

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
@@ -147,8 +147,13 @@ public class SimpleCache<K, V extends Identifiable<K>> implements Cache<K, V>, P
         Entry<V> entry = this.entries.get(id);
         if ((entry != null) && entry.done()) {
             if (this.timeout != null) {
-                // The EJB specification allows a 0 timeout, which means the bean is immediately eligible for removal.
-                this.scheduler.schedule(id, this.timeout.isZero() ? Instant.now() : Instant.now().plus(this.timeout));
+                if (!this.timeout.isZero()) {
+                    this.scheduler.schedule(id, Instant.now().plus(this.timeout));
+                } else {
+                    // The EJB specification allows a 0 timeout, which means the bean is immediately eligible for removal.
+                    // However, removing it directly is faster than scheduling it for immediate removal.
+                    remove(id);
+                }
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
@@ -147,13 +147,8 @@ public class SimpleCache<K, V extends Identifiable<K>> implements Cache<K, V>, P
         Entry<V> entry = this.entries.get(id);
         if ((entry != null) && entry.done()) {
             if (this.timeout != null) {
-                if (!this.timeout.isZero()) {
-                    this.scheduler.schedule(id, Instant.now().plus(this.timeout));
-                } else {
-                    // The EJB specification allows a 0 timeout, which means the bean is immediately eligible for removal.
-                    // However, removing it directly is faster than scheduling it for immediate removal.
-                    remove(id);
-                }
+                // The EJB specification allows a 0 timeout, which means the bean is immediately eligible for removal.
+                this.scheduler.schedule(id, this.timeout.isZero() ? Instant.now() : Instant.now().plus(this.timeout));
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptor.java
@@ -205,12 +205,14 @@ public class StatefulSessionSynchronizationInterceptor extends AbstractEJBInterc
      */
     static void releaseInstance(final StatefulSessionComponentInstance instance, boolean toDiscard) {
         try {
+            // calling setSynchronizationRegistered(false) before releasing the instance from cache,
+            // so that the instance can be destroyed in StatefulSessionComponent.destroyInstance(...)
+            instance.setSynchronizationRegistered(false);
             if (!instance.isDiscarded() && !toDiscard) {
                 // mark the SFSB instance as no longer in use
                 instance.getComponent().getCache().release(instance);
             }
         } finally {
-            instance.setSynchronizationRegistered(false);
             // release the lock on the SFSB instance
             releaseLock(instance);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/Annotated0TimeoutBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/Annotated0TimeoutBean.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.stateful.timeout;
+
+import javax.annotation.PreDestroy;
+import javax.ejb.Stateful;
+import javax.ejb.StatefulTimeout;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * stateful session bean with timeout value 0.
+ */
+@Stateful
+@StatefulTimeout(value = 0, unit = TimeUnit.MILLISECONDS)
+public class Annotated0TimeoutBean {
+
+    public static volatile boolean preDestroy = false;
+
+    @PreDestroy
+    public void preDestroy() {
+        preDestroy = true;
+    }
+
+    public void doStuff() {
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
@@ -162,4 +162,21 @@ public class StatefulTimeoutTestCase {
             userTransaction.commit();
         }
     }
+
+    /**
+     * Verifies that a stateful bean with timeout value 0 is eligible fore removal immediately, and its
+     * preDestroy method is invoked.
+     */
+    @Test
+    public void testStatefulTimeout0() throws Exception {
+        Annotated0TimeoutBean timeout0 = lookup(Annotated0TimeoutBean.class);
+        timeout0.doStuff();
+        Thread.sleep(2000);
+        try {
+            timeout0.doStuff();
+            throw new RuntimeException("Expecting NoSuchEJBException");
+        } catch (NoSuchEJBException expected) {
+        }
+        Assert.assertTrue(Annotated0TimeoutBean.preDestroy);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/timeout/StatefulTimeoutTestCase.java
@@ -164,14 +164,13 @@ public class StatefulTimeoutTestCase {
     }
 
     /**
-     * Verifies that a stateful bean with timeout value 0 is eligible fore removal immediately, and its
+     * Verifies that a stateful bean with timeout value 0 is eligible for removal immediately, and its
      * preDestroy method is invoked.
      */
     @Test
     public void testStatefulTimeout0() throws Exception {
         Annotated0TimeoutBean timeout0 = lookup(Annotated0TimeoutBean.class);
         timeout0.doStuff();
-        Thread.sleep(2000);
         try {
             timeout0.doStuff();
             throw new RuntimeException("Expecting NoSuchEJBException");


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12814