### PR TITLE
[WFLY-13080]: Opentracing is not working after redeployment.

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/resolver/JaegerTracerConfiguration.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/resolver/JaegerTracerConfiguration.java
@@ -100,12 +100,20 @@ public class JaegerTracerConfiguration implements TracerConfiguration {
 
     @Override
     public Tracer createTracer(String serviceName) {
-        Configuration.SenderConfiguration senderConfiguration = reporterConfig.getSenderConfiguration();
+        Configuration.SenderConfiguration initialConfiguration = reporterConfig.getSenderConfiguration();
+        Configuration.SenderConfiguration senderConfiguration = new Configuration.SenderConfiguration();
+        senderConfiguration.withAgentHost(initialConfiguration.getAgentHost())
+                .withAgentPort(initialConfiguration.getAgentPort())
+                .withAuthPassword(initialConfiguration.getAuthPassword())
+                .withAuthToken(initialConfiguration.getAuthToken())
+                .withAuthUsername(initialConfiguration.getAuthUsername())
+                .withEndpoint(initialConfiguration.getEndpoint());
         OutboundSocketBinding outboundSocketBinding = outboundSocketBindingSupplier.get();
         if(outboundSocketBinding != null) {
             senderConfiguration.withAgentHost(outboundSocketBinding.getUnresolvedDestinationAddress())
                     .withAgentPort(outboundSocketBinding.getDestinationPort());
         }
+        reporterConfig.withSender(senderConfiguration);
         return new Configuration(serviceName)
                 .withCodec(codecConfig)
                 .withReporter(reporterConfig)


### PR DESCRIPTION
* Recreating the sender configuration and the sender as it is not
  properly cleanup by the jaeger client when closing the tracer.

Jira: https://issues.redhat.com/browse/WFLY-13080
Upstream PR: https://github.com/wildfly/wildfly/pull/12979