### PR TITLE
[WFLY-13424]: External pooled connection factory won't be properl injected if it has several JNDI entries.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DefaultResourceAdapterQueueMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/DefaultResourceAdapterQueueMDB.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.messaging.jms.external;
+
+import static org.jboss.as.test.integration.messaging.jms.external.ExternalMessagingDeploymentTestCase.QUEUE_LOOKUP;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSPasswordCredential;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+/**
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+@MessageDriven(
+        activationConfig = {
+            @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+            @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = QUEUE_LOOKUP),
+            @ActivationConfigProperty(propertyName="user", propertyValue="guest"),
+            @ActivationConfigProperty(propertyName="password", propertyValue="guest")
+        }
+)
+public class DefaultResourceAdapterQueueMDB implements MessageListener {
+
+    @Inject
+    @JMSPasswordCredential(userName = "guest", password = "guest")
+    private JMSContext context;
+
+    @Override
+    public void onMessage(final Message m) {
+        try {
+            TextMessage message = (TextMessage) m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, message.getText());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/external/ExternalMessagingDeploymentRemoteTestCase.java
@@ -41,6 +41,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
@@ -104,6 +105,8 @@ public class ExternalMessagingDeploymentRemoteTestCase {
             op = Operations.createAddOperation(getExternalQueueAddress());
             op.get("entries").add(QUEUE_LOOKUP);
             op.get("entries").add("/queue/myAwesomeClientQueue");
+            execute(managementClient, op, true);
+            op = Operations.createWriteAttributeOperation(PathAddress.parseCLIStyleAddress("/subsystem=ejb3").toModelNode(), "default-resource-adapter-name", REMOTE_PCF);
             execute(managementClient, op, true);
             ServerReload.executeReloadAndWaitForCompletion(managementClient);
         }
@@ -188,7 +191,7 @@ public class ExternalMessagingDeploymentRemoteTestCase {
     public static WebArchive createArchive() {
         return create(WebArchive.class, "ClientMessagingDeploymentTestCase.war")
                 .addClass(MessagingServlet.class)
-                .addClasses(QueueMDB.class, TopicMDB.class)
+                .addClasses(DefaultResourceAdapterQueueMDB.class, TopicMDB.class)
                 .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
                         new SocketPermission("localhost", "resolve")), "permissions.xml")
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");


### PR DESCRIPTION
* if the bound name is not the first one then we get a reference to a
  reference service instead ofg the pcf service.
* resolving this so that we get the proper resource adapter service name.

Jira: https://issues.redhat.com/browse/WFLY-13424