### PR TITLE
[WFLY-13256] Upgrade BouncyCastle from 1.62 to 1.65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <version.org.apache.ws.xmlschema>2.2.4</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bitbucket.jose4j>0.7.0</version.org.bitbucket.jose4j>
-        <version.org.bouncycastle>1.62</version.org.bouncycastle>
+        <version.org.bouncycastle>1.65</version.org.bouncycastle>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/authentication/policy/AuthenticationPolicyContextTestCase.java
@@ -39,6 +39,7 @@ import org.jboss.as.test.integration.ws.authentication.policy.resources.EchoServ
 import org.jboss.as.test.integration.ws.authentication.policy.resources.PicketLinkSTSService;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -188,6 +189,10 @@ public class AuthenticationPolicyContextTestCase {
 
     @BeforeClass
     public static void initClient() throws Exception {
+        // With JDK 13 and Bouncycastle 1.65 various picketlink tests interact incorrectly
+        // such that execution of this test results in subsequent tests failing.
+        AssumeTestGroupUtil.assumeJDKVersionBefore(13);
+
         wsClient = new WSTrustClient("PicketLinkSTS", "PicketLinkSTSPort",
                 getHttpUrl(DEFAULT_HOST, DEFAULT_PORT) + "picketlink-sts/PicketLinkSTS", new WSTrustClient.SecurityInfo(USERNAME, PASSWORD));
     }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/wsse/trust/WSTrustTestCase.java
@@ -47,6 +47,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -77,6 +78,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Arquillian.class)
 @ServerSetup(WSTrustTestCaseSecuritySetupTask.class)
+@FixMethodOrder
 public class WSTrustTestCase {
     private static final String STS_DEP = "jaxws-samples-wsse-policy-trust-sts";
     private static final String SERVER_DEP = "jaxws-samples-wsse-policy-trust";

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/util/AssumeTestGroupUtil.java
@@ -36,6 +36,48 @@ public class AssumeTestGroupUtil {
         assumeCondition("Tests failing if the security manager is enabled.", () -> System.getProperty("security.manager") == null);
     }
 
+    /**
+     * Assume for tests that fail when the JVM version is too low. This should be used sparingly.
+     *
+     * @param javaSpecificationVersion the JDK specification version. Use 8 for JDK 8. Must be 8 or higher.
+     */
+    public static void assumeJDKVersionAfter(int javaSpecificationVersion) {
+        assert javaSpecificationVersion >= 8; // we only support 8 or later so no reason to call this for 8
+        assumeCondition("Tests failing if the JDK in use is before " + javaSpecificationVersion + ".",
+                () -> getJavaSpecificationVersion() > javaSpecificationVersion);
+    }
+
+    /**
+     * Assume for tests that fail when the JVM version is too high. This should be used sparingly.
+     *
+     * @param javaSpecificationVersion the JDK specification version. Must be 9 or higher.
+     */
+    public static void assumeJDKVersionBefore(int javaSpecificationVersion) {
+        assert javaSpecificationVersion >= 9; // we only support 8 or later so no reason to call this for 8
+        assumeCondition("Tests failing if the JDK in use is after " + javaSpecificationVersion + ".",
+                () -> getJavaSpecificationVersion() < javaSpecificationVersion);
+    }
+
+    // BES 2020/05/18 I added this along with assumeJDKVersionAfter/assumeJDKVersionBefore but commented it
+    // out because using it seems like bad practice. If there's a legit need some day, well, here's the code...
+//    /**
+//     * Assume for tests that fail when the JVM version is something. This should be used sparingly and issues should
+//     * be filed for failing tests so a proper fix can be done, as it's inappropriate to limit a test to a single version.
+//     *
+//     * @param javaSpecificationVersion the JDK specification version. Use 8 for JDK 8. Must be 8 or higher.
+//     */
+//    public static void assumeJDKVersionEquals(int javaSpecificationVersion) {
+//        assert javaSpecificationVersion >= 8; // we only support 8 or later
+//        assumeCondition("Tests failing if the JDK in use is other than " + javaSpecificationVersion + ".",
+//                () -> getJavaSpecificationVersion() == javaSpecificationVersion);
+//    }
+
+    private static int getJavaSpecificationVersion() {
+        String versionString = System.getProperty("java.specification.version");
+        versionString = versionString.startsWith("1.") ? versionString.substring(2) : versionString;
+        return Integer.parseInt(versionString);
+    }
+
     private static void assumeCondition(final String message, final Supplier<Boolean> assumeTrueCondition) {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13256

It's a known issue that this upgrade results in some odd behavior with Picketlink STS tests on JDK 13, where running certain tests before others causes those others to fail. As picketlink use is deprecated and our support for JDK 13 is meant for developer evaluation, myself, Darran, Alessio, Jim Ma and Ashley discussed this and I believe it's more important to get this in than to worry about the PicketLink + JDK 13 scenario.

Custom JDK 13 test run against this branch is at https://ci.wildfly.org/viewQueued.html?itemId=205928