### PR TITLE
WFLY-13147 Avoid processing deployments multiple times in Weld subsys…

### DIFF
--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/BeanDeploymentArchiveImpl.java
@@ -246,7 +246,12 @@ public class BeanDeploymentArchiveImpl implements WildFlyBeanDeploymentArchive {
                 if (moduleDependency.getIdentifier().equals(that.getModule().getIdentifier())) {
                     return true;
                 }
+            }
+        }
 
+        for (DependencySpec dependency : module.getDependencies()) {
+            if (dependency instanceof ModuleDependencySpec) {
+                ModuleDependencySpec moduleDependency = (ModuleDependencySpec) dependency;
                 // moduleDependency might be an alias - try to load it to get lined module
                 Module module = loadModule(moduleDependency);
                 if (module != null && module.getIdentifier().equals(that.getModule().getIdentifier())) {


### PR DESCRIPTION
…tem.

JIRA - https://issues.redhat.com/browse/WFLY-13147

_This basically a copy of what the issue suggsested as code changes_. All in all those changes make sense in avoiding loading dep modules that we know were/will be processed as separate units. Simple tests pass for me (as in tests in this repo executed with `-DallTests`).

However, I don't have a big enough sample to actually measure the impact on re-deploy times on a kind of application that it was reported against - @bstansberry does WFLY have some perf tests for deployment where this could be measured?
Or really, any more "obscure" deployment tests that we could/should run against.

CCing @mkouba just in case he has some thoughts about these changes.