### PR TITLE
[WFLY-13267] Convert EJB3 subsystem transformers to use chained transformers

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Model.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Model.java
@@ -10,12 +10,16 @@ import org.jboss.as.controller.ModelVersion;
 public enum EJB3Model {
 
     VERSION_1_2_0(1, 2, 0),
-    VERSION_1_2_1(1, 2, 1),
-    VERSION_1_3_0(1, 3, 0),
-    VERSION_4_0_0(4, 0, 0)
+    VERSION_1_2_1(1, 2, 1), // EAP 6.4.0
+    VERSION_1_3_0(1, 3, 0), // EAP 6.4.7
+    VERSION_3_0_0(3, 0, 0), //
+    VERSION_4_0_0(4, 0, 0), // EAP 7.0.0
+    VERSION_5_0_0(5, 0, 0), // EAP 7.2.0, EAP 7.1.0
+    VERSION_6_0_0(6, 0, 0),
+
     ;
 
-    static final EJB3Model CURRENT = VERSION_4_0_0;
+    static final EJB3Model CURRENT = VERSION_6_0_0;
 
     private final ModelVersion version;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJBTransformers.java
@@ -28,6 +28,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_1_2_1;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_1_3_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_3_0_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_4_0_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_5_0_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_6_0_0;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ALLOW_EXECUTION;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SFSB_CACHE;
@@ -57,24 +63,22 @@ import org.jboss.as.controller.transform.ResourceTransformationContext;
 import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeConverter;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
-import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.threads.PoolAttributeDefinitions;
 import org.jboss.dmr.ModelNode;
 
 /**
+ * EJB Transformers used to transform current model version to legacy model versions for domain mode.
+ *
  * @author Tomaz Cerar (c) 2017 Red Hat Inc.
+ * @author Richard Achmatowicz (c) 2020 Red Hat Inc.
  */
 public class EJBTransformers implements ExtensionTransformerRegistration {
-    private static final ModelVersion VERSION_1_2_1 = ModelVersion.create(1, 2, 1);
-    private static final ModelVersion VERSION_1_3_0 = ModelVersion.create(1, 3, 0);
-    private static final ModelVersion VERSION_3_0_0 = ModelVersion.create(3, 0, 0);
-    private static final ModelVersion VERSION_4_0_0 = ModelVersion.create(4, 0, 0);
-    private static final ModelVersion VERSION_5_0_0 = ModelVersion.create(5, 0, 0);
 
     @Override
     public String getSubsystemName() {
@@ -83,202 +87,198 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
 
     @Override
     public void registerTransformers(SubsystemTransformerRegistration subsystemRegistration) {
-        registerTransformers_1_2_1(subsystemRegistration);
-        registerTimerTransformers_1_3_0(subsystemRegistration);
-        registerTransformers_3_0_0(subsystemRegistration);
-        registerTransformers_4_0_0(subsystemRegistration);
-        registerTransformers_5_0_0(subsystemRegistration);
+
+        ModelVersion currentModel = subsystemRegistration.getCurrentSubsystemVersion();
+        ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(currentModel);
+
+        registerTransformers_5_0_0(chainedBuilder.createBuilder(currentModel, VERSION_5_0_0.getVersion()));
+        registerTransformers_4_0_0(chainedBuilder.createBuilder(VERSION_5_0_0.getVersion(), VERSION_4_0_0.getVersion()));
+        registerTransformers_3_0_0(chainedBuilder.createBuilder(VERSION_4_0_0.getVersion(), VERSION_3_0_0.getVersion()));
+        registerTransformers_1_3_0(chainedBuilder.createBuilder(VERSION_3_0_0.getVersion(), VERSION_1_3_0.getVersion()));
+        registerTransformers_1_2_1(chainedBuilder.createBuilder(VERSION_1_3_0.getVersion(), VERSION_1_2_1.getVersion()));
+
+        chainedBuilder.buildAndRegister(subsystemRegistration,new ModelVersion[]{VERSION_6_0_0.getVersion(), VERSION_5_0_0.getVersion(), VERSION_4_0_0.getVersion(), VERSION_3_0_0.getVersion(), VERSION_1_3_0.getVersion(), VERSION_1_2_1.getVersion()});
     }
 
-    private static void registerTransformers_1_2_1(SubsystemTransformerRegistration subsystemRegistration) {
-        registerTransformers_1_2_1_and_1_3_0(subsystemRegistration, VERSION_1_2_1);
+    /*
+     * Transformers for changes in model version 1.3.0
+     */
+    private static void registerTransformers_1_2_1(ResourceTransformationDescriptionBuilder subsystemBuilder) {
+
+        DataStoreTransformer dataStoreTransformer = new DataStoreTransformer();
+
+        ResourceTransformationDescriptionBuilder timerService = subsystemBuilder.addChildResource(EJB3SubsystemModel.TIMER_SERVICE_PATH);
+        timerService.getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.ALWAYS, EJB3SubsystemModel.DEFAULT_DATA_STORE)//this is ok, as default-data-store only has any sense with new model, but it is always set!
+                .end();
+        timerService.discardOperations(ModelDescriptionConstants.ADD);
+
+        // set a custom resource transformer for /subsystem=ejb/service=timer
+        timerService.setCustomResourceTransformer(dataStoreTransformer);
+
+        // reject /subsystem=ejb/service=timer database-data-store children
+        timerService.rejectChildResource(EJB3SubsystemModel.DATABASE_DATA_STORE_PATH);
+
+        ResourceTransformationDescriptionBuilder fileDataStore = timerService.addChildRedirection(EJB3SubsystemModel.FILE_DATA_STORE_PATH, (current, theBuilder) -> theBuilder.getCurrent());
+
+        // override the operation /subsystem=ejb/service=timer/file-data-store=F:add(path=, relative-to=)
+        fileDataStore.addOperationTransformationOverride(ModelDescriptionConstants.ADD)
+                .inheritResourceAttributeDefinitions()
+                .setCustomOperationTransformer(dataStoreTransformer)
+                .end();
     }
 
-    private static void registerTimerTransformers_1_3_0(SubsystemTransformerRegistration subsystemRegistration) {
-        registerTransformers_1_2_1_and_1_3_0(subsystemRegistration, VERSION_1_3_0);
-    }
-
-    private static void registerTransformers_1_2_1_and_1_3_0(SubsystemTransformerRegistration subsystemRegistration, ModelVersion version) {
-        final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+    /*
+     * Transformers for changes in model version 3.0.0
+     */
+    private static void registerTransformers_1_3_0(ResourceTransformationDescriptionBuilder subsystemBuilder) {
 
         StatefulCacheRefTransformer statefulCacheRefTransformer = new StatefulCacheRefTransformer();
-        builder.setCustomResourceTransformer(statefulCacheRefTransformer);
-
+        subsystemBuilder.setCustomResourceTransformer(statefulCacheRefTransformer);
         for (String name : Arrays.asList(WRITE_ATTRIBUTE_OPERATION, UNDEFINE_ATTRIBUTE_OPERATION, READ_ATTRIBUTE_OPERATION)) {
-            builder.addOperationTransformationOverride(name)
+            subsystemBuilder.addOperationTransformationOverride(name)
                     .inheritResourceAttributeDefinitions()
                     .setCustomOperationTransformer(statefulCacheRefTransformer)
                     .end();
         }
-
-        builder.addOperationTransformationOverride(ADD)
+        subsystemBuilder.addOperationTransformationOverride(ADD)
                 .inheritResourceAttributeDefinitions()
                 .setCustomOperationTransformer(new AddStatefulCacheRefTransformer())
                 .end();
 
         //This used to behave as 'true' and it is now defaulting as 'true'
-        builder.getAttributeBuilder().setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS);
-
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS);
-        // We can always discard this attribute, because it's meaningless without the security-manager subsystem, and
-        // a legacy slave can't have that subsystem in its profile.
-        builder.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(ModelNode.FALSE), EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS);
-        //builder.getAttributeBuilder().setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME);
-
-        builder.getAttributeBuilder().setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS);
-
-        registerPassivationStoreTransformers_1_2_1_and_1_3_0(builder);
-        registerRemoteTransformers(builder);
-        registerMdbDeliveryGroupTransformers(builder);
-        registerStrictMaxPoolTransformers(builder);
-        registerApplicationSecurityDomainDTransformers(builder);
-        registerIdentityTransformers(builder);
-        registerThreadPoolTransformers(builder);
-
-        builder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
-        if (version.equals(VERSION_1_2_1)) {
-            registerTimerTransformers_1_2_0(builder);
-        } else if (version.equals(VERSION_1_3_0)) {
-            registerTimerTransformers_1_3_0(builder);
-        }
-
-        // Rename new statistics-enabled attribute to old enable-statistics
-        builder.getAttributeBuilder()
-               .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
-
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, version);
-    }
-
-    private static void registerTransformers_3_0_0(SubsystemTransformerRegistration subsystemRegistration) {
-        final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        builder.getAttributeBuilder().setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
+        subsystemBuilder.getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS)
                 .end();
 
