### PR TITLE
[19.0.x] WFLY-13168 Invalidation caches use wrong key affinity

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
@@ -204,7 +204,7 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     public Affinity getWeakAffinity(I id) {
         CacheMode mode = this.cache.getCacheConfiguration().clustering().cacheMode();
         if (mode.isClustered()) {
-            Node node = mode.needsStateTransfer() && !mode.isScattered() ? this.locatePrimaryOwner(id) : this.registry.getGroup().getLocalMember();
+            Node node = !mode.isScattered() ? this.locatePrimaryOwner(id) : this.registry.getGroup().getLocalMember();
             Map.Entry<String, ?> entry = this.registry.getEntry(node);
             if (entry != null) {
                 return new NodeAffinity(entry.getKey());

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/KeyAffinityServiceFactoryServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/KeyAffinityServiceFactoryServiceConfigurator.java
@@ -81,7 +81,7 @@ public class KeyAffinityServiceFactoryServiceConfigurator extends CapabilityServ
             @Override
             public <K> KeyAffinityService<K> createService(Cache<K, ?> cache, KeyGenerator<K> generator) {
                 CacheMode mode = cache.getCacheConfiguration().clustering().cacheMode();
-                return mode.isDistributed() || mode.isReplicated() ? new KeyAffinityServiceImpl<>(executor, cache, generator, bufferSize, Collections.singleton(cache.getCacheManager().getAddress()), false) : new SimpleKeyAffinityService<>(generator);
+                return mode.isClustered() ? new KeyAffinityServiceImpl<>(executor, cache, generator, bufferSize, Collections.singleton(cache.getCacheManager().getAddress()), false) : new SimpleKeyAffinityService<>(generator);
             }
         };
     }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/routing/PrimaryOwnerRouteLocator.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/routing/PrimaryOwnerRouteLocator.java
@@ -46,7 +46,7 @@ public class PrimaryOwnerRouteLocator implements RouteLocator {
         this.registry = config.getRegistry();
         this.primaryOwnerLocator = new PrimaryOwnerLocator<>(config.getCache(), config.getMemberFactory(), this.registry.getGroup());
         CacheMode mode = config.getCache().getCacheConfiguration().clustering().cacheMode();
-        this.preferPrimary = mode.needsStateTransfer() && !mode.isScattered();
+        this.preferPrimary = mode.isClustered() && !mode.isScattered();
         this.localRoute = this.registry.getEntry(this.registry.getGroup().getLocalMember()).getKey();
     }
 

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/routing/PrimaryOwnerRouteLocatorTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/routing/PrimaryOwnerRouteLocatorTestCase.java
@@ -119,6 +119,7 @@ public class PrimaryOwnerRouteLocatorTestCase {
         RouteLocator locator = new PrimaryOwnerRouteLocator(config);
 
         switch (this.cache.getCacheConfiguration().clustering().cacheMode()) {
+            case INVALIDATION_SYNC:
             case REPL_SYNC:
             case DIST_SYNC: {
                 when(this.partitioner.getSegment(new Key<>("session"))).thenReturn(0);


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13168