### PR TITLE
[WFLY-13482] Exclude dependency legacy feature packs from licenses.xm…

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -3586,7 +3586,7 @@
                                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                                     <licensesConfigFile>${project.basedir}/src/license/full-feature-pack-licenses.xml</licensesConfigFile>
                                     <licensesOutputFile>${license.directory}/full-feature-pack-licenses.xml</licensesOutputFile>
-                                    <excludedArtifacts>infinispan-hibernate-cache-v51|jboss-ejb-client-legacy</excludedArtifacts>
+                                    <excludedArtifacts>infinispan-hibernate-cache-v51|jboss-ejb-client-legacy|wildfly-core-feature-pack|wildfly-servlet-feature-pack</excludedArtifacts>
                                 </configuration>
                             </execution>
                         </executions>

--- a/servlet-feature-pack/pom.xml
+++ b/servlet-feature-pack/pom.xml
@@ -550,6 +550,7 @@
                                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                                     <licensesConfigFile>${project.basedir}/src/license/servlet-feature-pack-licenses.xml</licensesConfigFile>
                                     <licensesOutputFile>${license.directory}/servlet-feature-pack-licenses.xml</licensesOutputFile>
+                                    <excludedArtifacts>wildfly-core-feature-pack</excludedArtifacts>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
…l generation

https://issues.redhat.com/browse/WFLY-13482

The license file generation for the galleon feature pack excludes the feature packs themselves, but the legacy feature pack generation does not. That leads to pointless diffs between dists generated from the two f-ps. So exclude the legacy f-ps the same way as is done with galleon.