### PR TITLE
[19.0.x][WFLY-13135] Upgrade WildFly Core 11.0.0.Beta9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.9.10</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta8</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta9</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13135

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 11.0.0.Beta9
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4838'>WFCORE-4838</a>] -         Upgrade slf4j-jboss-logmanager from 1.0.3.GA to 1.0.4.GA
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4844'>WFCORE-4844</a>] -         CommandLineArgumentUsage custom usage
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4854'>WFCORE-4854</a>] -         Layers for application and management core security realms
</li>
</ul>
                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4830'>WFCORE-4830</a>] -         HCs (slaves) can not register to the DC (master) during DC and its servers start up 
</li>
</ul>
                                            