### PR TITLE
[WFLY-13005] Upgrade BouncyCastle to 1.64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -315,7 +315,7 @@
         <version.org.apache.ws.xmlschema>2.2.4</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bitbucket.jose4j>0.6.5</version.org.bitbucket.jose4j>
-        <version.org.bouncycastle>1.62</version.org.bouncycastle>
+        <version.org.bouncycastle>1.64</version.org.bouncycastle>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00006</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13005

The jGit component in WildFly Core is introducing a dependency on BouncyCastle 1.64, before any refactoring submitting this PR for the initial updgrade.

@asoldano / @ronsigal Would it be possible for you to please check if this is ok for RestEasy?
@jimma / @rsearls  Would it be possible for you to please check if this is Ok for web services?

Hopefully this is just a small increment.