### PR TITLE
[19.0.x] Fix for WFLY-13210, open-tracing layer must depend on microprofile-config

### DIFF
--- a/ee-galleon-pack/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/open-tracing/layer-spec.xml
@@ -2,6 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="open-tracing">
     <dependencies>
         <layer name="cdi"/>
+        <layer name="microprofile-config"/>
     </dependencies>
     <feature spec="subsystem.microprofile-opentracing-smallrye"/>
 </layer-spec>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13210
Without microprofile-config, we can't deploy a jaxrs endpoint.

Upstream: #13086