### PR TITLE
[WFLY-12859]: Acceptor is open after broker starts but before queues are created resulting in QUEUE_DOES_NOT_EXIST message=AMQ229017 (the queue is in the standalone.xml file)

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BridgeAdd.java
@@ -39,7 +39,6 @@ import java.util.List;
 
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.TransformerConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -49,7 +48,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
@@ -99,16 +97,6 @@ public class BridgeAdd extends AbstractAddStepHandler {
         }
         // else the initial subsystem install is not complete; MessagingSubsystemAdd will add a
         // handler that calls addBridgeConfigs
-    }
-
-    static void addBridgeConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
-        if (model.hasDefined(CommonAttributes.BRIDGE)) {
-            final List<BridgeConfiguration> configs = configuration.getBridgeConfigurations();
-            for (Property prop : model.get(CommonAttributes.BRIDGE).asPropertyList()) {
-                configs.add(createBridgeConfiguration(context, prop.getName(), prop.getValue()));
-
-            }
-        }
     }
 
     static BridgeConfiguration createBridgeConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ClusterConnectionAdd.java
@@ -22,12 +22,6 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -35,7 +29,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
@@ -72,85 +65,5 @@ public class ClusterConnectionAdd extends AbstractAddStepHandler {
             context.reloadRequired();
         }
         // else MessagingSubsystemAdd will add a handler that calls addBroadcastGroupConfigs
