### PR TITLE
[WFLY-12661] Add tests and documentation for adding the ability to make use of the IP address of a remote client when making authorization decisions

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Elytron_Subsystem.adoc
@@ -297,6 +297,13 @@ always returns the same constant.
 
 |simple-role-decoder |Definition of a simple RoleDecoder that takes a
 single attribute and maps it directly to roles.
+
+|source-address-role-decoder |Definition of a RoleDecoder that maps roles
+based on the IP address of the remote client.
+
+|aggregate-role-decoder |A role decoder that is an aggregation of other
+role decoders. An aggregate role decoder combines the roles obtained using
+each role decoder.
 |=======================================================================
 
 [[role-mappers]]
@@ -528,6 +535,7 @@ and openssl provider loaders.
             "openssl"
         ]}},
         "aggregate-realm" => undefined,
+        "aggregate-role-decoder" => undefined,
         "aggregate-role-mapper" => undefined,
         "aggregate-sasl-server-factory" => undefined,
         "aggregate-security-event-listener" => undefined,
@@ -769,6 +777,7 @@ and openssl provider loaders.
         "simple-regex-realm-mapper" => undefined,
         "simple-role-decoder" => {"groups-to-roles" => {"attribute" => "groups"}},
         "size-rotating-file-audit-log" => undefined,
+        "source-address-role-decoder" => undefined,
         "syslog-audit-log" => undefined,
         "token-realm" => undefined,
         "trust-manager" => undefined,

--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -2522,13 +2522,91 @@ sections.
 A role decoder converts attributes from the identity provided by the
 security realm into roles. Role decoders are also specifically typed
 based on their functionality, for example _empty-role-decoder_,
-_simple-role-decoder_, and _custom-role-decoder_.
+_simple-role-decoder_, _custom-role-decoder_, and _aggregate-role-decoder_.
 
 Adding a role decoder takes the general form:
 
 [source,options="nowrap"]
 ----
 /subsystem=elytron/ROLE-DECODER-TYPE=roleDeoderName:add(....)
