### PR TITLE
[WFLY-12952] Register default readiness probe for deployment

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
@@ -97,6 +97,11 @@ on the `subsystem` resource to `DOWN`.
 This allows application to ensure that the HTTP liveness and readiness endpoints will return `DOWN` until their probes are deployed and used to determine the actual
 liveness and readiness state of the application.
 
+[NOTE]
+There is a specific behaviour for deployments that provides no _readiness_ probes. In that the case, WildFly automatically adds a readiness probe for the deployment that always return
+`UP`. This allows existing deployments that do not provide readiness probes to configure WildFly so it will not be ready until this deployment is actually deployed.
+
+
 == Component Reference
 
 The Eclipse MicroProfile Health is implemented by the SmallRye Health project.

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/health-smallrye/main/module.xml
@@ -42,6 +42,7 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.eclipse.microprofile.config.api"/>
         <module name="org.eclipse.microprofile.health.api"/>
         <module name="org.wildfly.extension.microprofile.config-smallrye" />
         <module name="org.jboss.as.weld.common" />

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -50,6 +50,10 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
         </dependency>

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/deployment/DeploymentProcessor.java
@@ -59,7 +59,7 @@ public class DeploymentProcessor implements DeploymentUnitProcessor {
         if (weldCapability.isPartOfWeldDeployment(deploymentUnit)) {
             final HealthReporter healthReporter = (HealthReporter) phaseContext.getServiceRegistry().getService(MicroProfileHealthSubsystemDefinition.HEALTH_REPORTER_SERVICE).getValue();
 
-            weldCapability.registerExtensionInstance(new CDIExtension(healthReporter, module.getClassLoader()), deploymentUnit);
+            weldCapability.registerExtensionInstance(new CDIExtension(healthReporter, module), deploymentUnit);
         }
 
     }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessOperationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessOperationTestCase.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2019 Red Hat inc.
+ */
+public class MicroProfileHealthApplicationWithoutReadinessOperationTestCase extends MicroProfileHealthApplicationReadyTestBase {
+
+    void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "microprofile-health-smallrye");
+        ModelNode checkOp = getEmptyOperation(operation, address);
+
+        ModelNode response = managementClient.getControllerClient().execute(checkOp);
+
+        final String opOutcome = response.get("outcome").asString();
+        assertEquals("success", opOutcome);
+
+        ModelNode result = response.get("result");
+        assertEquals(mustBeUP? "UP" : "DOWN", result.get("status").asString());
+
+        if (probeName != null) {
+            for (ModelNode check : result.get("checks").asList()) {
+                if (probeName.equals(check.get("name").asString())) {
+                    // probe name found
+                    // global outcome is driven by this probe state
+                    assertEquals(mustBeUP? "UP" : "DOWN", check.get("status").asString());
+                    return;
+                }
+            }
+            fail("Probe named " + probeName + " not found in " + result);
+        }
+
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessTestBase.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that an application without any readiness probe got one setup by WildFly so that the application
+ * is considered ready when it is deployed
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({MicroProfileHealthApplicationReadySetupTask.class})
+public abstract class MicroProfileHealthApplicationWithoutReadinessTestBase {
+
+    abstract void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException;
+
+    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBaseSetup")
+    public static Archive<?> deploySetup() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutReadinessTestBaseSetup.war")
+                .addClass(MicroProfileHealthApplicationReadySetupTask.class);
+        return war;
+    }
+
+    // deployment does not define any readiness probe
+    @Deployment(name = "MicroProfileHealthApplicationWithoutReadinessTestBase", managed = false)
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileHealthApplicationWithoutReadinessTestBase.war")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Test
+    @InSequence(1)
+    public void testApplicationReadinessBeforeDeployment() throws Exception {
+        checkGlobalOutcome(managementClient, "check-ready", false, null);
+
+        // deploy the archive
+        deployer.deploy("MicroProfileHealthApplicationWithoutReadinessTestBase");
+    }
+
+    @Test
+    @InSequence(2)
+    @OperateOnDeployment("MicroProfileHealthApplicationWithoutReadinessTestBase")
+    public void testApplicationReadinessAfterDeployment(@ArquillianResource URL url) throws Exception {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+
+            checkGlobalOutcome(managementClient, "check-ready", true, "ready-deployment.MicroProfileHealthApplicationWithoutReadinessTestBase.war");
+        }
+    }
+
+    @Test
+    @InSequence(3)
+    public void testHealthCheckAfterUndeployment() throws Exception {
+
+        deployer.undeploy("MicroProfileHealthApplicationWithoutReadinessTestBase");
+
+        checkGlobalOutcome(managementClient, "check-ready", false, null);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWitouhtReadinessHTTPEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWitouhtReadinessHTTPEndpointTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.as.arquillian.container.ManagementClient;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2019 Red Hat inc.
+ */
+public class MicroProfileHealthApplicationWitouhtReadinessHTTPEndpointTestCase extends MicroProfileHealthApplicationWithoutReadinessTestBase {
+
+    void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException {
+
+        assertEquals("check-ready", operation);
+        final String httpEndpoint = "/health/ready";
+
+        final String healthURL = "http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort() + httpEndpoint;
+
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+
+            CloseableHttpResponse resp = client.execute(new HttpGet(healthURL));
+            assertEquals(mustBeUP ? 200 : 503, resp.getStatusLine().getStatusCode());
+
+            String content = EntityUtils.toString(resp.getEntity());
+            resp.close();
+
+            try (
+                    JsonReader jsonReader = Json.createReader(new StringReader(content))
+            ) {
+                JsonObject payload = jsonReader.readObject();
+                String outcome = payload.getString("status");
+                assertEquals(mustBeUP ? "UP": "DOWN", outcome);
+
+                if (probeName != null) {
+                    for (JsonValue check : payload.getJsonArray("checks")) {
+                        if (probeName.equals(check.asJsonObject().getString("name"))) {
+                            // probe name found
+                            assertEquals(mustBeUP ? "UP" : "DOWN", check.asJsonObject().getString("status"));
+                            return;
+                        }
+                    }
+                    fail("Probe named " + probeName + " not found in " + content);
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/microprofile-tck/health/pom.xml
+++ b/testsuite/integration/microprofile-tck/health/pom.xml
@@ -76,7 +76,9 @@
                         <dependency>org.eclipse.microprofile.health:microprofile-health-tck</dependency>
                     </dependenciesToScan>
                     <systemPropertyVariables>
-                        <microprofile.jvm.args>${microprofile.jvm.args}</microprofile.jvm.args>
+                        <!-- Disable default procedures as the MP Metrics TCK must be run without them -->
+                        <!-- https://github.com/eclipse/microprofile-health/blob/master/tck/running_the_tck.asciidoc#disabling-default-vendor-procedures -->
+                        <microprofile.jvm.args>${microprofile.jvm.args} -Dmp.health.disable-default-procedures=true</microprofile.jvm.args>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
When a deployment does not provide any MicroProfile readiness probe,
add a default one (which returns UP as long as the deployment is deployed).

This allow to configure the overall server readiness to be DOWN when
the server is started and becomes UP as soon as a deployment is
deployed.

This default probe is disabled when the MicroProfile Health TCK is run.

JIRA: https://issues.redhat.com/browse/WFLY-12952