-    }
-
-    static void addClusterConnectionConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
-        if (model.hasDefined(CommonAttributes.CLUSTER_CONNECTION)) {
-            final List<ClusterConnectionConfiguration> configs = configuration.getClusterConfigurations();
-            for (Property prop : model.get(CommonAttributes.CLUSTER_CONNECTION).asPropertyList()) {
-                configs.add(createClusterConnectionConfiguration(context, prop.getName(), prop.getValue()));
-
-            }
-        }
-    }
-
-    static ClusterConnectionConfiguration createClusterConnectionConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
-
-        final String address = ClusterConnectionDefinition.ADDRESS.resolveModelAttribute(context, model).asString();
-        final String connectorName = ClusterConnectionDefinition.CONNECTOR_NAME.resolveModelAttribute(context, model).asString();
-        final long retryInterval = ClusterConnectionDefinition.RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
-        final boolean duplicateDetection = ClusterConnectionDefinition.USE_DUPLICATE_DETECTION.resolveModelAttribute(context, model).asBoolean();
-        final long connectionTTL = ClusterConnectionDefinition.CONNECTION_TTL.resolveModelAttribute(context, model).asInt();
-        final int initialConnectAttempts = ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
-        final int reconnectAttempts = ClusterConnectionDefinition.RECONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
-        final long maxRetryInterval = ClusterConnectionDefinition.MAX_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
-        final double retryIntervalMultiplier = ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER.resolveModelAttribute(context, model).asDouble();
-        final long clientFailureCheckPeriod = ClusterConnectionDefinition.CHECK_PERIOD.resolveModelAttribute(context, model).asInt();
-        final String messageLoadBalancingType = ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE.resolveModelAttribute(context, model).asString();
-
-        final int maxHops = ClusterConnectionDefinition.MAX_HOPS.resolveModelAttribute(context, model).asInt();
-        final int confirmationWindowSize = CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE.resolveModelAttribute(context, model).asInt();
-        final int producerWindowSize = ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.resolveModelAttribute(context, model).asInt();
-        final ModelNode discoveryNode = ClusterConnectionDefinition.DISCOVERY_GROUP_NAME.resolveModelAttribute(context, model);
-        final int minLargeMessageSize = CommonAttributes.MIN_LARGE_MESSAGE_SIZE.resolveModelAttribute(context, model).asInt();
-        final long callTimeout = CommonAttributes.CALL_TIMEOUT.resolveModelAttribute(context, model).asLong();
-        final long callFailoverTimeout = ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT.resolveModelAttribute(context, model).asLong();
-        final long clusterNotificationInterval = ClusterConnectionDefinition.NOTIFICATION_INTERVAL.resolveModelAttribute(context, model).asLong();
-        final int clusterNotificationAttempts = ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS.resolveModelAttribute(context, model).asInt();
-
-        ClusterConnectionConfiguration config = new ClusterConnectionConfiguration()
-                .setName(name)
-                .setAddress(address)
-                .setConnectorName(connectorName)
-                .setMinLargeMessageSize(minLargeMessageSize)
-                .setClientFailureCheckPeriod(clientFailureCheckPeriod)
-                .setConnectionTTL(connectionTTL)
-                .setRetryInterval(retryInterval)
-                .setRetryIntervalMultiplier(retryIntervalMultiplier)
-                .setMaxRetryInterval(maxRetryInterval)
-                .setInitialConnectAttempts(initialConnectAttempts)
-                .setReconnectAttempts(reconnectAttempts)
-                .setCallTimeout(callTimeout)
-                .setCallFailoverTimeout(callFailoverTimeout)
-                .setDuplicateDetection(duplicateDetection)
-                .setMessageLoadBalancingType(MessageLoadBalancingType.valueOf(messageLoadBalancingType))
-                .setMaxHops(maxHops)
-                .setConfirmationWindowSize(confirmationWindowSize)
-                .setProducerWindowSize(producerWindowSize)
-                .setClusterNotificationInterval(clusterNotificationInterval)
-                .setClusterNotificationAttempts(clusterNotificationAttempts);
-
-        final String discoveryGroupName = discoveryNode.isDefined() ? discoveryNode.asString() : null;
-        final List<String> staticConnectors = discoveryGroupName == null ? getStaticConnectors(model) : null;
-        final boolean allowDirectOnly = ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY.resolveModelAttribute(context, model).asBoolean();
-
-        if (discoveryGroupName != null) {
-            config.setDiscoveryGroupName(discoveryGroupName);
-        } else {
-            config.setStaticConnectors(staticConnectors)
-                    .setAllowDirectConnectionsOnly(allowDirectOnly);
-        }
-        return config;
-    }
-
-    private static List<String> getStaticConnectors(ModelNode model) {
-        if (!model.hasDefined(CommonAttributes.STATIC_CONNECTORS))
-            return null;
-
-        List<String> result = new ArrayList<String>();
-        for (ModelNode connector : model.require(CommonAttributes.STATIC_CONNECTORS).asList()) {
-            result.add(connector.asString());
-        }
-        return result;
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConfigurationHelper.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConfigurationHelper.java
@@ -15,17 +15,34 @@
  */
 package org.wildfly.extension.messaging.activemq;
 
+import static org.wildfly.extension.messaging.activemq.BridgeAdd.createBridgeConfiguration;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.DURABLE;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.FILTER;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.SELECTOR;
+import static org.wildfly.extension.messaging.activemq.DivertAdd.createDivertConfiguration;
+import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS;
+import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.GROUP_TIMEOUT;
+import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.REAPER_PERIOD;
+import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.TIMEOUT;
 import static org.wildfly.extension.messaging.activemq.QueueDefinition.DEFAULT_ROUTING_TYPE;
 import static org.wildfly.extension.messaging.activemq.QueueDefinition.ROUTING_TYPE;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.BridgeConfiguration;
+import org.apache.activemq.artemis.core.config.ClusterConnectionConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.server.cluster.impl.MessageLoadBalancingType;
+import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.apache.activemq.artemis.utils.SelectorTranslator;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -89,5 +106,166 @@ public class ConfigurationHelper {
                 .setFilterString(SelectorTranslator.convertToActiveMQFilterString(selector))
                 .setDurable(durable)
                 .setRoutingType(isQueue ? RoutingType.ANYCAST : RoutingType.MULTICAST);
+    }
+
+    static void addDivertConfigurations(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.DIVERT)) {
+            final List<DivertConfiguration> configs = configuration.getDivertConfigurations();
+            for (Property prop : model.get(CommonAttributes.DIVERT).asPropertyList()) {
+                configs.add(createDivertConfiguration(context, prop.getName(), prop.getValue()));
+
+            }
+        }
+    }
+
+    static Map<String, DiscoveryGroupConfiguration> addDiscoveryGroupConfigurations(final OperationContext context, final ModelNode model) throws OperationFailedException {
+        Map<String, DiscoveryGroupConfiguration> configs = new HashMap<>();
+        if (model.hasDefined(CommonAttributes.JGROUPS_DISCOVERY_GROUP)) {
+            for (Property prop : model.get(CommonAttributes.JGROUPS_DISCOVERY_GROUP).asPropertyList()) {
+                configs.put(prop.getName(), new DiscoveryGroupConfiguration()
+                        .setName(prop.getName())
+                        .setRefreshTimeout(DiscoveryGroupDefinition.REFRESH_TIMEOUT.resolveModelAttribute(context, prop.getValue()).asLong())
+                        .setDiscoveryInitialWaitTimeout(DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.resolveModelAttribute(context, prop.getValue()).asLong()));
+            }
+        }
+        if (model.hasDefined(CommonAttributes.SOCKET_DISCOVERY_GROUP)) {
+            for (Property prop : model.get(CommonAttributes.SOCKET_DISCOVERY_GROUP).asPropertyList()) {
+                configs.put(prop.getName(), new DiscoveryGroupConfiguration()
+                        .setName(prop.getName())
+                        .setRefreshTimeout(DiscoveryGroupDefinition.REFRESH_TIMEOUT.resolveModelAttribute(context, prop.getValue()).asLong())
+                        .setDiscoveryInitialWaitTimeout(DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.resolveModelAttribute(context, prop.getValue()).asLong()));
+            }
+        }
+        return configs;
+    }
+
+    static void addBridgeConfigurations(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.BRIDGE)) {
+            final List<BridgeConfiguration> configs = configuration.getBridgeConfigurations();
+            for (Property prop : model.get(CommonAttributes.BRIDGE).asPropertyList()) {
+                configs.add(createBridgeConfiguration(context, prop.getName(), prop.getValue()));
+            }
+        }
+    }
+
+    static void addGroupingHandlerConfiguration(final OperationContext context, final Configuration configuration, final ModelNode model) throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.GROUPING_HANDLER)) {
+            final Property prop = model.get(CommonAttributes.GROUPING_HANDLER).asProperty();
+            final String name = prop.getName();
+            final ModelNode node = prop.getValue();
+
+            final GroupingHandlerConfiguration.TYPE type = GroupingHandlerConfiguration.TYPE.valueOf(GroupingHandlerDefinition.TYPE.resolveModelAttribute(context, node).asString());
+            final String address = GROUPING_HANDLER_ADDRESS.resolveModelAttribute(context, node).asString();
+            final int timeout = TIMEOUT.resolveModelAttribute(context, node).asInt();
+            final long groupTimeout = GROUP_TIMEOUT.resolveModelAttribute(context, node).asLong();
+            final long reaperPeriod = REAPER_PERIOD.resolveModelAttribute(context, node).asLong();
+            final GroupingHandlerConfiguration conf = new GroupingHandlerConfiguration()
+                    .setName(SimpleString.toSimpleString(name))
+                    .setType(type)
+                    .setAddress(SimpleString.toSimpleString(address))
+                    .setTimeout(timeout)
+                    .setGroupTimeout(groupTimeout)
+                    .setReaperPeriod(reaperPeriod);
+            configuration.setGroupingHandlerConfiguration(conf);
+        }
+    }
+
+    static void addClusterConnectionConfigurations(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.CLUSTER_CONNECTION)) {
+            final List<ClusterConnectionConfiguration> configs = configuration.getClusterConfigurations();
+            for (Property prop : model.get(CommonAttributes.CLUSTER_CONNECTION).asPropertyList()) {
+                configs.add(createClusterConnectionConfiguration(context, prop.getName(), prop.getValue()));
+
+            }
+        }
+    }
+
+    private static ClusterConnectionConfiguration createClusterConnectionConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
+        final String address = ClusterConnectionDefinition.ADDRESS.resolveModelAttribute(context, model).asString();
+        final String connectorName = ClusterConnectionDefinition.CONNECTOR_NAME.resolveModelAttribute(context, model).asString();
+        final long retryInterval = ClusterConnectionDefinition.RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final boolean duplicateDetection = ClusterConnectionDefinition.USE_DUPLICATE_DETECTION.resolveModelAttribute(context, model).asBoolean();
+        final long connectionTTL = ClusterConnectionDefinition.CONNECTION_TTL.resolveModelAttribute(context, model).asInt();
+        final int initialConnectAttempts = ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
+        final int reconnectAttempts = ClusterConnectionDefinition.RECONNECT_ATTEMPTS.resolveModelAttribute(context, model).asInt();
+        final long maxRetryInterval = ClusterConnectionDefinition.MAX_RETRY_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final double retryIntervalMultiplier = ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER.resolveModelAttribute(context, model).asDouble();
+        final long clientFailureCheckPeriod = ClusterConnectionDefinition.CHECK_PERIOD.resolveModelAttribute(context, model).asInt();
+        final String messageLoadBalancingType = ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE.resolveModelAttribute(context, model).asString();
+
+        final int maxHops = ClusterConnectionDefinition.MAX_HOPS.resolveModelAttribute(context, model).asInt();
+        final int confirmationWindowSize = CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE.resolveModelAttribute(context, model).asInt();
+        final int producerWindowSize = ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.resolveModelAttribute(context, model).asInt();
+        final ModelNode discoveryNode = ClusterConnectionDefinition.DISCOVERY_GROUP_NAME.resolveModelAttribute(context, model);
+        final int minLargeMessageSize = CommonAttributes.MIN_LARGE_MESSAGE_SIZE.resolveModelAttribute(context, model).asInt();
+        final long callTimeout = CommonAttributes.CALL_TIMEOUT.resolveModelAttribute(context, model).asLong();
+        final long callFailoverTimeout = ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT.resolveModelAttribute(context, model).asLong();
+        final long clusterNotificationInterval = ClusterConnectionDefinition.NOTIFICATION_INTERVAL.resolveModelAttribute(context, model).asLong();
+        final int clusterNotificationAttempts = ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS.resolveModelAttribute(context, model).asInt();
+
+        ClusterConnectionConfiguration config = new ClusterConnectionConfiguration()
+                .setName(name)
+                .setAddress(address)
+                .setConnectorName(connectorName)
+                .setMinLargeMessageSize(minLargeMessageSize)
+                .setClientFailureCheckPeriod(clientFailureCheckPeriod)
+                .setConnectionTTL(connectionTTL)
+                .setRetryInterval(retryInterval)
+                .setRetryIntervalMultiplier(retryIntervalMultiplier)
+                .setMaxRetryInterval(maxRetryInterval)
+                .setInitialConnectAttempts(initialConnectAttempts)
+                .setReconnectAttempts(reconnectAttempts)
+                .setCallTimeout(callTimeout)
+                .setCallFailoverTimeout(callFailoverTimeout)
+                .setDuplicateDetection(duplicateDetection)
+                .setMessageLoadBalancingType(MessageLoadBalancingType.valueOf(messageLoadBalancingType))
+                .setMaxHops(maxHops)
+                .setConfirmationWindowSize(confirmationWindowSize)
+                .setProducerWindowSize(producerWindowSize)
+                .setClusterNotificationInterval(clusterNotificationInterval)
+                .setClusterNotificationAttempts(clusterNotificationAttempts);
+
+        final String discoveryGroupName = discoveryNode.isDefined() ? discoveryNode.asString() : null;
+        final List<String> staticConnectors = discoveryGroupName == null ? getStaticConnectors(model) : null;
+        final boolean allowDirectOnly = ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY.resolveModelAttribute(context, model).asBoolean();
+
+        if (discoveryGroupName != null) {
+            config.setDiscoveryGroupName(discoveryGroupName);
+        } else {
+            config.setStaticConnectors(staticConnectors)
+                    .setAllowDirectConnectionsOnly(allowDirectOnly);
+        }
+        return config;
+    }
+
+    private static List<String> getStaticConnectors(ModelNode model) {
+        if (!model.hasDefined(CommonAttributes.STATIC_CONNECTORS)) {
+            return null;
+        }
+
+        List<String> result = new ArrayList<>();
+        for (ModelNode connector : model.require(CommonAttributes.STATIC_CONNECTORS).asList()) {
+            result.add(connector.asString());
+        }
+        return result;
+    }
+
+    static void addConnectorServiceConfigurations(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.CONNECTOR_SERVICE)) {
+            final List<ConnectorServiceConfiguration> configs = configuration.getConnectorServiceConfigurations();
+            for (Property prop : model.get(CommonAttributes.CONNECTOR_SERVICE).asPropertyList()) {
+                configs.add(createConnectorServiceConfiguration(context, prop.getName(), prop.getValue()));
+            }
+        }
+    }
+
+    private static ConnectorServiceConfiguration createConnectorServiceConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
+        final String factoryClass = CommonAttributes.FACTORY_CLASS.resolveModelAttribute(context, model).asString();
+        Map<String, String> unwrappedParameters = CommonAttributes.PARAMS.unwrap(context, model);
+        Map<String, Object> parameters = new HashMap<String, Object>(unwrappedParameters);
+        return new ConnectorServiceConfiguration()
+                .setFactoryClassName(factoryClass)
+                .setParams(parameters)
+                .setName(name);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConfigurationHelper.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConfigurationHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.messaging.activemq;
+
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.DURABLE;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.FILTER;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.SELECTOR;
+import static org.wildfly.extension.messaging.activemq.QueueDefinition.DEFAULT_ROUTING_TYPE;
+import static org.wildfly.extension.messaging.activemq.QueueDefinition.ROUTING_TYPE;
+
+import java.util.List;
+import java.util.Locale;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
+import org.apache.activemq.artemis.utils.SelectorTranslator;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Helper to create Artemis configuration.
+ * @author Emmanuel Hugonnet (c) 2019 Red Hat, Inc.
+ */
+public class ConfigurationHelper {
+
+    static void addQueueConfigurations(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
+        if (model.hasDefined(CommonAttributes.QUEUE)) {
+            final List<CoreQueueConfiguration> configs = configuration.getQueueConfigurations();
+            for (Property prop : model.get(CommonAttributes.QUEUE).asPropertyList()) {
+                configs.add(createCoreQueueConfiguration(context, prop.getName(), prop.getValue()));
+            }
+        }
+        if (model.hasDefined(CommonAttributes.JMS_QUEUE)) {
+            final List<CoreQueueConfiguration> configs = configuration.getQueueConfigurations();
+            for (Property prop : model.get(CommonAttributes.JMS_QUEUE).asPropertyList()) {
+                configs.add(createJMSDestinationConfiguration(context, prop.getName(), prop.getValue(), true));
+            }
+        }
+        if (model.hasDefined(CommonAttributes.JMS_TOPIC)) {
+            final List<CoreQueueConfiguration> configs = configuration.getQueueConfigurations();
+            for (Property prop : model.get(CommonAttributes.JMS_TOPIC).asPropertyList()) {
+                configs.add(createJMSDestinationConfiguration(context, prop.getName(), prop.getValue(), false));
+            }
+        }
+    }
+
+    static CoreQueueConfiguration createCoreQueueConfiguration(final OperationContext context, String name, ModelNode model) throws OperationFailedException {
+        final String queueAddress = QueueDefinition.ADDRESS.resolveModelAttribute(context, model).asString();
+        final String filter = FILTER.resolveModelAttribute(context, model).asStringOrNull();
+        final String routing;
+        if(DEFAULT_ROUTING_TYPE != null && ! model.hasDefined(ROUTING_TYPE.getName())) {
+            routing = RoutingType.valueOf(DEFAULT_ROUTING_TYPE.toUpperCase(Locale.ENGLISH)).toString();
+        } else {
+            routing = ROUTING_TYPE.resolveModelAttribute(context, model).asString();
+        }
+        final boolean durable = DURABLE.resolveModelAttribute(context, model).asBoolean();
+
+        return new CoreQueueConfiguration()
+                .setAddress(queueAddress)
+                .setName(name)
+                .setFilterString(filter)
+                .setDurable(durable)
+                .setRoutingType(RoutingType.valueOf(routing));
+    }
+
+    static CoreQueueConfiguration createJMSDestinationConfiguration(final OperationContext context, String name, ModelNode model, boolean isQueue) throws OperationFailedException {
+        final String selector = SELECTOR.resolveModelAttribute(context, model).asStringOrNull();
+        final boolean durable = DURABLE.resolveModelAttribute(context, model).asBoolean();
+        final String destinationAddress = isQueue ? "jms.queue." + name : "jms.topic." + name;
+
+        return new CoreQueueConfiguration()
+                .setAddress(destinationAddress)
+                .setName(destinationAddress)
+                .setFilterString(SelectorTranslator.convertToActiveMQFilterString(selector))
+                .setDurable(durable)
+                .setRoutingType(isQueue ? RoutingType.ANYCAST : RoutingType.MULTICAST);
+    }
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorServiceDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ConnectorServiceDefinition.java
@@ -26,12 +26,6 @@ import static org.jboss.as.controller.registry.AttributeAccess.Flag.STORAGE_RUNT
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.activemq.artemis.core.config.Configuration;
-import org.apache.activemq.artemis.core.config.ConnectorServiceConfiguration;
 import org.apache.activemq.artemis.utils.ClassloadingUtil;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -41,7 +35,6 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
@@ -62,26 +55,6 @@ public class ConnectorServiceDefinition extends PersistentResourceDefinition {
                 MessagingExtension.getResourceDescriptionResolver(false, CommonAttributes.CONNECTOR_SERVICE),
                 new ConnectorServiceAddHandler(ATTRIBUTES),
                 new ActiveMQReloadRequiredHandlers.RemoveStepHandler());
-    }
-
-    static void addConnectorServiceConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
-        if (model.hasDefined(CommonAttributes.CONNECTOR_SERVICE)) {
-            final List<ConnectorServiceConfiguration> configs = configuration.getConnectorServiceConfigurations();
-            for (Property prop : model.get(CommonAttributes.CONNECTOR_SERVICE).asPropertyList()) {
-                configs.add(createConnectorServiceConfiguration(context, prop.getName(), prop.getValue()));
-            }
-        }
-    }
-
-    static ConnectorServiceConfiguration createConnectorServiceConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
-
-        final String factoryClass = CommonAttributes.FACTORY_CLASS.resolveModelAttribute(context, model).asString();
-        Map<String, String> unwrappedParameters = CommonAttributes.PARAMS.unwrap(context, model);
-        Map<String, Object> parameters = new HashMap<String, Object>(unwrappedParameters);
-        return new ConnectorServiceConfiguration()
-                .setFactoryClassName(factoryClass)
-                .setParams(parameters)
-                .setName(name);
     }
 
     @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -24,16 +24,11 @@ package org.wildfly.extension.messaging.activemq;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CLUSTER;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.wildfly.extension.messaging.activemq.shallow.ShallowResourceAdd;
 
 /**
@@ -73,30 +68,5 @@ public class DiscoveryGroupAdd extends ShallowResourceAdd {
             context.addStep(op, addHandler, OperationContext.Stage.MODEL, true);
         }
         super.execute(context, operation);
-    }
-
-    static Map<String, DiscoveryGroupConfiguration> addDiscoveryGroupConfigs(final OperationContext context, final ModelNode model) throws OperationFailedException {
-        Map<String, DiscoveryGroupConfiguration> configs = new HashMap<>();
-        if (model.hasDefined(CommonAttributes.JGROUPS_DISCOVERY_GROUP)) {
-            for (Property prop : model.get(CommonAttributes.JGROUPS_DISCOVERY_GROUP).asPropertyList()) {
-                configs.put(prop.getName(), createDiscoveryGroupConfiguration(context, prop.getName(), prop.getValue()));
-            }
-        }
-        if (model.hasDefined(CommonAttributes.SOCKET_DISCOVERY_GROUP)) {
-            for (Property prop : model.get(CommonAttributes.SOCKET_DISCOVERY_GROUP).asPropertyList()) {
-                configs.put(prop.getName(), createDiscoveryGroupConfiguration(context, prop.getName(), prop.getValue()));
-            }
-        }
-        return configs;
-    }
-
-    private static DiscoveryGroupConfiguration createDiscoveryGroupConfiguration(final OperationContext context, final String name, final ModelNode model) throws OperationFailedException {
-        final long refreshTimeout = DiscoveryGroupDefinition.REFRESH_TIMEOUT.resolveModelAttribute(context, model).asLong();
-        final long initialWaitTimeout = DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.resolveModelAttribute(context, model).asLong();
-
-        return new DiscoveryGroupConfiguration()
-                .setName(name)
-                .setRefreshTimeout(refreshTimeout)
-                .setDiscoveryInitialWaitTimeout(initialWaitTimeout);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DivertAdd.java
@@ -22,10 +22,8 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import java.util.List;
 
 import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.config.TransformerConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -36,7 +34,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
@@ -78,16 +75,6 @@ public class DivertAdd extends AbstractAddStepHandler {
         }
         // else the initial subsystem install is not complete; MessagingSubsystemAdd will add a
         // handler that calls addDivertConfigs
-    }
-
-    static void addDivertConfigs(final OperationContext context, final Configuration configuration, final ModelNode model)  throws OperationFailedException {
-        if (model.hasDefined(CommonAttributes.DIVERT)) {
-            final List<DivertConfiguration> configs = configuration.getDivertConfigurations();
-            for (Property prop : model.get(CommonAttributes.DIVERT).asPropertyList()) {
-                configs.add(createDivertConfiguration(context, prop.getName(), prop.getValue()));
-
-            }
-        }
     }
 
     static DivertConfiguration createDivertConfiguration(final OperationContext context, String name, ModelNode model) throws OperationFailedException {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GroupingHandlerAdd.java
@@ -22,15 +22,7 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS;
-import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.GROUP_TIMEOUT;
-import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.REAPER_PERIOD;
-import static org.wildfly.extension.messaging.activemq.GroupingHandlerDefinition.TIMEOUT;
-
-import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
-import org.apache.activemq.artemis.core.server.group.impl.GroupingHandlerConfiguration;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -39,7 +31,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
@@ -80,6 +71,7 @@ public class GroupingHandlerAdd extends AbstractAddStepHandler {
             // the groupingHandler is added as a child of the server resource. Requires a reload to restart the server with the grouping-handler
             if (context.isNormalServer()) {
                 context.addStep(new OperationStepHandler() {
+                    @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.reloadRequired();
                         context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
@@ -88,27 +80,5 @@ public class GroupingHandlerAdd extends AbstractAddStepHandler {
             }
         }
         // else the initial subsystem install is not complete and the grouping handler will be added in ServerAdd
-    }
-
-    static void addGroupingHandlerConfig(final OperationContext context, final Configuration configuration, final ModelNode model) throws OperationFailedException {
-        if (model.hasDefined(CommonAttributes.GROUPING_HANDLER)) {
-            final Property prop = model.get(CommonAttributes.GROUPING_HANDLER).asProperty();
-            final String name = prop.getName();
-            final ModelNode node = prop.getValue();
-
-            final GroupingHandlerConfiguration.TYPE type = GroupingHandlerConfiguration.TYPE.valueOf(GroupingHandlerDefinition.TYPE.resolveModelAttribute(context, node).asString());
-            final String address = GROUPING_HANDLER_ADDRESS.resolveModelAttribute(context, node).asString();
-            final int timeout = TIMEOUT.resolveModelAttribute(context, node).asInt();
-            final long groupTimeout = GROUP_TIMEOUT.resolveModelAttribute(context, node).asLong();
-            final long reaperPeriod = REAPER_PERIOD.resolveModelAttribute(context, node).asLong();
-            final GroupingHandlerConfiguration conf = new GroupingHandlerConfiguration()
-                    .setName(SimpleString.toSimpleString(name))
-                    .setType(type)
-                    .setAddress(SimpleString.toSimpleString(address))
-                    .setTimeout(timeout)
-                    .setGroupTimeout(groupTimeout)
-                    .setReaperPeriod(reaperPeriod);
-            configuration.setGroupingHandlerConfiguration(conf);
-        }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemAdd.java
@@ -187,7 +187,7 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 final List<BroadcastGroupConfiguration> broadcastGroupConfigurations =new ArrayList<>();
                 //this requires connectors
                 BroadcastGroupAdd.addBroadcastGroupConfigs(context, broadcastGroupConfigurations, connectors.keySet(), model);
-                final Map<String, DiscoveryGroupConfiguration> discoveryGroupConfigurations = DiscoveryGroupAdd.addDiscoveryGroupConfigs(context, model);
+                final Map<String, DiscoveryGroupConfiguration> discoveryGroupConfigurations = ConfigurationHelper.addDiscoveryGroupConfigurations(context, model);
                 final Map<String, String> clusterNames = new HashMap<>();
                 final Map<String, ServiceName> commandDispatcherFactories = new HashMap<>();
                 final Set<ServiceName> commandDispatcherFactoryServices = new HashSet<>();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -185,7 +185,7 @@ class ServerAdd extends AbstractAddStepHandler {
     private static final String ARTEMIS_BROKER_CONFIG_JDBC_LOCK_ACQUISITION_TIMEOUT_MILLIS = "brokerconfig.storeConfiguration.jdbcLockAcquisitionTimeoutMillis";
 
     private ServerAdd() {
-        super(ACTIVEMQ_SERVER_CAPABILITY, ServerDefinition.ATTRIBUTES);
+        super(ServerDefinition.ATTRIBUTES);
     }
 
     @Override
@@ -643,13 +643,13 @@ class ServerAdd extends AbstractAddStepHandler {
             processSecuritySettings(context, configuration, model);
 
             // Add in items from child resources
-            GroupingHandlerAdd.addGroupingHandlerConfig(context, configuration, model);
-            configuration.setDiscoveryGroupConfigurations(DiscoveryGroupAdd.addDiscoveryGroupConfigs(context, model));
-            DivertAdd.addDivertConfigs(context, configuration, model);
+            ConfigurationHelper.addGroupingHandlerConfiguration(context, configuration, model);
+            configuration.setDiscoveryGroupConfigurations(ConfigurationHelper.addDiscoveryGroupConfigurations(context, model));
+            ConfigurationHelper.addDivertConfigurations(context, configuration, model);
             ConfigurationHelper.addQueueConfigurations(context, configuration, model);
-            BridgeAdd.addBridgeConfigs(context, configuration, model);
-            ClusterConnectionAdd.addClusterConnectionConfigs(context, configuration, model);
-            ConnectorServiceDefinition.addConnectorServiceConfigs(context, configuration, model);
+            ConfigurationHelper.addBridgeConfigurations(context, configuration, model);
+            ConfigurationHelper.addClusterConnectionConfigurations(context, configuration, model);
+            ConfigurationHelper.addConnectorServiceConfigurations(context, configuration, model);
 
             return configuration;
         }


### PR DESCRIPTION
* JMS queues and topics are added to the broker configuration before it
starts so they are created before being available in WildFly
* Behaviour is now the same as in Artemis thus the acceptro starts after
all the queues are available

Jira: https://issues.redhat.com/browse/WFLY-12859