### PR TITLE
WFLY-12959 Upgrade microprofile-fault-tolerance-api to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
-        <version.org.eclipse.microprofile.fault-tolerance.api>2.0.2</version.org.eclipse.microprofile.fault-tolerance.api>
+        <version.org.eclipse.microprofile.fault-tolerance.api>2.0.3</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.health.api>2.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.metrics.api>2.2.1</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.openapi.api>1.1.2</version.org.eclipse.microprofile.openapi.api>


### PR DESCRIPTION
Jira
https://issues.redhat.com/browse/WFLY-12959