-        builder.getAttributeBuilder().setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS);
-        registerMdbDeliveryGroupTransformers(builder);
-        registerRemoteTransformers(builder);
-        registerStrictMaxPoolTransformers(builder);
-        registerApplicationSecurityDomainDTransformers(builder);
-        registerIdentityTransformers(builder);
-        registerThreadPoolTransformers(builder);
-
-        // Rename new statistics-enabled attribute to old enable-statistics
-        builder.getAttributeBuilder().addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_3_0_0);
-    }
-
-    private static void registerTransformers_4_0_0(SubsystemTransformerRegistration subsystemRegistration) {
-        final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-
-        registerApplicationSecurityDomainDTransformers(builder);
-        registerIdentityTransformers(builder);
-        registerThreadPoolTransformers(builder);
-        builder.addChildResource(RemotingProfileResourceDefinition.INSTANCE).getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.DEFINED, StaticEJBDiscoveryDefinition.INSTANCE)
+        // We can always discard this attribute, because it's meaningless without the security-manager subsystem, and a legacy slave can't have that subsystem in its profile.
+        subsystemBuilder.getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(ModelNode.FALSE), EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
                 .end();
 
-        builder.getAttributeBuilder().setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN);
+        subsystemBuilder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
 
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS);
+        // passivation store transformers
+        subsystemBuilder.addChildRedirection(PassivationStoreResourceDefinition.INSTANCE.getPathElement(), PathElement.pathElement(EJB3SubsystemModel.CLUSTER_PASSIVATION_STORE))
+                .getAttributeBuilder()
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(ModelNode.TRUE, true), EJB3SubsystemModel.PASSIVATE_EVENTS_ON_REPLICATE)
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("default"), true), EJB3SubsystemModel.CLIENT_MAPPINGS_CACHE)
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode().set(Long.valueOf(Integer.MAX_VALUE)), true), EJB3SubsystemModel.IDLE_TIMEOUT)
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode().set(TimeUnit.SECONDS.name()), true), EJB3SubsystemModel.IDLE_TIMEOUT_UNIT)
+                .end();
 
