### PR TITLE
WFLY-12929 HttpSessionListener.sessionDestroyed event can deadlock if it attempts write operations on a session

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -235,7 +235,7 @@ public class InfinispanSessionManager<MV, AV, L> implements SessionManager<L, Tr
         if (event.isPre()) {
             String id = event.getKey().getValue();
             InfinispanWebLogger.ROOT_LOGGER.tracef("Session %s will be removed", id);
-            Map.Entry<MV, AV> value = this.factory.findValue(id);
+            Map.Entry<MV, AV> value = this.factory.tryValue(id);
             if (value != null) {
                 ImmutableSession session = this.factory.createImmutableSession(id, value);
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-12929