### PR TITLE
[WFLY-13123] adding timeout for container stop operation for RemoteEJBClientStatefulFailover tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/stateful/failover/RemoteEJBClientStatefulFailoverTestBase.java
@@ -125,14 +125,14 @@ public abstract class RemoteEJBClientStatefulFailoverTestBase extends AbstractCl
                 deployer.undeploy(DEPLOYMENT_1);
                 deployer.undeploy(DEPLOYMENT_HELPER_1);
             } else {
-                stop(NODE_1);
+                stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_1);
             }
         } else {
             if (undeployOnly) {
                 deployer.undeploy(DEPLOYMENT_2);
                 deployer.undeploy(DEPLOYMENT_HELPER_2);
             } else {
-                stop(NODE_2);
+                stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_2);
             }
         }
         // invoke again


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13123

Fix for intermittent failure occuring in Narayana CI testing.
RemoteEJBClientStatefulFailover tests should be guarded with timeout when container will be stopped.