### PR TITLE
[WFLY-13415] Upgrade WildFly Core 12.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13415

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 12.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4897'>WFCORE-4897</a>] -         Upgrade the wildfly-maven-plugin from 1.2.1.Final to 2.0.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4912'>WFCORE-4912</a>] -         Upgrade Galleon from 4.2.4.Final to 4.2.5.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4913'>WFCORE-4913</a>] -         Upgrade wildfly-discovery-client to 1.2.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4930'>WFCORE-4930</a>] -         Upgrade jboss-logmanager from 2.1.14.Final to 2.1.15.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4934'>WFCORE-4934</a>] -         Upgrade Undertow to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4940'>WFCORE-4940</a>] -         Upgrade JBoss DMR 1.5.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4946'>WFCORE-4946</a>] -         Upgrade WildFly Elytron to 1.11.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4947'>WFCORE-4947</a>] -         Upgrade Elytron Web to 1.7.1.Final
</li>
</ul>
                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-1313'>WFCORE-1313</a>] -         User with slash or backslash char in LDAP name cannot log in through security-realm
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4841'>WFCORE-4841</a>] -         Logging subsystem capabilities do not work correctly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4882'>WFCORE-4882</a>] -         Correct minOccurts value for host element in XSD
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4901'>WFCORE-4901</a>] -         TCCL not set to application classloader when MBean Notification is invoked
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4908'>WFCORE-4908</a>] -         The write-attribute operation does not work on a hosts JVM resource
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4921'>WFCORE-4921</a>] -         Remove unused product.conf
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4922'>WFCORE-4922</a>] -         The embedded host and server handlers hang on start
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4924'>WFCORE-4924</a>] -         CLI enable-sasl-management doesn&#39;t handle &quot;plain-text&quot; attribute
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4925'>WFCORE-4925</a>] -         Correct GAV versions in ModelTestControllerVersion
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4932'>WFCORE-4932</a>] -         Reading of identity from security domain causes NPE
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4935'>WFCORE-4935</a>] -         When server is started at suspend mode, :shutdown does not trigger a shutdown
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4943'>WFCORE-4943</a>] -         Remove duplicate elytron&#39;s duplicate dependency to controller-client
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4906'>WFCORE-4906</a>] -         Exclude commons-codec dep from httpclient.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4911'>WFCORE-4911</a>] -         Remove org.apache.xml-resolver (it has been moved to WildFly)
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4915'>WFCORE-4915</a>] -         Tighten up the dependency tree of subsystem-test
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4918'>WFCORE-4918</a>] -         Optimize MMR logic within AttributeConverter.DEFAULT_VALUE
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4920'>WFCORE-4920</a>] -         Remove remaining uses of EAPRepositoryReachableUtil
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4941'>WFCORE-4941</a>] -         Optimize MMR logic within DiscardAttributeChecker.DEFAULT_VALUE
</li>
</ul>
                                    