### PR TITLE
WLFY-1208 Update Weld core to 3.1.3.Final and API to 3.1.SP2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,8 +378,8 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.2.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>3.1.SP1</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>3.1.3.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>3.1.SP2</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.2.3.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.2.Final</version.org.jboss.ws.common.tools>


### PR DESCRIPTION
JIRA - https://issues.jboss.org/browse/WFLY-12808

Updates Weld component, both API and core.
This is a very minor patch, release info is available [here](http://weld.cdi-spec.org/news/2019/11/28/weld-313Final/).