### PR TITLE
[WFLY-12510] Include wildfly-credential-reference_1_1.xsd when validating config

### DIFF
--- a/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
+++ b/clustering/jgroups/extension/src/main/resources/schema/jboss-as-jgroups_7_0.xsd
@@ -23,12 +23,12 @@
 <xs:schema targetNamespace="urn:jboss:domain:jgroups:7.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="urn:jboss:domain:jgroups:7.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="7.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem" type="tns:subsystem">
         <xs:annotation>

--- a/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-datasources_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:datasources:5.0" xmlns="urn:jboss:domain:datasources:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-resource-adapters_5_0.xsd
@@ -23,10 +23,10 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            targetNamespace="urn:jboss:domain:resource-adapters:5.0" xmlns="urn:jboss:domain:resource-adapters:5.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-  <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+  <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
   <xs:element name="subsystem" type="subsystemType"/>
 

--- a/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
+++ b/datasources-agroal/src/main/resources/schema/wildfly-agroal_1_0.xsd
@@ -21,10 +21,10 @@
   ~ 2110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:jboss:domain:datasources-agroal:1.0"
-           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns="urn:jboss:domain:datasources-agroal:1.0" xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            elementFormDefault="qualified" version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem" type="subsystemType"/>
 

--- a/dist-legacy/pom.xml
+++ b/dist-legacy/pom.xml
@@ -183,6 +183,10 @@
                             <!-- Parameters to test cases. -->
                             <systemPropertyVariables combine.children="append">
                                 <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
+                                <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                                <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                                <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                                <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -169,6 +169,10 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
+                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/ee-dist/pom.xml
+++ b/ee-dist/pom.xml
@@ -162,6 +162,10 @@
                     <systemPropertyVariables combine.children="append">
                         <jboss.dist>${basedir}/target/xml-validation</jboss.dist>
                         <jboss.actual.dist>${basedir}/target/${project.build.finalName}</jboss.actual.dist>
+                        <!-- FIXME: WFLY-12510, the 2 following properties are required by the StandardConfigsXMLValidationUnitTestCase to -->
+                        <!-- validate that existing schemas that references wildfly-credential-reference_1_0.xsd are valid                 -->
+                        <version.org.wildfly.core>${version.org.wildfly.core}</version.org.wildfly.core>
+                        <jboss.test.xml.validation.future.schemas>${version.org.wildfly.core}/wildfly-credential-reference_1_1.xsd</jboss.test.xml.validation.future.schemas>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
+++ b/mail/src/main/resources/schema/wildfly-mail_3_0.xsd
@@ -26,13 +26,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:mail:3.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            targetNamespace="urn:jboss:domain:mail:3.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="1.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <!-- The mail subsystem root element -->
     <xs:element name="subsystem" type="mail-subsystemType"/>

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_9_0.xsd
@@ -24,13 +24,13 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns="urn:jboss:domain:messaging-activemq:9.0"
-           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.0"
            targetNamespace="urn:jboss:domain:messaging-activemq:9.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
            version="9.0">
 
-    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+    <xs:import namespace="urn:wildfly:credential-reference:1.0" schemaLocation="wildfly-credential-reference_1_0.xsd"/>
 
     <xs:element name="subsystem">
         <xs:complexType>


### PR DESCRIPTION
This PR reverts https://github.com/wildfly/wildfly/commit/ea885a15dbb2adf3cd9ab9afc7832bed672e4669 and includes wildfly-credential-reference_1_1.xsd during the resolution of namespaces in the StandardConfigsXMLValidationUnitTestCase tests