### PR TITLE
[19.0.x] [WFLY-13023] Upgrade MicroProfile Config 1.4

### DIFF
--- a/ee-galleon-pack/pom.xml
+++ b/ee-galleon-pack/pom.xml
@@ -1513,7 +1513,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
             <exclusions>
                 <exclusion>
@@ -1525,7 +1525,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2983,7 +2983,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
             <exclusions>
                 <exclusion>
@@ -2995,7 +2995,7 @@
 
 
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -604,39 +604,6 @@
     </dependency>
     <dependency>
       <groupId>io.smallrye</groupId>
-      <artifactId>smallrye-config</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>io.smallrye</groupId>
-      <artifactId>smallrye-config-common</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>io.smallrye.config</groupId>
-      <artifactId>smallrye-config-source-file-system</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>io.smallrye</groupId>
       <artifactId>smallrye-health</artifactId>
       <licenses>
         <license>
@@ -660,6 +627,39 @@
     <dependency>
       <groupId>io.smallrye</groupId>
       <artifactId>smallrye-opentracing</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-common</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config-source-file-system</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/smallrye/config/main/module.xml
@@ -24,8 +24,8 @@
 
 <module xmlns="urn:jboss:module:1.8" name="io.smallrye.config">
     <resources>
-        <artifact name="${io.smallrye:smallrye-config}"/>
-        <artifact name="${io.smallrye:smallrye-config-common}"/>
+        <artifact name="${io.smallrye.config:smallrye-config}"/>
+        <artifact name="${io.smallrye.config:smallrye-config-common}"/>
         <artifact name="${io.smallrye.config:smallrye-config-source-file-system}"/>
     </resources>
 

--- a/microprofile/config-smallrye/pom.xml
+++ b/microprofile/config-smallrye/pom.xml
@@ -51,11 +51,11 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.smallrye</groupId>
+            <groupId>io.smallrye.config</groupId>
             <artifactId>smallrye-config-common</artifactId>
         </dependency>
         <dependency>

--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/DirConfigSourceRegistrationService.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/DirConfigSourceRegistrationService.java
@@ -25,7 +25,7 @@ package org.wildfly.extension.microprofile.config.smallrye;
 import java.io.File;
 import java.util.function.Supplier;
 
-import io.smallrye.config.FileSystemConfigSource;
+import io.smallrye.config.source.file.FileSystemConfigSource;
 
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.as.controller.OperationContext;

--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <version.io.reactivex.rxjava>2.2.5</version.io.reactivex.rxjava>
         <version.io.reactivex.rxjava1>1.2.0</version.io.reactivex.rxjava1>
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
-        <version.io.smallrye.smallrye-config>1.4.1</version.io.smallrye.smallrye-config>
+        <version.io.smallrye.smallrye-config>1.6.1</version.io.smallrye.smallrye-config>
         <version.io.smallrye.fault-tolerance>2.1.5</version.io.smallrye.fault-tolerance>
         <version.io.smallrye.smallrye-health>2.1.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
@@ -342,7 +342,7 @@
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
         <version.org.cryptacular>1.2.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
-        <version.org.eclipse.microprofile.config.api>1.3</version.org.eclipse.microprofile.config.api>
+        <version.org.eclipse.microprofile.config.api>1.4</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.fault-tolerance.api>2.0.3</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.health.api>2.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
@@ -1823,7 +1823,7 @@
             </dependency>
 
             <dependency>
-                <groupId>io.smallrye</groupId>
+                <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config</artifactId>
                 <version>${version.io.smallrye.smallrye-config}</version>
                 <exclusions>
@@ -1843,7 +1843,7 @@
             </dependency>
 
             <dependency>
-                <groupId>io.smallrye</groupId>
+                <groupId>io.smallrye.config</groupId>
                 <artifactId>smallrye-config-common</artifactId>
                 <version>${version.io.smallrye.smallrye-config}</version>
             </dependency>

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/MicroProfileConfigTestCase.java
@@ -200,9 +200,6 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
             assertTextContainsProperty(text, "integerDefault", -42);
             assertTextContainsProperty(text, SubsystemConfigSourceTask.INTEGER_OVERRIDDEN_PROP_NAME,
                     SubsystemConfigSourceTask.INTEGER_OVERRIDDEN_PROP_VALUE);
