### PR TITLE
[19.0.x][WFLY-13127] Upgrade smallrye openapi to 1.2.0 to bring in https://gi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         <version.io.smallrye.smallrye-health>2.1.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.open-api>1.1.20</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>1.2.0</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>


### PR DESCRIPTION
…thub.com/smallrye/smallrye-open-api/issues/248 fix

https://issues.redhat.com/browse/WFLY-13127

Upstream is #13014