-        // Rename new statistics-enabled attribute to old enable-statistics
-        builder.getAttributeBuilder()
-               .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS);
-
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_4_0_0);
+        // timer transformers
+        subsystemBuilder.addChildResource(EJB3SubsystemModel.TIMER_SERVICE_PATH)
+                .addChildResource(EJB3SubsystemModel.DATABASE_DATA_STORE_PATH)
+                .getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, REFRESH_INTERVAL, ALLOW_EXECUTION)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, REFRESH_INTERVAL, ALLOW_EXECUTION)
+                .end();
     }
 
-    private static void registerTransformers_5_0_0(SubsystemTransformerRegistration subsystemRegistration) {
-        final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+    /*
+     * Transformers for changes in model version 4.0.0
+     */
+    private static void registerTransformers_3_0_0(ResourceTransformationDescriptionBuilder subsystemBuilder) {
 
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS);
-        builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS);
+        subsystemBuilder.getAttributeBuilder()
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
+                .end();
 
-        registerThreadPoolTransformers(builder);
-
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_5_0_0);
-    }
-
-    private static void registerRemoteTransformers(ResourceTransformationDescriptionBuilder parent) {
-        ResourceTransformationDescriptionBuilder remoteService = parent.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH);
-        remoteService.getAttributeBuilder()
+        // remote transformers
+        subsystemBuilder.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH)
+                .getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, CLIENT_MAPPINGS_CLUSTER_NAME)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, CLIENT_MAPPINGS_CLUSTER_NAME)
                 .setDiscard(DiscardAttributeChecker.ALWAYS, EXECUTE_IN_WORKER) //as this does not affect functionality we just discard
                 .end();
-    }
 
-    private  static void registerIdentityTransformers(ResourceTransformationDescriptionBuilder parent) {
-        parent.rejectChildResource(EJB3SubsystemModel.IDENTITY_PATH);
-    }
+        // mdb delivery group transformers
+        subsystemBuilder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP));
 
-    private  static void registerApplicationSecurityDomainDTransformers(ResourceTransformationDescriptionBuilder parent) {
-        parent.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN));
-    }
-
-    private static void registerStrictMaxPoolTransformers(ResourceTransformationDescriptionBuilder parent) {
-        parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.STRICT_MAX_BEAN_INSTANCE_POOL))
+        // strict max pool transformers
+        subsystemBuilder.addChildResource(PathElement.pathElement(EJB3SubsystemModel.STRICT_MAX_BEAN_INSTANCE_POOL))
                 .getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(StrictMaxPoolResourceDefinition.DeriveSize.NONE.toString())), DERIVE_SIZE)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, DERIVE_SIZE);
+                .addRejectCheck(RejectAttributeChecker.DEFINED, DERIVE_SIZE)
+                .end();
     }
 