-
-            assertTextContainsProperty(text, "intBadValue", 0);
-            assertTextContainsProperty(text, "integerBadValue", "null");
         }
     }
 
@@ -224,9 +221,6 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
 
             assertTextContainsProperty(text, "longClassDefault", -42);
             assertTextContainsProperty(text, SubsystemConfigSourceTask.LONG_CLASS_OVERRIDDEN_PROP_NAME, SubsystemConfigSourceTask.LONG_OVERRIDDEN_PROP_VALUE);
-
-            assertTextContainsProperty(text, "longBadValue", 0);
-            assertTextContainsProperty(text, "longClassBadValue", "null");
         }
     }
 
@@ -248,9 +242,6 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
 
             assertTextContainsProperty(text, "floatClassDefault", Float.valueOf("-3.14e10"));
             assertTextContainsProperty(text, SubsystemConfigSourceTask.FLOAT_CLASS_OVERRIDDEN_PROP_NAME, SubsystemConfigSourceTask.FLOAT_OVERRIDDEN_PROP_VALUE);
-
-            assertTextContainsProperty(text, "floatBadValue", 0.0f);
-            assertTextContainsProperty(text, "floatClassBadValue", "null");
         }
     }
 
@@ -272,9 +263,6 @@ public class MicroProfileConfigTestCase extends AbstractMicroProfileConfigTestCa
 
             assertTextContainsProperty(text, "doubleClassDefault", Double.valueOf("-3.14e10"));
             assertTextContainsProperty(text, SubsystemConfigSourceTask.DOUBLE_CLASS_OVERRIDDEN_PROP_NAME, SubsystemConfigSourceTask.DOUBLE_OVERRIDDEN_PROP_VALUE);
