### PR TITLE
[WFLY-13441] Upgrade classmate from 1.3.4 to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
          -->
         <version.antlr>2.7.7</version.antlr>
         <version.com.beust>1.78</version.com.beust>
-        <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
+        <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.10.3</version.com.fasterxml.jackson>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13441

@scottmarlow @asoldano @mmusgrov @gsmet @Sanne @pferraro We looked at this as part of https://github.com/wildfly/wildfly/pull/12796 and AFAICT it seemed ok to everyone. IIRC it didn't happen just because the other upgrade it was associated with was really urgent while this was not and we just put this aside to disentangle them. And then I forgot about it.

We've now had a user request for this.

https://github.com/FasterXML/java-classmate/compare/classmate-1.3.4..classmate-1.5.1
https://github.com/FasterXML/java-classmate/compare/classmate-1.3.4..classmate-1.5.1#diff-780b48c08acd302f35338634f56df2ae