-    private static void registerThreadPoolTransformers(ResourceTransformationDescriptionBuilder parent) {
-        parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL))
+    /*
+     * Transformers for changes in model version 5.0.0
+     */
+    private static void registerTransformers_4_0_0(ResourceTransformationDescriptionBuilder subsystemBuilder) {
+
+        // application security domain
+        subsystemBuilder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN));
+
+        // identity transformers
+        subsystemBuilder.rejectChildResource(EJB3SubsystemModel.IDENTITY_PATH);
+
+        subsystemBuilder.addChildResource(RemotingProfileResourceDefinition.INSTANCE)
+                .getAttributeBuilder()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, StaticEJBDiscoveryDefinition.INSTANCE)
+                .end();
+
+        subsystemBuilder.getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ALLOW_EJB_NAME_REGEX)
+                .end();
+
+        subsystemBuilder.getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN)
+                .end();
+
+        // Rename new statistics-enabled attribute to old enable-statistics
+        subsystemBuilder.getAttributeBuilder()
+                .addRename(EJB3SubsystemModel.STATISTICS_ENABLED, EJB3SubsystemModel.ENABLE_STATISTICS)
+                .end();
+
+        // added - debug (the transformed model is missing a value for log-server-exceptions
+        subsystemBuilder.getAttributeBuilder()
+                .setValueConverter(AttributeConverter.Factory.createHardCoded(ModelNode.TRUE, true), EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS)
+                .end();
+    }
+
+    /*
+     * Transformers for changes in model version 6.0.0
+     */
+    private static void registerTransformers_5_0_0(ResourceTransformationDescriptionBuilder subsystemBuilder) {
+
+        // interceptors
+        subsystemBuilder.getAttributeBuilder()
+                .setDiscard(DiscardAttributeChecker.UNDEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS)
+                .end();
+
+        // thread pool
+        subsystemBuilder.addChildResource(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL))
                 .getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.UNDEFINED, PoolAttributeDefinitions.CORE_THREADS)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, PoolAttributeDefinitions.CORE_THREADS).end();
-    }
-
-    private static void registerMdbDeliveryGroupTransformers(ResourceTransformationDescriptionBuilder parent) {
-        parent.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP));
-    }
-
-    private static void registerTimerTransformers_1_2_0(ResourceTransformationDescriptionBuilder parent) {
-        ResourceTransformationDescriptionBuilder timerService = parent.addChildResource(EJB3SubsystemModel.TIMER_SERVICE_PATH);
-        registerDataStoreTransformers(timerService);
-    }
-
-    private static void registerDataStoreTransformers(ResourceTransformationDescriptionBuilder timerService) {
-
-        DataStoreTransformer dataStoreTransformer = new DataStoreTransformer();
-        timerService.getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.ALWAYS, EJB3SubsystemModel.DEFAULT_DATA_STORE)//this is ok, as default-data-store only has any sense with new model, but it is always set!
+                .addRejectCheck(RejectAttributeChecker.DEFINED, PoolAttributeDefinitions.CORE_THREADS)
                 .end();
-        timerService.discardOperations(ModelDescriptionConstants.ADD);
-        timerService.setCustomResourceTransformer(dataStoreTransformer);
-        timerService.rejectChildResource(EJB3SubsystemModel.DATABASE_DATA_STORE_PATH);
-        ResourceTransformationDescriptionBuilder fileDataStore = timerService.addChildRedirection(EJB3SubsystemModel.FILE_DATA_STORE_PATH, (current, builder) -> builder.getCurrent());
-
-        fileDataStore.addOperationTransformationOverride(ModelDescriptionConstants.ADD)
-                .inheritResourceAttributeDefinitions()
-                .setCustomOperationTransformer(dataStoreTransformer)
-                .end();
-
     }
 
-    private static void registerTimerTransformers_1_3_0(ResourceTransformationDescriptionBuilder parent) {
-        ResourceTransformationDescriptionBuilder timerService = parent.addChildResource(EJB3SubsystemModel.TIMER_SERVICE_PATH);
-        ResourceTransformationDescriptionBuilder db = timerService.addChildResource(EJB3SubsystemModel.DATABASE_DATA_STORE_PATH);
-                db.getAttributeBuilder()
-                        .setDiscard(DiscardAttributeChecker.DEFAULT_VALUE, REFRESH_INTERVAL, ALLOW_EXECUTION)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, REFRESH_INTERVAL, ALLOW_EXECUTION);
-    }
-
+    /*
+     * This transformer is used with the datastores in /subsystem=ejb3/service=timer
+     * <timer-service thread-pool-name= default-data-store=>
+     *   <data-stores>
+     *     <file-data-store name= path= relative-to=/>
+     *     <database-data-store name= datasource-jndi-name= database= .../>
+     *   </data-stores>
+     * </timer-service>
+     */
     private static class DataStoreTransformer implements CombinedTransformer {
 
         private DataStoreTransformer() {
         }
 
+        /**
+         * Registered against /subsystem=ejb3/service=timer/file-data-store=*:add(path=.., relative-to=..) only
+         */
         @Override
         public TransformedOperation transformOperation(final TransformationContext context, final PathAddress address, final ModelNode operation) throws OperationFailedException {
             Resource original = context.readResourceFromRoot(address);
@@ -302,6 +302,9 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
             return new TransformedOperation(operation, OperationResultTransformer.ORIGINAL_RESULT);
         }
 
+        /**
+         * Registered against /subsystem=ejb3/service=timer only
+         */
         @Override
         public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
             Resource untransformedResource = context.readResource(PathAddress.EMPTY_ADDRESS);
@@ -332,22 +335,6 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
         }
     }
 
