### PR TITLE
Fix for WFLY-13129, Example CLI script

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/CLI_Recipes.adoc
@@ -645,3 +645,26 @@ from the factory, the factory will stay associated to the security domain. Witho
 factory is no more active on the security-domain. Type _help security disable-http-auth-http-server_
 for a complete description of the command.
 
+[[mp-cli-script]]
+== Evolving standard configurations with support for Microprofile
+
+The CLI script _JBOSS_HOME/docs/examples/enable-microprofile.cli_ can be applied to a default standalone configuration
+to add support for Microprofile.
+
+Impact on updated configuration:
+
+* Addition of Microprofile subsystems. 
+* Removal of _security_ subsystem.
+* Removal of _ManagementRealm_.
+* Elytron security used for management and application entry points.
+ 
+By default the script updates _standalone.xml_ configuration. 
+Thanks to the _config=<config name>_ system property, the script can be applied to another standalone configuration.
+
+NB: this script has to be applied _offline_ with no server running. 
+
+* To update _standalone.xml_ server configuration:
+** _./bin/jboss-cli.sh --file=docs/examples/enable-microprofile.cli_
+* To update other standalone server configurations:
+** _./bin/jboss-cli.sh --file=docs/examples/enable-microprofile.cli 
+-Dconfig=<standalone-full.xml|standalone-ha.xml|standalone-full-ha.xml>_

--- a/galleon-pack/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
+++ b/galleon-pack/src/main/resources/packages/docs.examples/content/docs/examples/enable-microprofile.cli
@@ -1,0 +1,59 @@
+# This CLI script allows to enable Microprofile for the standalone configurations.
+# By default, standalone.xml is updated.
+# Run it from JBOSS_HOME as:
+# bin/jboss-cli.sh --file=docs/examples/enable-microprofile.cli [-Dconfig=<standalone-full.xml|standalone-ha.xml|standalone-full-ha.xml>]
+
+embed-server --server-config=${config:standalone.xml}
+
+echo INFO: Updating configuration to use elytron
+
+/subsystem=undertow/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=ejb3/application-security-domain=other:add(security-domain=ApplicationDomain)
+/subsystem=batch-jberet:write-attribute(name=security-domain, value=ApplicationDomain)
+
+# This applies to full configurations only.
+if (outcome == success) of /subsystem=messaging-activemq/server=default:read-resource
+  /subsystem=messaging-activemq/server=default:undefine-attribute(name=security-domain)
+  /subsystem=messaging-activemq/server=default:write-attribute(name=elytron-domain, value=ApplicationDomain)
+end-if
+
+/subsystem=remoting/http-connector=http-remoting-connector:write-attribute(name=sasl-authentication-factory, value=application-sasl-authentication)
+/subsystem=remoting/http-connector=http-remoting-connector:undefine-attribute(name=security-realm)
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+
+echo INFO: Removing security subsystem and ManagementRealm.
+
+/core-service=management/security-realm=ManagementRealm:remove
+/subsystem=security:remove
+/extension=org.jboss.as.security:remove
+
+echo INFO: Adding microprofile subsystems.
+
+if (outcome != success) of /subsystem=microprofile-fault-tolerance-smallrye:read-resource
+  /extension=org.wildfly.extension.microprofile.fault-tolerance-smallrye:add
+  /subsystem=microprofile-fault-tolerance-smallrye:add
+else
+  echo INFO: microprofile-fault-tolerance-smallrye already in configuration, subsystem not added.
+end-if
+
+if (outcome != success) of /subsystem=microprofile-jwt-smallrye:read-resource
+  /extension=org.wildfly.extension.microprofile.jwt-smallrye:add
+  /subsystem=microprofile-jwt-smallrye:add
+else
+  echo INFO: microprofile-jwt-smallrye already in configuration, subsystem not added.
+end-if
+
+if (outcome != success) of /subsystem=microprofile-openapi-smallrye:read-resource
+  /extension=org.wildfly.extension.microprofile.openapi-smallrye:add
+  /subsystem=microprofile-openapi-smallrye:add
+else
+  echo INFO: microprofile-openapi-smallrye already in configuration, subsystem not added.
+end-if
+
+echo INFO: Configuration done.
+
+stop-embedded-server

--- a/galleon-pack/src/main/resources/packages/docs.examples/package.xml
+++ b/galleon-pack/src/main/resources/packages/docs.examples/package.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+
+<package-spec xmlns="urn:jboss:galleon:package:2.0" name="docs.examples">
+</package-spec>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -58,6 +58,7 @@
     <default-packages>
         <package name="modules.all"/>
         <package name="docs.licenses.merge"/>
+        <package name="docs.examples"/>
     </default-packages>
     <package-schemas>
         <group name="org.jboss.as"/>

