### PR TITLE
[WFLY-13086] Upgrade gson from 2.8.2 to 2.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.9</version.com.github.fge.json-patch>
         <version.com.github.spullara.mustache>0.9.6</version.com.github.spullara.mustache>
-        <version.com.google.code.gson>2.8.2</version.com.google.code.gson>
+        <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
         <version.com.google.guava>25.0-jre</version.com.google.guava>
         <version.com.h2database>1.4.197</version.com.h2database>
         <version.com.microsoft.azure>6.1.0</version.com.microsoft.azure>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13086

Downstream dependency to align with Runtimes versions

Changes: https://github.com/google/gson/compare/gson-parent-2.8.2...gson-parent-2.8.5