### PR TITLE
WFLY-13303 : Upgrade Hibernate ORM from 5.3.15 to 5.3.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
         <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.harmcrest>1.3</version.org.harmcrest>
-        <version.org.hibernate>5.3.15.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.16.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.18.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13303
https://issues.redhat.com/browse/JBEAP-18367