### PR TITLE
[WFLY-12402] Clean up test deployment use of management classes and t…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -440,6 +440,7 @@
                                 <include>org/jboss/as/test/integration/jaxb/**/*Test.java</include>
                                 <include>org/jboss/as/test/integration/jaxrs/**/*TestCase.java</include>
                                 <include>org/jboss/as/test/integration/jaxrs/**/*Test.java</include>
+                                <include>org/jboss/as/test/integration/jca/**/*TestCase.java</include>
                                 <include>org/jboss/as/test/integration/json/**/*TestCase.java</include>
                                 <include>org/jboss/as/test/integration/json/**/*Test.java</include>
                                 <include>org/jboss/as/test/integration/jsp/**/*TestCase.java</include>
@@ -491,6 +492,9 @@
                                 <!-- requires ejb and remoting3 (deprecated) -->
                                 <exclude>org/jboss/as/test/integration/management/api/expression/ExpressionSubstitutionInContainerTestCase.java</exclude>
                                 <!-- requires ejb -->
+                                <exclude>org/jboss/as/test/integration/jca/deployment/EjbDeploymentTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/statistics/xa/XaDataSourcePoolStatisticsTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/tracer/*TestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/management/cli/RemoveEJBSubsystemTestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/management/deploy/runtime/StatefulEJBRemoteHomeRuntimeNameTestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/management/deploy/runtime/StatelessEJBRemoteHomeRuntimeNameTestCase.java</exclude>
@@ -517,7 +521,25 @@
                                 <exclude>org/jboss/as/test/integration/deployment/xml/datasource/DeployedXmlJpaDataSourceTestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/jaxrs/integration/ejb/*TestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/jaxrs/packaging/ear/*TestCase.java</exclude>
+                                <!-- JCA TBD -->
+                                <exclude>org/jboss/as/test/integration/jca/ear/*TestCase.java</exclude>
                                 <!-- No legacy security -->
+                                <exclude>org/jboss/as/test/integration/jca/anno/*TestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/basic/*TestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/ijdeployment/*TestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/metrics/RaCfgMetricUnitTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/moduledeployment/*TestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/DsWithSecurityDomainTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java</exclude>
+                                <!-- TODO why does this one need legacy security? Its name implies it should just be elytron -->
+                                <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithSecurityDomainTestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/security/workmanager/*TestCase.java</exclude>
+                                <exclude>org/jboss/as/test/integration/jca/statistics/ResourceAdapterStatisticsTestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/management/**/security/*TestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/security/aselytron/*TestCase.java</exclude>
                                 <exclude>org/jboss/as/test/integration/security/auditing/*TestCase.java</exclude>
@@ -1195,6 +1217,18 @@
                                     </environmentVariables>
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                                     <includes>
+                                        <include>org/jboss/as/test/integration/jca/anno/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/basic/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/ijdeployment/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/metrics/RaCfgMetricUnitTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/security/DsWithMixedSecurityTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/security/DsWithSecurityDomainTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/security/IronJacamarActivationRaWithSecurityDomainTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithElytronAuthContextTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/security/WildFlyActivationRaWithMixedSecurityTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/statistics/ResourceAdapterStatisticsTestCase.java</include>
                                         <include>org/jboss/as/test/integration/management/api/security/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/security/aselytron/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/security/auditing/*TestCase.java</include>
@@ -1211,12 +1245,43 @@
                                         <!-- ee-security subsystem missing, javax.enterprise.security.api not injected -->
                                         <exclude>org/jboss/as/test/integration/security/jaspi/EESecurityAuthMechanismTestCase.java</exclude>
                                         <!-- no ejb -->
+                                        <exclude>org/jboss/as/test/integration/jca/security/workmanager/*TestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/loginmodules/databases/ExternalDatabaseLoginTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/loginmodules/RunAsLoginModuleTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleUseNewClientCertTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java</exclude>
                                         <exclude>org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java</exclude>
+                                        <!-- truststore setting used in LDAPs testing was affected by some other test - need a separate execution -->
+                                        <exclude>org/jboss/as/test/integration/security/loginmodules/Ldap*TestCase.java</exclude>
                                     </excludes>
+                                </configuration>
+                            </execution>
+
+                            <!-- truststore setting used in LDAPs testing was affected by some other test - need an extra run -->
+                            <execution>
+                                <id>legacy-security-layers-ldap.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-legacy-security</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-legacy-security</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-legacy-security</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-legacy-security</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-legacy-security</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-legacy-security/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-legacy-security</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/security/loginmodules/Ldap*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/jca/moduledeployment/*TestCase.java</include>
+                                    </includes>
                                 </configuration>
                             </execution>
                         </executions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -206,7 +206,7 @@ public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestB
         raa.addAsManifestResource(RarInsideEarReDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client, org.jboss.as.controller, org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: org.jboss.as.controller-client, org.jboss.as.controller, org.jboss.dmr\n"),
                         "MANIFEST.MF");
 
         return raa;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/NoRaAnnoTestCase.java
@@ -51,8 +51,6 @@ import org.jboss.as.test.integration.jca.annorar.AnnoMessageListener1;
 import org.jboss.as.test.integration.jca.annorar.AnnoResourceAdapter;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.metadata.spec.ConnectorImpl;
@@ -66,8 +64,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -78,7 +74,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(NoRaAnnoTestCase.NoRaAnnoTestCaseSetup.class)
-public class NoRaAnnoTestCase extends ContainerResourceMgmtTestBase {
+public class NoRaAnnoTestCase {
 
     /**
      * The logger
@@ -120,14 +116,13 @@ public class NoRaAnnoTestCase extends ContainerResourceMgmtTestBase {
         ResourceAdapterArchive raa = ShrinkWrap.create(
                 ResourceAdapterArchive.class, "ra16anno.rar");
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class);
-        ja.addClasses(MgmtOperationException.class, XMLElementReader.class,
-                XMLElementWriter.class, NoRaAnnoTestCase.class);
+        ja.addClasses(NoRaAnnoTestCase.class);
         ja.addPackage(AbstractMgmtTestBase.class.getPackage()).addPackage(
                 AnnoConnectionFactory.class.getPackage());
         raa.addAsLibrary(ja)
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector\n"),
                         "MANIFEST.MF");
         return raa;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/anno/RaAnnoTestCase.java
@@ -50,8 +50,6 @@ import org.jboss.as.test.integration.jca.annorar.AnnoMessageListener1;
 import org.jboss.as.test.integration.jca.annorar.AnnoResourceAdapter;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.metadata.spec.ConnectorImpl;
@@ -65,8 +63,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -77,7 +73,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(RaAnnoTestCase.NoRaAnnoTestCaseSetup.class)
-public class RaAnnoTestCase extends ContainerResourceMgmtTestBase {
+public class RaAnnoTestCase {
 
     /**
      * The logger
@@ -119,15 +115,14 @@ public class RaAnnoTestCase extends ContainerResourceMgmtTestBase {
         ResourceAdapterArchive raa = ShrinkWrap.create(
                 ResourceAdapterArchive.class, "ra16anno.rar");
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class);
-        ja.addClasses(MgmtOperationException.class, XMLElementReader.class,
-                XMLElementWriter.class, RaAnnoTestCase.class);
+        ja.addClasses(RaAnnoTestCase.class);
         ja.addPackage(AbstractMgmtTestBase.class.getPackage()).addPackage(
                 AnnoConnectionFactory.class.getPackage());
         raa.addAsLibrary(ja)
                 .addAsManifestResource(RaAnnoTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector\n"),
                         "MANIFEST.MF");
         return raa;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/archive/ArchiveValidationDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/archive/ArchiveValidationDeploymentTestCase.java
@@ -33,16 +33,11 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
 import org.jboss.as.test.integration.jca.JcaMgmtServerSetupTask;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -87,18 +82,12 @@ public class ArchiveValidationDeploymentTestCase extends JcaMgmtBase {
 
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, name + ".rar");
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, name + ".jar");
-        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(ArchiveValidationDeploymentTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, JcaMgmtServerSetupTask.class);
+        ja.addPackage(MultipleConnectionFactory1.class.getPackage());
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(ArchiveValidationDeploymentTestCase.class.getPackage(), name + "ra.xml", "ra.xml")
-                .addAsManifestResource(ArchiveValidationDeploymentTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
-                .addAsManifestResource(
-                        new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.as.connector \n"),
-                        "MANIFEST.MF");
+                .addAsManifestResource(ArchiveValidationDeploymentTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment10TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment10TestCase.java
@@ -35,16 +35,11 @@ import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsyst
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,7 +50,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment10TestCase.BasicDeploymentTestCaseSetup.class)
-public class BasicDeployment10TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDeployment10TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -83,7 +78,7 @@ public class BasicDeployment10TestCase extends ContainerResourceMgmtTestBase {
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
 
         String deploymentName = "basic10.rar";
 
@@ -91,14 +86,12 @@ public class BasicDeployment10TestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(BasicDeployment10TestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class,
-                        BasicDeploymentTestCaseSetup.class);
+                addClasses(BasicDeployment10TestCase.class, BasicDeploymentTestCaseSetup.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment10TestCase.class.getPackage(), "ra10.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment10TestCase.class.getPackage(), "ra10.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment15TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment15TestCase.java
@@ -36,16 +36,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment15TestCase.BasicDeploymentTestCaseSetup.class)
-public class BasicDeployment15TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDeployment15TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -84,7 +79,7 @@ public class BasicDeployment15TestCase extends ContainerResourceMgmtTestBase {
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
 
         String deploymentName = "basic15.rar";
 
@@ -92,14 +87,12 @@ public class BasicDeployment15TestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(BasicDeployment15TestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class,
-                        BasicDeploymentTestCaseSetup.class);
+                addClasses(BasicDeployment15TestCase.class, BasicDeploymentTestCaseSetup.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());  // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment15TestCase.class.getPackage(), "ra15.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment15TestCase.class.getPackage(), "ra15.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment16TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment16TestCase.java
@@ -36,16 +36,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment16TestCase.BasicDeploymentTestCaseSetup.class)
-public class BasicDeployment16TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDeployment16TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -84,7 +79,7 @@ public class BasicDeployment16TestCase extends ContainerResourceMgmtTestBase {
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
 
         String deploymentName = "basic.rar";
 
@@ -92,14 +87,12 @@ public class BasicDeployment16TestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(BasicDeployment16TestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class,
-                        BasicDeploymentTestCaseSetup.class);
+                addClasses(BasicDeployment16TestCase.class, BasicDeploymentTestCaseSetup.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());  // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
@@ -36,16 +36,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDeployment17TestCase.BasicDeploymentTestCaseSetup.class)
-public class BasicDeployment17TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDeployment17TestCase {
 
     static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -84,7 +79,7 @@ public class BasicDeployment17TestCase extends ContainerResourceMgmtTestBase {
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
 
         String deploymentName = "basic17.rar";
 
@@ -92,14 +87,12 @@ public class BasicDeployment17TestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(BasicDeployment17TestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class,
-                        BasicDeploymentTestCaseSetup.class);
+                addClasses(BasicDeployment17TestCase.class, BasicDeploymentTestCaseSetup.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment17TestCase.class.getPackage(), "ra17.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment17TestCase.class.getPackage(), "ra17.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeployment16TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeployment16TestCase.java
@@ -35,16 +35,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,7 +51,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeployment16TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-public class BasicDoubleDeployment16TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDoubleDeployment16TestCase {
 
     // deployment archive name must match "archive" element.
     private static final String DEPLOYMENT_MODULE_NAME = "basic";
@@ -111,17 +106,13 @@ public class BasicDoubleDeployment16TestCase extends ContainerResourceMgmtTestBa
     public static ResourceAdapterArchive createDeployment() {
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, DEPLOYMENT_NAME);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, SUB_DEPLOYMENT_NAME);
-        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(MgmtOperationException.class,
-                XMLElementReader.class, XMLElementWriter.class, BasicDoubleDeployment16TestCase.class,
+        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(BasicDoubleDeployment16TestCase.class,
                 BasicDeploymentTestCaseSetup.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
 
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml")
-                .addAsManifestResource(
-                        new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
-                        "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_1TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_1TestCase.java
@@ -40,16 +40,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,7 +56,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeploymentFail16_1TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-public class BasicDoubleDeploymentFail16_1TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDoubleDeploymentFail16_1TestCase {
 
     // deployment archive name must match "archive" element.
     private static final String DEPLOYMENT_MODULE_NAME = "basic";
@@ -114,17 +109,13 @@ public class BasicDoubleDeploymentFail16_1TestCase extends ContainerResourceMgmt
     public static ResourceAdapterArchive createDeployment() {
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, DEPLOYMENT_NAME);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, SUB_DEPLOYMENT_NAME);
-        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(MgmtOperationException.class,
-                XMLElementReader.class, XMLElementWriter.class, BasicDoubleDeploymentFail16_1TestCase.class,
+        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(BasicDoubleDeploymentFail16_1TestCase.class,
                 BasicDeploymentTestCaseSetup.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
 
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml")
-                .addAsManifestResource(
-                        new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
-                        "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDeployment16TestCase.class.getPackage(), "ra16.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_2TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDoubleDeploymentFail16_2TestCase.java
@@ -40,16 +40,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,7 +56,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(BasicDoubleDeploymentFail16_2TestCase.BasicDoubleDeploymentTestCaseSetup.class)
-public class BasicDoubleDeploymentFail16_2TestCase extends ContainerResourceMgmtTestBase {
+public class BasicDoubleDeploymentFail16_2TestCase {
 
     // deployment archive name must match "archive" element.
     private static final String DEPLOYMENT_MODULE_NAME = "basic";
@@ -113,17 +108,13 @@ public class BasicDoubleDeploymentFail16_2TestCase extends ContainerResourceMgmt
     public static ResourceAdapterArchive createDeployment() {
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, DEPLOYMENT_NAME);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, SUB_DEPLOYMENT_NAME);
-        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(MgmtOperationException.class,
-                XMLElementReader.class, XMLElementWriter.class, BasicDoubleDeploymentFail16_2TestCase.class,
+        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(BasicDoubleDeploymentFail16_2TestCase.class,
                 BasicDoubleDeploymentTestCaseSetup.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
 
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(BasicDoubleDeploymentFail16_2TestCase.class.getPackage(), "ra16.xml", "ra.xml")
-                .addAsManifestResource(
-                        new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
-                        "MANIFEST.MF");
+        raa.addAsManifestResource(BasicDoubleDeploymentFail16_2TestCase.class.getPackage(), "ra16.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/DisabledValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/beanvalidation/DisabledValidationTestCase.java
@@ -31,13 +31,10 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
 import org.jboss.as.test.integration.jca.JcaMgmtServerSetupTask;
 import org.jboss.as.test.integration.jca.beanvalidation.ra.ValidConnectionFactory;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,7 +45,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @ServerSetup(DisabledValidationTestCase.DisabledValidationTestCaseSetup.class)
 @RunAsClient
-public class DisabledValidationTestCase extends JcaMgmtBase {
+public class DisabledValidationTestCase {
 
     static class DisabledValidationTestCaseSetup extends JcaMgmtServerSetupTask {
         ModelNode bvAddress = subsystemAddress.clone().add("bean-validation", "bean-validation");
@@ -75,8 +72,7 @@ public class DisabledValidationTestCase extends JcaMgmtBase {
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName + ".rar");
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, deploymentName + ".jar");
         ja.addPackage(ValidConnectionFactory.class.getPackage()).addClasses(DisabledValidationTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, JcaMgmtServerSetupTask.class,
-                JcaMgmtBase.class);
+                JcaMgmtServerSetupTask.class, JcaMgmtBase.class);
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(DisabledValidationTestCase.class.getPackage(), "ra.xml", "ra.xml").addAsManifestResource(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/CustomBootstrapContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/bootstrap/CustomBootstrapContextTestCase.java
@@ -41,14 +41,11 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.jca.rar.MultipleResourceAdapter2;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +54,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(CustomBootstrapContextTestCase.CustomBootstrapDeploymentTestCaseSetup.class)
-public class CustomBootstrapContextTestCase extends JcaMgmtBase {
+public class CustomBootstrapContextTestCase {
 
     public static String ctx = "customContext";
     public static String wm = "customWM";
@@ -112,16 +109,16 @@ public class CustomBootstrapContextTestCase extends JcaMgmtBase {
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, "bootstrap_archive_ij.rar");
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(CustomBootstrapContextTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, JcaMgmtServerSetupTask.class, JcaMgmtBase.class);
+                JcaMgmtServerSetupTask.class, JcaMgmtBase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(CustomBootstrapContextTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(CustomBootstrapContextTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.as.connector \n"),
+                                "Dependencies: org.jboss.as.connector \n"),
                         "MANIFEST.MF");
         return raa;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
@@ -118,7 +118,7 @@ public abstract class AbstractDatasourceCapacityPoliciesTestCase extends JcaMgmt
                 JcaTestsUtil.class,
                 TimeoutUtil.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector," +
-                "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper," +
+                "org.jboss.as.controller,org.jboss.dmr,org.jboss.staxmapper," +
                 "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters,org.jboss.remoting\n"), "MANIFEST.MF");
         jar.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/ResourceAdapterCapacityPoliciesTestCase.java
@@ -125,7 +125,7 @@ public class ResourceAdapterCapacityPoliciesTestCase extends JcaMgmtBase {
                 TimeoutUtil.class);
 
         rar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector," +
-                "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper," +
+                "org.jboss.as.controller,org.jboss.dmr,org.jboss.staxmapper," +
                 "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters,org.jboss.remoting\n"), "MANIFEST.MF");
         rar.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceNonCcmTestCase.java
@@ -63,7 +63,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(DatasourceNonCcmTestCase.DatasourceServerSetupTask.class)
-public class DatasourceNonCcmTestCase extends JcaMgmtBase {
+public class DatasourceNonCcmTestCase {
 
     private static final String NON_TX_DS_NAME = "NonJTADS";
 
@@ -149,11 +149,12 @@ public class DatasourceNonCcmTestCase extends JcaMgmtBase {
         jar.addAsManifestResource(new StringAsset(
                 "Dependencies: javax.inject.api,org.jboss.as.connector," +
                     "org.jboss.as.controller, " +
-                    "org.jboss.dmr,org.jboss.as.cli, " +
+                    "org.jboss.dmr, " +
                     "org.jboss.staxmapper,  " +
+                    // Needed for RemotingPermission class if security manager is enabled
+                    (System.getProperty("security.manager") == null ? "" : "org.jboss.remoting3,") +
                     "org.jboss.ironjacamar.impl, " +
-                    "org.jboss.ironjacamar.jdbcadapters, " +
-                    "org.jboss.remoting3\n"
+                    "org.jboss.ironjacamar.jdbcadapters\n"
         ), "MANIFEST.MF");
 
         jar.addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceSetTxQueryTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceSetTxQueryTimeoutTestCase.java
@@ -34,12 +34,8 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
 import org.jboss.as.test.integration.jca.JcaMgmtServerSetupTask;
-import org.jboss.as.test.integration.jca.JcaTestsUtil;
-import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.jca.DsMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
@@ -60,7 +56,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(DatasourceSetTxQueryTimeoutTestCase.DatasourceServerSetupTask.class)
-public class DatasourceSetTxQueryTimeoutTestCase extends JcaMgmtBase {
+public class DatasourceSetTxQueryTimeoutTestCase {
 
     private static final String TX_DS_NAME = "JTADS";
 
@@ -109,21 +105,14 @@ public class DatasourceSetTxQueryTimeoutTestCase extends JcaMgmtBase {
                 DatasourceSetTxQueryTimeoutTestCase.class,
                 Datasource.class,
                 JcaMgmtBase.class,
-                ManagementOperations.class,
                 ContainerResourceMgmtTestBase.class,
                 AbstractMgmtTestBase.class,
-                JcaMgmtServerSetupTask.class,
-                MgmtOperationException.class,
-                DsMgmtTestBase.class,
-                JcaTestsUtil.class);
+                JcaMgmtServerSetupTask.class);
         jar.addAsManifestResource(new StringAsset(
                 "Dependencies: javax.inject.api,org.jboss.as.connector," +
-                    "org.jboss.as.controller, " +
-                    "org.jboss.dmr,org.jboss.as.cli, " +
                     "org.jboss.staxmapper,  " +
                     "org.jboss.ironjacamar.impl, " +
-                    "org.jboss.ironjacamar.jdbcadapters, " +
-                    "org.jboss.remoting3\n"
+                    "org.jboss.ironjacamar.jdbcadapters\n"
         ), "MANIFEST.MF");
 
         jar.addAsManifestResource(createPermissionsXmlAsset(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ear/RarInsideEarReDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ear/RarInsideEarReDeploymentTestCase.java
@@ -125,7 +125,7 @@ public class RarInsideEarReDeploymentTestCase extends
                 "ra.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr\n"),
                         "MANIFEST.MF");
 
         final EnterpriseArchive ear = ShrinkWrap.create(

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDeploymentTestCase.java
@@ -34,16 +34,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.jca.beanvalidation.ra.ValidResourceAdapter;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -62,21 +58,19 @@ public class IronJacamarDeploymentTestCase extends ContainerResourceMgmtTestBase
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
         String deploymentName = "ij.rar";
 
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "ij.jar");
-        ja.addPackage(ValidResourceAdapter.class.getPackage()).addClasses(IronJacamarDeploymentTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(ValidResourceAdapter.class.getPackage());
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(IronJacamarDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(IronJacamarDeploymentTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector\n"),
                         "MANIFEST.MF");
 
         return raa;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDoubleDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/ijdeployment/IronJacamarDoubleDeploymentTestCase.java
@@ -32,17 +32,13 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.jca.beanvalidation.ra.ValidResourceAdapter;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -66,16 +62,14 @@ public class IronJacamarDoubleDeploymentTestCase extends ContainerResourceMgmtTe
 
         ResourceAdapterArchive raa = ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "ij.jar");
-        ja.addPackage(ValidResourceAdapter.class.getPackage()).addClasses(IronJacamarDoubleDeploymentTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(ValidResourceAdapter.class.getPackage());
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(IronJacamarDoubleDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(IronJacamarDoubleDeploymentTestCase.class.getPackage(), configName, "ironjacamar.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector\n"),
                         "MANIFEST.MF");
         return raa;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/AbstractModuleDeploymentTestCase.java
@@ -67,7 +67,7 @@ public abstract class AbstractModuleDeploymentTestCase extends
         if (withDependencies) {
             ja.addAsManifestResource(
                     new StringAsset(
-                            "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"),
+                            "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,javax.inject.api,org.jboss.as.connector\n"),
                     "MANIFEST.MF");
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowFlatTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowFlatTestCase.java
@@ -111,7 +111,7 @@ public class InflowFlatTestCase extends AbstractModuleDeploymentTestCase {
                 "ra.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr\n"),
                         "MANIFEST.MF");
 
         return raa;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowJarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/moduledeployment/InflowJarTestCase.java
@@ -107,7 +107,7 @@ public class InflowJarTestCase extends AbstractModuleDeploymentTestCase {
                 "ra.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                                "Dependencies: javax.inject.api,org.jboss.as.connector,org.jboss.as.controller-client,org.jboss.dmr\n"),
                         "MANIFEST.MF");
 
         return raa;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMaxPoolAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMaxPoolAttributeTestCase.java
@@ -108,12 +108,12 @@ public class DatasourceMaxPoolAttributeTestCase extends JcaMgmtBase {
                 "org.jboss.as.connector," +
                 "org.jboss.as.controller," +
                 "org.jboss.dmr," +
-                "org.jboss.as.cli," +
+                // Needed for RemotingPermission class if security manager is enabled
+                (System.getProperty("security.manager") == null ? "" : "org.jboss.remoting3,") +
                 "org.jboss.staxmapper," +
                 "org.jboss.ironjacamar.api," +
                 "org.jboss.ironjacamar.impl," +
-                "org.jboss.ironjacamar.jdbcadapters," +
-                "org.jboss.remoting3\n"), "MANIFEST.MF");
+                "org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
 
         jar.addAsManifestResource(createPermissionsXmlAsset(
                 new RuntimePermission("accessDeclaredMembers"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMinPoolAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourceMinPoolAttributeTestCase.java
@@ -108,12 +108,12 @@ public class DatasourceMinPoolAttributeTestCase extends JcaMgmtBase {
                 "org.jboss.as.connector," +
                 "org.jboss.as.controller," +
                 "org.jboss.dmr," +
-                "org.jboss.as.cli," +
+                // Needed for RemotingPermission class if security manager is enabled
+                (System.getProperty("security.manager") == null ? "" : "org.jboss.remoting3,") +
                 "org.jboss.staxmapper," +
                 "org.jboss.ironjacamar.api," +
                 "org.jboss.ironjacamar.impl," +
-                "org.jboss.ironjacamar.jdbcadapters," +
-                "org.jboss.remoting3\n"), "MANIFEST.MF");
+                "org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
 
         jar.addAsManifestResource(createPermissionsXmlAsset(
                 new RuntimePermission("accessDeclaredMembers"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/DatasourcePoolAttributesTestCase.java
@@ -107,9 +107,9 @@ public class DatasourcePoolAttributesTestCase extends JcaMgmtBase {
                 "org.jboss.as.connector," +
                 "org.jboss.as.controller," +
                 "org.jboss.dmr," +
-                "org.jboss.as.cli," +
-                "org.jboss.remoting3," +
                 "org.jboss.staxmapper," +
+                // Needed for RemotingPermission class if security manager is enabled
+                (System.getProperty("security.manager") == null ? "" : "org.jboss.remoting3,") +
                 "org.jboss.ironjacamar.api," +
                 "org.jboss.ironjacamar.impl," +
                 "org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/poolattributes/ResourceAdapterPoolAttributesTestCase.java
@@ -118,8 +118,10 @@ public class ResourceAdapterPoolAttributesTestCase extends JcaMgmtBase {
                 JcaTestsUtil.class);
 
         rar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector," +
-                "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper," +
-                "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters,org.jboss.remoting\n"), "MANIFEST.MF");
+                "org.jboss.as.controller,org.jboss.dmr,org.jboss.staxmapper," +
+                // Needed for RemotingPermission class if security manager is enabled
+                (System.getProperty("security.manager") == null ? "" : "org.jboss.remoting3,") +
+                "org.jboss.ironjacamar.impl, org.jboss.ironjacamar.jdbcadapters\n"), "MANIFEST.MF");
         rar.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),
                 new RemotingPermission("connect"),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceJdbcStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/statistics/DataSourceJdbcStatisticsTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBa
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
@@ -214,11 +213,7 @@ public class DataSourceJdbcStatisticsTestCase {
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "stat.jar");
         ja.addClasses(DataSourceJdbcStatisticsTestCase.class, MgmtOperationException.class, XMLElementReader.class,
                 XMLElementWriter.class, AbstractMgmtTestBase.class, JcaMgmtServerSetupTask.class, JcaMgmtBase.class,
-                ContainerResourceMgmtTestBase.class)
-                .addAsManifestResource(
-                        new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.as.connector \n"),
-                        "MANIFEST.MF");
+                ContainerResourceMgmtTestBase.class);
         return ja;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/LongRunningThreadsCheckTestCase.java
@@ -46,7 +46,6 @@ import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl;
 import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.integration.jca.rar.MultipleResourceAdapter3;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -54,8 +53,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -70,7 +67,7 @@ import java.lang.reflect.ReflectPermission;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(LongRunningThreadsCheckTestCase.TestCaseSetup.class)
-public class LongRunningThreadsCheckTestCase extends JcaMgmtBase {
+public class LongRunningThreadsCheckTestCase {
 
     public static String ctx = "customContext";
     public static String wm = "customWM";
@@ -137,16 +134,13 @@ public class LongRunningThreadsCheckTestCase extends JcaMgmtBase {
      * @return The deployment archive
      */
     @Deployment
