### PR TITLE
Add missing provided scope tags

### DIFF
--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -248,6 +248,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -453,6 +454,7 @@
                     <groupId>*</groupId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -1620,6 +1622,7 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The OpenAPI and JWT features missed the provided scope for a few items in the galleon pack pom.