### PR TITLE
[WFLY-13392] WFSM000001: Permission check failed ... FilePermission when Security Manager enabled and Web App tries to forward to jsp

### DIFF
--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ForwardJSPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ForwardJSPTestCase.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.servlets.ForwardServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URI;
+import java.net.URL;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that the servlet should be able to forward jsp resource within same deployment.
+ *
+ * @author Lin Gao
+ */
+@RunWith(Arquillian.class)
+public class ForwardJSPTestCase {
+
+    private static final String APP_NAME = "forward";
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_NAME, testable = false)
+    public static WebArchive deployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, APP_NAME + ".war");
+        war.addClasses(ForwardServlet.class);
+        war.addAsWebResource(ForwardServlet.class.getPackage(), "forward.jsp", "forward.jsp");
+        return war;
+    }
+
+    @Test
+    public void testForwardResource(@ArquillianResource URL webAppURL) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + ForwardServlet.SERVLET_PATH.substring(1));
+        final String respBody = Utils.makeCall(sysPropUri, 200);
+        assertTrue("jsp should be forwarded", respBody.contains("This is the forward.jsp"));
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/ForwardServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/ForwardServlet.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Servlet to check permissions granted to read resource within the same deployment.
+ *
+ * @author Lin Gao
+ */
+@WebServlet(ForwardServlet.SERVLET_PATH)
+public class ForwardServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/Forward";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        RequestDispatcher dispatcher = getServletContext().getRequestDispatcher("/forward.jsp");
+        dispatcher.forward(req,resp);
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/forward.jsp
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/forward.jsp
@@ -1,0 +1,5 @@
+<html>
+	<body>
+		This is the forward.jsp
+	</body>
+</html>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13392

This is the test for https://issues.redhat.com/browse/UNDERTOW-1703, which should pass when undertow gets upgraded(https://issues.redhat.com/browse/WFCORE-4942)