### PR TITLE
[19.0.x][WFLY-13326] Upgrade RESTEasy to 3.11.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
         <version.org.jboss.mod_cluster>1.4.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.10.1.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.4.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>3.11.0.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.11.2.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13326