### PR TITLE
WFLY-12858 Eliminate redundant buffer allocation/copying when marshalling CommandDispatcher commands/responses

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcher.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcher.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.server.dispatcher;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -139,7 +140,8 @@ public class ChannelCommandDispatcher<C> implements CommandDispatcher<C> {
 
     private <R> Buffer createBuffer(Command<R, ? super C> command) {
         try {
-            return new Buffer(this.marshaller.marshal(command));
+            ByteBuffer buffer = this.marshaller.marshal(command);
+            return new Buffer(buffer.array(), buffer.arrayOffset(), buffer.limit() - buffer.arrayOffset());
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherMarshaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherMarshaller.java
@@ -22,13 +22,14 @@
 
 package org.wildfly.clustering.server.dispatcher;
 
-import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.Marshalling;
 import org.wildfly.clustering.dispatcher.Command;
+import org.wildfly.clustering.marshalling.jboss.ByteBufferOutputStream;
 import org.wildfly.clustering.marshalling.jboss.MarshallingContext;
 import org.wildfly.clustering.marshalling.spi.IndexSerializer;
 
@@ -46,10 +47,10 @@ public class CommandDispatcherMarshaller<C> implements CommandMarshaller<C> {
     }
 
     @Override
-    public <R> byte[] marshal(Command<R, ? super C> command) throws IOException {
+    public <R> ByteBuffer marshal(Command<R, ? super C> command) throws IOException {
         int version = this.context.getCurrentVersion();
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        try (DataOutputStream output = new DataOutputStream(bytes)) {
+        ByteBufferOutputStream buffer = new ByteBufferOutputStream();
+        try (DataOutputStream output = new DataOutputStream(buffer)) {
             IndexSerializer.VARIABLE.writeInt(output, version);
             try (Marshaller marshaller = this.context.createMarshaller(version)) {
                 marshaller.start(Marshalling.createByteOutput(output));
@@ -57,7 +58,7 @@ public class CommandDispatcherMarshaller<C> implements CommandMarshaller<C> {
                 marshaller.writeObject(command);
                 marshaller.flush();
             }
-            return bytes.toByteArray();
+            return buffer.getBuffer();
         }
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandMarshaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandMarshaller.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.server.dispatcher;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.wildfly.clustering.dispatcher.Command;
 
@@ -38,5 +39,5 @@ public interface CommandMarshaller<C> {
      * @return a serialized command.
      * @throws IOException if marshalling fails.
      */
-    <R> byte[] marshal(Command<R, ? super C> command) throws IOException;
+    <R> ByteBuffer marshal(Command<R, ? super C> command) throws IOException;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-12858