### PR TITLE
Fix for WFLY-13461, Jaxrs requires bean-validation when cdi is present

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -124,7 +124,7 @@ Basic layers:
 Basic layers:
 
 * _bean-validation_: Support for Jakarta Bean Validation. Optionally depends on _cdi_.
-* _cdi_: Support for CDI.
+* _cdi_: Support for CDI. Optionally depends on _bean-validation_.
 * _datasources_: Support for datasources.
 * _ee-security_: Support for EE Security. Depends on _cdi_.
 * _jaxrs_: Support for JAXRS. Depends on _web-server_ (defined in the WildFly servlet feature-pack).

--- a/ee-galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/cdi/layer-spec.xml
@@ -2,6 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="cdi">
     <dependencies>
         <layer name="base-server"/>
+        <layer name="bean-validation" optional="true"/>
     </dependencies>
     <feature spec="subsystem.weld"/>
 </layer-spec>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13461
Optional dependency on bean-validation from cdi.