### PR TITLE
[WFLY-13386] Hung process instances and associated server.log WARN "Failed to reinstate timer 'kie-server.kie-server.EJBTimerScheduler' "

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
@@ -599,6 +599,8 @@ public class TimerImpl implements Timer {
             sb.append(this.persistent);
             sb.append(" timerService=");
             sb.append(this.timerService);
+            sb.append(" previousRun=");
+            sb.append(this.previousRun);
             sb.append(" initialExpiration=");
             sb.append(this.initialExpiration);
             sb.append(" intervalDuration(in milli sec)=");

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -117,7 +117,7 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
     /**
      * All timers which were created by this {@link TimerService}
      */
-    private final Map<String, TimerImpl> timers = Collections.synchronizedMap(new HashMap<String, TimerImpl>());
+    private final Map<String, TimerImpl> timers = new HashMap<String, TimerImpl>();
 
     /**
      * Holds the {@link java.util.concurrent.Future} of each of the timer tasks that have been scheduled
@@ -543,7 +543,9 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
     }
 
     public TimerImpl getTimer(final String timerId) {
-        return timers.get(timerId);
+        synchronized (this.timers) {
+            return this.timers.get(timerId);
+        }
     }
 
     /**
@@ -562,7 +564,10 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
      */
     public TimerImpl getTimer(TimerHandle handle) {
         TimerHandleImpl timerHandle = (TimerHandleImpl) handle;
-        TimerImpl timer = timers.get(timerHandle.getId());
+        TimerImpl timer = null;
+        synchronized (this.timers) {
+            timer = this.timers.get(timerHandle.getId());
+        }
         if (timer != null) {
             return timer;
         }
@@ -659,7 +664,6 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
             // cancel any scheduled Future for this timer
             this.cancelTimeout(timer);
             this.unregisterTimerResource(timer.getId());
-            this.timers.remove(timer.getId());
             return true;
         }
     }
@@ -668,7 +672,6 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         this.cancelTimeout(timer);
         timer.setTimerState(TimerState.EXPIRED, null);
         this.unregisterTimerResource(timer.getId());
