### PR TITLE
[19.0.x][WFLY-13229] Upgrade WildFly Core 11.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.9.10</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Beta10</version.org.wildfly.core>
+        <version.org.wildfly.core>11.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13229

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 11.0.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4825'>WFCORE-4825</a>] -         Upgrade Undertow to 2.0.30.Final fixes CVE-2019-14888 and  CVE-2020-1745
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4865'>WFCORE-4865</a>] -         Upgrade Remoting JMX to 3.0.4.Final
</li>
</ul>
                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4833'>WFCORE-4833</a>] -         Cannot configure Elytron legacy security domain integration in admin-only mode
</li>
</ul>
                                            