### PR TITLE
[WFLY-12811] Fix injection of MP Config in HealthCheck bean

### DIFF
--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/CDIExtension.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/CDIExtension.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.microprofile.health.deployment;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import javax.enterprise.event.Observes;
@@ -40,6 +41,7 @@ import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
+import org.jboss.modules.ModuleClassLoader;
 import org.wildfly.extension.microprofile.health.HealthReporter;
 
 /**
@@ -48,6 +50,7 @@ import org.wildfly.extension.microprofile.health.HealthReporter;
 public class CDIExtension implements Extension {
 
     private final HealthReporter reporter;
+    private ModuleClassLoader moduleClassLoader;
 
     static final class HealthLiteral extends AnnotationLiteral<Health> implements Health {
 
@@ -78,8 +81,9 @@ public class CDIExtension implements Extension {
     private final List<HealthCheck> readinessChecks = new ArrayList<>();
 
 
-    public CDIExtension(HealthReporter healthReporter) {
+    public CDIExtension(HealthReporter healthReporter, ModuleClassLoader moduleClassLoader) {
         this.reporter = healthReporter;
+        this.moduleClassLoader = moduleClassLoader;
     }
 
     /**
@@ -95,9 +99,9 @@ public class CDIExtension implements Extension {
     }
 
     private void addHealthChecks(AnnotationLiteral qualifier,
-                                 Consumer<HealthCheck> healthFunction, List<HealthCheck> healthChecks) {
+                                 BiConsumer<HealthCheck, ClassLoader> healthFunction, List<HealthCheck> healthChecks) {
         for (HealthCheck healthCheck : instance.select(HealthCheck.class, qualifier)) {
-            healthFunction.accept(healthCheck);
+            healthFunction.accept(healthCheck, moduleClassLoader);
             healthChecks.add(healthCheck);
         }
     }

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.weld.WeldCapability;
+import org.jboss.modules.Module;
 import org.wildfly.extension.microprofile.health.HealthReporter;
 import org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition;
 import org.wildfly.extension.microprofile.health._private.MicroProfileHealthLogger;
@@ -42,6 +43,7 @@ public class DeploymentProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        Module module = deploymentUnit.getAttachment(Attachments.MODULE);
 
         final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
 
@@ -57,7 +59,7 @@ public class DeploymentProcessor implements DeploymentUnitProcessor {
         if (weldCapability.isPartOfWeldDeployment(deploymentUnit)) {
             final HealthReporter healthReporter = (HealthReporter) phaseContext.getServiceRegistry().getService(MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_SERVICE).getValue();
 
-            weldCapability.registerExtensionInstance(new CDIExtension(healthReporter), deploymentUnit);
+            weldCapability.registerExtensionInstance(new CDIExtension(healthReporter, module.getClassLoader()), deploymentUnit);
         }
 
     }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/HealthConfigSource.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/HealthConfigSource.java
@@ -1,0 +1,31 @@
+package org.wildfly.test.integration.microprofile.health;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+public class HealthConfigSource implements ConfigSource {
+
+    private final HashMap<String, String> props;
+
+    public HealthConfigSource() {
+        props = new HashMap<>();
+        props.put("org.wildfly.test.integration.microprofile.health.MyProbe.propertyConfiguredByTheDeployment", Boolean.TRUE.toString());
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return props;
+    }
+
+    @Override
+    public String getValue(String propertyName) {
+        return props.get(propertyName);
+    }
+
+    @Override
+    public String getName() {
+        return "ConfigSource local to the deployment";
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthTestBase.java
@@ -36,6 +36,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -64,7 +65,8 @@ public abstract class MicroProfileHealthTestBase {
     @Deployment(name = "MicroProfileHealthTestCase", managed = false)
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthTestCase.war")
-                .addClasses(TestApplication.class, TestApplication.Resource.class, MyProbe.class, MyLiveProbe.class)
+                .addClasses(TestApplication.class, TestApplication.Resource.class, MyProbe.class, MyLiveProbe.class, HealthConfigSource.class)
+                .addAsServiceProvider(ConfigSource.class, HealthConfigSource.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MyProbe.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MyProbe.java
@@ -22,6 +22,10 @@
 
 package org.wildfly.test.integration.microprofile.health;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.health.Health;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
@@ -33,10 +37,24 @@ import org.eclipse.microprofile.health.Liveness;
 @Health
 public class MyProbe implements HealthCheck {
 
+    // Inject a property whose value is configured in a ConfigSource
+    // inside the deployment to check that MP Config properly injects properties
+    // when HealthChecks are called in WildFly management endpoints.
+    @Inject
+    @ConfigProperty
+    Provider<Boolean> propertyConfiguredByTheDeployment;
+
     static boolean up = true;
 
     @Override
     public HealthCheckResponse call() {
+
+        if (!propertyConfiguredByTheDeployment.get()) {
+            return HealthCheckResponse.named("myProbe")
+                    .down()
+                    .build();
+        }
+
         return HealthCheckResponse.named("myProbe")
                 .state(up)
                 .build();


### PR DESCRIPTION
* When HealthChecks are called from WildFly management endpoints for
  health, set the TCCL to the deployment's classloader so that resources that
  depend on it (such as MicroProfile Config) can be properly loaded.
* Add a ConfigProperty to MicroProfileHealthTestBase test whose value
  is only set in a ConfigSource inside the deployment to ensure that if
  the TCCL was not correct, the property would not be found and the test
  would fail.

JIRA: https://issues.jboss.org/browse/WFLY-12811