-    /*
-        * This transformer does the following:
-        * - maps <passivation-store/> to <cluster-passivation-store/>
-        * - sets appropriate defaults for IDLE_TIMEOUT, IDLE_TIMEOUT_UNIT, PASSIVATE_EVENTS_ON_REPLICATE, and CLIENT_MAPPINGS_CACHE
-        */
-    @SuppressWarnings("deprecation")
-    private static void registerPassivationStoreTransformers_1_2_1_and_1_3_0(ResourceTransformationDescriptionBuilder parent) {
-
-        ResourceTransformationDescriptionBuilder child = parent.addChildRedirection(PassivationStoreResourceDefinition.INSTANCE.getPathElement(), PathElement.pathElement(EJB3SubsystemModel.CLUSTER_PASSIVATION_STORE));
-        child.getAttributeBuilder()
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(ModelNode.TRUE, true), EJB3SubsystemModel.PASSIVATE_EVENTS_ON_REPLICATE)
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("default"), true), EJB3SubsystemModel.CLIENT_MAPPINGS_CACHE)
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode().set(Long.valueOf(Integer.MAX_VALUE)), true), EJB3SubsystemModel.IDLE_TIMEOUT)
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode().set(TimeUnit.SECONDS.name()), true), EJB3SubsystemModel.IDLE_TIMEOUT_UNIT)
-        ;
-    }
 
     /**
      * This Combined Transformer manages this transformation from EAP7 to previous versions (attribute definition/xml markup):
@@ -413,5 +400,6 @@ public class EJBTransformers implements ExtensionTransformerRegistration {
             return new TransformedOperation(operation, OperationResultTransformer.ORIGINAL_RESULT);
         }
     }
-
 }
+
+

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -9,6 +9,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_1_3_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_4_0_0;
+import static org.jboss.as.ejb3.subsystem.EJB3Model.VERSION_5_0_0;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STRICT_MAX_BEAN_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.STATISTICS_ENABLED;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.ENABLE_STATISTICS;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -24,6 +30,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
@@ -37,16 +44,27 @@ import org.junit.Test;
 
 /**
  * Test cases for transformers used in the EJB3 subsystem.
+ * <p>
+ * This checks the following features:
+ * - basic subsystem testing (i.e. current model version boots successfully)
+ * - registered transformers transform model and operations correctly between different API model versions
+ * - expressions appearing in XML configurations are correctly rejected if so required
+ * - bad attribute values are correctly rejected
  *
  * @author <a href="tomasz.cerar@redhat.com"> Tomasz Cerar</a>
  * @author Richard Achmatowicz (c) 2015 Red Hat Inc.
+ * @author Richard Achmatowicz (c) 2020 Red Hat Inc.
  */
 public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
 
     private static final String LEGACY_EJB_CLIENT_ARTIFACT = "org.jboss:jboss-ejb-client:2.1.2.Final";
 
