### PR TITLE
[19.x] WFLY-13121 jgroups channel protocol read-resource error with include-…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
@@ -266,7 +266,10 @@ public class ProtocolMetricsHandler extends AbstractRuntimeOnlyHandler {
         };
         FunctionExecutor<JChannel> executor = this.executors.get(channelServiceName);
         try {
-            context.getResult().set((executor != null) ? executor.execute(function) : null);
+            ModelNode value = (executor != null) ? executor.execute(function) : null;
+            if (value != null) {
+                context.getResult().set(value);
+            }
         } catch (Exception e) {
             context.getFailureDescription().set(e.getLocalizedMessage());
         } finally {


### PR DESCRIPTION
…runtime

https://issues.redhat.com/browse/WFLY-13121

In case this is desirable for 19.x as well.