### PR TITLE
[WFLY-13300] Upgrade hibernate-validator to 6.0.19.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <version.org.hibernate>5.3.15.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
-        <version.org.hibernate.validator>6.0.18.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>6.0.19.Final</version.org.hibernate.validator>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>9.4.18.Final</version.org.infinispan>
         <version.org.jasypt>1.9.3</version.org.jasypt>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13300

We need this upgrade to fix:
https://issues.redhat.com/browse/JBEAP-16121