### PR TITLE
[WFLY-13414] Upgrade WildFly Core 11.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.9.10</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>11.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>11.1.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13414

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

__WildFly Core 11.1.1.Final does not contain any changes compared to 11.1.0.Final (whose artifacts were improperly built).__

Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/11.0.0.Final...11.1.1.Final

## Release Notes - WildFly Core - Version 11.1.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4878'>WFCORE-4878</a>] -         Upgrade WildFly OpenSSL to 1.0.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4890'>WFCORE-4890</a>] -         Upgrade WildFly Elytron to 1.11.3.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4934'>WFCORE-4934</a>] -         Upgrade Undertow to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4946'>WFCORE-4946</a>] -         Upgrade WildFly Elytron to 1.11.4.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4947'>WFCORE-4947</a>] -         Upgrade Elytron Web to 1.7.1.Final
</li>
</ul>
                                                                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4905'>WFCORE-4905</a>] -         Provide common capability for Remoting connectors
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4909'>WFCORE-4909</a>] -         Correct GAV versions in ModelTestControllerVersion
</li>
</ul>
                                            

