### PR TITLE
[WFLY-13381] At EJB3 remote AssociationImpl, we need to take into acc…

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/AssociationImpl.java
@@ -186,7 +186,7 @@ final class AssociationImpl implements Association, AutoCloseable {
             Connection remotingConnection = invocationRequest.getProviderInterface(Connection.class);
             if(remotingConnection != null) {
                 SecurityActions.remotingContextSetConnection(remotingConnection);
-            } else {
+            } else if (invocationRequest.getSecurityIdentity() != null) {
                 SecurityActions.remotingContextSetConnection(new RemoteConnection() {
                     @Override
                     public SSLSession getSslSession() {


### PR DESCRIPTION
…ount the possibility of identity being null before setting up connection in SecurityActions.

With EJB over Remoting, it is always true that the identity won't be null because of Sasl anonymous user. But the same does not apply to EJB over HTTP. In this
case, security identity is null if http-remoting-connector lacks the security-realm attribute (at remoting subsystem model config):
<http-connector name="http-remoting-connector" connector-ref="default"/>

Jira: https://issues.redhat.com/browse/WFLY-13381
EAP Jira: https://issues.redhat.com/browse/JBEAP-16383