### PR TITLE
WFLY-13233 & WFLY-13238 Mutable attribute fixes

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiIncrementorBean.java
@@ -41,4 +41,9 @@ public class CdiIncrementorBean implements Incrementor {
     public int increment() {
         return this.count.incrementAndGet();
     }
+
+    @Override
+    public void reset() {
+        this.count.set(0);
+    }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiServlet.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.clustering.cluster.cdi;
 import java.io.IOException;
 
 import javax.inject.Inject;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -45,16 +46,33 @@ public class CdiServlet extends SimpleServlet {
     private Incrementor incrementor;
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        HttpSession session = req.getSession(true);
-        resp.addHeader(SESSION_ID_HEADER, session.getId());
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        this.increment(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        this.increment(request, response);
+    }
+
+    private void increment(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        HttpSession session = request.getSession(true);
+        response.addHeader(SESSION_ID_HEADER, session.getId());
 
         int value = this.incrementor.increment();
 
-        resp.setIntHeader(VALUE_HEADER, value);
+        response.setIntHeader(VALUE_HEADER, value);
 
-        this.getServletContext().log(req.getRequestURI() + ", value = " + value);
+        this.getServletContext().log(request.getRequestURI() + ", value = " + value);
 
-        resp.getWriter().write("Success");
+        response.getWriter().write("Success");
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        HttpSession session = request.getSession(true);
+        response.addHeader(SESSION_ID_HEADER, session.getId());
+
+        this.incrementor.reset();
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/bean/Incrementor.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/bean/Incrementor.java
@@ -30,4 +30,8 @@ import javax.ejb.Local;
 @Local
 public interface Incrementor {
     int increment();
+
+    default void reset() {
+        // Do nothing
+    }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractHotRodWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/AbstractHotRodWebFailoverTestCase.java
@@ -69,7 +69,7 @@ public abstract class AbstractHotRodWebFailoverTestCase extends AbstractWebFailo
     }
 
     @Override
-    protected void testGracefulSimpleFailover(URL baseURL1, URL baseURL2, URL baseURL3) throws Exception {
+    public void testGracefulSimpleFailover(URL baseURL1, URL baseURL2, URL baseURL3) throws Exception {
         super.testGracefulSimpleFailover(baseURL1, baseURL2, baseURL3);
 
         String readResource = String.format("/subsystem=infinispan/remote-cache-container=web/remote-cache=%s:read-resource(include-runtime=true, recursive=true)", this.deploymentName);
@@ -78,17 +78,14 @@ public abstract class AbstractHotRodWebFailoverTestCase extends AbstractWebFailo
         ModelNode result = execute(this.client1, readResource);
         Assert.assertNotEquals(0L, result.get("hits").asLong());
         Assert.assertNotEquals(0L, result.get("writes").asLong());
-        Assert.assertNotEquals(0L, result.get("near-cache-size").asLong());
 
         result = execute(this.client2, readResource);
         Assert.assertEquals(0L, result.get("hits").asLong());
         Assert.assertEquals(0L, result.get("writes").asLong());
-        Assert.assertEquals(0L, result.get("near-cache-size").asLong());
 
         result = execute(this.client3, readResource);
         Assert.assertNotEquals(0L, result.get("hits").asLong());
         Assert.assertNotEquals(0L, result.get("writes").asLong());
-        Assert.assertNotEquals(0L, result.get("near-cache-size").asLong());
 
         execute(this.client1, resetStatistics);
         execute(this.client2, resetStatistics);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/Mutable.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/Mutable.java
@@ -23,31 +23,39 @@ package org.jboss.as.test.clustering.single.web;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class Mutable implements Serializable {
     private static final long serialVersionUID = -5129400250276547619L;
     private transient boolean serialized = false;
-    private int value;
+    private final AtomicInteger value;
 
     public Mutable(int value) {
-        this.value = value;
+        this.value = new AtomicInteger(value);
     }
 
-    public int getValue() {
-        return this.value;
-    }
-
-    public void increment() {
-        this.value += 1;
+    public int increment() {
+        return this.value.incrementAndGet();
     }
 
     @Override
     public String toString() {
-        return String.valueOf(this.value);
+        return String.valueOf(this.value.get());
     }
 
     public boolean wasSerialized() {
         return this.serialized;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.value.get();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof Mutable)) return false;
+        return this.value.get() == ((Mutable) object).value.get();
     }
 
     private void writeObject(java.io.ObjectOutputStream out) throws IOException {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.function.Function;
 
+import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -65,32 +67,75 @@ public class SimpleServlet extends HttpServlet {
     }
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        HttpSession session = req.getSession(true);
-        resp.addHeader(SESSION_ID_HEADER, session.getId());
-        Mutable custom = (Mutable) session.getAttribute(ATTRIBUTE);
-        if (custom == null) {
-            if (!session.isNew()) throw new IllegalStateException();
-            custom = new Mutable(1);
-            session.setAttribute(ATTRIBUTE, custom);
-        } else {
-            if (session.isNew()) throw new IllegalStateException();
-            custom.increment();
+    protected void doHead(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        HttpSession session = request.getSession(true);
+        response.addHeader(SESSION_ID_HEADER, session.getId());
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        HttpSession session = request.getSession(true);
+        response.addHeader(SESSION_ID_HEADER, session.getId());
+        session.removeAttribute(ATTRIBUTE);
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
         }
-        resp.setIntHeader(VALUE_HEADER, custom.getValue());
-        resp.setHeader(HEADER_SERIALIZED, Boolean.toString(custom.wasSerialized()));
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        Function<HttpSession, Mutable> accessor = session -> {
+            Mutable mutable = (Mutable) session.getAttribute(ATTRIBUTE);
+            if (mutable == null) {
+                mutable = new Mutable(0);
+                session.setAttribute(ATTRIBUTE, mutable);
+            }
+            return mutable;
+        };
+        this.increment(request, response, accessor);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Function<HttpSession, Mutable> accessor = session -> {
+            Mutable mutable = (Mutable) session.getAttribute(ATTRIBUTE);
+            if (mutable == null) {
+                session.setAttribute(ATTRIBUTE, new Mutable(0));
+            }
+            return (mutable == null) ? (Mutable) session.getAttribute(ATTRIBUTE) : mutable;
+        };
+        this.increment(request, response, accessor);
+    }
+
+    private void increment(HttpServletRequest request, HttpServletResponse response, Function<HttpSession, Mutable> accessor) throws IOException {
+        HttpSession session = request.getSession(true);
+        response.addHeader(SESSION_ID_HEADER, session.getId());
+        Mutable mutable = accessor.apply(session);
+        int value = mutable.increment();
+        response.setIntHeader(VALUE_HEADER, value);
+        response.setHeader(HEADER_SERIALIZED, Boolean.toString(mutable.wasSerialized()));
+
+        Mutable current = (Mutable) session.getAttribute(ATTRIBUTE);
+        if (!mutable.equals(current)) {
+            throw new IllegalStateException(String.format("Session attribute value = %s, expected %s", current, mutable));
+        }
 
         try {
             String nodeName = System.getProperty("jboss.node.name");
-            resp.setHeader(HEADER_NODE_NAME, nodeName);
+            response.setHeader(HEADER_NODE_NAME, nodeName);
         } catch (Exception ignore) {
         }
 
-        this.getServletContext().log(req.getRequestURI() + ", value = " + custom.getValue());
+        this.getServletContext().log(request.getRequestURI() + ", value = " + value);
 
         // Long running request?
-        if (req.getParameter(REQUEST_DURATION_PARAM) != null) {
-            int duration = Integer.parseInt(req.getParameter(REQUEST_DURATION_PARAM));
+        if (request.getParameter(REQUEST_DURATION_PARAM) != null) {
+            int duration = Integer.parseInt(request.getParameter(REQUEST_DURATION_PARAM));
             try {
                 Thread.sleep(duration);
             } catch (InterruptedException e) {
@@ -98,6 +143,6 @@ public class SimpleServlet extends HttpServlet {
             }
         }
 
-        resp.getWriter().write("Success");
+        response.getWriter().write("Success");
     }
 }


### PR DESCRIPTION
... when accessed from non-primary or non-owner node using ATTRIBUTE granularity when cache is non-transactional

https://issues.redhat.com/browse/WFLY-13233
https://issues.redhat.com/browse/WFLY-13238