### PR TITLE
[WFLY-12962] Upgrade WildFly Core 11.0.0.Beta7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,7 +411,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.9.10</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -162,20 +162,6 @@
             <artifactId>cxf-rt-transports-http</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- FIXME once wildfly-core with WFCORE-4788 is integrated, remove this dependency -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.10</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- FIXME once wildfly-core with WFCORE-4788 is integrated, remove this dependency -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.12</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.ws.xmlschema</groupId>
             <artifactId>xmlschema-core</artifactId>


### PR DESCRIPTION
Remove temporary dependencies to httpcomponents as this release of
WildFly Core brings the upraded dependencies (from WFCORE-4788).

JIRA: https://issues.redhat.com/browse/WFLY-12962

---

## Release Notes - WildFly Core - Version 11.0.0.Beta7
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4697'>WFCORE-4697</a>] -         Upgrade WildFly Elytron to 1.11.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4788'>WFCORE-4788</a>] -         Upgrade org.apache.httpcomponents:httpclient 4.5.10
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4796'>WFCORE-4796</a>] -         Upgrade Elytron Web to 1.7.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4797'>WFCORE-4797</a>] -         Upgrade galleon to 4.2.3
</li>
</ul>
                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2147'>WFCORE-2147</a>] -         Impossible to use environment variables or system properties in permissions.xml and jboss-permissions.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4770'>WFCORE-4770</a>] -         CLI script execution at server boot
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4798'>WFCORE-4798</a>] -         Add necessary module dependencies to elytron-private module
</li>
</ul>
                                            