### PR TITLE
[WFLY-13244]: MicroProfile open-tracing should expliciely depends on microprofile-config.

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/opentracing-smallrye/main/module.xml
@@ -40,6 +40,7 @@
         <module name="org.wildfly.security.elytron"/>
 
         <module name="javax.enterprise.api" />
+        <module name="org.eclipse.microprofile.config.api"/>
         <module name="io.opentracing.opentracing-api"/>
         <module name="io.opentracing.opentracing-noop"/>
         <module name="io.opentracing.opentracing-util"/>

--- a/microprofile/opentracing-extension/pom.xml
+++ b/microprofile/opentracing-extension/pom.xml
@@ -85,6 +85,10 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-microprofile-config-smallrye</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-web-common</artifactId>
             <exclusions>
                 <exclusion>

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
@@ -49,10 +49,11 @@ public class SubsystemDefinition extends PersistentResourceDefinition {
 
     private static final String OPENTRACING_CAPABILITY_NAME = "org.wildfly.microprofile.opentracing";
     public static final String DEFAULT_TRACER_CAPABILITY_NAME = "org.wildfly.microprofile.opentracing.default-tracer";
+    private static final String MICROPROFILE_CONFIG_CAPABILITY_NAME = "org.wildfly.microprofile.config";
 
     private static final RuntimeCapability<Void> OPENTRACING_CAPABILITY = RuntimeCapability.Builder
             .of(OPENTRACING_CAPABILITY_NAME)
-            .addRequirements(WELD_CAPABILITY_NAME)
+            .addRequirements(WELD_CAPABILITY_NAME, MICROPROFILE_CONFIG_CAPABILITY_NAME)
             .build();
 
     public static final RuntimeCapability<Void> DEFAULT_TRACER_CAPABILITY = RuntimeCapability.Builder
@@ -67,9 +68,10 @@ public class SubsystemDefinition extends PersistentResourceDefinition {
         "io.opentracing.contrib.opentracing-tracerresolver",
         "io.opentracing.opentracing-api",
         "io.opentracing.opentracing-util",
+        "org.eclipse.microprofile.config.api",
         "org.eclipse.microprofile.opentracing",
         "org.eclipse.microprofile.restclient",
-        "io.opentracing.contrib.opentracing-jaxrs2"
+        "io.opentracing.contrib.opentracing-jaxrs2",
     };
 
     static final String[] EXPORTED_MODULES = {

--- a/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerDynamicFeature.java
+++ b/microprofile/opentracing-smallrye/src/main/java/org/wildfly/microprofile/opentracing/smallrye/TracerDynamicFeature.java
@@ -28,6 +28,7 @@ import io.opentracing.contrib.jaxrs2.server.OperationNameProvider;
 import io.opentracing.contrib.jaxrs2.server.OperationNameProvider.ClassNameOperationName;
 import io.opentracing.contrib.jaxrs2.server.ServerTracingDynamicFeature;
 import java.util.Optional;
+import javax.inject.Inject;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.container.DynamicFeature;
@@ -44,9 +45,14 @@ public class TracerDynamicFeature implements DynamicFeature {
     @Context
     ServletContext servletContext;
 
+    @Inject
+    Config config;
+
     @Override
     public void configure(ResourceInfo resourceInfo, FeatureContext context) {
-        Config config = ConfigProvider.getConfig();
+        if(config == null) {
+            config = ConfigProvider.getConfig();
+        }
         Optional<String> skipPattern = config.getOptionalValue("mp.opentracing.server.skip-pattern", String.class);
         Optional<String> operationNameProvider = config.getOptionalValue("mp.opentracing.server.operation-name-provider", String.class);
         Tracer tracer;

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/SubsystemConfigSourceTask.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/config/smallrye/SubsystemConfigSourceTask.java
@@ -87,7 +87,7 @@ public class SubsystemConfigSourceTask implements ServerSetupTask {
 
 
     // Contains list of created config sources --- this is used during tearDown
-    private LinkedList<String> registeredConfigSources = new LinkedList<>();
+    private final LinkedList<String> registeredConfigSources = new LinkedList<>();
 
     /* Default ordinal values, https://github.com/eclipse/microprofile-config#design
         - System.getProperties() (ordinal=400)

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ConfigHttpPathTask.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ConfigHttpPathTask.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.microprofile.opentracing;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Add a config-source with a property class in the microprofile-config-smallrye subsystem.
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+public class ConfigHttpPathTask implements ServerSetupTask {
+
+    public static final String MICROPROFILE_SUBSYSTEM_NAME = "microprofile-config-smallrye";
+    public static final String CONFIG_SOURCE = "config-source";
+    public static final String MP_OPENTRACING_SKIP_PATTERN = "mp.opentracing.server.skip-pattern";
+    public static final String MP_OPENTRACING_SERVER_OPERATION_NAME_PROVIDER = "mp.opentracing.server.operation-name-provider";
+    public static final String MP_OPENTRACING_CONFIG = "mpOpentracingConfig";
+
+    // Contains list of created config sources --- this is used during tearDown
+    private final LinkedList<String> registeredConfigSources = new LinkedList<>();
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        ModelControllerClient mgmtCli = managementClient.getControllerClient();
+        addPropertiesConfigSource(mgmtCli, MP_OPENTRACING_CONFIG, MP_OPENTRACING_SERVER_OPERATION_NAME_PROVIDER, "http-path");
+    }
+
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        ModelControllerClient mgmtCli = managementClient.getControllerClient();
+        removeConfigSource(mgmtCli, registeredConfigSources);
+    }
+
+    /**
+     * Adds config-source of type 'properties' with given value and priority ordinal value set to default.
+     *
+     * @param client           model controller client
+     * @param configSourceName name of the added config-source resource
+     * @param propName         name of the property to be created
+     * @param propValue        value of the property which shall be created
+     * @throws IOException
+     */
+    private void addPropertiesConfigSource(ModelControllerClient client, String configSourceName, String propName,
+            String propValue) throws IOException {
+        addPropertiesConfigSource(client, configSourceName, propName, propValue, -1);
+    }
+
+    /**
+     * Adds config-source of type 'properties' with given value and priority ordinal value.
+     *
+     * @param client           model controller client
+     * @param configSourceName name of the added config-source resource
+     * @param propName         name of the property to be created
+     * @param propValue        value of the property which shall be created
+     * @param ordinal          ordinal value of the priority of the added config-source; if less than zero, default is
+     *                         set
+     * @throws IOException
+     */
+    private void addPropertiesConfigSource(ModelControllerClient client, String configSourceName, String propName,
+            String propValue, int ordinal) throws IOException {
+        ModelNode op;
+        op = new ModelNode();
+        op.get(OP_ADDR).add(SUBSYSTEM, MICROPROFILE_SUBSYSTEM_NAME);
+        op.get(OP_ADDR).add(CONFIG_SOURCE, configSourceName);
+        op.get(OP).set(ADD);
+        op.get(PROPERTIES).add(propName, propValue);
+
+        if (ordinal >= 0) {
+            op.get("ordinal").set(ordinal);
+        }
+        client.execute(op);
+
+        registeredConfigSources.add(configSourceName);
+    }
+
+    /**
+     * Removes defined list of config-sources.
+     *
+     * @param client model controller client
+     * @param names  list of strings containing names of the config-sources to be removed
+     * @throws IOException
+     */
+    private void removeConfigSource(ModelControllerClient client, LinkedList<String> names) throws IOException {
+        for (String name : names) {
+            removeConfigSource(client, name);
+        }
+    }
+
+    /**
+     * Removes defined config-source.
+     *
+     * @param client model controller client
+     * @param name   string containing name of the config-source to be removed
+     * @throws IOException
+     */
+    private void removeConfigSource(ModelControllerClient client, String name) throws IOException {
+        ModelNode op;
+        op = new ModelNode();
+        op.get(OP_ADDR).add(SUBSYSTEM, MICROPROFILE_SUBSYSTEM_NAME);
+        op.get(OP_ADDR).add(CONFIG_SOURCE, name);
+        op.get(OP).set(REMOVE);
+        client.execute(op);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCDITestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCDITestCase.java
@@ -38,8 +38,7 @@ public class ResourceWithCDITestCase {
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
-        war.addClass(ResourceTracedTestCase.class);
-
+        war.addClass(ResourceWithCDITestCase.class);
         war.addClass(MockTracerFactory.class);
         war.addPackage(MockTracer.class.getPackage());
         war.addAsServiceProvider(TracerFactory.class, MockTracerFactory.class);

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/opentracing/ResourceWithCustomOperationNameBeanTestCase.java
@@ -40,7 +40,7 @@ public class ResourceWithCustomOperationNameBeanTestCase {
     @Deployment
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
-        war.addClass(ResourceTracedTestCase.class);
+        war.addClass(ResourceWithCustomOperationNameBeanTestCase.class);
 
         war.addClass(MockTracerFactory.class);
         war.addPackage(MockTracer.class.getPackage());


### PR DESCRIPTION
* Adding capability dependency on microprofile-config
* Injecting the config from the microprofile-config as configuration in the deployment.

Jira: https://issues.redhat.com/browse/WFLY-13244
