### PR TITLE
[WFLY-12942] Upgrade WildFly Core 11.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <version.org.reactivestreams>1.0.2</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-12942

---

## Release Notes - WildFly Core - Version 11.0.0.Beta6
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4391'>WFCORE-4391</a>] -         Upgrade apacheds-all to 2.0.0-M24 for Elytron tests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4777'>WFCORE-4777</a>] -         Upgrade JBoss Remoting from 5.0.16 to 5.0.17
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4779'>WFCORE-4779</a>] -         Upgrade Woodstox from 5.0.3 to 6.0.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4783'>WFCORE-4783</a>] -         Upgrade WildFly Elytron to 1.11.0.CR4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4784'>WFCORE-4784</a>] -         Upgrade Undertow to 2.0.29.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4786'>WFCORE-4786</a>] -         Upgrade Jandex 2.1.2.Final
</li>
</ul>
                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4172'>WFCORE-4172</a>] -         Add support for TLS 1.3
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4778'>WFCORE-4778</a>] -         Legacy LDAP realm, runtime operations and access to runtime attributes fail
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4782'>WFCORE-4782</a>] -         HttpManagementConstantHeadersTestCase doesn&#39;t do assertions on headerList.contains
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4700'>WFCORE-4700</a>] -         Add dependency on elytron-jwt
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4790'>WFCORE-4790</a>] -         Migrate deployment-scanner module to new MSC API
</li>
</ul>
                                    