### PR TITLE
[WFCORE-4788] Upgrade httpclient 4.5.10

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -162,6 +162,20 @@
             <artifactId>cxf-rt-transports-http</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- FIXME once wildfly-core with WFCORE-4788 is integrated, remove this dependency -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- FIXME once wildfly-core with WFCORE-4788 is integrated, remove this dependency -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.12</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.ws.xmlschema</groupId>
             <artifactId>xmlschema-core</artifactId>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/preservepath/PreservePathTestCase.java
@@ -140,11 +140,9 @@ public class PreservePathTestCase {
 
       if (preservePathOnForward != null && preservePathOnForward) {
          expectedServletPath = "/test";
-         // Note that in the true case, there is an extra slash before test. This might be removed in the future
-         expectedRequestURL = url + "/test";
+         expectedRequestURL = url + "test";
       } else{
          expectedServletPath = "/preserve-path.jsp";
-         // Note that in the true case, there is an extra slash before test. This might be removed in the future
          expectedRequestURL = url + "preserve-path.jsp";
       }
 


### PR DESCRIPTION
*Temporarily* add the httpclient dependency directly in the
integration test suite and fix the expectation of the
PreservePathTestCase assertion.

Once a release of WildFly Core that contains WFCORE-4788, the 2 added
dependencies will be removed from the pom.xml

JIRA: https://issues.redhat.com/browse/WFCORE-4788
