### PR TITLE
[WFLY-13142]: Can't create a Connection Factory using Jgroups discovery

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalConnectionFactoryAdd.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.wildfly.extension.messaging.activemq.jms;
-
 
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.DISCOVERY_GROUP;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HA;
@@ -137,7 +135,12 @@ public class ExternalConnectionFactoryAdd extends AbstractAddStepHandler {
     }
 
     static DiscoveryGroupConfiguration getDiscoveryGroup(final OperationContext context, final String name) throws OperationFailedException {
-        Resource discoveryGroup = context.readResourceFromRoot(context.getCurrentAddress().getParent().append(PathElement.pathElement(CommonAttributes.DISCOVERY_GROUP, name)), true);
+        Resource discoveryGroup;
+        try {
+            discoveryGroup = context.readResourceFromRoot(context.getCurrentAddress().getParent().append(PathElement.pathElement(CommonAttributes.JGROUPS_DISCOVERY_GROUP, name)), true);
+        } catch (Resource.NoSuchResourceException ex) {
+            discoveryGroup = context.readResourceFromRoot(context.getCurrentAddress().getParent().append(PathElement.pathElement(CommonAttributes.SOCKET_DISCOVERY_GROUP, name)), true);
+        }
         if (discoveryGroup != null) {
             final long refreshTimeout = DiscoveryGroupDefinition.REFRESH_TIMEOUT.resolveModelAttribute(context, discoveryGroup.getModel()).asLong();
             final long initialWaitTimeout = DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.resolveModelAttribute(context, discoveryGroup.getModel()).asLong();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ExternalPooledConnectionFactoryAdd.java
@@ -100,13 +100,24 @@ public class ExternalPooledConnectionFactoryAdd extends AbstractAddStepHandler {
         String jgroupsChannelName = null;
         final PathAddress serverAddress = MessagingServices.getActiveMQServerPathAddress(address);
         if (discoveryGroupName != null) {
-            PathAddress dgAddress;
+            Resource dgResource;
             if(isSubsystemResource(context)) {
-                dgAddress = address.getParent().append(CommonAttributes.DISCOVERY_GROUP, discoveryGroupName);
+                PathAddress dgAddress = address.getParent().append(CommonAttributes.SOCKET_DISCOVERY_GROUP, discoveryGroupName);
+                try {
+                    dgResource = context.readResourceFromRoot(dgAddress, false);
+                } catch(Resource.NoSuchResourceException ex) {
+                    dgAddress = address.getParent().append(CommonAttributes.JGROUPS_DISCOVERY_GROUP, discoveryGroupName);
+                    dgResource = context.readResourceFromRoot(dgAddress, false);
+                }
             } else {
-                dgAddress = serverAddress.append(CommonAttributes.DISCOVERY_GROUP, discoveryGroupName);
+                PathAddress dgAddress = serverAddress.append(CommonAttributes.SOCKET_DISCOVERY_GROUP, discoveryGroupName);
+                try {
+                    dgResource = context.readResourceFromRoot(dgAddress, false);
+                } catch(Resource.NoSuchResourceException ex) {
+                    dgAddress = address.getParent().append(CommonAttributes.JGROUPS_DISCOVERY_GROUP, discoveryGroupName);
+                    dgResource = context.readResourceFromRoot(dgAddress, false);
+                }
             }
-            Resource dgResource = context.readResourceFromRoot(dgAddress, false);
             ModelNode dgModel = dgResource.getModel();
             ModelNode jgroupCluster = JGROUPS_CLUSTER.resolveModelAttribute(context, dgModel);
             if(jgroupCluster.isDefined()) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryAdd.java
@@ -99,8 +99,12 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
         String jgroupClusterName = null;
         final PathAddress serverAddress = MessagingServices.getActiveMQServerPathAddress(address);
         if (discoveryGroupName != null) {
-            PathAddress dgAddress = serverAddress.append(CommonAttributes.DISCOVERY_GROUP, discoveryGroupName);
-            Resource dgResource = context.readResourceFromRoot(dgAddress, false);
+            Resource dgResource;
+            try {
+                dgResource = context.readResourceFromRoot(serverAddress.append(CommonAttributes.SOCKET_DISCOVERY_GROUP, discoveryGroupName), false);
+            } catch (Resource.NoSuchResourceException ex) {
+                dgResource = context.readResourceFromRoot(serverAddress.append(CommonAttributes.JGROUPS_DISCOVERY_GROUP, discoveryGroupName), false);
+            }
             ModelNode dgModel = dgResource.getModel();
             ModelNode jgroupCluster = JGROUPS_CLUSTER.resolveModelAttribute(context, dgModel);
             if(jgroupCluster.isDefined()) {


### PR DESCRIPTION
* Fixing the way we read discovery-group resources that are now at a 'new' address.
 
Jira: https://issues.redhat.com/browse/WFLY-13142

Integrating fix for external PCF https://github.com/wildfly/wildfly/pull/13025