### PR TITLE
[WFLY-12897] Upgrade WildFly Core 11.0.0.Beta5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta5</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-12897

---


## Release Notes - WildFly Core - Version 11.0.0.Beta5
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4771'>WFCORE-4771</a>] -         Upgrade Elytron Web to 1.7.0.CR3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4773'>WFCORE-4773</a>] -         Upgrade WildFly OpenSSL to 1.0.9.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4635'>WFCORE-4635</a>] -         Introduce multiple overloads of CapabilityServiceBuilder.provides() method
</li>
</ul>
                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2356'>WFCORE-2356</a>] -         Failure in a step ResultHandler should not always be reported as occurring during rollback
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-3948'>WFCORE-3948</a>] -         Potential race condition on deployment of EAR when Class-Path manifest entry is in use
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4766'>WFCORE-4766</a>] -         Add additional logging to ManagementInterfaceAddStepHandler.LenientVerifyInstallationStep
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4774'>WFCORE-4774</a>] -         .CLI command to write attribute is giving a StackOverflow Exception
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4775'>WFCORE-4775</a>] -         Some .CLI commands that has been working since WF9 fails on WF18
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4776'>WFCORE-4776</a>] -         NPE in EmbeddedServer for version/help arguments
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4598'>WFCORE-4598</a>] -         Migrate remoting module to new MSC API
</li>
</ul>
                                    