### PR TITLE
WFLY-13074 Don't start the app context unless the server is running.

### DIFF
--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapterService.java
@@ -33,6 +33,7 @@ import io.undertow.servlet.api.Deployment;
 import org.jboss.as.clustering.context.DefaultThreadFactory;
 import org.jboss.as.server.suspend.ServerActivity;
 import org.jboss.as.server.suspend.ServerActivityCallback;
+import org.jboss.as.server.suspend.SuspendController.State;
 import org.jboss.logging.Logger;
 import org.jboss.modcluster.container.Connector;
 import org.jboss.modcluster.container.ContainerEventHandler;
@@ -113,10 +114,16 @@ public class UndertowEventHandlerAdapterService implements UndertowEventListener
 
     private synchronized void onStart(Context context) {
         ContainerEventHandler handler = this.configuration.getContainerEventHandler();
+
         handler.add(context);
 
+        State state = this.configuration.getSuspendController().getState();
+
         // TODO break into onDeploymentAdd once implemented in Undertow
-        handler.start(context);
+        if(state == State.RUNNING) {
+            handler.start(context);
+        }
+
         this.contexts.add(context);
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13074

analysis is in the downstream 7.2.z issue, thanks.