### PR TITLE
[WFLY-13092] Remove the quotes from the FILE parameter due to GAL-309…

### DIFF
--- a/ee-galleon-pack/src/main/resources/feature_groups/domain-load-balancer.xml
+++ b/ee-galleon-pack/src/main/resources/feature_groups/domain-load-balancer.xml
@@ -13,7 +13,7 @@
         <param name="profile" value="load-balancer"/>
             <feature-group name="logging">
                 <include feature-id="subsystem.logging.root-logger.ROOT:subsystem=logging,root-logger=ROOT">
-                    <param name="handlers" value="[&quot;FILE&quot;]"/>
+                    <param name="handlers" value="[FILE]"/>
                 </include>
                 <exclude spec="subsystem.logging.console-handler"/>
             </feature-group>

--- a/servlet-galleon-pack/src/main/resources/feature_groups/domain-profile.xml
+++ b/servlet-galleon-pack/src/main/resources/feature_groups/domain-profile.xml
@@ -4,7 +4,7 @@
     <origin name="org.wildfly.core:wildfly-core-galleon-pack">
         <feature-group name="domain-profile">
             <include feature-id="subsystem.logging.root-logger.ROOT:subsystem=logging,root-logger=ROOT">
-                <param name="handlers" value="[&quot;FILE&quot;]"/>
+                <param name="handlers" value="[FILE]"/>
             </include>
             <exclude spec="subsystem.logging.console-handler"/>
             <exclude spec="subsystem.discovery"/>


### PR DESCRIPTION
… which attempts to resolve the capability name with the quotes in tact. This is just a simple workaround for that issue as it blocks WFCORE-4841.

https://issues.redhat.com/browse/WFLY-13092

This blocks https://github.com/wildfly/wildfly-core/pull/4084.