### PR TITLE
[WFLY-13187] Add wildflyee.api as non referenced module in LayersTestCase

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -77,6 +77,8 @@ public class LayersTestCase {
         "org.eclipse.yasson",
         // injected by ee
         "org.wildfly.naming",
+        // Brought by galleon ServerRootResourceDefinition
+        "wildflyee.api",
         };
 
     @Test


### PR DESCRIPTION
I'm not sure what is the procedure to follow on these cases. This change is harmless for LayersTestCase but it will allow LayersTestCase to pass when full integration tests are triggered by  https://github.com/wildfly/wildfly-core/pull/4089


Jira issue: https://issues.redhat.com/browse/WFLY-13187