### PR TITLE
[WFLY-13189] CDI layer should not add the BV subsystem

### DIFF
--- a/ee-galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
@@ -3,6 +3,5 @@
     <dependencies>
         <layer name="base-server"/>
     </dependencies>
-    <feature spec="subsystem.bean-validation"/>
     <feature spec="subsystem.weld"/>
 </layer-spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13189