### PR TITLE
[WFLY-13137] Remove unneeded use of relativePath in poms now that expressions are …

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -35,7 +35,6 @@
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-build</artifactId>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -35,7 +35,6 @@
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-dist</artifactId>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -35,7 +35,6 @@
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-galleon-pack</artifactId>

--- a/microprofile/fault-tolerance-smallrye/executor/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/executor/pom.xml
@@ -25,13 +25,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-microprofile-fault-tolerance-smallrye</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-microprofile-fault-tolerance-smallrye-executor</artifactId>

--- a/microprofile/fault-tolerance-smallrye/extension/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/extension/pom.xml
@@ -25,13 +25,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-microprofile-fault-tolerance-smallrye</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-microprofile-fault-tolerance-smallrye-extension</artifactId>

--- a/microprofile/fault-tolerance-smallrye/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/pom.xml
@@ -28,13 +28,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-microprofile</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-microprofile-fault-tolerance-smallrye</artifactId>

--- a/microprofile/jwt-smallrye/pom.xml
+++ b/microprofile/jwt-smallrye/pom.xml
@@ -22,13 +22,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-microprofile</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-microprofile-jwt-smallrye</artifactId>

--- a/microprofile/openapi-smallrye/pom.xml
+++ b/microprofile/openapi-smallrye/pom.xml
@@ -25,13 +25,12 @@
 
     <parent>
         <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
+        <artifactId>wildfly-microprofile</artifactId>
         <!--
         Maintain separation between the artifact id and the version to help prevent
         merge conflicts between commits changing the GA and those changing the V.
         -->
         <version>19.0.0.Beta4-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-microprofile-openapi-smallrye</artifactId>


### PR DESCRIPTION
…not used for groupId

No JIRA required. Partial back port of https://github.com/jbossas/jboss-eap7/pull/3395. This may not be needed for WildFly 19, but I figured I'd go ahead and port it over to this branch too just in case.

Upstream PR: #13098