### PR TITLE
[WFLY-13485] Upgrade WildFly Core 12.0.0.Beta3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.0.Beta2</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.0.Beta3</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13485

Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/12.0.0.Beta2...12.0.0.Beta3

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 12.0.0.Beta3
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4653'>WFCORE-4653</a>] -         Upgrade picketbox to 5.0.3.Final-redhat-00005
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4942'>WFCORE-4942</a>] -         Upgrade Undertow to 2.1.1.Final fixes CVE-2020-10719
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4953'>WFCORE-4953</a>] -         Upgrade WildFly Elytron to 1.12.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4966'>WFCORE-4966</a>] -         Upgrade WildFly OpenSSL to 1.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4968'>WFCORE-4968</a>] -         Upgrade WildFly Elytron to 1.12.0.CR2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4969'>WFCORE-4969</a>] -         Upgrade XNIO to 3.8.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4971'>WFCORE-4971</a>] -         Upgrade WildFly Elytron to 1.12.0.CR3
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4730'>WFCORE-4730</a>] -         Include the wildfly-openssl s390 binding
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4895'>WFCORE-4895</a>] -         Bootable jar runtime module
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4949'>WFCORE-4949</a>] -         Expose the original task in RequestController.QueuedTask
</li>
</ul>
                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4725'>WFCORE-4725</a>] -         Make IP address of remote EJB client accessible to the developer from within app authentication code
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4750'>WFCORE-4750</a>] -         Introduce regex mapper for security roles in Elytron
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4252'>WFCORE-4252</a>] -         JmxControlledStateNotificationsTestCase test cases fail with security manager on Java 11
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4957'>WFCORE-4957</a>] -         Reduce heap footprint of single attribute write-attribute handlers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4965'>WFCORE-4965</a>] -         Error loading a PKCS12 keystore inside a security-realm when using a credential-reference
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4954'>WFCORE-4954</a>] -         Add legacy controller for EAP 7.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4958'>WFCORE-4958</a>] -         Create the ModelTestModelControllerService variants for the EAP 7.3.0 controllers
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4961'>WFCORE-4961</a>] -         Move PARSE_MICROPROFILE_JWT_DETECTION Earlier
</li>
</ul>
                                    