--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/MPScriptTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/MPScriptTestCase.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package org.wildfly.test.manual.management;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.controller.PathAddress;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.wildfly.core.testrunner.Server;
+
+/**
+ * Apply CLI script to evolve standalone configurations with MP.
+ *
+ * @author jdenise
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class MPScriptTestCase {
+
+    private static final File ROOT = new File(System.getProperty("jboss.home"));
+    private static final Path CONFIG_DIR = ROOT.toPath().resolve("standalone").resolve("configuration");
+    private static final Path SCRIPT_FILE = ROOT.toPath().resolve("docs").resolve("examples").resolve("enable-microprofile.cli");
+    private static final String CONFIG_FILE_PROP = "config";
+    private static final String PREFIX = "copy-";
+
+    @Inject
+    private ServerController serverController;
+
+    private String currentConfig;
+
+    @Before
+    public void check() {
+        AssumeTestGroupUtil.assumeElytronProfileEnabled();
+    }
+
+    @Test
+    public void test() throws Exception {
+        currentConfig = "standalone.xml";
+        setupConfig();
+        doTest();
+    }
+
+    @Test
+    public void testFull() throws Exception {
+        currentConfig = "standalone-full.xml";
+        setupConfig();
+        doTest();
+    }
+
+    @Test
+    public void testHa() throws Exception {
+        currentConfig = "standalone-ha.xml";
+        setupConfig();
+        doTest();
+    }
+
+    @Test
+    public void testFullHa() throws Exception {
+        currentConfig = "standalone-full-ha.xml";
+        setupConfig();
+        doTest();
+    }
+
+    @Test
+    public void testFailure() throws Exception {
+        currentConfig = "standalone.xml";
+        setupConfig();
+        // Attempt to apply a second time, must fail
+        boolean error = false;
+        try {
+            // Rely on default config name property: standalone.xml
+            CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
+            for (String line : Files.readAllLines(SCRIPT_FILE, Charset.forName("UTF-8"))) {
+                ctx.handle(line);
+            }
+            error = true;
+        } catch (Exception ex) {
+            // XXX OK
+        }
+        if (error) {
+            throw new Exception("Should have failed");
+        }
+    }
+
+    @After
+    public void resetConfig() throws Exception {
+        Path copy = CONFIG_DIR.resolve(PREFIX + currentConfig);
+        if (Files.exists(copy)) {
+            Files.move(copy,
+                    CONFIG_DIR.resolve(currentConfig), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private void doTest() throws Exception {
+        serverController.start(currentConfig, Server.StartMode.NORMAL);
+        try {
+            ManagementClient client = serverController.getClient();
+            ModelNode rr = Util.createEmptyOperation(READ_RESOURCE_OPERATION, PathAddress.EMPTY_ADDRESS);
+            rr.get(RECURSIVE).set(true);
+            ModelNode result = client.executeForResult(rr);
+
+            //Check subsystems are present and security removed
+            Assert.assertTrue(result.has(SUBSYSTEM, "microprofile-fault-tolerance-smallrye"));
+            Assert.assertTrue(result.has(SUBSYSTEM, "microprofile-jwt-smallrye"));
+            Assert.assertTrue(result.has(SUBSYSTEM, "microprofile-openapi-smallrye"));
+            Assert.assertFalse(result.has(SUBSYSTEM, "security"));
+        } finally {
+            serverController.stop();
+        }
+    }
+
+    private void setupConfig() throws Exception {
+        System.setProperty(CONFIG_FILE_PROP, currentConfig);
+        try {
+            Files.copy(CONFIG_DIR.resolve(currentConfig), CONFIG_DIR.resolve(PREFIX + currentConfig));
+            CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
+            for (String line : Files.readAllLines(SCRIPT_FILE, Charset.forName("UTF-8"))) {
+                ctx.handle(line);
+            }
+        } finally {
+            System.clearProperty(CONFIG_FILE_PROP);
+        }
+    }
+}

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -132,9 +132,22 @@
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>${version.org.wildfly.plugin}</version>
+                <configuration>
+                    <offline>true</offline>
+                    <scripts>
+                        <script>${wildfly.dir}/docs/examples/enable-microprofile.cli</script>
+                    </scripts>
+                    <jboss-home>${wildfly.dir}</jboss-home>
+                    <stdout>none</stdout>
+                    <java-opts>${modular.jdk.args}</java-opts>
+                    <system-properties>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                        <module.path>${jboss.dist}/modules</module.path>
+                    </system-properties>
+                </configuration>
                 <executions>
                     <execution>
-                        <phase>none</phase>
+                        <phase>process-test-resources</phase>
                         <goals>
                             <goal>execute-commands</goal>
                         </goals>
@@ -149,6 +162,25 @@
                         <jboss.install.dir>${basedir}/target/wildfly</jboss.install.dir>
                     </systemPropertyVariables>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jboss.server.config.file.name>standalone.xml</jboss.server.config.file.name>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <id>standalone-enabled-microprofile-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -178,6 +210,19 @@
                                     <goal>copy-resources</goal>
                                 </goals>
                                 <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -237,6 +282,10 @@
                                 <id>default-test</id>
                                 <phase>test</phase>
                             </execution>
+                            <execution>
+                                <id>standalone-enabled-microprofile-test</id>
+                                <phase>none</phase>
+                            </execution>
                         </executions>
                         <configuration>
                             <systemPropertyVariables>
@@ -270,6 +319,23 @@
                                 <id>default-test</id>
                                 <phase>none</phase>
                             </execution>
+                            <execution>
+                                <id>standalone-enabled-microprofile-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -293,6 +359,23 @@
                             <execution>
                                 <id>default-test</id>
                                 <phase>test</phase>
+                            </execution>
+                            <execution>
+                                <id>standalone-enabled-microprofile-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -235,7 +235,9 @@
                                            <exclude>bin/*.sh</exclude>
                                            <exclude>bin/*.bat</exclude>
                                            <exclude>bin/*.ps1</exclude>
-                                           <exclude>docs/</exclude>
+                                           <exclude>docs/licenses/</exclude>
+                                           <exclude>docs/schema/</exclude>
+                                           <exclude>docs/examples/configs/</exclude>
                                            <exclude>modules/</exclude>
                                            <exclude>welcome-content/*.png</exclude>
                                            <exclude>standalone/data</exclude>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13129

Community doc is included in this PR.

Introduce a CLI script to apply to standalone configurations to contain microprofile, evolve security configuration to rely on elytron, remove security subsystem and ManagementRealm.