### PR TITLE
[19.0.x][WFLY-13172][WFLY-13173]  Secured management and health

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -132,6 +132,7 @@ Basic layers:
 * _jpa_: Support for JPA (using the latest WildFly supported Hibernate release).
 * _microprofile-config_: Support for MicroProfile Config.
 * _microprofile-metrics_: Support for MicroProfile Metrics.
+* _microprofile-health_: Support for MicroProfile Health.
 * _open-tracing_: Support for MicroProfile OpenTracing.
 * _resource-adapters_: Support for deployment of JCA adapters.
 * _h2-driver_: Support for the H2 JDBC driver.
@@ -162,7 +163,7 @@ Layers that you combine with "use-case tailored" layers to extend the capabiliti
 * _web-clustering_: Infinispan-based web session clustering.
 
 * _observability_: Support for MicroProfile monitoring and configuration features. 
-Includes Health support, _microprofile-config_, _microprofile-metrics_ (optional) and _open-tracing_ (optional).
+Includes Health support (optional), _microprofile-config_ (optional), _microprofile-metrics_ (optional) and _open-tracing_ (optional).
 
 ==== WildFly servlet layers
 

--- a/ee-galleon-pack/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/microprofile-config/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-config">
     <dependencies>
-        <layer name="management"/>
         <layer name="cdi"/>
     </dependencies>
     <feature spec="subsystem.microprofile-config-smallrye"/>

--- a/ee-galleon-pack/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/microprofile-health/layer-spec.xml
@@ -22,10 +22,10 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-metrics">
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="microprofile-health">
     <dependencies>
         <layer name="secure-management"/>
         <layer name="microprofile-config"/>
     </dependencies>
-    <feature-group name="metrics"/>
+    <feature-group name="health"/>
 </layer-spec>

--- a/ee-galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/observability/layer-spec.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="observability">
     <dependencies>
-        <!-- required by health subsystem -->
-        <layer name="microprofile-config"/>
+        <layer name="microprofile-config" optional="true"/>
         <layer name="microprofile-metrics" optional="true"/>
         <layer name="open-tracing" optional="true"/>
+        <layer name="microprofile-health" optional="true"/>
     </dependencies>
-    <feature-group name="health"/>
 </layer-spec>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -1478,6 +1478,42 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>microprofile-health-provisioning</id>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <install-dir>${layers.install.dir}/microprofile-health</install-dir>
+                            <record-state>false</record-state>
+                            <log-time>${galleon.log.time}</log-time>
+                            <offline>true</offline>
+                            <plugin-options>
+                                <jboss-maven-dist/>
+                                <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                <optional-packages>passive+</optional-packages>
+                            </plugin-options>
+                            <feature-packs>
+                                <feature-pack>
+                                    <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                    <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                    <version>${testsuite.ee.galleon.pack.version}</version>
+                                    <inherit-configs>false</inherit-configs>
+                                    <inherit-packages>false</inherit-packages>
+                                </feature-pack>
+                            </feature-packs>
+                            <configurations>
+                                <config>
+                                    <model>standalone</model>
+                                    <name>standalone.xml</name>
+                                    <layers>
+                                        <layer>microprofile-health</layer>
+                                    </layers>
+                                </config>
+                            </configurations>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>microprofile-metrics-provisioning</id>
                         <goals>
                             <goal>provision</goal>


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/WFLY-13172 and https://issues.redhat.com/browse/WFLY-13173
@bstansberry @pferraro @jmesnil I removed the dependency to management that was present in microprofile-config. It seemed not right. The only layers that depend on secure-management are metrics and health.

