### PR TITLE
[WFLY-13065] Options for reverse-proxy max-request-time and connection-idle-timeout are specified as seconds

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ReverseProxyTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ReverseProxyTestCase.java
@@ -51,11 +51,15 @@ import java.util.Set;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import org.jboss.as.test.shared.ServerReload;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
 
 /**
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ReverseProxyTestCase {
 
     @ContainerResource
@@ -74,6 +78,8 @@ public class ReverseProxyTestCase {
             addr.add("reverse-proxy", "myproxy");
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get("max-request-time").set(60000);
+            op.get("connection-idle-timeout").set(60000);
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
             //add the hosts
@@ -220,6 +226,29 @@ public class ReverseProxyTestCase {
             //for (int i = 0; i < 10; ++i) {
             //    Assert.assertEquals(session, performCall("name"));
             //}
+        }
+    }
+
+    private void configureMaxRequestTime(int value) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(ModelDescriptionConstants.OP_ADDR).add(ModelDescriptionConstants.SUBSYSTEM, "undertow");
+        op.get(ModelDescriptionConstants.OP_ADDR).add("configuration", "handler");
+        op.get(ModelDescriptionConstants.OP_ADDR).add("reverse-proxy", "myproxy");
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION);
+        op.get(ModelDescriptionConstants.NAME).set("max-request-time");
+        op.get(ModelDescriptionConstants.VALUE).set(value);
+
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        ServerReload.reloadIfRequired(managementClient);
+    }
+
+    @Test
+    public void testReverseProxyMaxRequestTime() throws Exception {
+        // set the max-request-time to a lower value than the wait
+        configureMaxRequestTime(10);
+        try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+            HttpResponse res = httpclient.execute(new HttpGet("http://" + url.getHost() + ":" + url.getPort() + "/proxy/name?wait=50"));
+            Assert.assertEquals("Service Unaviable expected because max-request-time is set to 10ms", 503, res.getStatusLine().getStatusCode());
         }
     }
 }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ServerNameServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/reverseproxy/ServerNameServlet.java
@@ -47,6 +47,11 @@ public class ServerNameServlet extends HttpServlet {
         if("true".equals(req.getParameter("session"))) {
             req.getSession(true);
         }
+        if (req.getParameter("wait") != null) {
+            try {
+                Thread.sleep(Long.parseLong(req.getParameter("wait")));
+            } catch (InterruptedException e) {}
+        }
         resp.getWriter().write(message);
         resp.getWriter().close();
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowTransformers.java
@@ -50,6 +50,7 @@ import static org.wildfly.extension.undertow.WebsocketsDefinition.PER_MESSAGE_DE
 import static org.wildfly.extension.undertow.filters.ModClusterDefinition.FAILOVER_STRATEGY;
 import static org.wildfly.extension.undertow.filters.ModClusterDefinition.MAX_AJP_PACKET_SIZE;
 import static org.wildfly.extension.undertow.handlers.ReverseProxyHandler.CONNECTIONS_PER_THREAD;
+import static org.wildfly.extension.undertow.handlers.ReverseProxyHandler.CONNECTION_IDLE_TIMEOUT;
 import static org.wildfly.extension.undertow.handlers.ReverseProxyHandler.MAX_RETRIES;
 
 import org.jboss.as.controller.ModelVersion;
@@ -107,6 +108,12 @@ public class UndertowTransformers implements ExtensionTransformerRegistration {
                 .addChildResource(UndertowExtension.PATH_SSO)
                 .getAttributeBuilder()
                     .addRejectCheck(REJECT_CREDENTIAL_REFERENCE_WITH_BOTH_STORE_AND_CLEAR_TEXT, ApplicationSecurityDomainSingleSignOnDefinition.Attribute.CREDENTIAL.getName())
+                .end();
+
+        subsystemBuilder.addChildResource(UndertowExtension.PATH_HANDLERS)
+                .addChildResource(PathElement.pathElement(Constants.REVERSE_PROXY))
+                .getAttributeBuilder()
+                    .setValueConverter(AttributeConverter.DEFAULT_VALUE, CONNECTION_IDLE_TIMEOUT)
                 .end();
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandler.java
@@ -53,6 +53,7 @@ public class ReverseProxyHandler extends Handler {
             .setRequired(false)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(30))
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -73,7 +74,7 @@ public class ReverseProxyHandler extends Handler {
             .setRequired(false)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(-1))
-            .setMeasurementUnit(MeasurementUnit.SECONDS)
+            .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -95,8 +96,8 @@ public class ReverseProxyHandler extends Handler {
     public static final AttributeDefinition CONNECTION_IDLE_TIMEOUT = new SimpleAttributeDefinitionBuilder(Constants.CONNECTION_IDLE_TIMEOUT, ModelType.INT)
             .setRequired(false)
             .setAllowExpression(true)
-            .setDefaultValue(new ModelNode(60L))
-            .setMeasurementUnit(MeasurementUnit.SECONDS)
+            .setDefaultValue(new ModelNode(60000))
+            .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
@@ -153,7 +154,13 @@ public class ReverseProxyHandler extends Handler {
             lb.addSessionCookieName(id);
         }
 
-        ProxyHandler handler = new ProxyHandler(lb, maxTime, ResponseCodeHandler.HANDLE_404, false, false, maxRetries);
-        return handler;
+        return ProxyHandler.builder()
+                .setProxyClient(lb)
+                .setMaxRequestTime(maxTime)
+                .setNext(ResponseCodeHandler.HANDLE_404)
+                .setRewriteHostHeader(false)
+                .setReuseXForwarded(false)
+                .setMaxConnectionRetries(maxRetries)
+                .build();
     }
 }

--- a/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_11_0.xsd
@@ -729,14 +729,14 @@
             <xs:element name="host" type="reverse-proxy-hostType" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute name="name" use="required" type="xs:string"/>
-        <xs:attribute name="connections-per-thread" use="optional" type="xs:integer"/>
-        <xs:attribute name="session-cookie-names" use="optional" type="xs:string"/>
-        <xs:attribute name="problem-server-retry" use="optional" type="xs:integer"/>
-        <xs:attribute name="max-request-time" use="optional" type="xs:integer"/>
-        <xs:attribute name="request-queue-size" use="optional" type="xs:integer"/>
-        <xs:attribute name="cached-connections-per-thread" use="optional" type="xs:integer"/>
-        <xs:attribute name="connection-idle-timeout" use="optional" type="xs:integer"/>
-        <xs:attribute name="max-retries" type="xs:int" use="optional" />
+        <xs:attribute name="connections-per-thread" use="optional" type="xs:integer" default="40"/>
+        <xs:attribute name="session-cookie-names" use="optional" type="xs:string" default="JSESSIONID"/>
+        <xs:attribute name="problem-server-retry" use="optional" type="xs:integer" default="30"/>
+        <xs:attribute name="max-request-time" use="optional" type="xs:integer" default="-1"/>
+        <xs:attribute name="request-queue-size" use="optional" type="xs:integer" default="10"/>
+        <xs:attribute name="cached-connections-per-thread" use="optional" type="xs:integer" default="5"/>
+        <xs:attribute name="connection-idle-timeout" use="optional" type="xs:integer" default="60000"/>
+        <xs:attribute name="max-retries" type="xs:int" use="optional" default="1"/>
     </xs:complexType>
 
     <xs:complexType name="reverse-proxy-hostType">

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowTransformersTestCase.java
@@ -256,6 +256,13 @@ public class UndertowTransformersTestCase extends AbstractSubsystemTest {
                 ModelNode transformed = transformedOperation.getTransformedOperation().get(Constants.MAX_POST_SIZE);
                 Assert.assertEquals(Constants.MAX_POST_SIZE + " should be transformed for value 0.", Long.MAX_VALUE, transformed.asLong());
             }
+            PathAddress address = PathAddress.pathAddress(op.get("address"));
+            if (address.getLastElement().getKey().equals(Constants.REVERSE_PROXY) && !op.get(Constants.CONNECTION_IDLE_TIMEOUT).isDefined()) {
+                TransformedOperation transformedOperation = mainServices.transformOperation(targetVersion, op.clone());
+                ModelNode transformed = transformedOperation.getTransformedOperation().get(Constants.CONNECTION_IDLE_TIMEOUT);
+                Assert.assertEquals(Constants.CONNECTION_IDLE_TIMEOUT + " should be transformed to the new default value.",
+                        ReverseProxyHandler.CONNECTION_IDLE_TIMEOUT.getDefaultValue().asInt(), transformed.asInt());
+            }
         }
     }
 

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-11.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-11.0.xml
@@ -88,7 +88,7 @@
    </servlet-container>
    <handlers>
       <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
-      <reverse-proxy connection-idle-timeout="60" connections-per-thread="30" max-retries="10" name="reverse-proxy">
+      <reverse-proxy connection-idle-timeout="60000" max-request-time="60000" connections-per-thread="30" max-retries="10" name="reverse-proxy">
          <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
          <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" ssl-context="TestContext"/>
       </reverse-proxy>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-convert.xml
@@ -86,7 +86,7 @@
    </servlet-container>
    <handlers>
       <file case-sensitive="false" directory-listing="true" follow-symlink="true" name="welcome-content" path="${jboss.home.dir}" safe-symlink-paths="/path/to/folder /second/path"/>
-      <reverse-proxy connection-idle-timeout="60" connections-per-thread="30" max-retries="10" name="reverse-proxy">
+      <reverse-proxy connections-per-thread="30" max-retries="10" name="reverse-proxy">
          <host instance-id="myRoute" name="server1" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" security-realm="UndertowRealm" />
          <host instance-id="myRoute" name="server2" outbound-socket-binding="ajp-remote" path="/test" scheme="ajp" security-realm="UndertowRealm" />
       </reverse-proxy>


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/WFLY-13065. Comments:

* It requires a bump for undertow xml version to 11 (I have cloned the changes previously done in 10).
* The only difference in the XML is that all the default values for the `reverse-proxy-handlerType` have been added.
* Test added to check the `max-request-time` with a very low value and check the connection is aborted (503 returned).
* I have also changed the creation of the `ProxyHandler` to use the builder (to avoid the deprecated warning). Here there are two values (`rewrite-host-header` and `reuse-x-forwarded`) that could also be added to the wildfly configuration (now they are always false). Just in case you want to use the same bump for them.

No hurry with this one. It's a minor thing and the bump complicates it a bit.