### PR TITLE
Fix for WFLY-12955, Upgrade galleon to 4.2.3

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -199,18 +199,6 @@
                         </executions>
                         <dependencies>
                             <dependency>
-                                <groupId>org.jboss.universe</groupId>
-                                <artifactId>community-universe</artifactId>
-                                <version>${version.org.jboss.universe.community-universe}</version>
-                                <scope>runtime</scope>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.jboss.universe.producer</groupId>
-                                <artifactId>wildfly-producers</artifactId>
-                                <version>${version.org.jboss.universe.producer.wildfly-producers}</version>
-                                <scope>runtime</scope>
-                            </dependency>
-                            <dependency>
                                 <groupId>org.wildfly.core</groupId>
                                 <artifactId>wildfly-core-galleon-pack</artifactId>
                                 <version>${version.org.wildfly.core}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -204,14 +204,12 @@
         <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.8.2</version.jacoco.plugin><!-- TODO property does not follow verion.groupId format -->
-        <version.org.jboss.galleon>4.2.2.Final</version.org.jboss.galleon>
-        <version.org.jboss.universe.producer.wildfly-producers>1.0.2.Final</version.org.jboss.universe.producer.wildfly-producers>
-        <version.org.jboss.universe.community-universe>1.0.2.Final</version.org.jboss.universe.community-universe>
+        <version.org.jboss.galleon>4.2.3.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>4.2.2.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.2.3.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.0.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12955

Upgrade galleon and removed universe and producer dependencies when generating offliner file.