### PR TITLE
Fix for WFLY-13093, Upgrade Galleon from 4.2.4.Final to 4.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,12 +228,12 @@
         <version.asciidoctor.plugin>1.5.6</version.asciidoctor.plugin>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.8.2</version.jacoco.plugin><!-- TODO property does not follow verion.groupId format -->
-        <version.org.jboss.galleon>4.2.4.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.2.5.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.12.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.common>1.5.2.Final</version.org.wildfly.common>
         <version.org.wildfly.component-matrix-plugin>1.0.3.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>4.2.4.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.2.6.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>2.0.0.Final</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>2.0.1.Final</version.org.wildfly.plugin>
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13093

Galleon changes since 4.2.4.Final: wildfly/galleon@4.2.4.Final...wildfly:4.2.5.Final

Galleon plugins changes since 4.2.4.Final: wildfly/galleon-plugins@wildfly-provisioning-parent-4.2.4.Final...wildfly:4.2.6.Final