### PR TITLE
[WFLY-13375] JNDI view does not show implementation classes for connection factories and destinations registered by 3rd party resource adapters.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/AdminObjectReferenceFactoryService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/AdminObjectReferenceFactoryService.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.services.resourceadapters;
 
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
@@ -38,7 +40,7 @@ import org.jboss.msc.value.InjectedValue;
  * Service responsible for exposing a {@link ManagedReferenceFactory} for an admin object
  * @author @author <a href="mailto:stefano.maestri@redhat.com">Stefano Maestri</a>
  */
-public class AdminObjectReferenceFactoryService implements Service<ManagedReferenceFactory>, ManagedReferenceFactory {
+public class AdminObjectReferenceFactoryService implements Service<ManagedReferenceFactory>, ContextListAndJndiViewManagedReferenceFactory {
     public static final ServiceName SERVICE_NAME_BASE =
         ServiceName.JBOSS.append("connector").append("admin-object").append("reference-factory");
 
@@ -63,5 +65,17 @@ public class AdminObjectReferenceFactoryService implements Service<ManagedRefere
 
     public Injector<Object> getAdminObjectInjector() {
         return adminObjectValue;
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return String.valueOf(value);
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ConnectionFactoryReferenceFactoryService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ConnectionFactoryReferenceFactoryService.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.connector.services.resourceadapters;
 
+import org.jboss.as.naming.ContextListAndJndiViewManagedReferenceFactory;
+import org.jboss.as.naming.ContextListManagedReferenceFactory;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ValueManagedReference;
@@ -38,7 +40,7 @@ import org.jboss.msc.value.InjectedValue;
  * Service responsible for exposing a {@link ManagedReferenceFactory} for a connection factory
  * @author @author <a href="mailto:stefano.maestri@redhat.com">Stefano Maestri</a>
  */
-public class ConnectionFactoryReferenceFactoryService implements Service<ManagedReferenceFactory>, ManagedReferenceFactory {
+public class ConnectionFactoryReferenceFactoryService implements Service<ManagedReferenceFactory>, ContextListAndJndiViewManagedReferenceFactory {
     public static final ServiceName SERVICE_NAME_BASE = ServiceName.JBOSS.append("connection-factory").append(
             "reference-factory");
 
@@ -72,5 +74,17 @@ public class ConnectionFactoryReferenceFactoryService implements Service<Managed
 
     public Injector<Object> getConnectionFactoryInjector() {
         return connectionFactoryValue;
+    }
+
+    @Override
+    public String getInstanceClassName() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return value != null ? value.getClass().getName() : ContextListManagedReferenceFactory.DEFAULT_INSTANCE_CLASS_NAME;
+    }
+
+    @Override
+    public String getJndiViewInstanceValue() {
+        final Object value = reference != null ? reference.getInstance() : null;
+        return String.valueOf(value);
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13375