### PR TITLE
Fix for WFLY-13406, Update layersTest to recognize bootable jar runtime

### DIFF
--- a/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
+++ b/testsuite/layers/src/test/java/org/jboss/as/test/layers/LayersTestCase.java
@@ -79,6 +79,8 @@ public class LayersTestCase {
         "org.wildfly.naming",
         // Brought by galleon ServerRootResourceDefinition
         "wildflyee.api",
+        // bootable jar runtime
+        "org.wildfly.bootable-jar"
         };
 
     @Test


### PR DESCRIPTION
Impact of fix for https://issues.redhat.com/browse/WFLY-13406
The newly introduced jboss module is not referenced from the module graph when starting from extentions.