### PR TITLE
[WFLY-12990] Upgrade WildFly Naming Client to 1.0.12.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
         <version.org.wildfly.core>11.0.0.Beta7</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.18.Final</version.org.wildfly.http-client>
-        <version.org.wildfly.naming-client>1.0.11.Final</version.org.wildfly.naming-client>
+        <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.9.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.24</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-12990

Includes fix for https://issues.redhat.com/browse/WFNC-56