### PR TITLE
[WFLY-13100]: Upgrade Jaeger Java Client to 0.34.3 and smallrye opentracing to 1.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <version.io.smallrye.smallrye-jwt>2.0.12</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.3.2</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>1.1.20</version.io.smallrye.open-api>
-        <version.io.smallrye.opentracing>1.3.0</version.io.smallrye.opentracing>
+        <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
@@ -348,7 +348,7 @@
         <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
         <version.org.eclipse.microprofile.metrics.api>2.2.1</version.org.eclipse.microprofile.metrics.api>
         <version.org.eclipse.microprofile.openapi.api>1.1.2</version.org.eclipse.microprofile.openapi.api>
-        <version.org.eclipse.microprofile.opentracing>1.3.2</version.org.eclipse.microprofile.opentracing>
+        <version.org.eclipse.microprofile.opentracing>1.3.3</version.org.eclipse.microprofile.opentracing>
         <version.org.eclipse.microprofile.rest.client.api>1.3.2</version.org.eclipse.microprofile.rest.client.api>
         <version.org.eclipse.yasson>1.0.5</version.org.eclipse.yasson>
         <version.org.eclipselink.version>2.7.3</version.org.eclipselink.version>

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
         <version.groovy-all>2.4.7</version.groovy-all>
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
-        <version.io.jaegertracing>0.34.1</version.io.jaegertracing>
+        <version.io.jaegertracing>0.34.3</version.io.jaegertracing>
         <version.io.netty>4.1.45.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>


### PR DESCRIPTION
     * upgrade smallrye opentracing to 1.3.4 to have the dependencies in
       sync with MP3.3
     * upgrade also eclipse opentracing-api to 1.3.3
     * Upgrade jaeger client to 0.34.3

    Jira: https://issues.redhat.com/browse/WFLY-13100
           https://issues.redhat.com/browse/WFLY-13080
           https://issues.redhat.com/browse/WFLY-13103

Upstream PR: https://github.com/wildfly/wildfly/pull/13002