### PR TITLE
[19.0.x][WFLY-13243] Upgrade cryptacular to 1.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00006</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>
-        <version.org.cryptacular>1.2.0</version.org.cryptacular>
+        <version.org.cryptacular>1.2.4</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.4</version.org.eclipse.microprofile.config.api>
         <version.org.eclipse.microprofile.fault-tolerance.api>2.1</version.org.eclipse.microprofile.fault-tolerance.api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13243

Upstream: #13117