-    public static EnterpriseArchive createDeployment() throws Exception {
+    public static EnterpriseArchive createDeployment() {
 
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "wm.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).addClasses(LongRunningThreadsCheckTestCase.class,
-                MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, JcaMgmtServerSetupTask.class,
-                JcaMgmtBase.class, JcaTestsUtil.class);
+                JcaMgmtServerSetupTask.class, JcaMgmtBase.class, JcaTestsUtil.class);
         ja.addPackage(AbstractMgmtTestBase.class.getPackage());
-        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.dmr, " +
-                        "org.jboss.as.controller-client, org.jboss.as.cli, " +
-                        "org.jboss.as.connector, org.jboss.threads"),
+        ja.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.connector, org.jboss.threads"),
                 "MANIFEST.MF");
 
         ResourceAdapterArchive ra1 = ShrinkWrap.create(ResourceAdapterArchive.class, "wm1.rar");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/workmanager/WorkManagerThreadsCheckTestCase.java
@@ -34,15 +34,10 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.jca.JcaMgmtBase;
-import org.jboss.as.test.integration.jca.JcaTestsUtil;
-import org.jboss.as.test.integration.management.ManagementOperations;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,14 +54,7 @@ public class WorkManagerThreadsCheckTestCase extends JcaMgmtBase {
 
     @Deployment
     public static Archive<?> deploytRar() {
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "dummy.jar");
-        jar.addClass(JcaMgmtBase.class).addClass(WorkManagerThreadsCheckTestCase.class)
-                .addClass(ContainerResourceMgmtTestBase.class).addClass(ManagementOperations.class)
-                .addClass(MgmtOperationException.class).addClass(JcaTestsUtil.class).addClass(AbstractMgmtTestBase.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector,"
-                + "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper,"
-                + "org.jboss.ironjacamar.impl\n"), "MANIFEST.MF");
-        return jar;
+        return ShrinkWrap.create(JavaArchive.class, "dummy.jar");
     }
 
     @Test

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
@@ -396,7 +396,6 @@ public abstract class AbstractDwmTestCase {
         jar.addClass(LongWork.class).addClass(ShortWork.class)
                 .addPackage(DistributedConnection1.class.getPackage());
         jar.addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector,"
-                + "org.jboss.as.controller,org.jboss.dmr,org.jboss.as.cli,org.jboss.staxmapper,"
                 + "org.jboss.ironjacamar.impl\n"), "MANIFEST.MF");
         return jar;
     }
