### PR TITLE
[WFLY-13284] Fix incorrect method call in EJB3IIOPResource write-attibute handler

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
@@ -98,7 +98,7 @@ public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
             @Override
             void applySetting(final IIOPSettingsService service, OperationContext context, final ModelNode model) throws OperationFailedException {
                 final boolean value = ENABLE_BY_DEFAULT.resolveModelAttribute(context, model).asBoolean();
-                service.setUseQualifiedName(value);
+                service.setEnabledByDefault(value);
             }
         });
     }


### PR DESCRIPTION
This PR does the following:
- corrects an obvious typo in the definition of a write-attribute handler for ENABLE_BY_DEFAULT attribute of the EJB3IIOPResourceDefinition

For more details, see:   https://issues.redhat.com/browse/WFLY-13284