### PR TITLE
[WFLY-13446] Dependency of wildfly-weld-common would be better to be ${project.groupId}

### DIFF
--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -227,7 +227,7 @@ projects that depend on this project.-->
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-weld-common</artifactId>
         </dependency>
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13446

Use `${project.groupId}` instead of `org.wildfly` for dependency in the same project.