### PR TITLE
WFLY-12957 MP Fault tolerance tests are failing on Ubuntu

### DIFF
--- a/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/pom.xml
@@ -161,22 +161,20 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>tck-suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
-                    <environmentVariables>
-                        <!-- Do not interrupt command execution when a timeout occurs - needed for bulkhead tests -->
-                        <hystrix.command.default.execution.isolation.thread.interruptOnTimeout>false</hystrix.command.default.execution.isolation.thread.interruptOnTimeout>
-                        <!-- Async actions don't have a timeout by default (because MP FT spec doesn't require it), but we define one
-                             to make sure tests don't hang (the io_smallrye_faulttolerance_asyncTimeout config property must be set to true)
-                             Of course the timeout value needs to be high enough; some tests require at least 20 seconds -->
-                        <hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds>60000</hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds>
-                        <!-- BulkheadFallbackRejectTest -->
-                        <hystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests>50</hystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests>
-                        <!-- Needed for extreme load in some bulkhead tests -->
-                        <hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize>true</hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize>
-                        <hystrix.threadpool.default.maximumSize>40</hystrix.threadpool.default.maximumSize>
-                    </environmentVariables>
                     <systemPropertyVariables>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <!-- hystrix.command.default.execution.isolation.thread.interruptOnTimeout:
+                             Do not interrupt command execution when a timeout occurs - needed for bulkhead tests -->
+                        <!-- hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds:
+                             Async actions don't have a timeout by default (because MP FT spec doesn't require it), but we define one
+                             to make sure tests don't hang (the io_smallrye_faulttolerance_asyncTimeout config property must be set to true)
+                             Of course the timeout value needs to be high enough; some tests require at least 20 seconds -->
+                        <!-- hystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests:
+                             Required for BulkheadFallbackRejectTest -->
+                        <!-- hystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize, hystrix.threadpool.default.maximumSize:
+                             Needed for extreme load in some bulkhead tests -->
+                        <jboss.args>-Dhystrix.command.default.execution.isolation.thread.interruptOnTimeout=false -Dhystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=60000 -Dhystrix.command.default.fallback.isolation.semaphore.maxConcurrentRequests=50 -Dhystrix.threadpool.default.allowMaximumSizeToDivergeFromCoreSize=true -Dhystrix.threadpool.default.maximumSize=40</jboss.args>
                         <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
                     </systemPropertyVariables>
                 </configuration>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/resources/arquillian.xml
@@ -29,6 +29,7 @@
             <property name="jbossHome">${jboss.home}</property>
             <property name="javaVmArguments">${microprofile.jvm.args}</property>
             <property name="serverConfig">standalone.xml</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>
             <property name="waitForPorts">9990</property>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -195,14 +195,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <environmentVariables>
-                        <!-- Required by org.wildfly.test.integration.microprofile.faulttolerance.sync.SyncCircuitBreakerDisabledTest -->
-                        <hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds>10</hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds>
-                    </environmentVariables>
                     <systemPropertyVariables>
                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
                         <!-- Override the standard module path that points at the shared module set from servlet-dist -->
                         <module.path>${project.build.directory}/wildfly/modules</module.path>
+                        <!-- hystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds:
+                             Required by org.wildfly.test.integration.microprofile.faulttolerance.sync.SyncCircuitBreakerDisabledTest -->
+                        <jboss.args>-Dhystrix.command.default.metrics.healthSnapshot.intervalInMilliseconds=10</jboss.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
* Pass properties instead of environmental variables

Jira
https://issues.redhat.com/browse/WFLY-12957

Replaces https://github.com/wildfly/wildfly/pull/12898