### PR TITLE
Port hotrod session manager fixes from Infinispan 10.1.x branch

### DIFF
--- a/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheProperties.java
+++ b/clustering/ee/hotrod/src/main/java/org/wildfly/clustering/ee/hotrod/RemoteCacheProperties.java
@@ -22,19 +22,18 @@
 
 package org.wildfly.clustering.ee.hotrod;
 
-import org.infinispan.client.hotrod.configuration.Configuration;
-import org.infinispan.client.hotrod.configuration.TransactionMode;
+import org.infinispan.client.hotrod.RemoteCache;
 import org.wildfly.clustering.ee.cache.CacheProperties;
 
 /**
  * @author Paul Ferraro
  */
-public class RemoteCacheManagerProperties implements CacheProperties {
+public class RemoteCacheProperties implements CacheProperties {
 
     private final boolean transactional;
 
-    public RemoteCacheManagerProperties(Configuration configuration) {
-        this.transactional = configuration.transaction().transactionMode() != TransactionMode.NONE;
+    public RemoteCacheProperties(RemoteCache<?, ?> cache) {
+        this.transactional = cache.getTransactionManager() != null;
     }
 
     @Override
@@ -44,7 +43,7 @@ public class RemoteCacheManagerProperties implements CacheProperties {
 
     @Override
     public boolean isLockOnWrite() {
-        return true;
+        return false;
     }
 
     @Override

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RegisteredRemoteCache.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RegisteredRemoteCache.java
@@ -31,6 +31,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
+import javax.transaction.TransactionManager;
+
 import org.infinispan.client.hotrod.CacheTopologyInfo;
 import org.infinispan.client.hotrod.DataFormat;
 import org.infinispan.client.hotrod.Flag;
@@ -73,8 +75,8 @@ public class RegisteredRemoteCache<K, V> extends RemoteCacheSupport<K, V> implem
     }
 
     @Override
-    public boolean removeWithVersion(K key, long version) {
-        return this.cache.removeWithVersion(key, version);
+    public TransactionManager getTransactionManager() {
+        return this.cache.getTransactionManager();
     }
 
     @Override
@@ -202,6 +204,11 @@ public class RegisteredRemoteCache<K, V> extends RemoteCacheSupport<K, V> implem
     @Override
     public boolean remove(Object key, Object value) {
         return this.cache.remove(key, value);
+    }
+
+    @Override
+    public boolean removeWithVersion(K key, long version) {
+        return this.cache.removeWithVersion(key, version);
     }
 
     @Override

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/RemoteCacheContainer.java
@@ -63,16 +63,19 @@ public interface RemoteCacheContainer extends org.infinispan.client.hotrod.Remot
 
     @Override
     default <K, V> RemoteCache<K, V> getCache() {
+        // Defer to global configuration for forceReturnValues
         return this.getCache(this.getConfiguration().forceReturnValues());
     }
 
     @Override
     default <K, V> RemoteCache<K, V> getCache(String cacheName) {
-        return this.getCache(cacheName, null, null);
+        // Defer to global configuration for forceReturnValues and transactional behavior
+        return this.getCache(cacheName, this.getConfiguration().forceReturnValues(), null, null);
     }
 
     @Override
     default <K, V> RemoteCache<K, V> getCache(String cacheName, TransactionMode transactionMode, TransactionManager transactionManager) {
+        // Defer to global configuration for forceReturnValues
         return this.getCache(cacheName, this.getConfiguration().forceReturnValues(), transactionMode, transactionManager);
     }
 

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/manager/RemoteCacheManager.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/manager/RemoteCacheManager.java
@@ -61,6 +61,11 @@ public class RemoteCacheManager extends org.infinispan.client.hotrod.RemoteCache
     }
 
     @Override
+    public <K, V> RemoteCache<K, V> getCache(String cacheName, TransactionMode transactionMode, TransactionManager transactionManager) {
+        return this.getCache(cacheName, this.getConfiguration().forceReturnValues(), transactionMode, transactionManager);
+    }
+
+    @Override
     public <K, V> RemoteCache<K, V> getCache(String cacheName, boolean forceReturnValue, TransactionMode transactionMode, TransactionManager transactionManager) {
         return new RegisteredRemoteCache<>(this, super.getCache(cacheName, forceReturnValue, transactionMode, transactionManager), this.registrar);
     }
@@ -83,5 +88,11 @@ public class RemoteCacheManager extends org.infinispan.client.hotrod.RemoteCache
         @SuppressWarnings("unchecked")
         Function<ClientListenerNotifier, NearCacheService<K, V>> factory = (cacheName != null) ? (Function<ClientListenerNotifier, NearCacheService<K, V>>) (Function<?, ?>) this.nearCacheFactories.get(cacheName) : null;
         return (factory != null) ? factory.apply(this.listenerNotifier) : super.createNearCacheService(cacheName, config);
+    }
+
+    @Override
+    public <K, V> RemoteCache<K, V> getCache(String cacheName) {
+        // Disable hotrod transactions for remote-caches returned via RemoteCacheManagerAdmin
+        return this.getCache(cacheName, TransactionMode.NONE);
     }
 }

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/near/EmptyNearCache.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/near/EmptyNearCache.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.client.near;
+
+import org.infinispan.client.hotrod.MetadataValue;
+import org.infinispan.client.hotrod.near.NearCache;
+
+/**
+ * An empty near cache.
+ * @author Paul Ferraro
+ */
+public class EmptyNearCache<K, V> implements NearCache<K, V> {
+
+    @Override
+    public void put(K key, MetadataValue<V> value) {
+    }
+
+    @Override
+    public void putIfAbsent(K key, MetadataValue<V> value) {
+    }
+
+    @Override
+    public boolean remove(K key) {
+        return false;
+    }
+
+    @Override
+    public MetadataValue<V> get(K key) {
+        return null;
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public int size() {
+        return 0;
+    }
+}

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/near/EmptyNearCacheService.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/near/EmptyNearCacheService.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.infinispan.client.near;
+
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
+import org.infinispan.client.hotrod.event.impl.ClientListenerNotifier;
+import org.infinispan.client.hotrod.near.NearCache;
+import org.infinispan.client.hotrod.near.NearCacheService;
+import org.wildfly.clustering.Registrar;
+import org.wildfly.clustering.Registration;
+import org.wildfly.clustering.infinispan.client.RegisteredRemoteCache;
+
+/**
+ * An empty near cache service.
+ * @author Paul Ferraro
+ */
+public class EmptyNearCacheService<K, V> extends NearCacheService<K, V> implements Registrar<String>, Registration {
+
+    public EmptyNearCacheService(ClientListenerNotifier notifier) {
+        super(null, notifier);
+    }
+
+    @Override
+    public void start(RemoteCache<K, V> cache) {
+        super.start(new DeafRemoteCache<>(cache, this));
+    }
+
+    @Override
+    public void stop(RemoteCache<K, V> cache) {
+        super.stop(new DeafRemoteCache<>(cache, this));
+    }
+
+    @Override
+    protected NearCache<K, V> createNearCache(NearCacheConfiguration config) {
+        return new EmptyNearCache<>();
+    }
+
+    @Override
+    public Registration register(String object) {
+        return this;
+    }
+
+    @Override
+    public void close() {
+        // Do nothing
+    }
+
+    // Remote cache decorator with disabled listener registration
+    private static class DeafRemoteCache<K, V> extends RegisteredRemoteCache<K, V> {
+
+        DeafRemoteCache(RemoteCache<K, V> cache, Registrar<String> registrar) {
+            super(cache.getRemoteCacheManager(), cache, registrar);
+        }
+
+        @Override
+        public void addClientListener(Object listener) {
+            // Disable listener registration
+        }
+
+        @Override
+        public void addClientListener(Object listener, Object[] filterFactoryParams, Object[] converterFactoryParams) {
+            // Disable listener registration
+        }
+
+        @Override
+        public void removeClientListener(Object listener) {
+            // Disable listener registration
+        }
+    }
+}

--- a/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/service/RemoteCacheServiceConfigurator.java
+++ b/clustering/infinispan/client/src/main/java/org/wildfly/clustering/infinispan/client/service/RemoteCacheServiceConfigurator.java
@@ -61,6 +61,10 @@ public class RemoteCacheServiceConfigurator<K, V> extends SimpleServiceNameProvi
 
     private volatile SupplierDependency<RemoteCacheContainer> container;
 
+    public RemoteCacheServiceConfigurator(ServiceName name, String containerName, String cacheName, String configurationName) {
+        this(name, containerName, cacheName, configurationName, null);
+    }
+
     public RemoteCacheServiceConfigurator(ServiceName name, String containerName, String cacheName, String configurationName, Function<ClientListenerNotifier, NearCacheService<K, V>> nearCacheFactory) {
         super(name);
         this.containerName = containerName;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
@@ -54,6 +54,7 @@ import org.infinispan.persistence.spi.SegmentedAdvancedLoadWriteStore;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.reactivestreams.Publisher;
 import org.wildfly.clustering.infinispan.client.RemoteCacheContainer;
+import org.wildfly.clustering.infinispan.client.near.EmptyNearCacheService;
 
 import io.reactivex.Flowable;
 import io.reactivex.functions.Consumer;
@@ -87,13 +88,19 @@ public class HotRodStore<K, V> implements SegmentedAdvancedLoadWriteStore<K, V>,
 
             // Administration support was introduced in protocol version 2.7
             if (protocolVersion.compareTo(ProtocolVersion.PROTOCOL_VERSION_27) < 0) {
-                this.remoteCache = remoteCacheContainer.getCache(cacheName, false);
+                // Auto-disable near cache
+                try (RemoteCacheContainer.NearCacheRegistration registration = remoteCacheContainer.registerNearCacheFactory(cacheName, EmptyNearCacheService::new)) {
+                    this.remoteCache = remoteCacheContainer.getCache(cacheName, false);
+                }
                 if (this.remoteCache == null) {
                     throw InfinispanLogger.ROOT_LOGGER.remoteCacheMustBeDefined(protocolVersion.toString(), cacheName);
                 }
             } else {
                 InfinispanLogger.ROOT_LOGGER.remoteCacheCreated(cacheName, cacheConfiguration);
-                this.remoteCache = remoteCacheContainer.administration().getOrCreateCache(cacheName, cacheConfiguration);
+                // Auto-disable near cache
+                try (RemoteCacheContainer.NearCacheRegistration registration = remoteCacheContainer.registerNearCacheFactory(cacheName, EmptyNearCacheService::new)) {
+                    this.remoteCache = remoteCacheContainer.administration().getOrCreateCache(cacheName, cacheConfiguration);
+                }
             }
         } catch (HotRodClientException ex) {
             throw new PersistenceException(ex);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/HotRodStore.java
@@ -109,12 +109,12 @@ public class HotRodStore<K, V> implements SegmentedAdvancedLoadWriteStore<K, V>,
 
     @Override
     public void start() {
-        // Do nothing -- remoteCacheContainer is already started
+        this.remoteCache.start();
     }
 
     @Override
     public void stop() {
-        // Do nothing -- remoteCacheContainer lifecycle is controlled by the application server
+        this.remoteCache.stop();
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/InvalidationNearCacheServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/InvalidationNearCacheServiceConfigurator.java
@@ -22,13 +22,10 @@
 
 package org.jboss.as.clustering.infinispan.subsystem.remote;
 
-import java.util.OptionalInt;
-
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
 import org.infinispan.client.hotrod.configuration.NearCacheConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
-import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.clustering.infinispan.subsystem.ComponentServiceConfigurator;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -41,7 +38,7 @@ import org.wildfly.clustering.service.ServiceConfigurator;
  */
 public class InvalidationNearCacheServiceConfigurator extends ComponentServiceConfigurator<NearCacheConfiguration> {
 
-    private volatile OptionalInt maxEntries;
+    private volatile int maxEntries;
 
     InvalidationNearCacheServiceConfigurator(PathAddress address) {
         super(RemoteCacheContainerComponent.NEAR_CACHE, address);
@@ -49,14 +46,15 @@ public class InvalidationNearCacheServiceConfigurator extends ComponentServiceCo
 
     @Override
     public ServiceConfigurator configure(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.maxEntries = ModelNodes.optionalInt(InvalidationNearCacheResourceDefinition.Attribute.MAX_ENTRIES.resolveModelAttribute(context, model));
+        this.maxEntries = InvalidationNearCacheResourceDefinition.Attribute.MAX_ENTRIES.resolveModelAttribute(context, model).asInt(-1);
         return this;
     }
 
     @Override
     public NearCacheConfiguration get() {
-        NearCacheConfigurationBuilder builder = new ConfigurationBuilder().nearCache().mode(NearCacheMode.INVALIDATED);
-        this.maxEntries.ifPresent(builder::maxEntries);
+        NearCacheConfigurationBuilder builder = new ConfigurationBuilder().nearCache()
+                .mode(NearCacheMode.INVALIDATED)
+                .maxEntries(this.maxEntries);
         return builder.create();
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/NoNearCacheServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/NoNearCacheServiceConfigurator.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.infinispan.subsystem.remote;
 
+import java.util.regex.Pattern;
+
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.NearCacheConfiguration;
 import org.infinispan.client.hotrod.configuration.NearCacheMode;
@@ -32,6 +34,7 @@ import org.jboss.as.controller.PathAddress;
  * @author Radoslav Husar
  */
 public class NoNearCacheServiceConfigurator extends ComponentServiceConfigurator<NearCacheConfiguration> {
+    private static final Pattern WEB_DEPLOYMENT_PATTERN = Pattern.compile(".+\\.war");
 
     NoNearCacheServiceConfigurator(PathAddress address) {
         super(RemoteCacheContainerComponent.NEAR_CACHE, address);
@@ -39,6 +42,6 @@ public class NoNearCacheServiceConfigurator extends ComponentServiceConfigurator
 
     @Override
     public NearCacheConfiguration get() {
-        return new ConfigurationBuilder().nearCache().mode(NearCacheMode.DISABLED).create();
+        return new ConfigurationBuilder().nearCache().mode(NearCacheMode.INVALIDATED).maxEntries(-1).cacheNamePattern(WEB_DEPLOYMENT_PATTERN).create();
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerServiceHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteCacheContainerServiceHandler.java
@@ -80,6 +80,7 @@ public class RemoteCacheContainerServiceHandler extends SimpleResourceServiceHan
         String name = context.getCurrentAddressValue();
 
         context.removeService(InfinispanBindingFactory.createRemoteCacheContainerBinding(name).getBinderServiceName());
+        context.removeService(new ServiceValueCaptorServiceConfigurator<>(this.registry.remove(new RemoteCacheContainerServiceConfigurator(address).getServiceName())).getServiceName());
 
         for (RemoteCacheContainerResourceDefinition.Capability component : EnumSet.allOf(RemoteCacheContainerResourceDefinition.Capability.class)) {
             ServiceName serviceName = component.getServiceName(address);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteTransactionServiceConfigurator.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/remote/RemoteTransactionServiceConfigurator.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.configuration.TransactionConfiguration;
 import org.infinispan.client.hotrod.configuration.TransactionConfigurationBuilder;
-import org.infinispan.transaction.tm.EmbeddedTransactionManager;
+import org.infinispan.client.hotrod.transaction.manager.RemoteTransactionManager;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.clustering.infinispan.TransactionManagerProvider;
 import org.jboss.as.clustering.infinispan.subsystem.ComponentServiceConfigurator;
@@ -71,7 +71,7 @@ public class RemoteTransactionServiceConfigurator extends ComponentServiceConfig
             }
             case BATCH: {
                 builder.transactionMode(org.infinispan.client.hotrod.configuration.TransactionMode.NON_DURABLE_XA);
-                builder.transactionManagerLookup(new TransactionManagerProvider(EmbeddedTransactionManager.getInstance()));
+                builder.transactionManagerLookup(new TransactionManagerProvider(RemoteTransactionManager.getInstance()));
                 break;
             }
             case NON_DURABLE_XA: {

--- a/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionMetaDataFactoryConfiguration.java
+++ b/clustering/web/hotrod/src/main/java/org/wildfly/clustering/web/hotrod/session/HotRodSessionMetaDataFactoryConfiguration.java
@@ -24,7 +24,7 @@ package org.wildfly.clustering.web.hotrod.session;
 
 import org.infinispan.client.hotrod.RemoteCache;
 import org.wildfly.clustering.ee.cache.CacheProperties;
-import org.wildfly.clustering.ee.hotrod.RemoteCacheManagerProperties;
+import org.wildfly.clustering.ee.hotrod.RemoteCacheProperties;
 
 /**
  * @author Paul Ferraro
@@ -34,6 +34,6 @@ public interface HotRodSessionMetaDataFactoryConfiguration {
     <CK, CV> RemoteCache<CK, CV> getCache();
 
     default CacheProperties getCacheProperties() {
-        return new RemoteCacheManagerProperties(this.getCache().getRemoteCacheManager().getConfiguration());
+        return new RemoteCacheProperties(this.getCache());
     }
 }

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/client/main/module.xml
@@ -32,6 +32,8 @@
     </resources>
 
     <dependencies>
+        <module name="javax.transaction.api"/>
+
         <module name="com.github.ben-manes.caffeine"/>
         <module name="org.infinispan.client.hotrod"/>
         <module name="org.infinispan.commons"/>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/InfinispanServerSetupTask.java
@@ -31,13 +31,11 @@ import org.jboss.as.test.shared.CLIServerSetupTask;
 public class InfinispanServerSetupTask extends CLIServerSetupTask {
     public InfinispanServerSetupTask() {
         this.builder.node(AbstractClusteringTestCase.TWO_NODES)
-                .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server-1:add(port=11622,host=%s)", AbstractClusteringTestCase.TESTSUITE_NODE0)
-                .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod)")
-                .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server-1])")
-                .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=other:add(remote-cache-container=web)")
-                .teardown("/subsystem=distributable-web/hotrod-single-sign-on-management=other:remove()")
-                .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
-                .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server-1:remove")
+                .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=11622,host=%s)", AbstractClusteringTestCase.TESTSUITE_NODE0)
+                .setup("/subsystem=infinispan/remote-cache-container=sso:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod)")
+                .setup("/subsystem=infinispan/remote-cache-container=sso/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
+                .teardown("/subsystem=infinispan/remote-cache-container=sso:remove")
+                .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")
                 ;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/RemoteElytronSingleSignOnTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/RemoteElytronSingleSignOnTestCase.java
@@ -57,7 +57,7 @@ public class RemoteElytronSingleSignOnTestCase extends AbstractSingleSignOnTestC
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
             this.builder.node(TWO_NODES)
-                    .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=other:add(remote-cache-container=web)")
+                    .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=other:add(remote-cache-container=sso)")
                     .teardown("/subsystem=distributable-web/hotrod-single-sign-on-management=other:remove")
             ;
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/RemoteSingleSignOnTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/sso/RemoteSingleSignOnTestCase.java
@@ -57,7 +57,7 @@ public class RemoteSingleSignOnTestCase extends AbstractSingleSignOnTestCase {
     public static class ServerSetupTask extends CLIServerSetupTask {
         public ServerSetupTask() {
             this.builder.node(TWO_NODES)
-                    .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=default-host:add(remote-cache-container=web)")
+                    .setup("/subsystem=distributable-web/hotrod-single-sign-on-management=default-host:add(remote-cache-container=sso)")
                     .teardown("/subsystem=distributable-web/hotrod-single-sign-on-management=default-host:remove")
             ;
         }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/AbstractWebFailoverTestCase.java
@@ -339,6 +339,8 @@ public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTest
                 }
             }
 
+            this.nonTxWait.run();
+
             try (CloseableHttpResponse response = client.execute(new HttpDelete(uri1))) {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             }
@@ -389,6 +391,8 @@ public abstract class AbstractWebFailoverTestCase extends AbstractClusteringTest
                     }
                 }
             }
+
+            this.nonTxWait.run();
 
             // Destroy session
             try (CloseableHttpResponse response = client.execute(new HttpDelete(uri1))) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseTransactionalHotRodWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/CoarseTransactionalHotRodWebFailoverTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.web.remote;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.web.AbstractWebFailoverTestCase;
+import org.jboss.as.test.clustering.single.web.Mutable;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ InfinispanServerSetupTask.class, LocalRoutingServerSetup.class })
+public class CoarseTransactionalHotRodWebFailoverTestCase extends AbstractHotRodWebFailoverTestCase {
+
+    private static final String DEPLOYMENT_NAME = CoarseTransactionalHotRodWebFailoverTestCase.class.getSimpleName() + ".war";
+
+    public CoarseTransactionalHotRodWebFailoverTestCase() {
+        super(DEPLOYMENT_NAME);
+    }
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> deployment2() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
+        war.addClasses(SimpleServlet.class, Mutable.class);
+        war.setWebXML(AbstractWebFailoverTestCase.class.getPackage(), "web.xml");
+        war.addAsWebInfResource(CoarseTransactionalHotRodWebFailoverTestCase.class.getPackage(), "jboss-all_coarse_transactional.xml", "jboss-all.xml");
+        war.addAsWebInfResource(CoarseTransactionalHotRodWebFailoverTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        return war;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineTransactionalHotRodWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/FineTransactionalHotRodWebFailoverTestCase.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.web.remote;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.clustering.cluster.web.AbstractWebFailoverTestCase;
+import org.jboss.as.test.clustering.single.web.Mutable;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ InfinispanServerSetupTask.class, LocalRoutingServerSetup.class })
+public class FineTransactionalHotRodWebFailoverTestCase extends AbstractHotRodWebFailoverTestCase {
+
+    private static final String DEPLOYMENT_NAME = FineTransactionalHotRodWebFailoverTestCase.class.getSimpleName() + ".war";
+
+    public FineTransactionalHotRodWebFailoverTestCase() {
+        super(DEPLOYMENT_NAME);
+    }
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> deployment2() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(NODE_3)
+    public static Archive<?> deployment3() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
+        war.addClasses(SimpleServlet.class, Mutable.class);
+        war.setWebXML(AbstractWebFailoverTestCase.class.getPackage(), "web.xml");
+        war.addAsWebInfResource(FineTransactionalHotRodWebFailoverTestCase.class.getPackage(), "jboss-all_fine_transactional.xml", "jboss-all.xml");
+        war.addAsWebInfResource(FineTransactionalHotRodWebFailoverTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        return war;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -35,7 +35,6 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
                 .setup("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:add(port=11622,host=%s)", AbstractClusteringTestCase.TESTSUITE_NODE0)
                 .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, statistics-enabled=true)")
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
-                .setup("/subsystem=infinispan/remote-cache-container=web/near-cache=invalidation:add()")
                 .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
                 .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server-1:remove")
                 ;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/InfinispanServerSetupTask.java
@@ -36,7 +36,7 @@ public class InfinispanServerSetupTask extends CLIServerSetupTask {
                 .setup("/subsystem=infinispan/remote-cache-container=web:add(default-remote-cluster=infinispan-server-cluster, module=org.wildfly.clustering.web.hotrod, statistics-enabled=true)")
                 .setup("/subsystem=infinispan/remote-cache-container=web/remote-cluster=infinispan-server-cluster:add(socket-bindings=[infinispan-server])")
                 .teardown("/subsystem=infinispan/remote-cache-container=web:remove")
-                .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server-1:remove")
+                .teardown("/socket-binding-group=standard-sockets/remote-destination-outbound-socket-binding=infinispan-server:remove")
                 ;
     }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_coarse_transactional.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_coarse_transactional.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss xmlns="urn:jboss:1.0">
+    <distributable-web xmlns="urn:jboss:distributable-web:1.0">
+        <hotrod-session-management remote-cache-container="web" cache-configuration="transactional" granularity="SESSION">
+            <local-affinity/>
+        </hotrod-session-management>
+    </distributable-web>
+</jboss>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_fine_transactional.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/remote/jboss-all_fine_transactional.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss xmlns="urn:jboss:1.0">
+    <distributable-web xmlns="urn:jboss:distributable-web:1.0">
+        <hotrod-session-management remote-cache-container="web" cache-configuration="transactional" granularity="ATTRIBUTE">
+            <local-affinity/>
+        </hotrod-session-management>
+    </distributable-web>
+</jboss>


### PR DESCRIPTION
Includes:
WFLY-13452 RemoteCacheContainer.getTransactionManager() always returns null
https://issues.redhat.com/browse/WFLY-13452

WFLY-13453 Near cache should auto-enable when hotrod session manager is used
https://issues.redhat.com/browse/WFLY-13453

WFLY-13454 Remote cache store should never use a near cache
https://issues.redhat.com/browse/WFLY-13454