-
-            assertTextContainsProperty(text, "doubleBadValue", 0.0d);
-            assertTextContainsProperty(text, "doubleClassBadValue", "null");
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/TestApplication.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/app/TestApplication.java
@@ -194,15 +194,6 @@ public class TestApplication extends Application {
         @ConfigProperty(name = SubsystemConfigSourceTask.INTEGER_OVERRIDDEN_PROP_NAME, defaultValue = "123")
         private Integer integerOverridden;
 
-
-        @Inject
-        @ConfigProperty(name = "intBadValue", defaultValue = "1.23")
-        private int intBadValue;
-
-        @Inject
-        @ConfigProperty(name = "integerBadValue", defaultValue = "illegalText1.23")
-        private Integer integerBadValue;
-
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -213,9 +204,6 @@ public class TestApplication extends Application {
 
             text.append("integerDefault = " + integerDefault + "\n");
             text.append(SubsystemConfigSourceTask.INTEGER_OVERRIDDEN_PROP_NAME + " = " + integerOverridden + "\n");
-
-            text.append("intBadValue = " + intBadValue + "\n");
-            text.append("integerBadValue = " + integerBadValue + "\n");
 
             return Response.ok(text).build();
         }
@@ -244,14 +232,6 @@ public class TestApplication extends Application {
         private Long longClassOverridden;
 
 
-        @Inject
-        @ConfigProperty(name = "longBadValue", defaultValue = "1.23")
-        private long longBadValue;
-
-        @Inject
-        @ConfigProperty(name = "longClassBadValue", defaultValue = "illegalText1.23")
-        private Long longClassBadValue;
-
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -262,9 +242,6 @@ public class TestApplication extends Application {
 
             text.append("longClassDefault = " + longClassDefault + "\n");
             text.append(SubsystemConfigSourceTask.LONG_CLASS_OVERRIDDEN_PROP_NAME + " = " + longClassOverridden + "\n");
-
-            text.append("longBadValue = " + longBadValue + "\n");
-            text.append("longClassBadValue = " + longClassBadValue + "\n");
 
             return Response.ok(text).build();
         }
@@ -292,15 +269,6 @@ public class TestApplication extends Application {
         @ConfigProperty(name = SubsystemConfigSourceTask.FLOAT_CLASS_OVERRIDDEN_PROP_NAME, defaultValue = "1.618")
         private Float floatClassOverridden;
 
-
-        @Inject
-        @ConfigProperty(name = "floatBadValue", defaultValue = "text1.23")
-        private float floatBadValue;
-
-        @Inject
-        @ConfigProperty(name = "floatClassBadValue", defaultValue = "illegalText1.23")
-        private Float floatClassBadValue;
-
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -311,9 +279,6 @@ public class TestApplication extends Application {
 
             text.append("floatClassDefault = " + floatClassDefault + "\n");
             text.append(SubsystemConfigSourceTask.FLOAT_CLASS_OVERRIDDEN_PROP_NAME + " = " + floatClassOverridden + "\n");
-
-            text.append("floatBadValue = " + floatBadValue + "\n");
-            text.append("floatClassBadValue = " + floatClassBadValue + "\n");
 
             return Response.ok(text).build();
         }
@@ -341,15 +306,6 @@ public class TestApplication extends Application {
         @ConfigProperty(name = SubsystemConfigSourceTask.DOUBLE_CLASS_OVERRIDDEN_PROP_NAME, defaultValue = "1.618")
         private Double doubleClassOverridden;
 
-
-        @Inject
-        @ConfigProperty(name = "doubleBadValue", defaultValue = "text1.23")
-        private double doubleBadValue;
-
-        @Inject
-        @ConfigProperty(name = "doubleClassBadValue", defaultValue = "illegalText1.23")
-        private Double doubleClassBadValue;
-
         @GET
         @Produces("text/plain")
         public Response doGet() {
@@ -360,9 +316,6 @@ public class TestApplication extends Application {
 
             text.append("doubleClassDefault = " + doubleClassDefault + "\n");
             text.append(SubsystemConfigSourceTask.DOUBLE_CLASS_OVERRIDDEN_PROP_NAME + " = " + doubleClassOverridden + "\n");
-
-            text.append("doubleBadValue = " + doubleBadValue + "\n");
-            text.append("doubleClassBadValue = " + doubleClassBadValue + "\n");
 
             return Response.ok(text).build();
         }

--- a/testsuite/integration/microprofile-tck/config/pom.xml
+++ b/testsuite/integration/microprofile-tck/config/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
+++ b/testsuite/integration/microprofile-tck/config/src/test/java/org/wildfly/extension/microprofile/config/test/DeploymentProcessor.java
@@ -43,6 +43,8 @@ public class DeploymentProcessor implements ApplicationArchiveProcessor {
             extensionsJar.addPackage(IsEqual.class.getPackage());
             extensionsJar.addPackage(IsCloseTo.class.getPackage());
             extensionsJar.addPackage(ReflectiveTypeFinder.class.getPackage());
+            extensionsJar.addPackage(junit.framework.Assert.class.getPackage());
+            extensionsJar.addPackage(org.junit.Assert.class.getPackage());
 
             WebArchive war = WebArchive.class.cast(archive);
             war.addAsLibraries(extensionsJar);

--- a/testsuite/integration/microprofile-tck/config/tck-suite.xml
+++ b/testsuite/integration/microprofile-tck/config/tck-suite.xml
@@ -2,7 +2,7 @@
 
 <suite name="microprofile-config-TCK" verbose="2" configfailurepolicy="continue" >
 
-    <test name="microprofile-config 1.2 TCK">
+    <test name="microprofile-config TCK">
         <packages>
             <package name="org.eclipse.microprofile.config.tck.*">
             </package>


### PR DESCRIPTION
* Upgrade smallrye-config 1.6.1
* Update the GAV of smallrye-config artifacts
* Removed invalid assertions from MicroProfileConfigTestCase: if the
  only value provided by @ConfigProperty is invalid, the deployment must
  fail.
JIRA: https://issues.redhat.com/browse/WFLY-13023

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>
