### PR TITLE
[WFLY-12686] Upgrade MicroProfile Metrics to 2.2.1

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2995,6 +2995,28 @@
 
 
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-source-file-system</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-microprofile-config-smallrye</artifactId>
             <exclusions>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -610,6 +610,28 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-config-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-source-file-system</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
       <licenses>
         <license>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
@@ -25,6 +25,8 @@
 <module xmlns="urn:jboss:module:1.8" name="io.smallrye.config">
     <resources>
         <artifact name="${io.smallrye:smallrye-config}"/>
+        <artifact name="${io.smallrye:smallrye-config-common}"/>
+        <artifact name="${io.smallrye.config:smallrye-config-source-file-system}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1525,6 +1525,30 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-source-file-system</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye</groupId>
             <artifactId>smallrye-health</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/config-smallrye/pom.xml
+++ b/microprofile/config-smallrye/pom.xml
@@ -55,6 +55,15 @@
             <artifactId>smallrye-config</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-source-file-system</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/DirConfigSourceService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/DirConfigSourceService.java
@@ -25,7 +25,7 @@ package org.wildfly.extension.microprofile.config.smallrye;
 import java.io.File;
 import java.util.function.Supplier;
 
-import io.smallrye.config.DirConfigSource;
+import io.smallrye.config.FileSystemConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.services.path.AbsolutePathService;
@@ -78,7 +78,7 @@ class DirConfigSourceService implements Service<ConfigSource> {
         String dirPath = pathManager.get().resolveRelativePathEntry(path, relativeToPath);
         File dir = new File(dirPath);
         MicroProfileConfigLogger.ROOT_LOGGER.loadConfigSourceFromDir(dir.getAbsolutePath());
-        configSource = new DirConfigSource(dir, ordinal);
+        configSource = new FileSystemConfigSource(dir, ordinal);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
         <version.io.opentracing.servlet>0.2.3</version.io.opentracing.servlet>
         <version.io.reactivex.rxjava>2.2.5</version.io.reactivex.rxjava>
         <version.io.rest-assured>3.0.0</version.io.rest-assured>
-        <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>1.4.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>2.0.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-metrics>2.3.2</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
@@ -1694,6 +1694,18 @@
                         <artifactId>cdi-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-config-common</artifactId>
+                <version>${version.io.smallrye.smallrye-config}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.smallrye.config</groupId>
+                <artifactId>smallrye-config-source-file-system</artifactId>
+                <version>${version.io.smallrye.smallrye-config}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <version.io.rest-assured>3.0.0</version.io.rest-assured>
         <version.io.smallrye.smallrye-config>1.3.6</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-health>2.0.0</version.io.smallrye.smallrye-health>
-        <version.io.smallrye.smallrye-metrics>2.1.5</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>2.3.2</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -317,7 +317,7 @@
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.health.api>2.0.1</version.org.eclipse.microprofile.health.api>
-        <version.org.eclipse.microprofile.metrics.api>2.0.2</version.org.eclipse.microprofile.metrics.api>
+        <version.org.eclipse.microprofile.metrics.api>2.2.1</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.opentracing>1.3.1</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.5</version.org.eclipse.yasson>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/AssertUtils.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/AssertUtils.java
@@ -22,7 +22,12 @@
 
 package org.wildfly.test.integration.microprofile.config.smallrye;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2017 Red Hat inc.
@@ -30,8 +35,23 @@ import org.junit.Assert;
 public class AssertUtils {
 
     public static void assertTextContainsProperty(String text, String propName, Object propValue) {
-        // Include also newline at the end of the line to assure that whole value is checked.
-        Assert.assertTrue("String '" + propName + " = " + propValue + "' not found in the following output:\n" + text,
-                text.contains(propName + " = " + propValue + "\n"));
+        assertTextContainsProperty(text, propName, propValue, true);
+    }
+
+    public static void assertTextContainsProperty(String text, String propName, Object propValue, boolean exactMatch) {
+        if (exactMatch) {
+            // Include also newline at the end of the line to assure that whole value is checked.
+            assertTrue("String '" + propName + " = " + propValue + "' not found in the following output:\n" + text,
+                    text.contains(propName + " = " + propValue + "\n"));
+        } else {
+            // Find the line starting with "${propName} ="
+            List<String> matchingLines = Arrays.stream(text.split("\n"))
+                    .filter(line -> line.startsWith(propName + " ="))
+                    .collect(Collectors.toList());
+            assertEquals(1, matchingLines.size());
+            assertTrue("Text " + propValue + "not found for property " + propName + " in " + text,
+                    matchingLines.get(0).contains(propValue.toString()));
+
+        }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
@@ -26,10 +26,8 @@ import static org.wildfly.test.integration.microprofile.config.smallrye.AssertUt
 
 import java.net.URL;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Optional;
-import java.util.Set;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -296,13 +294,11 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
             petsList.add("cat");
             petsList.add("lama,yokohama");
 
-            Set<String> petsSet = new HashSet<>();
-            petsSet.add("dog");
-            petsSet.add("mouse,house");
-
             assertTextContainsProperty(text, "myPets as String array", Arrays.toString(new String[]{"horse","monkey,donkey"}));
             assertTextContainsProperty(text, "myPets as String list", petsList);
-            assertTextContainsProperty(text, "myPets as String set", petsSet); // TODO - not sure whether this is safe as Set doesn't assure order?
+            // order is not guaranteed for set so we test each set item individually
+            assertTextContainsProperty(text, "myPets as String set", "dog", false);
+            assertTextContainsProperty(text, "myPets as String set", "mouse,house", false);
         }
     }
 
@@ -322,14 +318,11 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
             petsList.add("donkey");
             petsList.add("shrek,fiona");
 
-            Set<String> petsSet = new HashSet<>();
-            petsSet.add("donkey");
-            petsSet.add("shrek,fiona");
-
             assertTextContainsProperty(text, "myPetsOverridden as String array", Arrays.toString(new String[] {"donkey", "shrek,fiona"}));
             assertTextContainsProperty(text, "myPetsOverridden as String list", petsList);
-            assertTextContainsProperty(text, "myPetsOverridden as String set", petsSet); // TODO - not sure whether this is safe as Set doesn't assure order?
-//            Assert.assertTrue(text.contains("myPetsOverridden as String set = [donkey,shrek]") || text.contains("myPetsOverridden as String set = [shrek,donkey]"));
+            // order is not guaranteed for set so we test each set item individually
+            assertTextContainsProperty(text, "myPetsOverridden as String set", "donkey", false);
+            assertTextContainsProperty(text, "myPetsOverridden as String set", "shrek,fiona", false);
         }
     }
 

