### PR TITLE
[WFLY-12903] - EJBComponent.checkCallerSecurityIdentityRole check for…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -626,15 +626,17 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
             return !identity.isAnonymous();
         }
         Roles roles = identity.getRoles("ejb", true);
-        if(roles.contains(roleName)) {
-            return true;
-        }
-        if(securityMetaData.getSecurityRoleLinks() != null) {
-            Collection<String> linked = securityMetaData.getSecurityRoleLinks().get(roleName);
-            if(linked != null) {
-                for (String role : roles) {
-                    if (linked.contains(role)) {
-                        return true;
+        if(roles != null) {
+            if(roles.contains(roleName)) {
+                return true;
+            }
+            if(securityMetaData.getSecurityRoleLinks() != null) {
+                Collection<String> linked = securityMetaData.getSecurityRoleLinks().get(roleName);
+                if(linked != null) {
+                    for (String role : roles) {
+                        if (linked.contains(role)) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
… null roles

https://issues.redhat.com/browse/WFLY-12903

Just a simple check to avoid NPE if custom elytron classes dont follow contract.