### PR TITLE
WFLY-13425 Upgrade smallrye-open-api to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <version.org.glassfish.jakarta.el>3.0.3.jbossorg-2</version.org.glassfish.jakarta.el>
         <version.org.glassfish.jakarta.enterprise.concurrent>1.1.1</version.org.glassfish.jakarta.enterprise.concurrent>
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
-        <version.org.harmcrest>1.3</version.org.harmcrest>
+        <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
         <version.org.hibernate>5.3.16.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
@@ -5670,7 +5670,7 @@
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
-                <version>${version.org.harmcrest}</version>
+                <version>${version.org.hamcrest}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.open-api>1.2.1</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>1.2.3</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13425

https://github.com/smallrye/smallrye-open-api/releases/tag/1.2.2
https://github.com/smallrye/smallrye-open-api/releases/tag/1.2.3