-    private static String formatSubsystemArtifact(ModelTestControllerVersion version) {
+    private static String formatWildflySubsystemArtifact(ModelTestControllerVersion version) {
         return formatArtifact("org.wildfly:wildfly-ejb3:%s", version);
+    }
+
+    private static String formatEAPSubsystemArtifact(ModelTestControllerVersion version) {
+        return formatArtifact("org.jboss.eap:wildfly-ejb3:%s", version);
     }
 
     private static String formatLegacySubsystemArtifact(ModelTestControllerVersion version) {
@@ -73,7 +91,7 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String[] getSubsystemTemplatePaths() throws IOException {
-        return new String[] {
+        return new String[]{
                 "/subsystem-templates/ejb3.xml"
         };
     }
@@ -84,13 +102,126 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
         super.testSchemaOfSubsystemTemplates();
     }
 
+    /*
+     * Transformer tests not involving rejection
+     */
+
     @Test
     public void testTransformerEAP640() throws Exception {
         ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_4_0;
-        testTransformation(ModelVersion.create(1, 3, 0), controller,
+
+        testTransformation(VERSION_1_3_0.getVersion(), controller,
                 formatLegacySubsystemArtifact(controller),
                 formatArtifact("org.jboss.as:jboss-as-threads:%s", controller),
                 "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-3");
+    }
+
+    @Test
+    public void testTransformerEAP647() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_4_7;
+
+        testTransformation(VERSION_1_3_0.getVersion(), controller,
+                formatLegacySubsystemArtifact(controller),
+                formatArtifact("org.jboss.as:jboss-as-threads:%s", controller),
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-3");
+    }
+
+    @Test
+    public void testTransformerEAP700() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_0_0;
+
+        testTransformation(VERSION_4_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.jboss.eap:wildfly-clustering-ejb-spi:7.0.0.GA-redhat-2",
+                "org.wildfly.core:wildfly-threads:2.1.2.Final-redhat-1",
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-4");
+    }
+
+    @Test
+    public void testTransformerEAP710() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_1_0;
+
+        testTransformation(VERSION_5_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.jboss.eap:wildfly-clustering-ejb-spi:7.1.0.GA-redhat-11",
+                "org.wildfly.core:wildfly-threads:3.0.10.Final-redhat-1",
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.5.Final-redhat-1");
+    }
+
+    @Test
+    public void testTransformerEAP720() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_2_0;
+
+        testTransformation(VERSION_5_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.wildfly.core:wildfly-threads:6.0.11.Final-redhat-00001",
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.6.Final-redhat-1");
+    }
+
+    /*
+     * Transformer tests involving rejection
+     */
+
+    @Test
+    public void testRejectionsEAP640() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_4_0;
+
+        this.testRejections(VERSION_1_3_0.getVersion(), controller,
+                formatLegacySubsystemArtifact(controller),
+                LEGACY_EJB_CLIENT_ARTIFACT,
+                formatArtifact("org.jboss.as:jboss-as-threads:%s", controller),
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-3");
+    }
+
+    @Test
+    public void testRejectionsEAP647() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_4_7;
+
+        this.testRejections(VERSION_1_3_0.getVersion(), controller,
+                formatLegacySubsystemArtifact(controller),
+                formatArtifact("org.jboss.as:jboss-as-threads:%s", controller),
+                LEGACY_EJB_CLIENT_ARTIFACT,
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-3");
+    }
+
+    @Test
+    public void testRejectionsEAP700() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_0_0;
+
+        this.testRejections(VERSION_4_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.jboss.eap:wildfly-clustering-ejb-spi:7.0.0.GA-redhat-2",
+                "org.wildfly.core:wildfly-threads:2.1.2.Final-redhat-1",
+                LEGACY_EJB_CLIENT_ARTIFACT,
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-4");
+    }
+
+    @Test
+    public void testRejectionsEAP710() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_1_0;
+
+        this.testRejections(VERSION_5_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.jboss.eap:wildfly-clustering-ejb-spi:7.1.0.GA-redhat-11",
+                "org.wildfly.core:wildfly-threads:3.0.10.Final-redhat-1",
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.5.Final-redhat-1");
+    }
+
+    @Test
+    public void testRejectionsEAP720() throws Exception {
+        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_7_2_0;
+
+        this.testRejections(VERSION_5_0_0.getVersion(), controller,
+                formatEAPSubsystemArtifact(controller),
+                "org.wildfly.core:wildfly-threads:6.0.11.Final-redhat-00001",
+                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.6.Final-redhat-1");
+    }
+
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider",
+                buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain"));
     }
 
     /**
@@ -102,7 +233,7 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
      * @param mavenResourceURLs
      * @throws Exception
      */
-    private void testTransformation(ModelVersion model, ModelTestControllerVersion controller, String ... mavenResourceURLs) throws Exception {
+    private void testTransformation(ModelVersion model, ModelTestControllerVersion controller, String... mavenResourceURLs) throws Exception {
 
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
@@ -120,45 +251,34 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
         // check that both versions of the legacy model are the same and valid
-        checkSubsystemModelTransformation(services, model, null);
+        checkSubsystemModelTransformation(services, model, new DefaultModelFixer());
 
-        PathAddress ejb3PathAddress = PathAddress.pathAddress(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME);
-        Map<String, String> attributeRenames = new HashMap<>();
-        attributeRenames.put(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.getName(), EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.getName());
-        attributeRenames.put(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.getName(), EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.getName());
+        if (EJB3Model.VERSION_1_2_1.matches(model) || EJB3Model.VERSION_1_3_0.matches(model)) {
+            PathAddress ejb3PathAddress = PathAddress.pathAddress(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME);
+            Map<String, String> attributeRenames = new HashMap<>();
+            attributeRenames.put(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.getName(), EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.getName());
+            attributeRenames.put(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.getName(), EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.getName());
 
-        for (Map.Entry<String, String> renames : attributeRenames.entrySet()){
-            ModelNode operation = Util.getWriteAttributeOperation(ejb3PathAddress, renames.getKey(), "test");
-            testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
+            for (Map.Entry<String, String> renames : attributeRenames.entrySet()) {
+                ModelNode operation = Util.getWriteAttributeOperation(ejb3PathAddress, renames.getKey(), "test");
+                testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
 
-            operation = Util.getReadAttributeOperation(ejb3PathAddress, renames.getKey());
-            testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
+                operation = Util.getReadAttributeOperation(ejb3PathAddress, renames.getKey());
+                testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
 
-            operation = Util.getUndefineAttributeOperation(ejb3PathAddress, renames.getKey());
-            testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
+                operation = Util.getUndefineAttributeOperation(ejb3PathAddress, renames.getKey());
+                testAttributeRenameTransform(model, services, legacyServices, operation, renames.getKey(), renames.getValue());
+            }
         }
     }
 
-    @Test
-    public void testRejectionsEAP640() throws Exception {
-        ModelTestControllerVersion controller = ModelTestControllerVersion.EAP_6_4_0;
-        this.testRejections(ModelVersion.create(1, 3, 0), controller,
-                formatLegacySubsystemArtifact(controller),
-                formatArtifact("org.jboss.as:jboss-as-threads:%s", controller), LEGACY_EJB_CLIENT_ARTIFACT,
-                "org.jboss.spec.javax.rmi:jboss-rmi-api_1.0_spec:1.0.4.Final-redhat-3");
-    }
 
-    @Override
-    protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider", buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain"));
-    }
-
-    private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String ... mavenResourceURLs) throws Exception {
+    private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String... mavenResourceURLs) throws Exception {
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization());
 
         // initialize the legacy services and add required jars
-        builder.createLegacyKernelServicesBuilder(null, controller, model)
+        builder.createLegacyKernelServicesBuilder(this.createAdditionalInitialization(), controller, model)
                 .addMavenResourceURL(mavenResourceURLs)
                 .dontPersistXml();
 
@@ -171,15 +291,41 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
         List<ModelNode> operations = builder.parseXmlResource("subsystem-ejb3-transform-reject.xml");
 
         ModelTestUtils.checkFailedTransformedBootOperations(services, model, operations, createFailedOperationTransformationConfig(services, model));
-
     }
 
     private static FailedOperationTransformationConfig createFailedOperationTransformationConfig(KernelServices services, ModelVersion version) {
         FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
         PathAddress subsystemAddress = PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH);
 
