### PR TITLE
WFLY-13404 : Upgrade Hibernate ORM from 5.3.16 to 5.3.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.harmcrest>1.3</version.org.harmcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.16.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.17.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.19.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13404
https://issues.redhat.com/browse/JBEAP-18793