### PR TITLE
Fix for WFLY-13017, cloud-server layer to extend jaxrs-server layer

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -145,8 +145,8 @@ Undertow subsystem is configured with _other_ _application-security-domain_ that
 ====
 
 * _datasources-web-server_: A servlet container (_web-server_ layer) with an optional dependency on _datasources_ layer.
-* _jaxrs-server_: An extension of _datasources-web-server_ layer with _jaxrs_ and optional dependencies on _cdi_ and _jpa_ layers.
-* _cloud-server_: A _cloud-profile_ with core features and tools.
+* _jaxrs-server_: An extension of _datasources-web-server_ layer with optional dependencies on _jaxrs_, _cdi_, _bean-validation_ and _jpa_ layers.
+* _cloud-server_: An extension of _jaxrs-server_ with optional dependencies on _ee-security_, _jms-activemq_, _observability_ and _resource-adapters_.
 
 
 Decorator layers:

--- a/galleon-pack/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/cloud-server/layer-spec.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cloud-server">
     <dependencies>
-        <layer name="cloud-profile"/>
-        <layer name="core-server"/>
-        <layer name="core-tools"/>
+        <layer name="jaxrs-server"/>
+        <layer name="ee-security" optional="true"/>
+        <layer name="jms-activemq" optional="true"/>
+        <layer name="observability" optional="true"/>
+        <layer name="resource-adapters" optional="true"/>
     </dependencies>
-    <feature-group name="undertow-elytron-security"/>
-    <packages>
-        <!-- Support for installing legacy one-off patches -->
-        <package name="org.jboss.as.patching.cli" optional="true"/>
-    </packages>
 </layer-spec>

--- a/galleon-pack/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/jaxrs-server/layer-spec.xml
@@ -2,7 +2,9 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jaxrs-server">
     <dependencies>
         <layer name="datasources-web-server"/>
-        <layer name="jaxrs" />
+        <!-- cloud-server depends on jaxrs-server, jaxrs could be excluded from cloud-server,
+             this is why jaxrs is an optional dependency -->
+        <layer name="jaxrs" optional="true"/>
         <layer name="bean-validation" optional="true"/>
         <layer name="cdi" optional="true"/>
         <layer name="jpa" optional="true"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13017

Refactor cloud-server to align dependencies of datasources-web-server, jaxrs-server and cloud-server.
