### PR TITLE
[WFLY-12968] SecurityDomainContextRealm is not caching passwords correctly

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/elytron/SecurityDomainContextRealm.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/elytron/SecurityDomainContextRealm.java
@@ -169,7 +169,8 @@ public class SecurityDomainContextRealm implements SecurityRealm {
                 final Subject jaasSubject = new Subject();
                 Object jaasCredential = evidence;
                 if (evidence instanceof PasswordGuessEvidence) {
-                    jaasCredential = ((PasswordGuessEvidence) evidence).getGuess();
+                    // the original array may be cleared, some auth managers cache the password, so clone it
+                    jaasCredential = ((PasswordGuessEvidence) evidence).getGuess().clone();
                 }
                 final boolean isValid = domainContext.getAuthenticationManager().isValid(principal, jaasCredential, jaasSubject);
                 if (isValid) {

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/LoginCounterLoginModule.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/LoginCounterLoginModule.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.elytron.intermediate;
+
+import java.security.Principal;
+import java.security.acl.Group;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.security.auth.login.LoginException;
+import org.jboss.security.auth.spi.AbstractServerLoginModule;
+
+/**
+ * Login module that counts the number of times called. Configure with
+ * password-stacking set to useFirstPass and with flag to optional.
+ *
+ * @author rmartinc
+ */
+public class LoginCounterLoginModule extends AbstractServerLoginModule {
+
+    private static final AtomicInteger timesCalled = new AtomicInteger(0);
+    private static final AtomicInteger timesSuccess  = new AtomicInteger(0);
+
+    @Override
+    public boolean login() throws LoginException {
+        boolean result = super.login();
+        timesCalled.incrementAndGet();
+        if (result) {
+            timesSuccess.incrementAndGet();
+        }
+        return result;
+    }
+
+    public static int getTimesCalled() {
+        return timesCalled.get();
+    }
+
+    public static int getTimesSuccess() {
+        return timesSuccess.get();
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    protected Principal getIdentity() {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    protected Group[] getRoleSets() throws LoginException {
+        throw new UnsupportedOperationException("Not supported.");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/PrincipalCounterServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/PrincipalCounterServlet.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.elytron.intermediate;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet that uses the LoginCounterLoginModule to return the logged user
+ * and the times the login module was called (timesCalled). The format
+ * of the response is {username}:{timesCalled} in "text/plain" format.
+ *
+ * @author rmartinc
+ */
+@WebServlet(name = "PrincipalPrintingServlet", urlPatterns = { PrincipalCounterServlet.SERVLET_PATH })
+public class PrincipalCounterServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/countPrincipal";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        try (PrintWriter writer = resp.getWriter()) {
+            final String username = req.getUserPrincipal() == null? "null" : req.getUserPrincipal().getName();
+            writer.write(username + ":" + LoginCounterLoginModule.getTimesCalled());
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/SecurityDomainContextRealmTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/SecurityDomainContextRealmTestCase.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.elytron.intermediate;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.config.SecurityDomain;
+import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.security.common.AbstractElytronSetupTask;
+import org.wildfly.test.security.common.ModelNodeUtil;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.undertow.common.UndertowApplicationSecurityDomain;
+
+/**
+ * Test to check the login using the elytron intermediate configuration (elytron
+ * relaying on an old security domain). This class just configures a
+ * UsersRoles security domain and tests the login.
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({
+    SecurityDomainContextRealmTestCase.SecurityDomainsSetup.class,
+    SecurityDomainContextRealmTestCase.SecurityElytronRealmSetup.class,
+    SecurityDomainContextRealmTestCase.ElytronSetup.class})
+public class SecurityDomainContextRealmTestCase {
+
+    private static final String DEPLOYMENT = "SecurityDomainContextRealmDep";
+    private static final String SECURITY_DOMAIN_NAME = "SecurityDomainContextRealmSecDom";
+    private static final String ELYTRON_REALM_NAME = "SecurityDomainContextRealmRealm";
+    private static final String ELYTRON_DOMAIN_NAME = "SecurityDomainContextRealmDom";
+
+    @Deployment(name = DEPLOYMENT)
+    public static WebArchive deployment() {
+        final Package currentPackage = SecurityDomainContextRealmTestCase.class.getPackage();
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war")
+                .addClasses(PrincipalCounterServlet.class, LoginCounterLoginModule.class)
+                .addAsWebInfResource(currentPackage, "security-domain-context-realm-web.xml", "web.xml")
+                .addAsWebInfResource(Utils.getJBossWebXmlAsset(ELYTRON_DOMAIN_NAME), "jboss-web.xml")
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties");
+    }
+
+    @Test
+    @OperateOnDeployment(DEPLOYMENT)
+    public void testLogin(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = new URL(webAppURL.toExternalForm() + PrincipalCounterServlet.SERVLET_PATH);
+        // test login KO (401)
+        Utils.makeCallWithBasicAuthn(url, "user1", "Bad-Password", HttpServletResponse.SC_UNAUTHORIZED);
+        // test login OK but without Users role (403)
+        Utils.makeCallWithBasicAuthn(url, "admin", "admin", HttpServletResponse.SC_FORBIDDEN);
+        // test login OK
+        String output = Utils.makeCallWithBasicAuthn(url, "user1", "password1", HttpServletResponse.SC_OK);
+        Assert.assertThat("Username is correct", output, CoreMatchers.startsWith("user1:"));
+        int counter = Integer.parseInt(output.substring("user1:".length()));
+        // test login OK with cache
+        output = Utils.makeCallWithBasicAuthn(url, "user1", "password1", HttpServletResponse.SC_OK);
+        Assert.assertThat("Username is correct", output, CoreMatchers.startsWith("user1:"));
+        // ensure cache is in place and the login counter has not been incremented
+        int newCounter = Integer.parseInt(output.substring("user1:".length()));
+        Assert.assertThat("Cache is working and same login count", newCounter, CoreMatchers.is(counter));
+    }
+
+    /**
+     * Creates a security-domain with default cache to be used as legacy realm.
+     * The LoginCounterLoginModule is added to count the number of logins.
+     *
+     * <security-domain name="SecurityDomainContextRealmSecDom" cache-type="default">
+     *     <authentication>
+     *         <login-module code="UsersRoles" flag="required">
+     *             <module-option name="rolesProperties" value="/path/to/roles.properties"/>
+     *             <module-option name="usersProperties" value="/path/to/users.properties"/>
+     *             <module-option name="password-stacking" value="useFirstPass"/>
+     *         </login-module>
+     *         <login-module code="org.wildfly.test.elytron.LoginCounterLoginModule" flag="optional">
+     *             <module-option name="password-stacking" value="useFirstPass"/>
+     *         </login-module>
+     *     </authentication>
+     * </security-domain>
+     */
+    static class SecurityDomainsSetup extends AbstractSecurityDomainsServerSetupTask {
+
+        @Override
+        protected SecurityDomain[] getSecurityDomains() throws Exception {
+            Map<String, String> lmOptions = new HashMap<>();
+            String usersProperties = new File(SecurityDomainContextRealmTestCase.class.getResource("users.properties").getFile()).getAbsolutePath();
+            String rolesProperties = new File(SecurityDomainContextRealmTestCase.class.getResource("roles.properties").getFile()).getAbsolutePath();
+            lmOptions.put("password-stacking", "useFirstPass");
+            lmOptions.put("usersProperties", usersProperties);
+            lmOptions.put("rolesProperties", rolesProperties);
+            final SecurityModule.Builder userRolesBuilder = new SecurityModule.Builder()
+                    .name("UsersRoles")
+                    .options(lmOptions)
+                    .flag("required");
+
+            lmOptions = new HashMap<>();
+            lmOptions.put("password-stacking", "useFirstPass");
+            final SecurityModule.Builder counterBuilder = new SecurityModule.Builder()
+                    .name(LoginCounterLoginModule.class.getName())
+                    .options(lmOptions)
+                    .flag("optional");
+
+            final SecurityDomain sd = new SecurityDomain.Builder()
+                    .name(SECURITY_DOMAIN_NAME)
+                    .cacheType("default")
+                    .loginModules(userRolesBuilder.build(), counterBuilder.build())
+                    .build();
+
+            return new SecurityDomain[]{sd};
+        }
+    }
+
+    /**
+     * Creates the elytron realm mapper to use in the mixed configuration:
+     *
+     *  <security-realms>
+     *      <elytron-realm name="SecurityDomainContextRealmRealm" legacy-jaas-config="SecurityDomainContextRealmSecDom"/>
+     *  </security-realms>
+     */
+    static class SecurityElytronRealmSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient mc, String string) throws Exception {
+            // /subsystem=security/elytron-realm=ELYTRON_REALM_NAME:add(legacy-jaas-config=SECURITY_DOMAIN_NAME)
+            ModelNode op = Util.createAddOperation(
+                PathAddress.pathAddress().append("subsystem", "security").append("elytron-realm", ELYTRON_REALM_NAME));
+            ModelNodeUtil.setIfNotNull(op, "legacy-jaas-config", SECURITY_DOMAIN_NAME);
+            CoreUtils.applyUpdate(op, mc.getControllerClient());
+            ServerReload.reloadIfRequired(mc);
+        }
+
+        @Override
+        public void tearDown(ManagementClient mc, String string) throws Exception {
+            // /subsystem=security/elytron-realm=ELYTRON_REALM_NAME:remove
+            CoreUtils.applyUpdate(Util.createRemoveOperation(
+                    PathAddress.pathAddress().append("subsystem", "security").append("elytron-realm", ELYTRON_REALM_NAME)),
+                    mc.getControllerClient());
+            ServerReload.reloadIfRequired(mc);
+        }
+    }
+
+    /**
+     * Creates the elytron setup to use the legacy security domain.
+     */
+    static class ElytronSetup extends AbstractElytronSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            return new ConfigurableElement[]{
+                SimpleSecurityDomain.builder()
+                    .withName(ELYTRON_DOMAIN_NAME)
+                    .withDefaultRealm(ELYTRON_REALM_NAME)
+                    .withPermissionMapper("default-permission-mapper")
+                    .withRealms(SimpleSecurityDomain.SecurityDomainRealm.builder()
+                        .withRealm(ELYTRON_REALM_NAME)
+                        .build())
+                    .build(),
+                UndertowApplicationSecurityDomain.builder()
+                    .withName(ELYTRON_DOMAIN_NAME)
+                    .withSecurityDomain(ELYTRON_DOMAIN_NAME)
+                    .build()
+            };
+        }
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/roles.properties
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/roles.properties
@@ -1,0 +1,4 @@
+user1=Users,Role1
+user2=Users,Role2
+admin=Admin
+hr=HR

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/security-domain-context-realm-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/security-domain-context-realm-web.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Test realm</realm-name>
+    </login-config>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>secured-area</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>Users</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>Users</role-name>
+    </security-role>
+</web-app>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/users.properties
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/elytron/intermediate/users.properties
@@ -1,0 +1,5 @@
+#$REALM_NAME=UsersRoles$
+user1=password1
+user2=password2
+admin=admin
+hr=hr


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12968

Fix for a cache issue when intermediate configuration is used in elytron. The test was much more complicated than the real fix. ;-)