### PR TITLE
[WFLY-13432] Provide capability for Undertow HTTP_UPGRADE_REGISTRY

### DIFF
--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -82,7 +82,6 @@ public class MigrateTestCase extends AbstractSubsystemTest {
 
         ModelNode response = services.executeOperation(migrateOp);
 
-        //System.out.println("response = " + response);
         checkOutcome(response);
 
         ModelNode warnings = response.get(RESULT, "migration-warnings");
@@ -92,7 +91,6 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         assertEquals(warnings.toString(), 1 + 1 + 3, warnings.asList().size());
 
         model = services.readWholeModel();
-        //System.out.println("model = " + model);
 
         assertFalse(model.get(SUBSYSTEM, MESSAGING_ACTIVEMQ_SUBSYSTEM_NAME, "server", "unmigrated-backup", "ha-policy").isDefined());
         assertFalse(model.get(SUBSYSTEM, MESSAGING_ACTIVEMQ_SUBSYSTEM_NAME, "server", "unmigrated-shared-store", "ha-policy").isDefined());
@@ -225,7 +223,10 @@ public class MigrateTestCase extends AbstractSubsystemTest {
                             rootRegistration, ExtensionRegistryType.SERVER));
                 }
             }, null));
-            registerCapabilities(capabilityRegistry, JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(), "org.wildfly.remoting.http-listener-registry");
+            registerCapabilities(capabilityRegistry,
+                    JGroupsDefaultRequirement.CHANNEL_FACTORY.getName(),
+                    "org.wildfly.remoting.http-listener-registry",                          // static capability
+                    "org.wildfly.undertow.listener.http-upgrade-registry.default");         // dynamic capability based on httpListenerName
         }
 
         @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/Capabilities.java
