### PR TITLE
[WFLY-13050] Metrics should be optional in the observability layer

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -126,8 +126,7 @@ Basic layers:
 * _microprofile-fault-tolerance_: Support for MicroProfile Fault Tolerance.
 * _microprofile-jwt_: Support for MicroProfile JWT.
 * _microprofile-metrics_: Support for MicroProfile Metrics.
-* _observability_: Support for MicroProfile monitoring and configuration features (Config, Health, Metrics, OpenTracing).
-* _open-tracing_: Support for MicroProfile OpenTracing. This layer is an optional dependency of the _observability_ layer.
+* _open-tracing_: Support for MicroProfile OpenTracing.
 * _resource-adapters_: Support for deployment of JCA adapters.
 * _h2-driver_: Support for the H2 JDBC driver.
 * _h2-datasource_: Support for an H2 datasource. Depends on _h2-driver_.
@@ -155,6 +154,9 @@ Decorator layers:
 Layers that you combine with "use-case tailored" layers to extend the capabilities of the provisioned server.
 
 * _web-clustering_: Infinispan-based web session clustering.
+
+* _observability_: Support for MicroProfile monitoring and configuration features. 
+Includes Health support, _microprofile-config_, _microprofile-metrics_ (optional) and _open-tracing_ (optional).
 
 ==== WildFly servlet layers
 

--- a/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
+        <!-- required by health subsystem -->
         <layer name="microprofile-config"/>
-        <layer name="microprofile-metrics"/>
+        <layer name="microprofile-metrics" optional="true"/>
         <layer name="open-tracing" optional="true"/>
     </dependencies>
     <feature-group name="health"/>


### PR DESCRIPTION
This is just a conflict resolution of #12956

https://issues.redhat.com/browse/WFLY-13050