+----
+
+==== Create an Elytron Role Decoder that makes use of the IP Address of the Remote Client
+
+A role decoder that is configured on a security realm assigns roles to
+an identity based on attributes provided by the security realm. It is
+also possible to configure a role decoder that makes use of the IP
+address of the remote client when determining the roles associated
+with an identity. As an example, we might want to make use of the IP
+address of the remote client in order to assign a user a particular
+role when establishing a connection to the server from a corporate
+network and a different role when establishing a connection to the
+server from a different network.
+
+Adding a role decoder that makes use of the remote client's IP
+address takes the general form:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/source-address-role-decoder=roleDecoderName:add(source-address="...", pattern="...", roles=[...])
+----
+
+In particular, a _source-address-role-decoder_ has the following attributes:
+
+* _source-address_ - The IP address of the remote client.
+
+* _pattern_ - A regular expression that specifies the IP address to match.
+
+* _roles_ - The list of roles to assign if the source IP address matches the given address.
+
+Only one of _source-address_ and _pattern_ should be specified.
+
+For example, the following _source-address-role-decoder_ could be configured to specify
+that a user should be assigned the "Administrator" role when establishing a connection
+to the server from the 10.10.10.10 IP address:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/source-address-role-decoder=decoder1:add(source-address="10.10.10.10", roles=["Administrator"])
+----
+
+Once a _source-address-role-decoder_ has been configured, it can be referenced from a _security-domain_:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/security-domain=exampleSD:add(..., role-decoder=decoder1)
+----
+
+It is also possible to assign permissions to an identity based on its roles using a
+link:Using_the_Elytron_Subsystem{outfilesuffix}#create-an-elytron-permission-mapper[simple permission mapper].
+
+Example configuration:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/source-address-role-decoder=decoder1:add(source-address="10.10.10.10", roles=["Administrator"])
+/subsystem=elytron/simple-permission-mapper=ipPermissionMapper:add(permission-mappings=[{roles=["Administrator"], permission-sets=[{permission-set=login-permission}]}])
+/subsystem=elytron/security-domain=exampleSD:add(..., role-decoder=decoder1, permission-mapper=ipPermissionMapper)
+----
+
+The above example configures a security domain with a source address role decoder that
+will assign the "Administrator" role when the IP address of the remote client matches
+the configured address and a simple permission mapper that only assigns the
+"LoginPermission" if the identity has the "Administrator" role. Thus, authentication
+will succeed if the IP address of the remote client matches the configured address.
+
+It is also possible to configure an _aggregate-role-decoder_. This consists of
+two or more _role-decoder_ elements where each element is a reference to a configured
+role decoder. Each role decoder will be applied and the returned value will be a union of
+the roles returned by each decoder.
+
+Example configuration:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/source-address-role-decoder=decoder1:add(source-address="10.10.10.10", roles=["Administrator"])
+/subsystem=elytron/source-address-role-decoder=decoder2:add(source-address="12.12.12.12", roles=["Users"])
+/subsystem=elytron/aggregate-role-decoder=aggregateDecoder:add(role-decoders=[decoder1, decoder2])
 ----
 
 [[create-an-elytron-permission-set]]

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationWithSourceAddressRoleDecoderMatchTestCase.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.ejb.client.RequestSendFailedException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ServletElytronDomainSetup;
+
+/**
+ * Test authentication with the use of a source address role decoder where the IP address of the remote
+ * client matches the address configured on the decoder.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMatchTestCase.ElytronDomainSetupOverride.class, EjbElytronDomainSetup.class, ServletElytronDomainSetup.class })
+@Category(CommonCriteria.class)
+public class AuthenticationWithSourceAddressRoleDecoderMatchTestCase {
+
+    private static final String APPLICATION_NAME = "authentication-with-source-address-role-decoder";
+
+    @ArquillianResource
+    private ManagementClient mgmtClient;
+
+    @Deployment
+    public static JavaArchive createDeployment() throws IOException {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, APPLICATION_NAME + ".jar");
+        jar.addClasses(SecurityInformation.class, SecuredBean.class);
+        return jar;
+    }
+
+    /*
+     The EJB being used in this test class is secured using the "elytron-tests" security domain. This security
+     domain is configured with:
+      1) a source-address-role-decoder that assigns the "admin" role if the IP address of the remote client is TestSuiteEnvironment.getServerAddress()
+      2) a permission-mapper that assigns the "LoginPermission" if the identity has the "admin" role unless the principal
+         is "user2"
+     */
+
+    private static String getIPAddress() throws IllegalStateException {
+        try {
+            return InetAddress.getByName(TestSuiteEnvironment.getServerAddress()).getHostAddress();
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    public void testAuthenticationIPAddressAndPermissionMapperMatch() throws Exception {
+        Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user1", "password1");
+        SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        assertEquals("user1", targetBean.getPrincipalName());
+
+        ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "admin", "admin");
+        targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        assertEquals("admin", targetBean.getPrincipalName());
+    }
+
+    @Test
+    public void testAuthenticationIPAddressMatchAndPermissionMapperMismatch() throws Exception {
+        final Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user2", "password2");
+        final SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+    }
+
+    @Test
+    public void testAuthenticationInvalidCredentials() throws Exception {
+        Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user1", "badpassword");
+        SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+
+        ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user2", "badpassword");
+        targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+    }
+
+
+    private static Properties createEjbClientConfiguration(String hostName, String user, String password) {
+        final Properties pr = new Properties();
+        pr.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        pr.put("remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS", "JBOSS-LOCAL-USER");
+        pr.put("remote.connections", "default");
+        pr.put("remote.connection.default.host", hostName);
+        pr.put("remote.connection.default.port", "8080");
+        pr.put("remote.connection.default.username", user);
+        pr.put("remote.connection.default.password", password);
+        return pr;
+    }
+
+    private static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface, Properties ejbProperties) throws Exception {
+        final Properties jndiProperties = new Properties();
+        jndiProperties.putAll(ejbProperties);
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"
+                + remoteInterface.getName());
+    }
+
+    static class ElytronDomainSetupOverride extends ElytronDomainSetup {
+        public ElytronDomainSetupOverride() {
+            super(new File(AuthenticationWithSourceAddressRoleDecoderMatchTestCase.class.getResource("users.properties").getFile()).getAbsolutePath(),
+                    new File(AuthenticationWithSourceAddressRoleDecoderMatchTestCase.class.getResource("roles.properties").getFile()).getAbsolutePath(),
+                    "elytron-tests",
+                    "ipPermissionMapper",
+                    getIPAddress());
+        }
+    }
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.java
@@ -1,0 +1,159 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.ejb.client.RequestSendFailedException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.elytron.EjbElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ElytronDomainSetup;
+import org.wildfly.test.security.common.elytron.ServletElytronDomainSetup;
+
+/**
+ * Test authentication with the use of a source address role decoder where the IP address of the remote
+ * client does not match the address configured on the decoder.
+ *
+ * @author <a href="mailto:fjuma@redhat.com">Farah Juma</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.ElytronDomainSetupOverride.class, EjbElytronDomainSetup.class, ServletElytronDomainSetup.class })
+@Category(CommonCriteria.class)
+public class AuthenticationWithSourceAddressRoleDecoderMismatchTestCase {
+
+    private static final String APPLICATION_NAME = "authentication-with-source-address-role-decoder";
+
+    @ArquillianResource
+    private ManagementClient mgmtClient;
+
+    @Deployment
+    public static JavaArchive createDeployment() throws IOException {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, APPLICATION_NAME + ".jar");
+        jar.addClasses(SecurityInformation.class, SecuredBean.class);
+        return jar;
+    }
+
+    /*
+     The EJB being used in this test class is secured using the "elytron-tests" security domain. This security
+     domain is configured with:
+      1) a source-address-role-decoder that assigns the "admin" role if the IP address of the remote client is 999.999.999.999
+      2) a permission-mapper that assigns the "LoginPermission" if the identity has the "admin" role unless the principal
+         is "user2"
+     */
+
+    @Test
+    public void testAuthenticationIPAddressMismatch() throws Exception {
+        Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user1", "password1");
+        SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+
+        ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user2", "password2");
+        targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+    }
+
+    @Test
+    public void testAuthenticationIPAddressMismatchWithSecurityRealmRole() throws Exception {
+        final Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "admin", "admin");
+        final SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        Assert.assertEquals("admin", targetBean.getPrincipalName());
+    }
+
+    @Test
+    public void testAuthenticationInvalidCredentials() throws Exception {
+        Properties ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user1", "badpassword");
+        SecurityInformation targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+
+        ejbClientConfiguration = createEjbClientConfiguration(Utils.getHost(mgmtClient), "user2", "badpassword");
+        targetBean = lookupEJB(SecuredBean.class, SecurityInformation.class, ejbClientConfiguration);
+        try {
+            targetBean.getPrincipalName();
+            Assert.fail("Expected RequestSendFailedException not thrown");
+        } catch (RequestSendFailedException expected) {
+        }
+    }
+
+    private static Properties createEjbClientConfiguration(String hostName, String user, String password) {
+        final Properties pr = new Properties();
+        pr.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        pr.put("remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS", "JBOSS-LOCAL-USER");
+        pr.put("remote.connections", "default");
+        pr.put("remote.connection.default.host", hostName);
+        pr.put("remote.connection.default.port", "8080");
+        pr.put("remote.connection.default.username", user);
+        pr.put("remote.connection.default.password", password);
+        return pr;
+    }
+
+    private static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface, Properties ejbProperties) throws Exception {
+        final Properties jndiProperties = new Properties();
+        jndiProperties.putAll(ejbProperties);
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"
+                + remoteInterface.getName());
+    }
+
+    static class ElytronDomainSetupOverride extends ElytronDomainSetup {
+        public ElytronDomainSetupOverride() {
+            super(new File(AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.class.getResource("users.properties").getFile()).getAbsolutePath(),
+                    new File(AuthenticationWithSourceAddressRoleDecoderMismatchTestCase.class.getResource("roles.properties").getFile()).getAbsolutePath(),
+                    "elytron-tests",
+                    "ipPermissionMapper",
+                    "999.999.999.999");
+        }
+    }
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/SecuredBean.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/SecuredBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb;
+
+import javax.annotation.Resource;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.EJBContext;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * Simple EJB to return information about the current Principal.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@Stateless
+@Remote(SecurityInformation.class)
+@SecurityDomain("elytron-tests")
+@RolesAllowed("Users")
+public class SecuredBean implements SecurityInformation {
+
+    @Resource
+    private EJBContext context;
+
+    @Override
+    public String getPrincipalName() {
+        return context.getCallerPrincipal().getName();
+    }
+
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/SecurityInformation.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/SecurityInformation.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.ejb;
+
+public interface SecurityInformation {
+
+    String getPrincipalName();
+
+}
+

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/roles.properties
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/ejb/roles.properties
@@ -1,4 +1,4 @@
 user1=Users,Role1
 user2=Users,Role2
-admin=Admin
+admin=Users,Admin
 hr=HR

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/IntermediateWhoAmI.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/IntermediateWhoAmI.java
@@ -16,4 +16,8 @@ public class IntermediateWhoAmI implements WhoAmI {
         return whoAmIBean.whoAmI();
     }
 
+    public String whoAmIRestricted() {
+        return whoAmIBean.whoAmIRestricted();
+    }
+
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ServerWhoAmI.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ServerWhoAmI.java
@@ -4,6 +4,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 
 import javax.annotation.Resource;
 import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateless;
 
@@ -19,6 +20,11 @@ public class ServerWhoAmI implements WhoAmI {
     private SessionContext ctx;
 
     public String whoAmI() {
+        return ctx.getCallerPrincipal().getName();
+    }
+
+    @RolesAllowed("admin")
+    public String whoAmIRestricted() {
         return ctx.getCallerPrincipal().getName();
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/WhoAmI.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/WhoAmI.java
@@ -10,4 +10,6 @@ public interface WhoAmI {
 
     String whoAmI();
 
+    String whoAmIRestricted();
+
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/roles.properties
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/roles.properties
@@ -1,2 +1,4 @@
 ejbRemoteTests=testRole
 ejbRemoteTestsOverriding=testRole
+alice=employee
+bob=admin

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/users.properties
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/users.properties
@@ -1,3 +1,5 @@
 #$REALM_NAME=ejb-outbound-remoting-tests$
 ejbRemoteTests=ejbRemoteTestsPassword
 ejbRemoteTestsOverriding=ejbRemoteTestsPasswordOverriding
+alice=password1
+bob=password2

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ElytronDomainSetup.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/ElytronDomainSetup.java
@@ -45,23 +45,36 @@ import org.wildfly.extension.elytron.ElytronExtension;
 public class ElytronDomainSetup implements ServerSetupTask {
 
     private static final String DEFAULT_SECURITY_DOMAIN_NAME = "elytron-tests";
+    private static final String DEFAULT_PERMISSION_MAPPER_NAME = "default-permission-mapper";
 
     private PathAddress realmAddress;
 
     private PathAddress domainAddress;
+    private PathAddress permissionMapperAddress;
+    private PathAddress roleDecoder1Address;
+    private PathAddress roleDecoder2Address;
+    private PathAddress aggregateRoleDecoderAddress;
 
     private final String usersFile;
     private final String groupsFile;
     private final String securityDomainName;
+    private final String permissionMapperName;
+    private final String ipAddress;
 
     public ElytronDomainSetup(final String usersFile, final String groupsFile) {
-        this(usersFile, groupsFile, DEFAULT_SECURITY_DOMAIN_NAME);
+        this(usersFile, groupsFile, DEFAULT_SECURITY_DOMAIN_NAME, DEFAULT_PERMISSION_MAPPER_NAME, null);
     }
 
-    public ElytronDomainSetup(final String usersFile, final String groupsFile, final String securityDomainName) {
+    public ElytronDomainSetup(final String usersFile, final String groupsFile, String securityDomainName) {
+        this(usersFile, groupsFile, securityDomainName, DEFAULT_PERMISSION_MAPPER_NAME, null);
+    }
+
+    public ElytronDomainSetup(final String usersFile, final String groupsFile, final String securityDomainName, final String permissionMapperName, final String ipAddress) {
         this.usersFile = usersFile;
         this.groupsFile = groupsFile;
         this.securityDomainName = securityDomainName;
+        this.permissionMapperName = permissionMapperName;
+        this.ipAddress = ipAddress;
     }
 
     protected String getSecurityDomainName() {
@@ -100,6 +113,10 @@ public class ElytronDomainSetup implements ServerSetupTask {
         return groupsFile;
     }
 
+    protected String getPermissionMapperName() {
+        return permissionMapperName;
+    }
+
     protected boolean isUsersFilePlain() {
         return true;
     }
@@ -126,10 +143,62 @@ public class ElytronDomainSetup implements ServerSetupTask {
         addRealm.get("users-properties").get("plain-text").set(isUsersFilePlain()); // not hashed
         addRealm.get("groups-properties").get("path").set(getGroupsFile());
         steps.add(addRealm);
+        if (! permissionMapperName.equals(DEFAULT_PERMISSION_MAPPER_NAME)) {
+            permissionMapperAddress = PathAddress.pathAddress()
+                    .append(SUBSYSTEM, ElytronExtension.SUBSYSTEM_NAME)
+                    .append("simple-permission-mapper", permissionMapperName);
+
+            // /subsystem=elytron/simple-permission-mapper=ipPermissionMapper:add(permission-mappings=[{roles=[admin],
+            // permission-sets=[{permission-set=login-permission}]}, {principals=[user2],permission-sets=[]}], mapping-mode="and")
+            // (ensure that user1 is assigned the admin role if the IP address of the remote client matches the configured
+            //  address and ensure user2 is not assigned the admin role even if the IP address of the remote client matches)
+            ModelNode addPermissionMapper = Util.createAddOperation(permissionMapperAddress);
+            ModelNode permissionMapping1 = new ModelNode();
+            permissionMapping1.get("roles").add("Admin");
+            ModelNode permissionSet = new ModelNode();
+            permissionSet.get("permission-set").set("login-permission");
+            permissionMapping1.get("permission-sets").add(permissionSet);
+            addPermissionMapper.get("permission-mappings").add(permissionMapping1);
+            ModelNode permissionMapping2 = new ModelNode();
+            permissionMapping2.get("principals").add("user2");
+            addPermissionMapper.get("permission-mappings").add(permissionMapping2);
+            addPermissionMapper.get("mapping-mode").set("and");
+            steps.add(addPermissionMapper);
+
+            // /subsystem=elytron/source-address-role-decoder=decoder1:add(source-address=IP_ADDRESS, roles=["Admin"])
+            roleDecoder1Address = PathAddress.pathAddress()
+                    .append(SUBSYSTEM, ElytronExtension.SUBSYSTEM_NAME)
+                    .append("source-address-role-decoder", "decoder1");
+            ModelNode addRoleDecoder1 = Util.createAddOperation(roleDecoder1Address);
+            addRoleDecoder1.get("source-address").set(ipAddress);
+            addRoleDecoder1.get("roles").add("Admin");
+            steps.add(addRoleDecoder1);
+
+            // /subsystem=elytron/source-address-role-decoder=decoder2:add(source-address="99.99.99.99", roles=["Employee"])
+            roleDecoder2Address = PathAddress.pathAddress()
+                    .append(SUBSYSTEM, ElytronExtension.SUBSYSTEM_NAME)
+                    .append("source-address-role-decoder", "decoder2");
+            ModelNode addRoleDecoder2 = Util.createAddOperation(roleDecoder2Address);
+            addRoleDecoder2.get("source-address").set("99.99.99.99");
+            addRoleDecoder2.get("roles").add("Employee");
+            steps.add(addRoleDecoder2);
+
+            // /subsystem=elytron/aggregate-role-decoder=aggregateDecoder:add(role-decoders=[decoder1, decoder2])
+            aggregateRoleDecoderAddress = PathAddress.pathAddress()
+                    .append(SUBSYSTEM, ElytronExtension.SUBSYSTEM_NAME)
+                    .append("aggregate-role-decoder", "aggregateRoleDecoder");
+            ModelNode addAggregateRoleDecoder = Util.createAddOperation(aggregateRoleDecoderAddress);
+            addAggregateRoleDecoder.get("role-decoders").add("decoder1");
+            addAggregateRoleDecoder.get("role-decoders").add("decoder2");
+            steps.add(addAggregateRoleDecoder);
+        }
 
         // /subsystem=elytron/security-domain=EjbDomain:add(default-realm=UsersRoles, realms=[{realm=UsersRoles}])
         ModelNode addDomain = Util.createAddOperation(domainAddress);
-        addDomain.get("permission-mapper").set("default-permission-mapper"); // LoginPermission for everyone (defined in standalone-elytron.xml)
+        addDomain.get("permission-mapper").set(permissionMapperName);
+        if (! permissionMapperName.equals(DEFAULT_PERMISSION_MAPPER_NAME)) {
+            addDomain.get("role-decoder").set("aggregateRoleDecoder");
+        }
         addDomain.get("default-realm").set(getSecurityRealmName());
         addDomain.get("realms").get(0).get("realm").set(getSecurityRealmName());
         addDomain.get("realms").get(0).get("role-decoder").set("groups-to-roles"); // use attribute "groups" as roles (defined in standalone-elytron.xml)
@@ -143,6 +212,12 @@ public class ElytronDomainSetup implements ServerSetupTask {
     public void tearDown(final ManagementClient managementClient, final String containerId) {
         applyRemoveAllowReload(managementClient.getControllerClient(), domainAddress, false);
         applyRemoveAllowReload(managementClient.getControllerClient(), realmAddress, false);
+        if (! permissionMapperName.equals(DEFAULT_PERMISSION_MAPPER_NAME)) {
+            applyRemoveAllowReload(managementClient.getControllerClient(), permissionMapperAddress, false);
+            applyRemoveAllowReload(managementClient.getControllerClient(), aggregateRoleDecoderAddress, false);
+            applyRemoveAllowReload(managementClient.getControllerClient(), roleDecoder1Address, false);
+            applyRemoveAllowReload(managementClient.getControllerClient(), roleDecoder2Address, false);
+        }
     }
 
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12661

Depends on https://github.com/wildfly/wildfly-core/pull/4024