### PR TITLE
[WFLY-13171] Validate requirement for modules previously exported by javax.ejb.api on JSF implementations

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -44,12 +44,6 @@
         <module name="org.apache.xalan" services="import"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api and
-             reexported by javaee.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 
     <resources>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
@@ -44,12 +44,6 @@
         <module name="org.apache.xalan" services="import"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api and
-             reexported by javaee.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 
     <resources>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
@@ -54,12 +54,6 @@
         <module name="org.apache.commons.codec"/>
         <module name="org.apache.commons.beanutils"/>
         <module name="org.apache.commons.digester"/>
-
-        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
-             Prior to WFLY-5922 they were exported by javax.ejb.api and
-             reexported by javaee.api. -->
-        <module name="javax.xml.rpc.api"/>
-        <module name="javax.rmi.api"/>
     </dependencies>
 
     <resources>

--- a/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/main/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/main/module.xml
@@ -29,7 +29,16 @@
 
     <dependencies>
         <module name="javax.faces.api"/>
-        <module name="javaee.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="javax.websocket.api" />
+        <module name="javax.validation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.ejb.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.glassfish.jakarta.el"/>
+        <module name="javax.api"/>
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>

--- a/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/myfaces/module.xml
+++ b/jsf/subsystem/src/test/resources/modules/com/sun/jsf-impl/myfaces/module.xml
@@ -29,7 +29,16 @@
 
     <dependencies>
         <module name="javax.faces.api" slot="myfaces"/>
-        <module name="javaee.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="javax.websocket.api" />
+        <module name="javax.validation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.ejb.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.glassfish.jakarta.el"/>
+        <module name="javax.api"/>
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>

--- a/jsf/subsystem/src/test/resources/modules2/com/sun/jsf-impl/myfaces2/module.xml
+++ b/jsf/subsystem/src/test/resources/modules2/com/sun/jsf-impl/myfaces2/module.xml
@@ -29,7 +29,16 @@
 
     <dependencies>
         <module name="javax.faces.api" slot="myfaces"/>
-        <module name="javaee.api"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="javax.servlet.jsp.api"/>
+        <module name="javax.websocket.api" />
+        <module name="javax.validation.api"/>
+        <module name="javax.json.api"/>
+        <module name="javax.ejb.api"/>
+        <module name="javax.xml.bind.api"/>
+        <module name="org.glassfish.jakarta.el"/>
+        <module name="javax.api"/>
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>


### PR DESCRIPTION
Clean up JSF module implementations removing unused dependencies. Also, get rid of `javaee.api` from the modules used in the test cases.

Jira issue: https://issues.redhat.com/browse/WFLY-13171

cc: @fjuma @ashley-abdelsayed98 