### PR TITLE
[WFLY-12999] EJB Client authentication does not work using SASL DIGEST-MD5 and EXTERNAL mechanisms in Legacy security - test

### DIFF
--- a/testsuite/integration/basic/src/test/resources/org/jboss/as/test/integration/ejb/security/jboss-ejb-client.properties
+++ b/testsuite/integration/basic/src/test/resources/org/jboss/as/test/integration/ejb/security/jboss-ejb-client.properties
@@ -5,7 +5,6 @@ remote.connection.default.host=${node0:localhost}
 remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
 
 remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=true
-remote.connection.default.connect.options.org.xnio.Options.SASL_DISALLOWED_MECHANISMS=DIGEST,DIGEST-MD5,JBOSS-LOCAL-USER
 # The following setting is required when deferring to JAAS
 remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-12999
Test for WFCORE: https://issues.redhat.com/browse/WFCORE-4803
Needs WFCORE PR first: https://github.com/wildfly/wildfly-core/pull/4061

Test should fail now until the fix included in WFCORE.

Modifications in SaslLegacyMechanismConfigurationTestCase in order ti add the DIGEST-MD5 configuration that failed. Although a test was added in WFCORE it's better if the test is complete.