### PR TITLE
[WFLY-12712] Upgrade RESTEasy to 3.10.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -363,7 +363,7 @@
         <version.org.jboss.mod_cluster>1.4.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.10.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.4.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>3.9.3.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.10.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
Thanks for submitting your Pull Request!

https://issues.redhat.com/browse/WFLY-12712

This incorporates one Feature Request, WFLY-12298 (Allow to change RESTEasy settings via CLI), which has been merged.