### PR TITLE
WFLY-13159 Datasource resolution fails for application layer alias when using Hibernate bytecode enhancement

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/JPA_Reference_Guide.adoc
@@ -846,6 +846,8 @@ unit bootstrap, which improves JPA integration with CDI. Setting the
 wildfly.jpa.twophasebootstrap hint to false, disables the two phase
 bootstrap (for the persistence unit that contains the hint).
 
+|wildfly.jpa.applicationdatasource |set to true when using an application defined DataSource or resource reference to a global DataSource.
+
 |wildfly.jpa.allowdefaultdatasourceuse |set to false to prevent
 persistence unit from using the default data source. Defaults to true.
 This is only important for persistence units that do not specify a

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -152,6 +152,8 @@ public class Configuration {
      */
     public static final String JPA_ALLOW_TWO_PHASE_BOOTSTRAP = "wildfly.jpa.twophasebootstrap";
 
+    private static final String JPA_ALLOW_APPLICATION_DEFINED_DATASOURCE = "wildfly.jpa.applicationdatasource";
+
     /**
      * set to false to ignore default data source (defaults to true)
      */
@@ -292,6 +294,20 @@ public class Configuration {
     }
 
     /**
+     * Determine if persistence unit can use application defined DataSource (e.g. DataSourceDefinition or resource ref).
+     *
+     * @param pu
+     * @return true if application defined DataSource can be used, false (default) if not.
+     */
+    public static boolean allowApplicationDefinedDatasource(PersistenceUnitMetadata pu) {
+        boolean result = false;
+        if (pu.getProperties().containsKey(Configuration.JPA_ALLOW_APPLICATION_DEFINED_DATASOURCE)) {
+            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_ALLOW_APPLICATION_DEFINED_DATASOURCE));
+        }
+        return result;
+    }
+
+    /**
      * Determine if the default data-source should be used
      *
      * @param pu
@@ -368,4 +384,5 @@ public class Configuration {
         }
         return result;
     }
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -1044,7 +1044,7 @@ public class PersistenceUnitServiceHandler {
                     final PersistenceProviderAdaptor adaptor = getPersistenceProviderAdaptor(pu, persistenceProviderDeploymentHolder, phaseContext.getDeploymentUnit(), provider, platform);
                     final boolean twoPhaseBootStrapCapable = (adaptor instanceof TwoPhaseBootstrapCapable) && Configuration.allowTwoPhaseBootstrap(pu);
                     // only add the next phase dependency, if the persistence unit service is starting early.
-                    if( Configuration.needClassFileTransformer(pu)) {
+                    if( Configuration.needClassFileTransformer(pu) && !Configuration.allowApplicationDefinedDatasource(pu)) {
                         // wait until the persistence unit service is started before starting the next deployment phase
                         phaseContext.addToAttachmentList(Attachments.NEXT_PHASE_DEPS, twoPhaseBootStrapCapable ? puServiceName.append(FIRST_PHASE) : puServiceName);
                     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/datasourcedefinition/persistence.xml
@@ -4,10 +4,9 @@
         <jta-data-source>java:app/DataSource</jta-data-source>
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
-            <!-- @DataSourceDefinition need to be started from the install phase, set wildfly.jpa.twophasebootstrap=false,
-                 to delay starting the persistence unit service until the install phase.
-             -->
-            <property name="wildfly.jpa.twophasebootstrap" value="false"/>
+            <property name="wildfly.jpa.twophasebootstrap" value="true"/>
+            <property name="jboss.as.jpa.classtransformer" value="true"/>
+            <property name="wildfly.jpa.applicationdatasource" value="true"/>
         </properties>
     </persistence-unit>
 </persistence>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/DataSourceResourceReferenceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/DataSourceResourceReferenceTestCase.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jpa.resourceref;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verify that persistence unit using DataSource resource reference can work with entity class enhancement enabled.
+ *
+ */
+@RunWith(Arquillian.class)
+public class DataSourceResourceReferenceTestCase {
+
+    private static final String ARCHIVE_NAME = "DataSourceResourceReferenceTestCase.ear";
+
+    @Deployment
+    public static Archive<?> deployment() {
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, ARCHIVE_NAME);
+        ear.addAsResource(DataSourceResourceReferenceTestCase.class.getPackage(), "application.xml", "application.xml");
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
+        jar.addClasses(MyEjb.class, DataSourceResourceReferenceTestCase.class, Employee.class);
+        jar.addAsManifestResource(DataSourceResourceReferenceTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        ear.addAsModule(jar);
+
+        return ear;
+    }
+
+    /**
+     * Test that an application defined DataSource (via resource reference) can be used by persistence unit, in
+     * addition to using (Hibernate ORM) bytecode enhancement.
+     *
+     * Note that the persistence.xml "jboss.as.jpa.classtransformer" is true to enable bytecode enhancement.
+     * "wildfly.jpa.applicationdatasource" is also set to true, if it was false (default), the application
+     * deployment would fail with:
+     *
+     * Required services that are not installed:" => ["jboss.naming.context.java.app.DataSourceResourceReferenceTestCase.env.testDS"],
+     * "WFLYCTL0180: Services with missing/unavailable dependencies" => ["jboss.persistenceunit.\"DataSourceResourceReferenceTestCase.ear/
+     *  ejb.jar#mainPu\".__FIRST_PHASE__ is missing [jboss.naming.context.java.app.DataSourceResourceReferenceTestCase.env.testDS]"
+     *
+     * @throws NamingException
+     */
+    @Test
+    public void testPostConstruct() throws NamingException {
+        MyEjb myEjb = (MyEjb) new InitialContext().lookup("java:module/" + MyEjb.class.getSimpleName());
+        Assert.assertEquals(null,  myEjb.queryEmployeeName(100));
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/Employee.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/Employee.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jpa.resourceref;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+/**
+ * Employee entity class
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Employee {
+    @Id
+    private int id;
+
+    private String name;
+
+    private String address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/MyEjb.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/MyEjb.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.jpa.resourceref;
+
+import javax.ejb.Stateful;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateful
+@TransactionManagement(TransactionManagementType.CONTAINER)
+public class MyEjb {
+
+    @PersistenceContext(unitName = "mainPu")
+    EntityManager em;
+
+    public Employee queryEmployeeName(int id) {
+        return em.find(Employee.class, id);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/application.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/application.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<application xmlns="http://java.sun.com/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="6"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/application_6.xsd">
+    <module>
+        <ejb>ejb.jar</ejb>
+    </module>
+    <resource-ref>
+        <res-ref-name>testDS</res-ref-name>
+        <lookup-name>java:jboss/datasources/ExampleDS</lookup-name>
+    </resource-ref>
+
+</application>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/resourceref/persistence.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
+    <persistence-unit name="mainPu">
+        <description>Persistence Unit.</description>
+        <jta-data-source>java:app/env/testDS</jta-data-source>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <property name="jboss.as.jpa.classtransformer" value="true"/>
+            <!--  set wildfly.jpa.applicationdatasource to true, to allow application 
+                  level datasource to be used, otherwise the default of false would be used which
+                  is the default behaviour (application datasource cannot be used with JPA bytecode enhancement) -->
+            <property name="wildfly.jpa.applicationdatasource" value="true"/>            
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13159
https://issues.redhat.com/browse/JBEAP-18803

This is a bug fix that addresses applications that use bytecode enhancing and a DataSource defined by the application (e.g. resource reference).