### PR TITLE
[WFLY-13009] Send moduleAvailability message only after module started

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -389,11 +389,12 @@ final class AssociationImpl implements Association, AutoCloseable {
 
             @Override
             public void deploymentAvailable(final DeploymentModuleIdentifier deployment, final ModuleDeployment moduleDeployment) {
-                moduleAvailabilityListener.moduleAvailable(Collections.singletonList(toModuleIdentifier(deployment)));
             }
 
             @Override
             public void deploymentStarted(final DeploymentModuleIdentifier deployment, final ModuleDeployment moduleDeployment) {
+                // only send out moduleAvailability until module has started (WFLY-13009)
+                moduleAvailabilityListener.moduleAvailable(Collections.singletonList(toModuleIdentifier(deployment)));
             }
 
             @Override


### PR DESCRIPTION
This PR makes the following changes:
- moves the sending of the moduleAvailable update message from server to EJB client from the method DeploymentRepositoiryListener.deploymentAvailable() to the method deploymentStarted()
- this ensures that the module is marked as available for invocations only after it has been started 
- this fixes the issue seen in EJBCLIENT-362

For more details, see the issue  https://issues.redhat.com/browse/WFLY-13009