### PR TITLE
WFLY-12909 Fix license names for org.hdrhistogram:HdrHistogram licenses

### DIFF
--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -2128,12 +2128,12 @@
       <artifactId>HdrHistogram</artifactId>
       <licenses>
         <license>
-          <name>Public Domain, per Creative Commons CC0</name>
-          <url>http://creativecommons.org/publicdomain/zero/1.0/</url>
+          <name>BSD 2-Clause "Simplified" License</name>
+          <url>https://opensource.org/licenses/BSD-2-Clause</url>
         </license>
         <license>
-          <name>BSD-2-Clause</name>
-          <url>https://opensource.org/licenses/BSD-2-Clause</url>
+          <name>Creative Commons Zero v1.0 Universal</name>
+          <url>http://creativecommons.org/publicdomain/zero/1.0/</url>
         </license>
       </licenses>
     </dependency>


### PR DESCRIPTION
Jira
https://issues.redhat.com/browse/WFLY-12909

Fixed names, swapped order.