### PR TITLE
[19.0.x] [WFLY-13022] Upgrade MicroProfile Metrics 2.3

### DIFF
--- a/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
+++ b/microprofile/metrics-smallrye/src/main/resources/io/smallrye/metrics/base-metrics.properties
@@ -23,6 +23,11 @@ cpu.processCpuLoad.type: gauge
 cpu.processCpuLoad.unit: none
 cpu.processCpuLoad.description: Displays the "recent cpu usage" for the Java Virtual Machine process.
 cpu.processCpuLoad.mbean: java.lang:type=OperatingSystem/ProcessCpuLoad
+cpu.processCpuTime.displayName: Process CPU Time
+cpu.processCpuTime.type: gauge
+cpu.processCpuTime.unit: nanoseconds
+cpu.processCpuTime.description: Displays the CPU time used by the process on which the Java virtual machine is running in nanoseconds
+cpu.processCpuTime.mbean: java.lang:type=OperatingSystem/ProcessCpuTime
 cpu.systemLoadAverage.displayName: System Load Average
 cpu.systemLoadAverage.type: gauge
 cpu.systemLoadAverage.unit: none

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <version.io.smallrye.fault-tolerance>2.1.5</version.io.smallrye.fault-tolerance>
         <version.io.smallrye.smallrye-health>2.1.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.12</version.io.smallrye.smallrye-jwt>
-        <version.io.smallrye.smallrye-metrics>2.3.2</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>1.1.20</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
@@ -346,7 +346,7 @@
         <version.org.eclipse.microprofile.fault-tolerance.api>2.0.3</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.health.api>2.1</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
-        <version.org.eclipse.microprofile.metrics.api>2.2.1</version.org.eclipse.microprofile.metrics.api>
+        <version.org.eclipse.microprofile.metrics.api>2.3</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.openapi.api>1.1.2</version.org.eclipse.microprofile.openapi.api>
         <version.org.eclipse.microprofile.opentracing>1.3.2</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>

--- a/testsuite/integration/microprofile-tck/metrics/pom.xml
+++ b/testsuite/integration/microprofile-tck/metrics/pom.xml
@@ -47,6 +47,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
* also upgrade smallrye-metrics to 2.4.0
* add optional base metrics cpu.processCpuTime

JIRA: https://issues.redhat.com/browse/WFLY-13022

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>