-        removeTimerFromInternalCache(timer);
     }
 
     /**
@@ -784,12 +787,13 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         // if there's no transaction, then trigger a schedule immediately.
         // Else, the timer will be scheduled on tx synchronization callback
         if (!transactionActive()) {
-            this.timers.put(timer.getId(), timer);
             // set active if the timer is started if it was read
             // from persistence as current running to ensure correct schedule here
             timer.setTimerState(TimerState.ACTIVE, null);
             // create and schedule a timer task
-            this.registerTimerResource(timer.getId());
+            if (!this.registerTimerResource(timer)) {
+                return;
+            }
             timer.scheduleTimeout(true);
         } else {
             addWaitingOnTxCompletionTimer(timer);
@@ -933,10 +937,6 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         }
     }
 
-    private void removeTimerFromInternalCache(final TimerImpl timer) {
-        timers.remove(timer.getId());
-        EJB3_TIMER_LOGGER.debugv("Removed timer {0} from internal cache", timer);
-    }
 
     public boolean isScheduled(final String tid){
         synchronized (this.scheduledTimerFutures) {
@@ -1133,12 +1133,22 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         return resource;
     }
 
-    private void registerTimerResource(final String timerId) {
-        this.resource.timerCreated(timerId);
+    private boolean registerTimerResource(final TimerImpl timer) {
+        synchronized (this.timers) {
+            if (this.timers.containsKey(timer.getId())) {
+                return false;
+            }
+            this.timers.put(timer.getId(), timer);
+            this.resource.timerCreated(timer.getId());
+            return true;
+        }
     }
 
     private void unregisterTimerResource(final String timerId) {
-        this.resource.timerRemoved(timerId);
+        synchronized (this.timers) {
+            this.timers.remove(timerId);
+            this.resource.timerRemoved(timerId);
+        }
     }
 
     /**
@@ -1178,9 +1188,10 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         public void afterCompletion(int status) {
             if (status == Status.STATUS_COMMITTED) {
                 EJB3_TIMER_LOGGER.debugv("commit timer creation: {0}", this.timer);
-                timers.put(timer.getId(), timer);
 
-                registerTimerResource(timer.getId());
+                if (!registerTimerResource(timer)) {
+                    return;
+                }
                 TimerState timerState = this.timer.getState();
                 switch (timerState) {
                     case CREATED:
@@ -1218,7 +1229,6 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
                 if (status == Status.STATUS_COMMITTED) {
                     cancelTimeout(timer);
                     unregisterTimerResource(timer.getId());
-                    removeTimerFromInternalCache(timer);
                 } else {
                     timer.setTimerState(TimerState.ACTIVE, null);
                 }
@@ -1335,7 +1345,7 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
             TimerImpl timer = TimerServiceImpl.this.getTimer(timerId);
             if(timer != null) {
                 TimerServiceImpl.this.cancelTimeout(timer);
-                TimerServiceImpl.this.removeTimerFromInternalCache(timer);
+                TimerServiceImpl.this.unregisterTimerResource(timer.getId());
             }
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerTask.java
@@ -91,7 +91,7 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
         try {
             final TimerImpl timer = timerService.getTimer(timerId);
             try {
-                if (cancelled) {
+                if (timer == null || cancelled) {
                     EJB3_TIMER_LOGGER.debugf("Timer task was cancelled for %s", timer);
                     return;
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
@@ -829,12 +829,12 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
                                 try {
                                     String id = resultSet.getString(1);
                                     if (!existing.remove(id)) {
-                                        synchronized (DatabaseTimerPersistence.this) {
-                                            knownTimerIds.get(timedObjectId).add(id);
-                                        }
                                         final Holder holder = timerFromResult(resultSet, timerService);
                                         if(holder != null) {
-                                            listener.timerAdded(holder.timer);
+                                            synchronized (DatabaseTimerPersistence.this) {
+                                                knownTimerIds.get(timedObjectId).add(id);
+                                                listener.timerAdded(holder.timer);
+                                            }
                                         }
                                     } else {
                                         final Holder holder = timerFromResult(resultSet, listener.getTimerService());
@@ -844,12 +844,11 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
                                             // remove and add -> the probable cause is db glitch
                                             EnumSet<TimerState> valid = EnumSet.of(TimerState.IN_TIMEOUT, TimerState.RETRY_TIMEOUT, TimerState.CREATED, TimerState.ACTIVE);
                                             boolean validDBTimer = valid.contains(holder.timer.getState());
-                                            boolean validMemoryTimer = !valid.contains(oldTimer.getState());
+                                            boolean validMemoryTimer = oldTimer != null && !valid.contains(oldTimer.getState());
                                             // if timers memory - db are in non intersect subsets of valid/invalid states. we put them in sync
                                             if (validMemoryTimer && validDBTimer) {
                                                 synchronized (DatabaseTimerPersistence.this) {
-                                                    Set<String> timers = knownTimerIds.get(timedObjectId);
-                                                    timers.remove(oldTimer.getId());
+                                                    knownTimerIds.get(timedObjectId).add(holder.timer.getId());
                                                     listener.timerSync(oldTimer, holder.timer);
                                                 }
 


### PR DESCRIPTION
If activate the refresh task in the database persistence there are at least
two threads compiting for registering a timer.

The refresh task is executing at the same time a new timer is being registered
if this happens the same timer will be try to registered by ejb and refresh task

this is due the fact the ejb action register in the database in its own tx (outside ejb tx)
the refresh task tries to load from its own tx

so if this order happens
1 ejb thread register the timer in the database
2 refresh task thread  load the timer from the dabase
3 ejb thread registers the timer in the dmr
4 refresh task thread register the timer in the dmr (FAIL as duplicated)



