### PR TITLE
servlet-feature-pack-licenses: fix jboss-el-api_3.0_spec license name

### DIFF
--- a/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
+++ b/servlet-feature-pack/src/license/servlet-feature-pack-licenses.xml
@@ -393,7 +393,7 @@
           <distribution>repo</distribution>
         </license>
         <license>
-          <name>GNU Lesser General Public License v2.1 only</name>
+          <name>GNU Lesser General Public License v2.1 or later</name>
           <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
           <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
Correct License name is "GNU Lesser General Public License v2.1 or later", see in [jboss-el-api_3.0_spec pom](https://github.com/jboss/jboss-jakarta-el-api_spec/blob/jboss-el-api_3.0_spec-2.0.0.Final/pom.xml#L70)