--- a/testsuite/integration/microprofile-tck/config/tck-suite.xml
+++ b/testsuite/integration/microprofile-tck/config/tck-suite.xml
@@ -26,6 +26,20 @@
                     <exclude name=".*" />
                 </methods>
             </class>
+
+            <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/pull/407 -->
+            <class name="org.eclipse.microprofile.config.tck.ConfigProviderTest">
+                <methods>
+                    <exclude name="testEnvironmentConfigSource"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.config.tck.EmptyValuesTest">
+                <methods>
+                    <exclude name="testEmptyStringPropertyFromConfigFile"/>
+                    <exclude name="testEmptyStringProgrammaticLookup"/>
+                    <exclude name="testEmptyStringValues"/>
+                </methods>
+            </class>
         </classes>
     </test>
 


### PR DESCRIPTION
This PR contains 3 upgrades:

* Upgrade MicroProfile Metrics to 2.2.1
* Upgrade smallrye-metrics to 2.3.2
* Upgrade smallrye-config 1.4.1

The 3 components must be upgraded together as smallrye-metrics  2.3.2 is depending on MicroProfile Metrics 2.2.1 and smallrye-config 1.4.1

---
## [WFLY-12687] Upgrade smallrye-config 1.4.1

smallrye-config has been splitted in multiple artifacts.

* added io.smallrye:smallrye-config-common and
  io.smallrye.config.smallrye-config-source-file-system dependencies
* DirConfigSource class has been renamed to FileSystemConfigSource
* exclude tests from MicroProfile Config TCK that are challenged by
   smallrye-config (see
   https://github.com/eclipse/microprofile-config/pull/407)

 JIRA: https://issues.jboss.org/browse/WFLY-12687

---
## [WFLY-12686] Upgrade MicroProfile Metrics to 2.2.1

* upgrade smallrye-metrics to 2.3.2

JIRA: https://issues.jboss.org/browse/WFLY-12686
JIRA: https://issues.jboss.org/browse/WFLY-12735

---
