### PR TITLE
WFLY-13359 Upgrade JGroups to 4.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
         <version.org.jboss.ws.spi>3.3.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jctools.jctools-core>2.1.2</version.org.jctools.jctools-core>
-        <version.org.jgroups>4.2.1.Final</version.org.jgroups>
+        <version.org.jgroups>4.2.2.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.2.1.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.15.Final</version.org.jgroups.kubernetes>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/WFLY-13359

Most importantly brings in fix for 'JGRP-2412 GMS: reduce likelihood of merges on concurrent new member startup' which could resolve the issue we have been seeing on CI.