### PR TITLE
[WFLY-13293] When deploying "ROOT.war" in EAP7.x, the context root value output through jboss-cli is not valid

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -542,17 +542,6 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
         }
     }
 
-    /*
-    This is to address WFLY-1894 but should probably be moved to some other place.
-     */
-    private String resolveContextPath() {
-        if (deploymentName.equals(host.getValue().getDefaultWebModule())) {
-            return "/";
-        } else {
-            return contextPath;
-        }
-    }
-
     private DeploymentInfo createServletConfig() throws StartException {
         final ComponentRegistry componentRegistry = componentRegistryInjectedValue.getValue();
         try {
@@ -561,7 +550,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
             }
             mergedMetaData.resolveRunAs();
             final DeploymentInfo d = new DeploymentInfo();
-            d.setContextPath(resolveContextPath());
+            d.setContextPath(contextPath);
             if (mergedMetaData.getDescriptionGroup() != null) {
                 d.setDisplayName(mergedMetaData.getDescriptionGroup().getDisplayName());
             }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13293

I have moved the final calculation of the app context from the info service to the deployment processor (this way both use the same context and teh issue is resolved). Let me know if you see something wrong.