### PR TITLE
[19.0.x] WFLY-13216 /openapi throws 406 when Accept header is sufficiently complex

### DIFF
--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIFormatTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/OpenAPIFormatTestCase.java
@@ -87,6 +87,35 @@ public class OpenAPIFormatTestCase {
                     }
                 }
             }
+
+            // Validate return type honors Accept header
+            request.setHeader("Accept", "application/json");
+            try (CloseableHttpResponse response = client.execute(request)) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                List<String> urls = validateContent(response);
+                // Ensure relative urls are valid
+                for (String url : urls) {
+                    try (CloseableHttpResponse r = client.execute(new HttpGet(baseURL.toURI().resolve(url + "/test/echo/foo")))) {
+                        Assert.assertEquals(HttpServletResponse.SC_OK, r.getStatusLine().getStatusCode());
+                        Assert.assertEquals("foo", EntityUtils.toString(r.getEntity()));
+                    }
+                }
+            }
+
+            // Validate return type honors complex, but unambiguous Accept header
+            request.setHeader("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9,application/json;q=0.99, application/yaml;q=0.98");
+            try (CloseableHttpResponse response = client.execute(request)) {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                List<String> urls = validateContent(response);
+                // Ensure relative urls are valid
+                for (String url : urls) {
+                    try (CloseableHttpResponse r = client.execute(new HttpGet(baseURL.toURI().resolve(url + "/test/echo/foo")))) {
+                        Assert.assertEquals(HttpServletResponse.SC_OK, r.getStatusLine().getStatusCode());
+                        Assert.assertEquals("foo", EntityUtils.toString(r.getEntity()));
+                    }
+                }
+            }
+
             // Ensure format parameter is still read when Accept header is not sufficiently specific
             request.setHeader("Accept", MediaType.WILDCARD + ", " + new MediaType(MediaType.APPLICATION_JSON_TYPE.getType(), MediaType.MEDIA_TYPE_WILDCARD).toString());
             try (CloseableHttpResponse response = client.execute(request)) {

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/EchoResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/openapi/service/EchoResource.java
@@ -27,11 +27,13 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 
+import org.infinispan.commons.dataconversion.MediaType;
+
 /**
  * @author Paul Ferraro
  */
 @Path("/echo")
-@Produces("text/plain")
+@Produces(MediaType.TEXT_PLAIN_TYPE)
 public class EchoResource {
 
     @GET


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13216

Master PR: https://github.com/wildfly/wildfly/pull/13093