### PR TITLE
[WFLY-13349] Upgrade WildFly Core 12.0.0.Beta1

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
@@ -23,12 +23,12 @@
 <xs:schema targetNamespace="urn:jboss:domain:jgroups:7.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="urn:jboss:domain:jgroups:7.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="7.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:datasources:5.0" xmlns="urn:jboss:domain:datasources:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:resource-adapters:5.0" xmlns="urn:jboss:domain:resource-adapters:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
@@ -21,10 +21,10 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:1.0"
-           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            elementFormDefault="qualified" version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem" type="subsystemType"/>
 

--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:12.0">
+<domain xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="master">
+<host xmlns="urn:jboss:domain:13.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0">
+<host xmlns="urn:jboss:domain:13.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="master">
+<host xmlns="urn:jboss:domain:13.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:12.0">
+<server xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:12.0">
+<server xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:12.0">
+<server xmlns="urn:jboss:domain:13.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
@@ -26,13 +26,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:3.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:mail:3.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <!-- The mail subsystem root element -->
     <xs:element name="subsystem" type="mail-subsystemType"/>

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
@@ -24,13 +24,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:messaging-activemq:9.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
            targetNamespace="urn:jboss:domain:messaging-activemq:9.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="9.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
 
     <xs:element name="subsystem">
         <xs:complexType>

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:12.0">
+<domain xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="master">
+<host xmlns="urn:jboss:domain:13.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0">
+<host xmlns="urn:jboss:domain:13.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="master">
+<host xmlns="urn:jboss:domain:13.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:12.0">
+<server xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0"
+<domain xmlns="urn:jboss:domain:13.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0">
+<domain xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0"
+<domain xmlns="urn:jboss:domain:13.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0">
+<domain xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0">
+<domain xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="master">
+<host xmlns="urn:jboss:domain:13.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:12.0" name="slave">
+<host xmlns="urn:jboss:domain:13.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:12.0"
+<host xmlns="urn:jboss:domain:13.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:12.0">
+<server xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:12.0"
+<domain xmlns="urn:jboss:domain:13.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:12.0">
+<host name="master" xmlns="urn:jboss:domain:13.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:12.0">
+<host name="master" xmlns="urn:jboss:domain:13.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
This combines #13191 and #12601 as they require each other to work.
JIRA's:

- https://issues.redhat.com/browse/WFLY-13349
- https://issues.jboss.org/browse/WFLY-12510

---


## Release Notes - WildFly Core - Version 12.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4864'>WFCORE-4864</a>] -         Bump the jackson databind test dep to 2.10.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4876'>WFCORE-4876</a>] -         Upgrade JBoss Remoting to 5.0.18.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4878'>WFCORE-4878</a>] -         Upgrade WildFly OpenSSL to 1.0.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4881'>WFCORE-4881</a>] -         Upgrade XNIO to 3.8.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4884'>WFCORE-4884</a>] -         Upgrade wildfly-common 1.5.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4885'>WFCORE-4885</a>] -         Upgrade Jandex 2.1.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4886'>WFCORE-4886</a>] -         Upgrade httpclient 4.5.12
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4887'>WFCORE-4887</a>] -         Upgrade slf4j 1.7.30
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4890'>WFCORE-4890</a>] -         Upgrade WildFly Elytron to 1.11.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4621'>WFCORE-4621</a>] -         Create a &#39;wildflyee.api&#39; module to serve the Jakarta EE APIs to external modules
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4764'>WFCORE-4764</a>] -         Availability of web console during the startup of the Domain Controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4812'>WFCORE-4812</a>] -         Consolidate instances of DefaultValueAttributeConverter
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4814'>WFCORE-4814</a>] -         Consolidate common instances of DiscardAttributeChecker that discard an attribute set to the default value
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4860'>WFCORE-4860</a>] -         Performance degradation with the LogContextSelector on Java 11 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4874'>WFCORE-4874</a>] -         Improve the WFLYSRV0002 error message
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4893'>WFCORE-4893</a>] -         Expose the process state from the embed server and controller
</li>
</ul>
                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4150'>WFCORE-4150</a>] -         Support automatically adding / updating credentials in the CredentialStore
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4737'>WFCORE-4737</a>] -         CVE-2019-14887 The &#39;enabled-protocols&#39; value in legacy security is not respected if OpenSSL security provider is in use
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4803'>WFCORE-4803</a>] -         EJB Client authentication does not work using SASL DIGEST-MD5 and EXTERNAL mechanisms in Legacy security
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4819'>WFCORE-4819</a>] -         Add OperationDefinition generated by default SimpleResourceDefinition logic never contains parameters
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4875'>WFCORE-4875</a>] -         Provide common capability for Remoting connectors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4883'>WFCORE-4883</a>] -         CompositeOperationTestCase fails intermittently 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4900'>WFCORE-4900</a>] -         Wildfly-openssl can not load library wfssl on RHEL6
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4455'>WFCORE-4455</a>] -         Drop the org.slf4j.ext module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4754'>WFCORE-4754</a>] -         Bump the Elytron subsystem version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4877'>WFCORE-4877</a>] -         Move testsuite/layers in ts.layers profile
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4892'>WFCORE-4892</a>] -         Remove the ch.qos.cal10n module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4894'>WFCORE-4894</a>] -         Upgrade jackson databind to 2.10.3 ...
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4898'>WFCORE-4898</a>] -         Bump the kernel management API version to 13.0.0 and the xsd to 13.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4903'>WFCORE-4903</a>] -         Update manualmode tests so HTTP authentication is not dependent on commons-codec
</li>
</ul>
                                    