### PR TITLE
[WFLY-9440] Register requirement for jacc-policy capability

### DIFF
--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -285,7 +285,7 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
                 buildDynamicCapabilityName("org.wildfly.ejb3.mdb-delivery-group", "2"),
                 buildDynamicCapabilityName("org.wildfly.ejb3.mdb-delivery-group", "3"),
                 buildDynamicCapabilityName("org.wildfly.ejb3.pool-config", "pool"),
-                "org.wildfly.remoting.endpoint");
+                "org.wildfly.remoting.endpoint", "org.wildfly.security.jacc-policy");
     }
 
     private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String... mavenResourceURLs) throws Exception {


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-9440

Similiar fix is needed for Undertow, but for now I wasn't sure whether it makes sense to add implementation of CapabilityReferenceRecorder for use with boolean attributes to core.

Please make sure your PR meets the following requirements:
- [ ] Pull Request title is properly formatted: `[WFLY-XYZ] Subject` or `WFLY-XYZ Subject`
- [ ] Pull Request contains link to the JIRA issue(s)
- [ ] Pull Request contains description of the issue(s)
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted

For bigger changes, major and minor component upgrades make sure your PR also meets following requirements:
- [ ] Pull Request requires a change to the documentation
- [ ] Documentation have been updated accordingly
- [ ] Tests were added to cover changes

For new features ensure as well:
- [ ] Analysis was done
- [ ] Test Plan has been done
- [ ] Tests were verified in advance

If you are not an active contributor of the WildFly project you can request sponsorship by one of the members to help guide you through the process.