@@ -76,6 +76,13 @@ public class Capabilities {
     static final String HTTP_LISTENER_REGISTRY_CAPABILITY_NAME = "org.wildfly.remoting.http-listener-registry";
 
     /**
+     * The capability for the Http Upgrade Registry
+     *
+     * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/undertow/http-upgrade-registry/capability.adoc">documentation</a>
+     */
+    static final String HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME = "org.wildfly.undertow.listener.http-upgrade-registry";
+
+    /**
      * The capability for the SocketBinding capability
      *
      * @see <a href="https://github.com/wildfly/wildfly-capabilities/blob/master/org/wildfly/network/socket-binding/capability.adoc">documentation</a>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorAdd.java
@@ -55,14 +55,14 @@ public class HTTPAcceptorAdd extends ActiveMQReloadRequiredHandlers.AddStepHandl
     void launchServices(OperationContext context, String activeMQServerName, String acceptorName, ModelNode model) throws OperationFailedException {
         String httpConnectorName = HTTPAcceptorDefinition.HTTP_LISTENER.resolveModelAttribute(context, model).asString();
 
-        HTTPUpgradeService.installService(context.getServiceTarget(),
+        HTTPUpgradeService.installService(context.getCapabilityServiceTarget(),
                 activeMQServerName,
                 acceptorName,
                 httpConnectorName);
 
         boolean upgradeLegacy = HTTPAcceptorDefinition.UPGRADE_LEGACY.resolveModelAttribute(context, model).asBoolean();
         if (upgradeLegacy) {
-            HTTPUpgradeService.LegacyHttpUpgradeService.installService(context.getServiceTarget(),
+            HTTPUpgradeService.LegacyHttpUpgradeService.installService(context,
                     activeMQServerName,
                     acceptorName,
                     httpConnectorName);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.wildfly.extension.messaging.activemq.Capabilities.HTTP_LISTENER_REGISTRY_CAPABILITY_NAME;
+import static org.wildfly.extension.messaging.activemq.Capabilities.HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.HTTP_ACCEPTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.PARAMS;
 
@@ -53,18 +54,20 @@ import org.wildfly.extension.messaging.activemq.MessagingServices.ServerNameMapp
  */
 public class HTTPAcceptorDefinition extends PersistentResourceDefinition {
 
+    static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq", true, HTTPUpgradeService.class)
+            .setDynamicNameMapper(new ServerNameMapper("http-upgrade-service"))
+            .addRequirements(HTTP_LISTENER_REGISTRY_CAPABILITY_NAME)
+            .addAdditionalRequiredPackages("io.undertow.core", "org.jboss.as.remoting", "org.jboss.xnio", "org.jboss.xnio.netty.netty-xnio-transport")
+            .build();
+
     static final SimpleAttributeDefinition HTTP_LISTENER = create(CommonAttributes.HTTP_LISTENER, ModelType.STRING)
             .setRequired(true)
+            .setCapabilityReference(HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME, CAPABILITY)
             .build();
     static final SimpleAttributeDefinition UPGRADE_LEGACY = create("upgrade-legacy", ModelType.BOOLEAN)
             .setDefaultValue(ModelNode.TRUE)
             .setRequired(false)
             .setAllowExpression(true)
-            .build();
-    static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq", true, HTTPUpgradeService.class)
-            .setDynamicNameMapper(new ServerNameMapper("http-upgrade-service"))
-            .addRequirements(HTTP_LISTENER_REGISTRY_CAPABILITY_NAME)
-            .addAdditionalRequiredPackages("io.undertow.core", "org.jboss.as.remoting", "org.jboss.xnio", "org.jboss.xnio.netty.netty-xnio-transport")
             .build();
     static AttributeDefinition[] ATTRIBUTES = { HTTP_LISTENER, PARAMS, UPGRADE_LEGACY };
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingServices.java
@@ -41,7 +41,6 @@ public class MessagingServices {
      * The service name is "jboss.messaging-activemq"
      */
     static final ServiceName JBOSS_MESSAGING_ACTIVEMQ = ServiceName.JBOSS.append(MessagingExtension.SUBSYSTEM_NAME);
-    static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
     public static final ServiceName ACTIVEMQ_CLIENT_THREAD_POOL = JBOSS_MESSAGING_ACTIVEMQ.append("client-thread-pool");
 
     // Cached by MessagingSubsystemAdd at the beginning of runtime processing

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -28,6 +28,7 @@ import static org.jboss.as.controller.security.CredentialReference.rollbackCrede
 import static org.wildfly.extension.messaging.activemq.Capabilities.ACTIVEMQ_SERVER_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.DATA_SOURCE_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.ELYTRON_DOMAIN_CAPABILITY;
+import static org.wildfly.extension.messaging.activemq.Capabilities.HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME;
 import static org.wildfly.extension.messaging.activemq.Capabilities.JMX_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.Capabilities.PATH_MANAGER_CAPABILITY;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ADDRESS_SETTING;
@@ -119,6 +120,7 @@ import java.util.function.Supplier;
 import javax.management.MBeanServer;
 import javax.sql.DataSource;
 
+import io.undertow.server.handlers.ChannelUpgradeHandler;
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
 import org.apache.activemq.artemis.api.core.Interceptor;
@@ -373,7 +375,7 @@ class ServerAdd extends AbstractAddStepHandler {
                 }
             }
             for (String httpListener : httpListeners) {
-                serviceBuilder.requires(MessagingServices.HTTP_UPGRADE_REGISTRY.append(httpListener));
+                serviceBuilder.requires(context.getCapabilityServiceName(HTTP_UPGRADE_REGISTRY_CAPABILITY_NAME, httpListener, ChannelUpgradeHandler.class));
             }
 
             //this requires connectors

--- a/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
+++ b/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
@@ -30,12 +30,14 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.network.NetworkInterfaceBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
 import org.jboss.modcluster.container.Connector;
 import org.junit.Test;
 import org.wildfly.extension.undertow.AjpListenerService;
+import org.wildfly.extension.undertow.Constants;
 import org.wildfly.extension.undertow.HttpListenerService;
 import org.wildfly.extension.undertow.HttpsListenerService;
 import org.wildfly.extension.undertow.ListenerService;
@@ -48,9 +50,9 @@ public class UndertowConnectorTestCase {
     @Test
     public void getType() {
         OptionMap options = OptionMap.builder().getMap();
-        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService("", "", options, OptionMap.EMPTY)).getType());
-        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService("", "", options, OptionMap.EMPTY, false, false, false)).getType());
-        assertSame(Connector.Type.HTTPS, new UndertowConnector(new HttpsListenerService("", "", options, null, OptionMap.EMPTY, false)).getType());
+        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService(PathAddress.pathAddress(Constants.AJP_LISTENER, "dummy"), "", options, OptionMap.EMPTY)).getType());
+        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService(PathAddress.pathAddress(Constants.HTTP_LISTENER, "dummy"), "" , options, OptionMap.EMPTY, false, false, false)).getType());
+        assertSame(Connector.Type.HTTPS, new UndertowConnector(new HttpsListenerService(PathAddress.pathAddress(Constants.HTTPS_LISTENER, "dummy"), "", options, null, OptionMap.EMPTY, false)).getType());
     }
 
     @Test