+        // EAP 6.4.0
         if (EJB3Model.VERSION_1_2_1.matches(version)) {
 
+            // register rejections for changes in 3.0.0
+
+            // register rejections for changes in 4.0.0
+            // reject the resource /subsystem=ejb3/mdb-delivery-group=delivery-group-name
+            config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP, "delivery-group-name")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+
+            // register rejections for changes in 5.0.0
+
+            // reject the resource /subsystem=ejb3/application-security-domain=domain
+            config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN, "domain")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            // reject the resource /subsystem=ejb3/service=identity
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.IDENTITY_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            // reject the resource /subsystem=ejb3/remoting-profile=profile and its children
+            PathAddress remotingProfileAddress = subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE, "profile"));
+            PathAddress ejbReceiverAddress = remotingProfileAddress.append(PathElement.pathElement(EJB3SubsystemModel.REMOTING_EJB_RECEIVER, "receiver"));
+            PathAddress channelCreationOptionsAddress = ejbReceiverAddress.append(PathElement.pathElement(EJB3SubsystemModel.CHANNEL_CREATION_OPTIONS));
+            config.addFailedAttribute(remotingProfileAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            config.addFailedAttribute(ejbReceiverAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
+            config.addFailedAttribute(channelCreationOptionsAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
+
+            // register rejections for changes in 6.0.0
+
+            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
+
+            // register rejections for changes in 7.0.0
 
             // create a chained config to apply multiple transformation configs to each one of a collection of attributes
             FailedOperationTransformationConfig.ChainedConfig chainedSubsystemConfig = FailedOperationTransformationConfig.ChainedConfig.createBuilder(
@@ -212,29 +358,9 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
             PathAddress databaseDataStore = subsystemAddress.append(EJB3SubsystemModel.TIMER_SERVICE_PATH, EJB3SubsystemModel.DATABASE_DATA_STORE_PATH);
             config.addFailedAttribute(databaseDataStore, FailedOperationTransformationConfig.REJECTED_RESOURCE);
 
-            // reject the resource /subsystem=ejb3/mdb-delivery-group=delivery-group-name
-            config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP, "delivery-group-name")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
-
-            // reject the resource /subsystem=ejb3/remoting-profile=profile and its children
-            PathAddress remotingProfileAddress = subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE, "profile"));
-            PathAddress ejbReceiverAddress = remotingProfileAddress.append(PathElement.pathElement(EJB3SubsystemModel.REMOTING_EJB_RECEIVER, "receiver"));
-            PathAddress channelCreationOptionsAddress = ejbReceiverAddress.append(PathElement.pathElement(EJB3SubsystemModel.CHANNEL_CREATION_OPTIONS));
-            config.addFailedAttribute(remotingProfileAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
-            config.addFailedAttribute(ejbReceiverAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
-            config.addFailedAttribute(channelCreationOptionsAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
-
             // reject the attribute 'cluster' from resource /subsystem=ejb3/service=remote
-            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.REMOTE_SERVICE_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME));
-
-            // reject the resource /subsystem=ejb3/application-security-domain=domain
-            config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN, "domain")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
-
-            // reject the resource /subsystem=ejb3/service=identity
-            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.IDENTITY_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
-
-            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
-            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
-
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.REMOTE_SERVICE_PATH),
+                    new FailedOperationTransformationConfig.NewAttributesConfig(EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME));
             //Special handling for this test!!!!
             //Don't transform the resulting composite, instead rather transform the individual steps
             config.setDontTransformComposite();
@@ -243,6 +369,7 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
             config.setCallback(() -> removeExtraFileStoreConfig.removeExtraFileDataStore());
         }
 
