### PR TITLE
[WFLY-13101] Tests for Microprofile Health 2.2

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/ConcreteHealthCheckResponseTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/ConcreteHealthCheckResponseTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.wildfly.test.integration.microprofile.health.deployment.LivenessHealthCheck;
+
+/**
+ * Validates HealthCheckResponse concrete class which was introduced in MicroProfile Health v. 2.2
+ * @author Fabio Burzigotti
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ConcreteHealthCheckResponseTestCase {
+    private static final String DEPLOYMENT_NAME = ConcreteHealthCheckResponseTestCase.class.getSimpleName() + ".war";
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME)
+                .addClass(LivenessHealthCheck.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                ;
+    }
+
+    @Test
+    @Ignore("https://github.com/eclipse/microprofile-health/issues/243")
+    public void test(@ArquillianResource URL baseURL) throws IOException, URISyntaxException {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpUriRequest request = new HttpGet(
+                    String.format("http://%s:%d/health", managementClient.getMgmtAddress(), managementClient.getMgmtPort()));
+
+            try (CloseableHttpResponse response = client.execute(request)) {
+                Assert.assertEquals(
+                        "Health check endpoint call failed",
+                        HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+
+                final String responseContent = EntityUtils.toString(response.getEntity());
+                HealthCheckResponse typedResponse = new ObjectMapper().readValue(
+                        responseContent, HealthCheckResponse.class);
+
+                final String healthCheckName = typedResponse.getName();
+                Assert.assertEquals(
+                        String.format("Typed response instance \"name\" property has unexpected value: %s", healthCheckName),
+                        healthCheckName, LivenessHealthCheck.HEALTH_CHECK_NAME);
+            }
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/deployment/LivenessHealthCheck.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/health/deployment/LivenessHealthCheck.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.health.deployment;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+/**
+ * Defines a simple {@code Liveness} health check
+ * @author Fabio Burzigotti
+ */
+@Liveness
+public class LivenessHealthCheck implements HealthCheck {
+
+    public static final String HEALTH_CHECK_NAME = "live";
+
+    @Override
+    public HealthCheckResponse call() {
+        return HealthCheckResponse.named(HEALTH_CHECK_NAME).up().withData("key", "value").build();
+    }
+}


### PR DESCRIPTION
This PR adds a test case for validating `HealthCheckResponse` class, which has been defined as concrete in the latest MicroProfile Health 2.2 release. This is basically the main change introduced by this last version of the spec from the end user point of view.

* Please be aware that this PR depends on https://github.com/wildfly/wildfly/pull/12983 and thus _shouuld not_ be merged before the latter is, as well.
 
* JIRA issue: https://issues.redhat.com/browse/WFLY-13101

This test case was run against the Wildfly feature branch which already has the MicroProfile/SmallRye upgrade, see [1].

The test failed, because there's a mismatch in the spec between a property name and the actual payload JSON schema. An issue to MicroProfile Health project has been filed [2] and the test case has been marked as ignored for this reason.

[1]
https://github.com/jmesnil/wildfly/tree/WFLY-13048_upgrade_microprofile-health_2.2

[2]
https://github.com/eclipse/microprofile-health/issues/243

- [x] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [x] Pull Request contains link to the JIRA issue(s)
- [x] Pull Request contains description of the issue(s)
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
