### PR TITLE
[WFLY-13390]:migrate operation on legacy messaging subsystem fails wi…

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -825,4 +825,8 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 90, value = "Can not migrate broadcast group %s as no network configuration is properly defined.")
     String couldNotMigrateBroadcastGroup(PathAddress address);
+
+    @Message(id = 91, value = "Can not migrate broadcast group %s as no connector is properly defined.")
+    String couldNotMigrateBroadcastGroupWithoutConnectors(PathAddress address);
 }
+

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -159,6 +159,7 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 6 warnings about broadcast-group attributes that can not be migrated.
         // 2 warnings about broadcast-group attributes not migrated because they have an expression.
         // 3 warnings about broadcast-group not migrated because they don't have a proper network configuration.
+        // 1 warnings about broadcast-group not migrated because they don't have a connector.
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about discovery-group attributes not migrated because they have an expression.
         // 3 warnings about interceptors that can not be migrated (for remoting-interceptors, remoting-incoming-interceptors & remoting-outgoing-interceptors attributes)
@@ -166,7 +167,7 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 1 warning about HA migration (attributes have expressions)
         // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.
         // 1 warning about use-nio being ignored for netty-throughput remote-connector resource.
-        int expectedNumberOfWarnings = 6 + 2 + 3 + 5 + 2 + 3 + 3 + 1 + 1 + 1;
+        int expectedNumberOfWarnings = 6 + 2 + 3 + 1 + 5 + 2 + 3 + 3 + 1 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -131,6 +131,9 @@
                 <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
                 <connector-ref>in-vm</connector-ref>
             </broadcast-group>
+            <broadcast-group name="groupV">
+                <socket-binding>messaging-group</socket-binding>
+            </broadcast-group>
         </broadcast-groups>
         <discovery-groups>
             <discovery-group name="groupC">


### PR DESCRIPTION
…th WF19.

* Adding a warning if no connector is defined in a broadcastgroup

Jira: https://issues.redhat.com/browse/WFLY-13390