### PR TITLE
[WFLY-13221] Remove package-schema cruft from wildfly-feature-pack-build.xml files

### DIFF
--- a/dist-legacy/src/verifier/verifications.xml
+++ b/dist-legacy/src/verifier/verifications.xml
@@ -30,6 +30,9 @@ limitations under the License.
     8) The 'slot' attribute in the module.xml above has a value equal to the value of the 'ee.dist.product.slot' property
     9) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property
+    10) Schemas coming from a module distributed directly by the ee-galleon-pack are copied to docs/schema
+    11) Schemas coming from a module distributed by the transitive servlet-galleon-pack are copied to docs/schema
+    12) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -70,6 +73,18 @@ limitations under the License.
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-txn_5_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-undertow_10_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-io_3_0.xsd</location>
       <exists>true</exists>
     </file>
   </files>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -28,6 +28,10 @@ limitations under the License.
        'full.dist.product.release.name' property
     7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property
+    8) Schemas coming from a module distributed directly by the galleon-pack are copied to docs/schema
+   10) Schemas coming from a module distributed by the transitive ee-galleon-pack are copied to docs/schema
+   11) Schemas coming from a module distributed by the transitive servlet-galleon-pack are copied to docs/schema
+   12) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -60,6 +64,22 @@ limitations under the License.
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-microprofile-openapi-smallrye_1_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-messaging-activemq_9_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/jboss-as-naming_2_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/jboss-as-deployment-scanner_2_0.xsd</location>
       <exists>true</exists>
     </file>
   </files>

--- a/ee-dist/src/verifier/verifications.xml
+++ b/ee-dist/src/verifier/verifications.xml
@@ -29,6 +29,9 @@ limitations under the License.
     7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property
     8) Various modules provided by the feature pack that provides the complete MicroProfile feature set are not present
+    9) Schemas coming from a module distributed directly by the ee-galleon-pack are copied to docs/schema
+    10) Schemas coming from a module distributed by the transitive servlet-galleon-pack are copied to docs/schema
+    11) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -114,6 +117,18 @@ limitations under the License.
     <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/security/elytron-jwt/main</location>
       <exists>false</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-txn_5_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-undertow_10_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/docs/schema/wildfly-io_3_0.xsd</location>
+      <exists>true</exists>
     </file>
   </files>
 </verifications>

--- a/ee-galleon-pack/wildfly-feature-pack-build.xml
+++ b/ee-galleon-pack/wildfly-feature-pack-build.xml
@@ -47,11 +47,8 @@
         <package name="bin"/>
     </default-packages>
     <package-schemas>
-        <group name="org.jboss.as"/>
         <group name="org.jboss.metadata"/>
         <group name="org.wildfly"/>
-        <group name="org.wildfly.core"/>
-        <group name="org.wildfly.security"/>
     </package-schemas>
 
     <config name="standalone.xml" model="standalone"/>

--- a/galleon-pack/wildfly-feature-pack-build.xml
+++ b/galleon-pack/wildfly-feature-pack-build.xml
@@ -60,11 +60,7 @@
         <package name="docs.licenses.merge"/>
     </default-packages>
     <package-schemas>
-        <group name="org.jboss.as"/>
-        <group name="org.jboss.metadata"/>
         <group name="org.wildfly"/>
-        <group name="org.wildfly.core"/>
-        <group name="org.wildfly.security"/>
     </package-schemas>
 
     <config name="standalone.xml" model="standalone"/>

--- a/servlet-dist-legacy/src/verifier/verifications.xml
+++ b/servlet-dist-legacy/src/verifier/verifications.xml
@@ -28,6 +28,8 @@ limitations under the License.
        'servlet.dist.product.release.name' property in this maven module's pom
     7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property in this maven module's pom
+    8) Schemas coming from a module distributed directly by the servlet-feature-pack are copied to docs/schema
+    9) Schemas coming from a module distributed by the transitive core-feature-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -60,6 +62,14 @@ limitations under the License.
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/docs/schema/jboss-as-ee_5_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/docs/schema/wildfly-core-management_1_0.xsd</location>
       <exists>true</exists>
     </file>
   </files>

--- a/servlet-dist/src/verifier/verifications.xml
+++ b/servlet-dist/src/verifier/verifications.xml
@@ -28,6 +28,8 @@ limitations under the License.
        'servlet.dist.product.release.name' property in this maven module's pom
     7) JBoss-Product-Release-Version key in manifest.mf has value starting with the value of the
        'verifier.product.release.version' property in this maven module's pom
+    8) Schemas coming from a module distributed directly by the servlet-galleon-pack are copied to docs/schema
+    9) Schemas coming from a module distributed by the transitive core-galleon-pack are copied to docs/schema
 -->
   <files>
     <file>
@@ -60,6 +62,14 @@ limitations under the License.
     </file>
     <file>
       <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/server/main/wildfly-server-${version.org.wildfly.core}.jar</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/docs/schema/jboss-as-ee_5_0.xsd</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-servlet-${server.output.dir.version}/docs/schema/wildfly-core-management_1_0.xsd</location>
       <exists>true</exists>
     </file>
   </files>

--- a/servlet-galleon-pack/wildfly-feature-pack-build.xml
+++ b/servlet-galleon-pack/wildfly-feature-pack-build.xml
@@ -37,11 +37,7 @@
         <package name="docs.licenses.merge"/>
     </default-packages>
     <package-schemas>
-        <group name="org.jboss.as"/>
         <group name="org.wildfly"/>
-        <group name="org.wildfly.core"/>
-<!--        <group name="org.jboss.metadata"/> -->
-<!--        <group name="org.wildfly.security"/> -->
     </package-schemas>
 
     <config name="standalone.xml" model="standalone"/>


### PR DESCRIPTION
Cleans up the `package-schemas` removing any package that doesn't need to be processed  to extract a schema from the module included in the current feature pack.

Adds some verifications to check the existence of files coming from the current feature pack and the transitive ones. The  schema filtering is done based on the legacy ones. I leave them as they were originally.

Jira issue: https://issues.redhat.com/browse/WFLY-13221