### PR TITLE
WFLY-12857 DatabaseTimerPersistence has unused instances of resultSet

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
@@ -331,7 +331,6 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
         String createTimer = sql(CREATE_TIMER);
         Connection connection = null;
         PreparedStatement statement = null;
-        ResultSet resultSet = null;
         try {
             synchronized (this) {
                 knownTimerIds.get(timerEntity.getTimedObjectId()).add(timerEntity.getId());
@@ -343,7 +342,6 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
         } catch (SQLException e) {
             throw new RuntimeException(e);
         } finally {
-            safeClose(resultSet);
             safeClose(statement);
             safeClose(connection);
         }
@@ -353,7 +351,6 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
     public void persistTimer(final TimerImpl timerEntity) {
         Connection connection = null;
         PreparedStatement statement = null;
-        ResultSet resultSet = null;
         try {
             connection = dataSource.getConnection();
             if (timerEntity.getState() == TimerState.CANCELED ||
@@ -387,7 +384,6 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
         } catch (SQLException e) {
             throw new RuntimeException(e);
         } finally {
-            safeClose(resultSet);
             safeClose(statement);
             safeClose(connection);
         }


### PR DESCRIPTION
DatabaseTimerPersistence has unused instances of resultSet
https://issues.redhat.com/browse/WFLY-12857

Please make sure your PR meets the following requirements:
- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