+        // EAP 6.4.7
         if (EJB3Model.VERSION_1_3_0.matches(version)) {
 
             // create a chained config to apply multiple transformation configs to each one of a collection of attributes
@@ -275,7 +402,8 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
             config.addFailedAttribute(channelCreationOptionsAddress, FailedOperationTransformationConfig.REJECTED_RESOURCE);
 
             // reject the attribute 'cluster' from resource /subsystem=ejb3/service=remote
-            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.REMOTE_SERVICE_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME));
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.REMOTE_SERVICE_PATH),
+                    new FailedOperationTransformationConfig.NewAttributesConfig(EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME));
 
             // reject the resource /subsystem=ejb3/application-security-domain=domain
             config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN, "domain")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
@@ -287,12 +415,73 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
             config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
         }
 
+        // need to include all changes from current to 4.0.0
+        if (EJB3Model.VERSION_4_0_0.matches(version)) {
+
+            config.addFailedAttribute(subsystemAddress,
+                    new FailedOperationTransformationConfig.NewAttributesConfig(
+                            EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS,
+                            EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS,
+                            EJB3SubsystemRootResourceDefinition.ENABLE_GRACEFUL_TXN_SHUTDOWN)
+            );
+
+            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
+
+            // reject the resource /subsystem=ejb3/application-security-domain=domain
+            config.addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.APPLICATION_SECURITY_DOMAIN, "domain")), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+
+            // reject the resource /subsystem=ejb3/service=identity
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.IDENTITY_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
+        }
+
+        // need to include all changes from current to 5.0.0
+        if (EJB3Model.VERSION_5_0_0.matches(version)) {
+
+            config.addFailedAttribute(subsystemAddress,
+                    new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.CLIENT_INTERCEPTORS, EJB3SubsystemRootResourceDefinition.SERVER_INTERCEPTORS));
+
+            // reject the attribute core-threads from resource /subsystem=ejb3/thread-pool=default
+            config.addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.THREAD_POOL_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(PoolAttributeDefinitions.CORE_THREADS));
+
+        }
         return config;
     }
 
-    private static class CorrectFalseToTrue extends FailedOperationTransformationConfig.AttributesPathAddressConfig<CorrectFalseToTrue>{
 
-        public CorrectFalseToTrue(AttributeDefinition...defs) {
+    /*
+     * Class to fix up some irredeemable errors in the legacy model before comparison
+     */
+    private static class DefaultModelFixer implements ModelFixer {
+
+        private final String SLSB_STRICT_MAX_POOL = "slsb-strict-max-pool";
+        private final String MDB_STRICT_MAX_POOL = "mdb-strict-max-pool";
+
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            // /subsystem=ejb3/strict-max-pool=* attribute derive-size has a default in legacy but none in current, which fails the model comparison
+
+            if (modelNode.hasDefined(STRICT_MAX_BEAN_INSTANCE_POOL) && modelNode.get(STRICT_MAX_BEAN_INSTANCE_POOL).hasDefined(MDB_STRICT_MAX_POOL)) {
+                modelNode.get(STRICT_MAX_BEAN_INSTANCE_POOL, MDB_STRICT_MAX_POOL, StrictMaxPoolResourceDefinition.DERIVE_SIZE.getName()).set(new ModelNode());
+            }
+            if (modelNode.hasDefined(STRICT_MAX_BEAN_INSTANCE_POOL) && modelNode.get(STRICT_MAX_BEAN_INSTANCE_POOL).hasDefined(SLSB_STRICT_MAX_POOL)) {
+                modelNode.get(STRICT_MAX_BEAN_INSTANCE_POOL, SLSB_STRICT_MAX_POOL, StrictMaxPoolResourceDefinition.DERIVE_SIZE.getName()).set(new ModelNode());
+            }
+
+            if (modelNode.hasDefined(STATISTICS_ENABLED) && modelNode.hasDefined(ENABLE_STATISTICS)
+                                                         && modelNode.get(STATISTICS_ENABLED).equals(modelNode.get(ENABLE_STATISTICS))) {
+                // In a legacy kernel before WFCORE-4183 a read-resource result incorrectly includes a value for both an attribute and its alias. Correct that
+                modelNode.get(ENABLE_STATISTICS).set(new ModelNode());
+            }
+
+            return modelNode;
+
+        }
+    }
+
+    private static class CorrectFalseToTrue extends FailedOperationTransformationConfig.AttributesPathAddressConfig<CorrectFalseToTrue> {
+
+        public CorrectFalseToTrue(AttributeDefinition... defs) {
             super(convert(defs));
         }
 


### PR DESCRIPTION
This PR does the following:
- adds in transformer tests for the ejb3 subsystem for EAP versions 7.0.0, 7.1.0 and 7.2.0
- refactors the transformers to use the chained transformer approach, to simplify understanding of the transformers and make maintenance easier  

For more details, see: https://issues.redhat.com/browse/WFLY-13267
