### PR TITLE
[WFLY-12957]: MP Fault tolerance tests are failing on Ubuntu

### DIFF
--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -173,6 +173,7 @@
                     <systemPropertyVariables>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <mp.health.args>-Dhystrix.command.default.execution.isolation.thread.interruptOnTimeout=false -Dhystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=60000 -Dhystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests=50 -Dhystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true -Dhystrix.threadpool.default.maximumSize=40</mp.health.args>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
@@ -27,7 +27,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="javaVmArguments">${microprofile.jvm.args} ${mp.health.args}</property>
             <property name="serverConfig">standalone.xml</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -203,6 +203,7 @@
                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <mp.health.args>-Dhystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds=10</mp.health.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/testsuite/integration/microprofile/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/microprofile/src/test/config/arq/arquillian.xml
@@ -28,7 +28,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${jboss.install.dir}</property>
-            <property name="javaVmArguments">${server.jvm.args}</property>
+            <property name="javaVmArguments">${server.jvm.args} ${mp.health.args}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>


### PR DESCRIPTION
* Passing the environmùent variables with dots as server args.

Jira: https://issues.redhat.com/browse/WFLY-12957