### PR TITLE
WFLY-13378 Upgrade Eclipse MicroProfile Fault Tolerance API to 2.1.1-RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
         <version.org.cryptacular>1.2.4</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.6.1</version.org.eclipse.jdt.core.compiler>
         <version.org.eclipse.microprofile.config.api>1.4</version.org.eclipse.microprofile.config.api>
-        <version.org.eclipse.microprofile.fault-tolerance.api>2.1</version.org.eclipse.microprofile.fault-tolerance.api>
+        <version.org.eclipse.microprofile.fault-tolerance.api>2.1.1-RC1</version.org.eclipse.microprofile.fault-tolerance.api>
         <version.org.eclipse.microprofile.health.api>2.2</version.org.eclipse.microprofile.health.api>
         <version.org.eclipse.microprofile.jwt.api>1.1.1</version.org.eclipse.microprofile.jwt.api>
         <version.org.eclipse.microprofile.metrics.api>2.3</version.org.eclipse.microprofile.metrics.api>

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.base.io.IOUtil;
 
 /**
@@ -70,15 +69,6 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
 
         if (!applicationArchive.contains("META-INF/beans.xml")) {
             applicationArchive.add(EmptyAsset.INSTANCE, "META-INF/beans.xml");
-        }
-
-        if (applicationArchive instanceof WebArchive
-                && applicationArchive.contains("META-INF/microprofile-config.properties")
-                && !applicationArchive.contains("WEB-INF/classes/META-INF/microprofile-config.properties")) {
-            // workaround for https://github.com/eclipse/microprofile-fault-tolerance/pull/495
-            // this entire `if` should be removed when that PR is merged and MP FT released
-            applicationArchive.move("META-INF/microprofile-config.properties",
-                    "WEB-INF/classes/META-INF/microprofile-config.properties");
         }
 
         String config;


### PR DESCRIPTION
Resolves
https://issues.redhat.com/browse/WFLY-13378

Brings in TCK fixes and improvements.