### PR TITLE
[WFLY-13052] MicroProfile Config TCK ShouldThrowException

### DIFF
--- a/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
+++ b/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
@@ -1,3 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.wildfly.extension.microprofile.config.test;
 
 import org.hamcrest.Matchers;

--- a/testsuite/integration/microprofile-tck/config/tck-suite.xml
+++ b/testsuite/integration/microprofile-tck/config/tck-suite.xml
@@ -8,25 +8,6 @@
             </package>
         </packages>
         <classes>
-            <!-- Exclude these 3 classes as they rely on a @ShouldThrowException(DeploymentException.class)
-                 that is not working with Arquillian WildFly container (https://issues.jboss.org/browse/WFARQ-59)
-            -->
-            <class name="org.eclipse.microprofile.config.tck.broken.MissingConverterOnInstanceInjectionTest">
-                <methods>
-                    <exclude name=".*" />
-                </methods>
-            </class>
-            <class name="org.eclipse.microprofile.config.tck.broken.MissingValueOnInstanceInjectionTest">
-                <methods>
-                    <exclude name=".*" />
-                </methods>
-            </class>
-            <class name="org.eclipse.microprofile.config.tck.broken.WrongConverterOnInstanceInjectionTest">
-                <methods>
-                    <exclude name=".*" />
-                </methods>
-            </class>
-
             <!-- TCK and spec dispute: https://github.com/eclipse/microprofile-config/pull/407 -->
             <class name="org.eclipse.microprofile.config.tck.ConfigProviderTest">
                 <methods>


### PR DESCRIPTION
Add an Arquillian DeploymentExceptionTransformer to ensure that a
DeploymentException is properly thrown when the deployment on WildFly
Server is unsuccessful (the actual cause of the deployment failure is
lost but they are not asserted by the tests that uses
@ShouldThrowException.

* Remove corresponding excluded tests from tck-suite.xml

JIRA: https://issues.redhat.com/browse/WFLY-13052

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
