### PR TITLE
[WFLY-13125] Adding support for External HTTP authentication mechanis…

### DIFF
--- a/docs/src/main/asciidoc/_elytron/General_Elytron_Architecture.adoc
+++ b/docs/src/main/asciidoc/_elytron/General_Elytron_Architecture.adoc
@@ -128,8 +128,9 @@ duplicated is so that mechanism specific mappings can be applied.
 == HTTP Authentication
 
 The HttpAuthenticationFactory is an authentication policy for
-authentication using HTTP authentication mechanisms, in addition to
-being a policy it is also a factory for configured authentication
+authentication using HTTP authentication mechanisms, including the BASIC,
+DIGEST, EXTERNAL, FORM, SPNEGO, and CLIENT_CERT mechanisms. In addition to
+being a policy, it is also a factory for configured authentication
 mechanisms backed by a SecurityDomain.
 
 The HttpAuthenticationFactory references the following:
@@ -148,7 +149,7 @@ mechanisms.
 
 Additional configuration can be supplied for the authentication
 mechanisms, the configuration will be described in more detail later but
-the purpose of the MechanismConfigurationSelector is to obtain
+the purpose of the `MechanismConfigurationSelector` is to obtain
 configuration specific to the mechanism selected. This can include
 information about realm names a mechanism should present to a remote
 client plus additional NameRewriters and RealmMappers to use during the

--- a/docs/src/main/asciidoc/_high-availability/subsystem-support/mod_cluster_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_high-availability/subsystem-support/mod_cluster_Subsystem.adoc
@@ -416,3 +416,18 @@ which corresponds the following in the xml configuration file:
 ----
 
 include::SSL_Configuration_using_Elytron_Subsystem.adoc[leveloffset=+1]