--- a/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowEngineTestCase.java
+++ b/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowEngineTestCase.java
@@ -30,9 +30,11 @@ import static org.mockito.Mockito.mock;
 import java.util.Collections;
 import java.util.Iterator;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.modcluster.container.Connector;
 import org.jboss.modcluster.container.Engine;
 import org.junit.Test;
+import org.wildfly.extension.undertow.Constants;
 import org.wildfly.extension.undertow.Host;
 import org.wildfly.extension.undertow.HttpsListenerService;
 import org.wildfly.extension.undertow.Server;
@@ -50,7 +52,7 @@ public class UndertowEngineTestCase {
     private final String hostName = "default-host";
     private final String route = "route";
     private final Host host = new Host(this.hostName, Collections.emptyList(), "ROOT.war", StatusCodes.NOT_FOUND, false);
-    private final HttpsListenerService listener = new HttpsListenerService("default", "https", OptionMap.EMPTY, null, OptionMap.EMPTY, false);
+    private final HttpsListenerService listener = new HttpsListenerService(PathAddress.pathAddress(Constants.HTTPS_LISTENER, "default"), "https", OptionMap.EMPTY, null, OptionMap.EMPTY, false);
 
     private final UndertowService service = new TestUndertowService("default-container", this.serverName, this.hostName, this.route, this.server);
     private final Server server = new TestServer(this.serverName, this.hostName, this.service, this.host, this.listener);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
@@ -50,7 +50,7 @@ class AjpListenerAdd extends ListenerAdd {
         }
         OptionMap.Builder listenerBuilder = OptionMap.builder().addAll(listenerOptions);
         AjpListenerResourceDefinition.MAX_AJP_PACKET_SIZE.resolveOption(context, model,listenerBuilder);
-        return new AjpListenerService(name, scheme, listenerBuilder.getMap(), socketOptions);
+        return new AjpListenerService(context.getCurrentAddress(), scheme, listenerBuilder.getMap(), socketOptions);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -60,7 +60,7 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
             .build();
 
     private AjpListenerResourceDefinition() {
-        super(UndertowExtension.AJP_LISTENER_PATH);
+        super(new Parameters(UndertowExtension.AJP_LISTENER_PATH, UndertowExtension.getResolver(Constants.LISTENER)));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
@@ -29,6 +29,7 @@ import io.undertow.UndertowOptions;
 import io.undertow.server.OpenListener;
 import io.undertow.server.protocol.ajp.AjpOpenListener;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.msc.service.StartContext;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
@@ -46,9 +47,11 @@ public class AjpListenerService extends ListenerService {
 
     private volatile AcceptingChannel<StreamConnection> server;
     private final String scheme;
+    private final PathAddress address;
 
-    public AjpListenerService(String name, final String scheme, OptionMap listenerOptions, OptionMap socketOptions) {
-        super(name, listenerOptions, socketOptions, false);
+    public AjpListenerService(final PathAddress address, final String scheme, OptionMap listenerOptions, OptionMap socketOptions) {
+        super(address.getLastElement().getValue(), listenerOptions, socketOptions, false);
+        this.address = address;
         this.scheme = scheme;
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Capabilities.java
@@ -43,6 +43,7 @@ public final class Capabilities {
     public static final String CAPABILITY_WEBSOCKET = "org.wildfly.undertow.servlet-container.websocket";
     public static final String CAPABILITY_HTTP_INVOKER = "org.wildfly.undertow.http-invoker";
     public static final String CAPABILITY_HTTP_INVOKER_HOST = "org.wildfly.undertow.http-invoker.host";
+    public static final String CAPABILITY_HTTP_UPGRADE_REGISTRY = "org.wildfly.undertow.listener.http-upgrade-registry";
     public static final String CAPABILITY_APPLICATION_SECURITY_DOMAIN = "org.wildfly.undertow.application-security-domain";
     public static final String CAPABILITY_APPLICATION_SECURITY_DOMAIN_KNOWN_DEPLOYMENTS = "org.wildfly.undertow.application-security-domain.known-deployments";
     public static final String CAPABILITY_REVERSE_PROXY_HANDLER_HOST = "org.wildfly.undertow.reverse-proxy.host";
@@ -57,6 +58,7 @@ public final class Capabilities {
     public static final String REF_SOCKET_BINDING = "org.wildfly.network.socket-binding";
     public static final String REF_SSL_CONTEXT = "org.wildfly.security.ssl-context";
     public static final String REF_HTTP_AUTHENTICATION_FACTORY = "org.wildfly.security.http-authentication-factory";
+    public static final String REF_HTTP_LISTENER_REGISTRY = "org.wildfly.remoting.http-listener-registry";
     public static final String REF_JACC_POLICY = "org.wildfly.security.jacc-policy";
     public static final String REF_OUTBOUND_SOCKET = "org.wildfly.network.outbound-socket-binding";
     public static final String REF_REQUEST_CONTROLLER = "org.wildfly.request-controller";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -39,8 +39,6 @@ import org.xnio.OptionMap;
  */
 public class HttpListenerAdd extends ListenerAdd {
 
-    static final ServiceName REGISTRY_SERVICE_NAME = ServiceName.JBOSS.append("http", "listener", "registry");
-
     HttpListenerAdd(ListenerResourceDefinition definition) {
         super(definition);
     }
@@ -54,10 +52,9 @@ public class HttpListenerAdd extends ListenerAdd {
         HttpListenerResourceDefinition.ENABLE_HTTP2.resolveOption(context, model,listenerBuilder);
         HttpListenerResourceDefinition.REQUIRE_HOST_HTTP11.resolveOption(context, model,listenerBuilder);
 
-
         handleHttp2Options(context, model, listenerBuilder);
 
-        return new HttpListenerService(name, serverName, listenerBuilder.getMap(), socketOptions, certificateForwarding, proxyAddressForwarding, proxyProtocol);
+        return new HttpListenerService(context.getCurrentAddress(), serverName, listenerBuilder.getMap(), socketOptions, certificateForwarding, proxyAddressForwarding, proxyProtocol);
     }
 
     static void handleHttp2Options(OperationContext context, ModelNode model, OptionMap.Builder listenerBuilder) throws OperationFailedException {
@@ -76,6 +73,6 @@ public class HttpListenerAdd extends ListenerAdd {
             ServiceName serviceName = context.getCapabilityServiceName(REF_SOCKET_BINDING, redirectBindingRef.asString(), SocketBinding.class);
             serviceBuilder.addDependency(serviceName, SocketBinding.class, service.getRedirectSocket());
         }
-        serviceBuilder.addDependency(REGISTRY_SERVICE_NAME, ListenerRegistry.class, ((HttpListenerService) service).getHttpListenerRegistry());
+        serviceBuilder.addCapabilityRequirement(Capabilities.REF_HTTP_LISTENER_REGISTRY, ListenerRegistry.class, ((HttpListenerService) service).getHttpListenerRegistry());
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
@@ -25,9 +25,11 @@ package org.wildfly.extension.undertow;
 import io.undertow.UndertowOptions;
 import io.undertow.protocols.http2.Http2Channel;
 
+import io.undertow.server.handlers.ChannelUpgradeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -42,10 +44,16 @@ import java.util.List;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
+ * @author Richard Achmatowicz (c) 2020 Red Hat Inc.
  */
 public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
-    protected static final HttpListenerResourceDefinition INSTANCE = new HttpListenerResourceDefinition();
 
+    static final RuntimeCapability<Void> HTTP_UPGRADE_REGISTRY_CAPABILITY =
+            RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HTTP_UPGRADE_REGISTRY, true, ChannelUpgradeHandler.class)
+            .setAllowMultipleRegistrations(true)
+            .build();
+
+    protected static final HttpListenerResourceDefinition INSTANCE = new HttpListenerResourceDefinition();
 
     protected static final SimpleAttributeDefinition CERTIFICATE_FORWARDING = new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_FORWARDING, ModelType.BOOLEAN)
             .setRequired(false)
@@ -132,7 +140,8 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .build();
 
     private HttpListenerResourceDefinition() {
-        super(UndertowExtension.HTTP_LISTENER_PATH);
+        super(new Parameters(UndertowExtension.HTTP_LISTENER_PATH, UndertowExtension.getResolver(Constants.LISTENER))
+                .setCapabilities(HTTP_UPGRADE_REGISTRY_CAPABILITY));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -75,12 +75,14 @@ public class HttpsListenerAdd extends ListenerAdd {
 
         final boolean certificateForwarding = HttpListenerResourceDefinition.CERTIFICATE_FORWARDING.resolveModelAttribute(context, model).asBoolean();
         final boolean proxyAddressForwarding = HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING.resolveModelAttribute(context, model).asBoolean();
-        return new HttpsListenerService(name, serverName, listenerBuilder.getMap(), cipherSuites, builder.getMap(), certificateForwarding, proxyAddressForwarding, proxyProtocol);
+
+        return new HttpsListenerService(context.getCurrentAddress(), serverName, listenerBuilder.getMap(), cipherSuites, builder.getMap(), certificateForwarding, proxyAddressForwarding, proxyProtocol);
     }
 
     @Override
     void configureAdditionalDependencies(OperationContext context, CapabilityServiceBuilder serviceBuilder, ModelNode model, ListenerService service) throws OperationFailedException {
-        serviceBuilder.addDependency(HttpListenerAdd.REGISTRY_SERVICE_NAME, ListenerRegistry.class, ((HttpListenerService) service).getHttpListenerRegistry());
+
+        serviceBuilder.addCapabilityRequirement(Capabilities.REF_HTTP_LISTENER_REGISTRY, ListenerRegistry.class, ((HttpListenerService) service).getHttpListenerRegistry());
 
         ModelNode sslContextModel = HttpsListenerResourceDefinition.SSL_CONTEXT.resolveModelAttribute(context, model);
         ModelNode securityRealmModel = HttpsListenerResourceDefinition.SECURITY_REALM.resolveModelAttribute(context, model);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
@@ -119,7 +119,7 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
             .setDeprecated(ModelVersion.create(4, 0, 0)).setMeasurementUnit(MeasurementUnit.SECONDS).setRequired(false).setAllowExpression(true).setAlternatives(Constants.SSL_CONTEXT).build();
 
     private HttpsListenerResourceDefinition() {
-        super(UndertowExtension.HTTPS_LISTENER_PATH);
+        super(new Parameters(UndertowExtension.HTTPS_LISTENER_PATH, UndertowExtension.getResolver(Constants.LISTENER)));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
@@ -36,6 +36,7 @@ import io.undertow.server.protocol.http.AlpnOpenListener;
 import io.undertow.server.protocol.http.HttpOpenListener;
 import io.undertow.server.protocol.http2.Http2OpenListener;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.network.NetworkUtils;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.wildfly.security.ssl.CipherSuiteSelector;
@@ -66,12 +67,12 @@ public class HttpsListenerService extends HttpListenerService {
     private final String cipherSuites;
     private final boolean proxyProtocol;
 
-    public HttpsListenerService(final String name, String serverName, OptionMap listenerOptions, String cipherSuites, OptionMap socketOptions, boolean proxyProtocol) {
-        this(name, serverName, listenerOptions, cipherSuites, socketOptions, false, false, proxyProtocol);
+    public HttpsListenerService(final PathAddress address, String serverName, OptionMap listenerOptions, String cipherSuites, OptionMap socketOptions, boolean proxyProtocol) {
+        this(address, serverName, listenerOptions, cipherSuites, socketOptions, false, false, proxyProtocol);
     }
 
-    HttpsListenerService(final String name, String serverName, OptionMap listenerOptions, String cipherSuites, OptionMap socketOptions, boolean certificateForwarding, boolean proxyAddressForwarding, boolean proxyProtocol) {
-        super(name, serverName, listenerOptions, socketOptions, certificateForwarding, proxyAddressForwarding, proxyProtocol);
+    HttpsListenerService(final PathAddress address, String serverName, OptionMap listenerOptions, String cipherSuites, OptionMap socketOptions, boolean certificateForwarding, boolean proxyAddressForwarding, boolean proxyProtocol) {
+        super(address, serverName, listenerOptions, socketOptions, certificateForwarding, proxyAddressForwarding, proxyProtocol);
         this.cipherSuites = cipherSuites;
         this.proxyProtocol = proxyProtocol;
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -44,12 +44,10 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -239,9 +237,9 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
         ATTRIBUTES.addAll(SOCKET_OPTIONS);
     }
 
-    public ListenerResourceDefinition(PathElement pathElement) {
-        super(new SimpleResourceDefinition.Parameters(pathElement, UndertowExtension.getResolver(Constants.LISTENER))
-                .addCapabilities(LISTENER_CAPABILITY));
+    public ListenerResourceDefinition(Parameters parameters) {
+        // this Persistent Parameters will be cast to Parameters
+        super(parameters.setDescriptionResolver(UndertowExtension.getResolver(Constants.LISTENER)).addCapabilities(LISTENER_CAPABILITY));
     }
 
     public Collection<AttributeDefinition> getAttributes() {

--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -252,7 +252,7 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
                         .setInitialMode(ServiceController.Mode.ACTIVE).install();
                 // ListenerRegistry.Listener listener = new ListenerRegistry.Listener("http", "default", "default",
                 // InetSocketAddress.createUnresolved("localhost",8080));
-                target.addService(HttpListenerAdd.REGISTRY_SERVICE_NAME, new HttpListenerRegistryService())
+                target.addService(ServiceName.parse(Capabilities.REF_HTTP_LISTENER_REGISTRY), new HttpListenerRegistryService())
                         .setInitialMode(ServiceController.Mode.ACTIVE).install();
                 SecurityRealmService srs = new SecurityRealmService("UndertowRealm", false);
                 final ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "temp");


### PR DESCRIPTION
This PR does the following:
- adds in a capability for the HTTP_UPGRADE_REGISTRY service which is used by a number of subsystems to support HTTP Upgrade
- updates the messaging-activemq subsystem to generate service names using the capability
- provides an alias so that other subsystems (in Wildfly core) can move to using the capability at a later date

For more details: see  https://issues.redhat.com/browse/WFLY-13432