### PR TITLE
[WFLY-13042]: Jaeger tracer sender-binding isn't configurable.

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
@@ -20,6 +20,7 @@ import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -60,6 +61,7 @@ public class TracerAttributes {
     public static final SimpleAttributeDefinition SENDER_BINDING = SimpleAttributeDefinitionBuilder.create(TracerConfigurationConstants.SENDER_AGENT_BINDING, ModelType.STRING, true)
             .setAttributeGroup("sender-configuration")
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()
             .build();
     public static final SimpleAttributeDefinition SENDER_ENDPOINT = SimpleAttributeDefinitionBuilder.create(TracerConfigurationConstants.SENDER_ENDPOINT, ModelType.STRING, true)

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracerConfigurationApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/application/TracerConfigurationApplication.java
@@ -7,6 +7,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import io.opentracing.Tracer;
+import java.lang.reflect.Field;
+import java.net.DatagramSocket;
+import org.jboss.as.network.NetworkUtils;
 
 /**
  * @author Sultan Zhantemirov (c) 2019 Red Hat, Inc.
@@ -23,8 +26,41 @@ public class TracerConfigurationApplication extends Application {
         @GET
         @Produces("text/plain")
         public String get() {
+            if (checkClass(this.tracer, "JaegerTracer")) {
+                return tracer.toString() + getSenderConfiguration();
+            }
             return tracer.toString();
         }
 
+        private String getSenderConfiguration() {
+            try {
+                Field reporterField = this.tracer.getClass().getDeclaredField("reporter");
+                reporterField.setAccessible(true);
+                Object reporter = reporterField.get(this.tracer);
+                if (checkClass(reporter, "RemoteReporter")) {
+                    Field senderField = reporter.getClass().getDeclaredField("sender");
+                    senderField.setAccessible(true);
+                    Object sender = senderField.get(reporter);
+                    if (checkClass(sender, "UdpSender")) {
+                        Field transportField = sender.getClass().getDeclaredField("udpTransport");
+                        transportField.setAccessible(true);
+                        Object transport = transportField.get(sender);
+                        if (checkClass(transport, "ThriftUdpTransport")) {
+                            Field socketField = transport.getClass().getDeclaredField("socket");
+                            socketField.setAccessible(true);
+                            DatagramSocket socket = (DatagramSocket) socketField.get(transport);
+                            return "sender-binding=" + NetworkUtils.formatIPAddressForURI(socket.getInetAddress()) + ":" + socket.getPort();
+                        }
+                    }
+                }
+            } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
+                throw new RuntimeException("Error getting network configuration details", ex);
+            }
+            return "";
+        }
+
+        private boolean checkClass(Object obj, String simpleName) {
+            return simpleName.equals(obj.getClass().getSimpleName());
+        }
     }
 }


### PR DESCRIPTION
* Obtaining the socket-bindings when the tracer is being configured.
* Adding security constraint on the attribute definition.

Jira: https://issues.redhat.com/browse/WFLY-13042