### PR TITLE
[WFLY-13247] Upgrade Jakarta Mail to 1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
         <version.jakarta.enterprise>2.0.2</version.jakarta.enterprise>
         <version.jakarta.json.bind.api>1.0.2</version.jakarta.json.bind.api>
-        <version.jakarta.mail>1.6.4</version.jakarta.mail>
+        <version.jakarta.mail>1.6.5</version.jakarta.mail>
         <version.jakarta.persistence>2.2.3</version.jakarta.persistence>
         <version.jakarta.security.enterprise>1.0.2</version.jakarta.security.enterprise>
         <version.jakarta.validation>2.0.2</version.jakarta.validation>


### PR DESCRIPTION
Jakarta Mail 1.6.5 Final Release 
https://github.com/eclipse-ee4j/mail/releases/tag/1.6.5

Jira issue: https://issues.redhat.com/browse/WFLY-13247