### PR TITLE
WFLY-12733 EJB Timers: Forcing refresh timers in a database-data-stor…

### DIFF
--- a/docs/src/main/asciidoc/_developer-guide/ejb3/EJB3_Clustered_Database_Timers.adoc
+++ b/docs/src/main/asciidoc/_developer-guide/ejb3/EJB3_Clustered_Database_Timers.adoc
@@ -112,6 +112,75 @@ in jboss-ejb3.xml:
 </jboss:ejb-jar>
 ----
 
+[[programmatically-refresh-timer]]
+== Programmatically Refresh Timer
+
+In a clustered deployment, multiple nodes updating timer datastore may cause the in-memory timer state to be temporarily
+out of sync. Some application may find the `refresh-interval` configuration not sufficient in some cases, and
+need to programmatically refresh timers. This can be done with EE interceptors configured for those business methods
+that need this capability, as illustrated in the following steps:
+
+* Implement an EE interceptor that enables `wildfly.ejb.timer.refresh.enabled` to true. For example,
+
+[source,java,options="nowrap"]
+----
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+/**
+ * An interceptor to enable programmatic timer refresh across multiple nodes.
+ */
+@Interceptor
+public class RefreshInterceptor {
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        context.getContextData().put("wildfly.ejb.timer.refresh.enabled", Boolean.TRUE);
+        return context.proceed();
+    }
+}
+----
+
+* Configure the EE interceptor to the target stateless or singleton bean business methods.
+When `wildfly.ejb.timer.refresh.enabled` is set to true, calling `TimerService.getAllTimers()`
+will first refresh from timer datastore before returning timers. For example,
+
+[source,java,options="nowrap"]
+----
+@Singleton
+public class RefreshBean1 ... {
+
+    @Interceptors(RefreshInterceptor.class)
+    public void businessMethod1() {
+        ...
+        // since wildfly.ejb.timer.refresh.enabled is set to true in interceptor for this business method,
+        // calling timerService.getAllTimers() will first refresh from timer datastore before returning timers.
+        final Collection<Timer> allTimers = timerService.getAllTimers();
+        ...
+    }
+}
+----
+
+* Applications may configure such an interceptor to certain business methods that require this capability.
+Alternatively, applications may implement a dedicated business method to programmatically refresh timers, to
+be invoked by other parts of the application when needed. For example,
+
+[source,java,options="nowrap"]
+----
+    @Interceptors(RefreshInterceptor.class)
+    public List<Timer> getAllTimerInfoWithRefresh() {
+        return timerService.getAllTimers();
+    }
+
+    public void businessMethod1() {
+        final LocalBusinessInterface businessObject = sessionContext.getBusinessObject(LocalBusinessInterface.class);
+        businessObject.getAllTimerInfoWithRefresh();
+
+        // timer has been programmatically refreshed from datastore.
+        // continue with other business logic...
+    }
+----
+
 [[technical-details]]
 == Technical details
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
@@ -168,17 +168,15 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
         extractDialects();
         investigateDialect();
         checkDatabase();