+
+== Remote User Authentication with Elytron
+
+It is possible to accept a `REMOTE_USER` already authenticated by the Apache httpd server with Elytron via the AJP protocol.
+This can be done by setting up Elytron to secure a WildFly deployment and specifying for the External HTTP mechanism to
+be used. This is done by creating a security domain and specifying the External mechanism as one of the mechanism
+configurations to be used by the `http-authentication-factory`:
+
+----
+/subsystem=elytron/http-authentication-factory=web-tests:add(security-domain=example-domain, http-server-mechanism-factory=example-factory,
+mechanism-configurations=[{mechanism-name=EXTERNAL}])
+----
+
+Elytron will accept the externally authenticated user and use the specified security domain to perform role mapping to
+complete authorization.

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/Credentials.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/Credentials.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.external;
+
+/**
+ * Credentials for WebSecurityExternalAuthTestCase
+ */
+public class Credentials {
+    public static final String BAD_USER_NAME = "marcus";
+    public static final String BAD_USER_ROLE = "notallowed";
+
+    public static final String GOOD_USER_NAME = "anil";
+    public static final String AUTHORIZED_WITHOUT_AUTHENTICATION_USER_NAME = "noAuthentication";
+    public static final String CORRECT_ROLE = "gooduser";
+
+    public static final String NOT_USED_PASSWORD = "notUsed";
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/ExternalAuthSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/ExternalAuthSecurityDomainSetup.java
@@ -38,13 +38,6 @@ public class ExternalAuthSecurityDomainSetup extends AbstractSecurityDomainSetup
     protected static final String WEB_SECURITY_DOMAIN = "web-tests";
     private CLIWrapper cli;
 
-    protected static final String BAD_USER_NAME = "marcus";
-    protected static final String BAD_USER_PASSWORD = "marcus";
-    private static final String BAD_USER_ROLE = "notallowed";
-
-    private static final String GOOD_USER_NAME = "anil";
-    private static final String GOOD_USER_PASSWORD = "anil";
-    private static final String GOOD_USER_ROLE = "gooduser";
     private PropertyFileBasedDomain ps;
     private UndertowDomainMapper domainMapper;
 
@@ -105,8 +98,9 @@ public class ExternalAuthSecurityDomainSetup extends AbstractSecurityDomainSetup
 
     private void setupElytronBasedSecurityDomain() throws Exception {
         ps = PropertyFileBasedDomain.builder()
-                .withUser(BAD_USER_NAME, BAD_USER_PASSWORD, BAD_USER_ROLE)
-                .withUser(GOOD_USER_NAME, GOOD_USER_PASSWORD, GOOD_USER_ROLE)
+                .withUser(Credentials.BAD_USER_NAME, Credentials.NOT_USED_PASSWORD, Credentials.BAD_USER_ROLE)
+                .withUser(Credentials.GOOD_USER_NAME, Credentials.NOT_USED_PASSWORD, Credentials.CORRECT_ROLE)
+                .withUser(Credentials.AUTHORIZED_WITHOUT_AUTHENTICATION_USER_NAME, Credentials.NOT_USED_PASSWORD, Credentials.CORRECT_ROLE)
                 .withName(WEB_SECURITY_DOMAIN).build();
         ps.create(cli);
         domainMapper = UndertowDomainMapper.builder().withName(WEB_SECURITY_DOMAIN).build();

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/ExternalLoginModule.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/ExternalLoginModule.java
@@ -66,8 +66,11 @@ public class ExternalLoginModule extends AbstractServerLoginModule {
         Group roles = new SimpleGroup("Roles");
         Group[] groups = { roles };
         //group mapping would go here
-        if(getIdentity().getName().equals("anil")) {
-            roles.addMember(new SimplePrincipal("gooduser"));
+        if(getIdentity().getName().equals(Credentials.GOOD_USER_NAME)) {
+            roles.addMember(new SimplePrincipal(Credentials.CORRECT_ROLE));
+        }
+        if(getIdentity().getName().equals(Credentials.AUTHORIZED_WITHOUT_AUTHENTICATION_USER_NAME)) {
+            roles.addMember(new SimplePrincipal(Credentials.CORRECT_ROLE));
         }
         roles.addMember(getIdentity());
         return groups;

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/UserHandler.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/UserHandler.java
@@ -18,7 +18,7 @@ public class UserHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         String user = exchange.getRequestHeaders().getFirst("User");
-        if(user != null) {
+        if(user != null && (user.equals(Credentials.GOOD_USER_NAME) || user.equals(Credentials.BAD_USER_NAME))) {
             exchange.putAttachment(ExternalAuthenticationMechanism.EXTERNAL_PRINCIPAL, user);
             exchange.putAttachment(HttpServerExchange.REMOTE_USER, user);
             exchange.putAttachment(ExternalAuthenticationMechanism.EXTERNAL_AUTHENTICATION_TYPE, "user-header");

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/UserHandler.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/UserHandler.java
@@ -20,6 +20,7 @@ public class UserHandler implements HttpHandler {
         String user = exchange.getRequestHeaders().getFirst("User");
         if(user != null) {
             exchange.putAttachment(ExternalAuthenticationMechanism.EXTERNAL_PRINCIPAL, user);
+            exchange.putAttachment(HttpServerExchange.REMOTE_USER, user);
             exchange.putAttachment(ExternalAuthenticationMechanism.EXTERNAL_AUTHENTICATION_TYPE, "user-header");
         }
         next.handleRequest(exchange);

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/WebSecurityExternalAuthTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/external/WebSecurityExternalAuthTestCase.java
@@ -46,6 +46,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * Unit Test to test external custom login module.
  *
@@ -98,7 +100,7 @@ public class WebSecurityExternalAuthTestCase {
      */
     @Test
     public void testSucessfulAuth() throws Exception {
-        makeCall("anil", 200);
+        makeCall(Credentials.GOOD_USER_NAME, HttpServletResponse.SC_OK);
     }
 
     /**
@@ -112,7 +114,17 @@ public class WebSecurityExternalAuthTestCase {
      * @throws Exception
      */
     @Test
-    public void testUnsuccessfulAuth() throws Exception {
-        makeCall("marcus", 403);
+    public void testUnsuccessfulAuthr() throws Exception {
+        makeCall(Credentials.BAD_USER_NAME, HttpServletResponse.SC_FORBIDDEN);
+    }
+
+    /**
+     * Test with a user who is not authenticated, but has correct authorization permissions
+     *
+     * Should be a HTTP/403
+     */
+    @Test
+    public void testUnsuccessfulAuthn() throws Exception {
+        makeCall(Credentials.AUTHORIZED_WITHOUT_AUTHENTICATION_USER_NAME, HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/UndertowDomainMapper.java
@@ -69,6 +69,7 @@ public class UndertowDomainMapper  extends AbstractConfigurableElement {
                         + "  mechanism-configurations=["
                         + "    {mechanism-name=DIGEST,mechanism-realm-configurations=[{realm-name=%1$s}]},"
                         + "    {mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=%1$s}]},"
+                        + "    {mechanism-name=EXTERNAL},"
                         + "    {mechanism-name=FORM}])", name));
 
         if (applicationDomains.isEmpty()) {


### PR DESCRIPTION
…m with Elytron

https://issues.redhat.com/browse/WFLY-13125
https://issues.redhat.com/browse/EAP7-1323

This PR adds support for the external HTTP mechanism with Elytron

Analysis document: wildfly/wildfly-proposals#282
Depends on  wildfly/wildfly-core#4177, wildfly-security/wildfly-elytron#1386, wildfly-security/elytron-web#174, and undertow-io/undertow#881