### PR TITLE
[WFLY-12549] Includes config-sources from microprofile-config-smallrye subsystem

### DIFF
--- a/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemAdd.java
+++ b/microprofile/config-smallrye/src/main/java/org/wildfly/extension/microprofile/config/smallrye/MicroProfileConfigSubsystemAdd.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.microprofile.config.smallrye;
 
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigProviderResolver;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
@@ -35,8 +37,6 @@ import org.wildfly.extension.microprofile.config.smallrye._private.MicroProfileC
 import org.wildfly.extension.microprofile.config.smallrye.deployment.DependencyProcessor;
 import org.wildfly.extension.microprofile.config.smallrye.deployment.SubsystemDeploymentProcessor;
 
-import io.smallrye.config.SmallRyeConfigProviderResolver;
-
 /**
  * Handler responsible for adding the subsystem resource to the model
  *
@@ -44,17 +44,38 @@ import io.smallrye.config.SmallRyeConfigProviderResolver;
  */
 class MicroProfileConfigSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
-    static {
-        // Set the static resolver reference eagerly
-        ConfigProviderResolver.setInstance(new SmallRyeConfigProviderResolver());
-    }
-
     final Iterable<ConfigSourceProvider> providers;
     final Iterable<ConfigSource> sources;
 
     MicroProfileConfigSubsystemAdd(Iterable<ConfigSourceProvider> providers, Iterable<ConfigSource> sources) {
         this.providers = providers;
         this.sources = sources;
+
+        // Override smallrye-config's ConfigProviderResolver so that
+        // the builder loads config sources from the microprofile-config-smallrye subsystem by default
+        ConfigProviderResolver.setInstance(new SmallRyeConfigProviderResolver() {
+
+            @Override
+            public SmallRyeConfigBuilder getBuilder() {
+                // The builder will take into account the config-sources available when the Config object is created.
+                // any config-sources added or modified subsequently will not be taken into account.
+                return new SmallRyeConfigBuilder() {
+                    @Override
+                    public SmallRyeConfigBuilder forClassLoader(ClassLoader classLoader) {
+                        SmallRyeConfigBuilder builder = super.forClassLoader(classLoader);
+                        for (ConfigSourceProvider provider : providers) {
+                            for (ConfigSource source : provider.getConfigSources(classLoader)) {
+                                builder.withSources(source);
+                            }
+                        }
+                        for (ConfigSource source : sources) {
+                            builder.withSources(source);
+                        }
+                        return builder;
+                    }
+                };
+            }
+        });
     }
 
     /**
@@ -69,7 +90,7 @@ class MicroProfileConfigSubsystemAdd extends AbstractBoottimeAddStepHandler {
             @Override
             public void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(MicroProfileConfigExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_MICROPROFILE_CONFIG, new DependencyProcessor());
-                processorTarget.addDeploymentProcessor(MicroProfileConfigExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_MICROPROFILE_CONFIG, new SubsystemDeploymentProcessor(MicroProfileConfigSubsystemAdd.this.providers, MicroProfileConfigSubsystemAdd.this.sources));
+                processorTarget.addDeploymentProcessor(MicroProfileConfigExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_MICROPROFILE_CONFIG, new SubsystemDeploymentProcessor());
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsCollectorService.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MetricsCollectorService.java
@@ -24,15 +24,12 @@ package org.wildfly.extension.microprofile.metrics;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.CLIENT_FACTORY_CAPABILITY;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.MANAGEMENT_EXECUTOR;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.WILDFLY_COLLECTOR_SERVICE;
-import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
 import io.smallrye.metrics.MetricRegistries;
-import io.smallrye.metrics.setup.JmxRegistrar;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.as.controller.LocalModelControllerClient;
 import org.jboss.as.controller.ModelControllerClientFactory;
@@ -40,7 +37,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
 /**
@@ -54,7 +50,6 @@ public class MetricsCollectorService implements Service<MetricCollector> {
     private final String globalPrefix;
 
     private MetricCollector metricCollector;
-    private JmxRegistrar jmxRegistrar;
     private LocalModelControllerClient modelControllerClient;
 
     static void install(OperationContext context, List<String> exposedSubsystems, String prefix) {
@@ -74,14 +69,7 @@ public class MetricsCollectorService implements Service<MetricCollector> {
     }
 
     @Override
-    public void start(StartContext context) throws StartException {
-        jmxRegistrar = new JmxRegistrar();
-        try {
-            jmxRegistrar.init();
-        } catch (IOException e) {
-            throw LOGGER.failedInitializeJMXRegistrar(e);
-        }
-
+    public void start(StartContext context) {
         modelControllerClient = modelControllerClientFactory.get().createClient(managementExecutor.get());
 
         this.metricCollector = new MetricCollector(modelControllerClient, exposedSubsystems, globalPrefix);
@@ -98,8 +86,6 @@ public class MetricsCollectorService implements Service<MetricCollector> {
         }
 
         modelControllerClient.close();
-
-        jmxRegistrar = null;
     }
 
     @Override

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/MicroProfileMetricsSubsystemAdd.java
@@ -30,10 +30,13 @@ import static org.jboss.as.server.deployment.Phase.DEPENDENCIES_MICROPROFILE_MET
 import static org.jboss.as.server.deployment.Phase.INSTALL;
 import static org.jboss.as.server.deployment.Phase.POST_MODULE_MICROPROFILE_METRICS;
 import static org.wildfly.extension.microprofile.metrics.MicroProfileMetricsSubsystemDefinition.WILDFLY_COLLECTOR_SERVICE;
+import static org.wildfly.extension.microprofile.metrics._private.MicroProfileMetricsLogger.LOGGER;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
+import io.smallrye.metrics.setup.JmxRegistrar;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -88,6 +91,14 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 ImmutableManagementResourceRegistration rootResourceRegistration = context.getRootResourceRegistration();
                 Resource rootResource = context.readResourceFromRoot(EMPTY_ADDRESS);
                 metricCollector.collectResourceMetrics(rootResource, rootResourceRegistration, Function.identity());
+
+                JmxRegistrar jmxRegistrar = new JmxRegistrar();
+                try {
+                    jmxRegistrar.init();
+                } catch (IOException e) {
+                    throw LOGGER.failedInitializeJMXRegistrar(e);
+                }
+
             }
         }, VERIFY);
 
@@ -95,4 +106,6 @@ class MicroProfileMetricsSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         MicroProfileMetricsLogger.LOGGER.activatingSubsystem();
     }
+
+
 }

--- a/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
+++ b/microprofile/metrics-smallrye/src/main/java/org/wildfly/extension/microprofile/metrics/_private/MicroProfileMetricsLogger.java
@@ -33,7 +33,6 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.msc.service.StartException;
 
 /**
  * Log messages for WildFly microprofile-metrics-smallrye Extension.
@@ -56,7 +55,7 @@ public interface MicroProfileMetricsLogger extends BasicLogger {
 
 
     @Message(id = 2, value = "Failed to initialize metrics from JMX MBeans")
-    StartException failedInitializeJMXRegistrar(@Cause IOException e);
+    IllegalArgumentException failedInitializeJMXRegistrar(@Cause IOException e);
 
     @Message(id = 3, value = "Unable to read attribute %s on %s: %s.")
     IllegalStateException unableToReadAttribute(String attributeName, PathAddress address, String error);

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/config/MicroProfileMetricsGlobalTagsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/config/MicroProfileMetricsGlobalTagsTestCase.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.metrics.config;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.ServerReload.executeReloadAndWaitForCompletion;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.test.integration.microprofile.metrics.MetricsHelper.getPrometheusMetrics;
+
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.test.integration.microprofile.metrics.TestApplication;
+import org.wildfly.test.integration.microprofile.metrics.config.resource.ResourceSimple;
+
+/**
+ * Test that global metrics tag defined in a config-source by the mp.metrics.tag config property
+ * in microprofile-config-smallrye subsystem are taken into account.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2018 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({MicroProfileMetricsGlobalTagsTestCase.AddMPMetricsTags.class})
+public class MicroProfileMetricsGlobalTagsTestCase {
+
+
+    static class AddMPMetricsTags implements ServerSetupTask {
+
+        static final String MY_GLOBAL_METRIC_TAG = UUID.randomUUID().toString();
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            managementClient.getControllerClient().execute(addOrRemoveMPMetricsConfigSource(true));
+            // force reload so that vendor and base metrics are registered at boot time with the tags from the config source
+            executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            managementClient.getControllerClient().execute(addOrRemoveMPMetricsConfigSource(false));
+            executeReloadAndWaitForCompletion(managementClient);
+        }
+
+        private ModelNode addOrRemoveMPMetricsConfigSource(boolean add) {
+            final ModelNode address = Operations.createAddress(SUBSYSTEM, "microprofile-config-smallrye", "config-source", "mp-metrics");
+
+            if (add) {
+                ModelNode addOperation = Operations.createAddOperation(address);
+                addOperation.get(PROPERTIES).add("mp.metrics.tags", "my_metric_tag=" + MY_GLOBAL_METRIC_TAG);
+                return addOperation;
+            }
+            return Operations.createRemoveOperation(address);
+        }
+    }
+
+    @Deployment
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "MicroProfileMetricsGlobalTagsTestCase.war")
+                .addClasses(TestApplication.class)
+                .addClass(ResourceSimple.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+        return war;
+    }
+
+    @BeforeClass
+    public static void skipSecurityManager() {
+        AssumeTestGroupUtil.assumeSecurityManagerDisabled();
+    }
+
+    @ContainerResource
+    ManagementClient managementClient;
+
+    @ArquillianResource URL url;
+
+    @Test
+    public void testMetricsContainsGlobalTags() throws Exception {
+        String tagInPrometheusOutput = "my_metric_tag=\"" + AddMPMetricsTags.MY_GLOBAL_METRIC_TAG + "\"";
+
+        performCall(url);
+
+        String applicationMetrics = getPrometheusMetrics(managementClient, "application", true);
+        assertTrue(applicationMetrics, applicationMetrics.contains(tagInPrometheusOutput));
+
+        String baseMetrics = getPrometheusMetrics(managementClient, "base", true);
+        assertTrue(baseMetrics, baseMetrics.contains(tagInPrometheusOutput));
+
+        String vendorMetrics = getPrometheusMetrics(managementClient, "vendor", true);
+        assertTrue(vendorMetrics, vendorMetrics.contains(tagInPrometheusOutput));
+    }
+
+    private static String performCall(URL url) throws Exception {
+        URL appURL = new URL(url.toExternalForm() + "microprofile-metrics-app/hello2");
+        return HttpRequest.get(appURL.toExternalForm(), 10, TimeUnit.SECONDS);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/config/resource/ResourceSimple.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/metrics/config/resource/ResourceSimple.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.microprofile.metrics.config.resource;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+@Path("/hello2")
+public class ResourceSimple {
+    @GET
+    @Produces("text/plain")
+    @Counted(description = "counter of the Hello call", absolute = true)
+    public Response hello2() {
+        return Response.ok("Hello From WildFly!").build();
+    }
+}


### PR DESCRIPTION
Override the ConfigProviderResolver so that the ConfigBuilder will
include by default ConfigSource defined in the
microprofile-config-smallrye subsystem.
This allows other subsystems (such as microprofile-metrics-smallrye) to
use the Config API and get the config properties from the
microprofile-config-smallrye subsystems (which was alreayd the case for
deployments).

Add a test that check that mp.metrics.tags defined in the config
subsystem are properly read by the metrics subsystem (and appended to
the metrics output).

JIRA: https://issues.redhat.com/browse/WFLY-12549

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>