+        refreshTask = new RefreshTask();
         if (refreshInterval > 0) {
-            refreshTask = new RefreshTask();
             timerInjectedValue.getValue().schedule(refreshTask, refreshInterval, refreshInterval);
         }
     }
 
     @Override
     public synchronized void stop(final StopContext context) {
-        if (refreshTask != null) {
-            refreshTask.cancel();
-        }
+        refreshTask.cancel();
         knownTimerIds.clear();
         managedReference.release();
         managedReference = null;
@@ -531,6 +529,10 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
     @Override
     public DatabaseTimerPersistence getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
+    }
+
+    public void refreshTimers() {
+        refreshTask.run();
     }
 
     private Holder timerFromResult(final ResultSet resultSet, final TimerServiceImpl timerService) throws SQLException {

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -21,6 +21,21 @@
  */
 package org.jboss.as.test.multinode.ejb.timer.database;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Properties;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+
 import org.h2.tools.Server;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -42,21 +57,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import java.net.URI;
-import java.util.List;
-import java.util.Properties;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 /**
  * Tests that a timer created on a node with timeout disabled can be run on a different node in the cluster.
@@ -202,7 +202,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
     }
 
 
-    public Context getRemoteContext(ManagementClient managementClient) throws Exception {
+    public static Context getRemoteContext(ManagementClient managementClient) throws Exception {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBean1.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBean1.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.timer.database;
+
+import javax.ejb.ConcurrencyManagement;
+import javax.ejb.ConcurrencyManagementType;
+import javax.ejb.Singleton;
+
+@Singleton
+@ConcurrencyManagement(ConcurrencyManagementType.BEAN)
+public class RefreshBean1 extends RefreshBeanBase implements RefreshIF {
+
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBean2.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBean2.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.timer.database;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class RefreshBean2 extends RefreshBeanBase implements RefreshIF {
+
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBeanBase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshBeanBase.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.timer.database;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerConfig;
+import javax.ejb.TimerService;
+import javax.interceptor.Interceptors;
+
+public abstract class RefreshBeanBase implements RefreshIF {
+    @Resource
+    TimerService timerService;
+
+    @Resource
+    SessionContext sessionContext;
+
+    @Timeout
+    void timeout(Timer timer) {
+        //noop, all timers will be cancelled before expiry.
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void createTimer(final long delay, final Serializable info) {
+        timerService.createSingleActionTimer(delay, new TimerConfig(info, true));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Interceptors(RefreshInterceptor.class)
+    public List<Serializable> getAllTimerInfoWithRefresh() {
+        final Collection<Timer> allTimers = timerService.getAllTimers();
+        return allTimers.stream().map(Timer::getInfo).collect(Collectors.toList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Serializable> getAllTimerInfoWithRefresh2() {
+        final RefreshIF businessObject = sessionContext.getBusinessObject(RefreshIF.class);
+        return businessObject.getAllTimerInfoWithRefresh();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Serializable> getAllTimerInfoNoRefresh() {
+        return getAllTimerInfoWithRefresh();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void cancelTimers() {
+        final Collection<Timer> timers = timerService.getTimers();
+        for (Timer timer : timers) {
+            try {
+                timer.cancel();
+            } catch (Exception e) {
+                //ignore
+            }
+        }
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshIF.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshIF.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.timer.database;
+
+import java.io.Serializable;
+import java.util.List;
+import javax.ejb.Remote;
+
+@Remote
+public interface RefreshIF {
+    /**
+     * Used to indicate in which node and by which bean the timer is created.
+     */
+    enum Info {
+        /**
+         * The timer is created in the client node and by bean 1.
+         */
+        CLIENT1,
+
+        /**
+         * The timer is created in the server node and by bean 1.
+         */
+        SERVER1
+    }
+
+    /**
+     * Creates a timer to expire {@code delay} milliseconds later, with {@code info}
+     * as the timer info.
+     *
+     * @param delay number of milliseconds after which the timer is set to expire
+     * @param info timer info
+     */
+    void createTimer(long delay, Serializable info);
+
+    /**
+     * Gets all timers after programmatic refresh. Any implementation method
+     * should be configured to have an interceptor that enables programmatic
+     * timer refresh.
+     *
+     * @return list of timer info
+     */
+    List<Serializable> getAllTimerInfoWithRefresh();
+
+    /**
+     * Gets all timers after programmatic refresh. Any implementation method
+     * should be configured to have an interceptor that enables programmatic
+     * timer refresh.
+     * <p>
+     * This method demonstrates that a bean class can invoke its own business
+     * method that enables programmatic timer refresh, without replying on an
+     * external client invocation.
+     *
+     * @return list of timer info
+     */
+    List<Serializable> getAllTimerInfoWithRefresh2();
+
+    /**
+     * Gets all timers without programmatic refresh. Any implementation method
+     * should NOT be configured to have an interceptor that enables programmatic
+     * timer refresh.
+     *
+     * @return list of timer info
+     */
+    List<Serializable> getAllTimerInfoNoRefresh();
+
+    /**
+     * Cancels timers of this bean.
+     */
+    void cancelTimers();
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshInterceptor.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/RefreshInterceptor.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.timer.database;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+/**
+ * An interceptor to enable programmatic timer refresh across multiple nodes.
+ */
+@Interceptor
+public class RefreshInterceptor {
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        context.getContextData().put("wildfly.ejb.timer.refresh.enabled", Boolean.TRUE);
+        return context.proceed();
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/jboss-ejb-client-refresh-test.xml
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/jboss-ejb-client-refresh-test.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.2">
+    <client-context>
+        <ejb-receivers exclude-local-receiver="false">
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>


### PR DESCRIPTION
…e in a clustered environment

Related Issues:
https://issues.redhat.com/browse/WFLY-12733
https://issues.redhat.com/browse/EAP7-1377

Analysis document:
https://github.com/wildfly/wildfly-proposals/pull/283

This feature allows applications to programmatically refresh timer datastore, by configurable a flag through an interceptor.