### PR TITLE
[WFLY-12841] Ban log4j:log4j as we provide a jboss-logmanager based fork. Switch t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8675,6 +8675,7 @@
                                             <exclude>jboss.web:el-api</exclude>
                                             <exclude>jboss.web:jsp-api</exclude>
                                             <exclude>jboss.web:servlet-api</exclude>
+                                            <exclude>log4j:log4j</exclude>
                                             <exclude>net.sf.kxml:kxml2</exclude>
                                             <exclude>org.apache.geronimo.specs:geronimo-activation_1.1_spec</exclude>
                                             <exclude>org.apache.geronimo.specs:geronimo-jaxb_2.1_spec</exclude>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -122,8 +122,8 @@
         </dependency>
         <!-- Required for artemis-commons, just needs to be on the class path -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -58,8 +58,8 @@
         </dependency>
         <!-- The following are required at for JAXB on Java 11 -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/rts/pom.xml
+++ b/testsuite/integration/rts/pom.xml
@@ -56,8 +56,8 @@
         </dependency>
         <!-- The following are required at for JAXB on Java 11 -->
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -63,8 +63,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
…estsuite client use to the fork

https://issues.jboss.org/browse/WFLY-12841