### PR TITLE
[WFLY-13203] Upgrade WildFly Core 11.0.0.Beta10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.9.10</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta9</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Beta10</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13203

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 11.0.0.Beta10
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4824'>WFCORE-4824</a>] -         Upgrade JBoss Modules from 1.9.2 to 1.10.0.Final
</li>
</ul>
                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4862'>WFCORE-4862</a>] -         NPE starting the server by using incorrect git repository configurations
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4850'>WFCORE-4850</a>] -         Updating mockserver to 5.9.0. Exclusion of dependency from xom.io7m
</li>
</ul>
                                    