@@ -408,7 +407,7 @@ public abstract class AbstractDwmTestCase {
                         "ironjacamar.xml")
                 .addAsManifestResource(
                         new StringAsset(
-                                "Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.as.connector \n"),
+                                "Dependencies: org.jboss.as.connector \n"),
                         "MANIFEST.MF");
         return rar;
     }

--- a/testsuite/integration/smoke/pom.xml
+++ b/testsuite/integration/smoke/pom.xml
@@ -171,6 +171,11 @@
                                 <excludes>
                                     <!-- Requires legacy security -->
                                     <exclude>org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java</exclude>
+                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java</exclude>
+                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java</exclude>
+                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java</exclude>
+                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java</exclude>
+                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java</exclude>
                                     <exclude>org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java</exclude>
                                     <!-- Requires EJB -->
                                     <exclude>org/jboss/as/test/smoke/ejb3/**/*TestCase.java</exclude>
@@ -185,17 +190,6 @@
                                     <exclude>org/jboss/as/test/smoke/sar/**/*TestCase.java</exclude>
                                     <!-- Requires webservices -->
                                     <exclude>org/jboss/as/test/smoke/webservices/**/*TestCase.java</exclude>
-                                    <!-- Requires org.jboss.as.cli for a test fixture that ends up in the server vm (see WFCORE-4614 / WFLY-12402 -->
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/activation/IronJacamarActivationTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/EarPackagedMultiRarDeploymentTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/EarDeploymentTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/inflow/InflowTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/pure/PureTestCase.java</exclude>
-                                    <exclude>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java</exclude>
                                     <!-- FIXME Why do these fail? Particularly ManagedBeanTestCase -->
                                     <exclude>org/jboss/as/test/smoke/managedbean/ManagedBeanTestCase.java</exclude>
                                     <exclude>org/jboss/as/test/smoke/deployment/rar/tests/afterresourcecreation/AfterResourceCreationDeploymentTestCase.java</exclude>
@@ -520,6 +514,11 @@
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                                     <includes>
                                         <include>org/jboss/as/test/smoke/mgmt/resourceadapter/ResourceAdapterOperationsUnitTestCase.java</include>
+                                        <include>org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java</include>
+                                        <include>org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java</include>
+                                        <include>org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java</include>
+                                        <include>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java</include>
+                                        <include>org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java</include>
                                         <include>org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java</include>
                                     </includes>
                                 </configuration>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/activation/IronJacamarActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/activation/IronJacamarActivationTestCase.java
@@ -27,18 +27,12 @@ import javax.annotation.Resource;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject2;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,7 +42,7 @@ import org.junit.runner.RunWith;
  *         JBQA-5736 -IronJacamar deployment test
  */
 @RunWith(Arquillian.class)
-public class IronJacamarActivationTestCase extends ContainerResourceMgmtTestBase {
+public class IronJacamarActivationTestCase {
 
 
     /**
@@ -57,21 +51,19 @@ public class IronJacamarActivationTestCase extends ContainerResourceMgmtTestBase
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
         String deploymentName = "archive_ij.rar";
 
         ResourceAdapterArchive raa =
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(IronJacamarActivationTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                addClasses(IronJacamarActivationTestCase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(IronJacamarActivationTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(IronJacamarActivationTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+                .addAsManifestResource(IronJacamarActivationTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml");
 
         return raa;
     }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
@@ -35,18 +35,13 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyAdminObjectInterface;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyConnection;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyConnectionFactory;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,7 +53,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(ConfigPropertyTestCase.ConfigPropertyTestClassSetup.class)
-public class ConfigPropertyTestCase extends ContainerResourceMgmtTestBase {
+public class ConfigPropertyTestCase {
 
     /**
      * Class that performs setup before the deployment is deployed
@@ -158,13 +153,12 @@ public class ConfigPropertyTestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "as7_1452.jar");
         ja.addPackage("org.jboss.as.test.smoke.deployment.rar.configproperty")
-                .addClasses(ConfigPropertyTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                .addClasses(ConfigPropertyTestCase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage()); // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(ConfigPropertyTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(ConfigPropertyTestCase.class.getPackage(), "ra.xml", "ra.xml");
 
         return raa;
     }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/EarDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/eardeployment/EarDeploymentTestCase.java
@@ -81,7 +81,7 @@ public class EarDeploymentTestCase extends ContainerResourceMgmtTestBase {
         ja.addPackage(MultipleConnectionFactory1.class.getPackage());
         raa.addAsManifestResource(EarDeploymentTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
                 .addAsManifestResource(EarDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
 
         WebArchive wa = ShrinkWrap.create(WebArchive.class, "servlet.war");
         wa.addClasses(RaServlet.class);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/EarPackagedMultiRarDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earmultirar/EarPackagedMultiRarDeploymentTestCase.java
@@ -28,19 +28,14 @@ import javax.annotation.Resource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject2;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory2;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,7 +45,7 @@ import org.junit.runner.RunWith;
  *         Deployment of a RAR packaged inside an EAR.
  */
 @RunWith(Arquillian.class)
-public class EarPackagedMultiRarDeploymentTestCase extends ContainerResourceMgmtTestBase {
+public class EarPackagedMultiRarDeploymentTestCase {
 
     /**
      * Define the deployment
@@ -80,14 +75,13 @@ public class EarPackagedMultiRarDeploymentTestCase extends ContainerResourceMgmt
         final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(EarPackagedMultiRarDeploymentTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                addClasses(EarPackagedMultiRarDeploymentTestCase.class);
 
         ja.addPackage(AbstractMgmtTestBase.class.getPackage());
         ear.addAsLibrary(ja);
         ear.addAsModule(raa);
         ear.addAsModule(raa2);
-        ear.addAsManifestResource(EarPackagedMultiRarDeploymentTestCase.class.getPackage(), "application.xml", "application.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        ear.addAsManifestResource(EarPackagedMultiRarDeploymentTestCase.class.getPackage(), "application.xml", "application.xml");
         return ear;
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
@@ -34,19 +34,14 @@ import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +52,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(EarPackagedDeploymentTestCase.EarPackagedDeploymentTestCaseSetup.class)
-public class EarPackagedDeploymentTestCase extends ContainerResourceMgmtTestBase {
+public class EarPackagedDeploymentTestCase {
 
     static class EarPackagedDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -85,7 +80,7 @@ public class EarPackagedDeploymentTestCase extends ContainerResourceMgmtTestBase
      * @return The deployment archive
      */
     @Deployment
-    public static EnterpriseArchive createDeployment() throws Exception {
+    public static EnterpriseArchive createDeployment() {
 
         String deploymentName = "ear_packaged.ear";
         String subDeploymentName = "ear_packaged.rar";
@@ -94,13 +89,12 @@ public class EarPackagedDeploymentTestCase extends ContainerResourceMgmtTestBase
                 ShrinkWrap.create(ResourceAdapterArchive.class, subDeploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(EarPackagedDeploymentTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                addClasses(EarPackagedDeploymentTestCase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());  // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(EarPackagedDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(EarPackagedDeploymentTestCase.class.getPackage(), "ra.xml", "ra.xml");
 
         final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentName);
         ear.addAsModule(raa);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/inflow/InflowTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/inflow/InflowTestCase.java
@@ -32,9 +32,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.connector.util.ConnectorServices;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.smoke.deployment.rar.inflow.PureInflowResourceAdapter;
 import org.jboss.jca.core.spi.mdr.MetadataRepository;
 import org.jboss.jca.core.spi.rar.Endpoint;
@@ -46,8 +43,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +52,7 @@ import org.junit.runner.RunWith;
  *         JBQA-5741 -Inflow RA deployment test
  */
 @RunWith(Arquillian.class)
-public class InflowTestCase extends ContainerResourceMgmtTestBase {
+public class InflowTestCase {
 
 
     /**
@@ -73,13 +68,12 @@ public class InflowTestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(PureInflowResourceAdapter.class.getPackage()).
-                addClasses(InflowTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+                addClasses(InflowTestCase.class);
         raa.addAsLibrary(ja);
 
         raa.addAsManifestResource(InflowTestCase.class.getPackage(), "ra.xml", "ra.xml")
                 .addAsManifestResource(InflowTestCase.class.getPackage(), "ironjacamar.xml", "ironjacamar.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
 
         return raa;
     }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
@@ -36,18 +36,14 @@ import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,7 +54,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleActivationTestCase.MultipleActivationTestCaseSetup.class)
-public class MultipleActivationTestCase extends ContainerResourceMgmtTestBase {
+public class MultipleActivationTestCase {
 
     static class MultipleActivationTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -94,13 +90,12 @@ public class MultipleActivationTestCase extends ContainerResourceMgmtTestBase {
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(MultipleActivationTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                addClasses(MultipleActivationTestCase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());  // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(MultipleActivationTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(MultipleActivationTestCase.class.getPackage(), "ra.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
@@ -35,7 +35,6 @@ import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
@@ -44,11 +43,8 @@ import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory2;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,7 +55,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleObjectActivationTestCase.MultipleObjectActivationTestCaseSetup.class)
-public class MultipleObjectActivationTestCase extends ContainerResourceMgmtTestBase {
+public class MultipleObjectActivationTestCase {
 
     static class MultipleObjectActivationTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -94,13 +90,12 @@ public class MultipleObjectActivationTestCase extends ContainerResourceMgmtTestB
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(MultipleObjectActivationTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+                addClasses(MultipleObjectActivationTestCase.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());   // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(MultipleObjectActivationTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(MultipleObjectActivationTestCase.class.getPackage(), "ra.xml", "ra.xml");
         return raa;
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
@@ -35,18 +35,14 @@ import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
 import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +53,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(MultipleObjectPartialActivationTestCase.MultipleObjectPartialActivationTestCaseSetup.class)
-public class MultipleObjectPartialActivationTestCase extends ContainerResourceMgmtTestBase {
+public class MultipleObjectPartialActivationTestCase {
 
     static class MultipleObjectPartialActivationTestCaseSetup extends AbstractMgmtServerSetupTask {
 
@@ -92,13 +88,12 @@ public class MultipleObjectPartialActivationTestCase extends ContainerResourceMg
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
         ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
-                addClasses(MultipleObjectPartialActivationTestCase.class, AbstractMgmtTestBase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class, MultipleObjectPartialActivationTestCaseSetup.class, AbstractMgmtServerSetupTask.class);
+                addClasses(MultipleObjectPartialActivationTestCase.class, MultipleObjectPartialActivationTestCaseSetup.class);
 
-        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());   // needed to process the @ServerSetup annotation on the server side
         raa.addAsLibrary(ja);
 
-        raa.addAsManifestResource(MultipleObjectPartialActivationTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        raa.addAsManifestResource(MultipleObjectPartialActivationTestCase.class.getPackage(), "ra.xml", "ra.xml");
 
         //org.apache.httpcomponents,
         return raa;

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/pure/PureTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/pure/PureTestCase.java
@@ -30,9 +30,6 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.connector.util.ConnectorServices;
-import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
-import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.smoke.deployment.rar.inflow.PureInflowResourceAdapter;
 import org.jboss.jca.core.spi.mdr.MetadataRepository;
 import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
@@ -42,8 +39,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,7 +48,7 @@ import org.junit.runner.RunWith;
  *         JBQA-5742 -Pure RA deployment test
  */
 @RunWith(Arquillian.class)
-public class PureTestCase extends ContainerResourceMgmtTestBase {
+public class PureTestCase {
 
     /**
      * Define the deployment
@@ -61,20 +56,19 @@ public class PureTestCase extends ContainerResourceMgmtTestBase {
      * @return The deployment archive
      */
     @Deployment
-    public static ResourceAdapterArchive createDeployment() throws Exception {
+    public static ResourceAdapterArchive createDeployment() {
         String deploymentName = "pure.rar";
 
         ResourceAdapterArchive raa =
                 ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
         JavaArchive javaArchive = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
-        javaArchive.addClasses(PureTestCase.class, MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class);
+        javaArchive.addClasses(PureTestCase.class);
         javaArchive.addPackage(PureInflowResourceAdapter.class.getPackage());
-        javaArchive.addPackage(AbstractMgmtTestBase.class.getPackage());
 
         raa.addAsLibrary(javaArchive);
 
         raa.addAsManifestResource(PureTestCase.class.getPackage(), "ra.xml", "ra.xml")
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Dependencies: javax.inject.api,org.jboss.as.connector\n"), "MANIFEST.MF");
 
         return raa;
     }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSBridgeTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSBridgeTest.java
@@ -49,7 +49,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,8 +84,7 @@ public class DefaultJMSBridgeTest {
                 .addClass(CreateQueueSetupTask.class)
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
-                        ArchivePaths.create("beans.xml"))
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+                        ArchivePaths.create("beans.xml"));
     }
 
     /**

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSConnectionFactoryTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/DefaultJMSConnectionFactoryTest.java
@@ -49,7 +49,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,9 +82,7 @@ public class DefaultJMSConnectionFactoryTest {
                 .addClass(CreateQueueSetupTask.class)
                 .addPackage(JMSOperations.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE,
-                        ArchivePaths.create("beans.xml"))
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
-                        "MANIFEST.MF");
+                        ArchivePaths.create("beans.xml"));
     }
 
     @Test

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/JMSBridgeTest.java
@@ -99,7 +99,7 @@ public class JMSBridgeTest {
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
                         ArchivePaths.create("beans.xml"))
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli,org.jboss.remoting3\n"), "MANIFEST.MF")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.remoting3\n"), "MANIFEST.MF")
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new RemotingPermission("createEndpoint"),
                         new RemotingPermission("connect"),

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToJMSQueueTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/SendToJMSQueueTest.java
@@ -41,7 +41,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -79,8 +78,7 @@ public class SendToJMSQueueTest {
                 .addClass(CreateQueueSetupTask.class)
                 .addAsManifestResource(
                         EmptyAsset.INSTANCE,
-                        ArchivePaths.create("beans.xml"))
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+                        ArchivePaths.create("beans.xml"));
     }
 
     @Test


### PR DESCRIPTION
…hereby increase number of tests that can run in the ts.layers profile with Galleon slimmed servers

1) Eliminate no-longer needed dependencies on the org.jboss.as.cli module, which typically is not provisioned in ts.layers provisioning.
2) General cleanup of tests that used this or ones near those (primarily jca/ra/ds related tests) to better clarify between code that needs 'management' functionality and code that does not.
a) Deployments usually do not, particularly those in @RunAsClient tests. So remove the management code from the deployments as much as possible.
b) However, if the test class goes in the deployment and a @ServerSetup is on that class, the ServerSetupTask impl class and its superclasses must be present, even though they are not executed on the server side. Server side code processing the deployment will try and examine them.  Other classes used in the setup tasks do not need to be in the deployment though, as the setup task executes on the test driver side.
c) A number of tests were subclassing AbstractMgmtTestBase directly or transitively but were not using any of its functionality, instead relying on a ServerSetupTask for such things. In such cases the test class was changed to no longer subclass unnecessarily.
3) Following from this a large number of tests that previously could not run in the ts.layers profile now can, so they have been enabled.

https://issues.redhat.com/browse/WFLY-12402