### PR TITLE
[WFLY-12880]: Upgrade Jaeger Client to 0.34.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <version.groovy-all>2.4.7</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
-        <version.io.jaegertracing>0.34.0</version.io.jaegertracing>
+        <version.io.jaegertracing>0.34.1</version.io.jaegertracing>
         <version.io.netty>4.1.42.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>
@@ -304,7 +304,7 @@
         <version.org.apache.openjpa>2.4.2</version.org.apache.openjpa>
         <version.org.apache.qpid.proton>0.33.2</version.org.apache.qpid.proton>
         <version.org.apache.santuario>2.1.4</version.org.apache.santuario>
-        <version.org.apache.thrift>0.12.0</version.org.apache.thrift>
+        <version.org.apache.thrift>0.13.0</version.org.apache.thrift>
         <version.org.apache.velocity>2.1</version.org.apache.velocity>
         <version.org.apache.ws.security>2.2.4</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.4</version.org.apache.ws.xmlschema>


### PR DESCRIPTION
* Upgrade Jaeger client to 0.5.4.1
* Upgrade Apache Thrift to 0.13.0

Jira: https://issues.redhat.com/browse/WFLY-12880