### PR TITLE
[WFLY-12850] Upgrade WildFly Core 11.0.0.Beta4

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:10.0">
+<domain xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="master">
+<host xmlns="urn:jboss:domain:11.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0">
+<host xmlns="urn:jboss:domain:11.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="master">
+<host xmlns="urn:jboss:domain:11.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:10.0">
+<server xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:10.0">
+<server xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:10.0">
+<server xmlns="urn:jboss:domain:11.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:10.0">
+<domain xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="master">
+<host xmlns="urn:jboss:domain:11.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0">
+<host xmlns="urn:jboss:domain:11.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="master">
+<host xmlns="urn:jboss:domain:11.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:10.0">
+<server xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0"
+<domain xmlns="urn:jboss:domain:11.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0">
+<domain xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0"
+<domain xmlns="urn:jboss:domain:11.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0">
+<domain xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0">
+<domain xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="master">
+<host xmlns="urn:jboss:domain:11.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:10.0" name="slave">
+<host xmlns="urn:jboss:domain:11.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:10.0"
+<host xmlns="urn:jboss:domain:11.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:10.0">
+<server xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:10.0"
+<domain xmlns="urn:jboss:domain:11.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:10.0">
+<host name="master" xmlns="urn:jboss:domain:11.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:10.0">
+<host name="master" xmlns="urn:jboss:domain:11.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-12850

---


## Release Notes - WildFly Core - Version 11.0.0.Beta4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4759'>WFCORE-4759</a>] -         Upgrade to Galleon and WFGP 4.2.1.Final
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4769'>WFCORE-4769</a>] -         Upgrade WildFly Elytron to 1.11.0.CR3
</li>
</ul>
                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-1110'>WFCORE-1110</a>] -         Allow addition of HTTP headers to management console responses
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4704'>WFCORE-4704</a>] -         WS integration with WildFly Elytron - AuthenticationClient for Authentication / SSL
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-3948'>WFCORE-3948</a>] -         Potential race condition on deployment of EAR when Class-Path manifest entry is in use
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4765'>WFCORE-4765</a>] -         Remove licenses for artifacts that are not in the distribution
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4768'>WFCORE-4768</a>] -         WFLYIO001: Worker &#39;default&#39; has auto-configured to 24 core threads should be IO threads
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4749'>WFCORE-4749</a>] -         Add version 11 of the urn:jboss:domain / wildfly-config schema
</li>
<li>[<a href='https://issues.jboss.org/browse/WFCORE-4760'>WFCORE-4760</a>] -         Add HostExcludeResourceDefinition.KnownRelease values
</li>
</ul>
                                    