### PR TITLE
[WFLY-13489] Reduce some debug logging from tests. Change some tests …

### DIFF
--- a/testsuite/compat/src/test/resources/logging.properties
+++ b/testsuite/compat/src/test/resources/logging.properties
@@ -22,7 +22,6 @@
 
 # Additional logger names to configure (root logger is always configured)
 loggers=sun.rmi,org.jboss.shrinkwrap
-logger.org.jboss.shrinkwrap.level=INFO
 logger.sun.rmi.level=WARNING
 
 # Root logger level
@@ -31,16 +30,8 @@ logger.level=INFO
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=INFO
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -50,6 +41,3 @@ handler.FILE.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
@@ -73,7 +73,7 @@ public class ReplyingMDB implements MessageListener {
             if (message instanceof TextMessage) {
                 if (text.equals("await") && !message.getJMSRedelivered()) {
                     // we have received the first message
-                    log.infof("Message [%s, %s] contains text 'await'", message, text);
+                    log.debugf("Message [%s, %s] contains text 'await'", message, text);
                     // synchronize with test to start with undeploy
                     HelperSingletonImpl.barrier.await(WAIT_S, SECONDS);
                     HelperSingletonImpl.barrier.reset();
@@ -96,7 +96,7 @@ public class ReplyingMDB implements MessageListener {
             Destination destination = message.getJMSReplyTo();
             message.setJMSDeliveryMode(NON_PERSISTENT);
             sender.send(destination, replyMessage);
-            log.infof("onMessage method [OK], msg: [%s] with id [%s]. Replying to destination [%s].",
+            log.debugf("onMessage method [OK], msg: [%s] with id [%s]. Replying to destination [%s].",
                     text, message, destination);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/byreference/HelloBean.java
@@ -22,17 +22,17 @@
 package org.jboss.as.test.integration.ejb.remote.byreference;
 
 
-import java.util.logging.Logger;
-
 import javax.ejb.Stateless;
+
+import org.jboss.logging.Logger;
 
 @Stateless
 public class HelloBean implements HelloRemote {
 
-    private Logger log = Logger.getLogger(this.getClass().getSimpleName().toString());
+    private final Logger log = Logger.getLogger(this.getClass());
 
     public TransferReturnValue hello ( TransferParameter param ) throws RemoteByReferenceException {
-        log.info("hello("+ param +") = Hello " + param );
+        log.debug("hello("+ param +") = Hello " + param );
 
         if(param == null)
             throw new RemoteByReferenceException("Param was null");
@@ -42,7 +42,7 @@ public class HelloBean implements HelloRemote {
 
     @Override
     public SerializableObject helloSerializable(SerializableObject param) throws RemoteByReferenceException {
-        log.info("helloserializable("+ param +") = Hello " + param );
+        log.debug("helloserializable("+ param +") = Hello " + param );
 
         if(param == null)
             throw new RemoteByReferenceException("Param was null");
@@ -53,7 +53,7 @@ public class HelloBean implements HelloRemote {
 
     @Override
     public NonSerializableObject helloNonSerializable(NonSerializableObject param) throws RemoteByReferenceException {
-        log.info("helloserializable("+ param +") = Hello " + param );
+        log.debug("helloserializable("+ param +") = Hello " + param );
 
         if(param == null)
             throw new RemoteByReferenceException("Param was null");
@@ -65,7 +65,7 @@ public class HelloBean implements HelloRemote {
     @Override
     public SerializableObject helloNonSerializableToSerializable(NonSerializableObject param)
             throws RemoteByReferenceException {
-        log.info("helloserializable("+ param +") = Hello " + param );
+        log.debug("helloserializable("+ param +") = Hello " + param );
 
         if(param == null)
             throw new RemoteByReferenceException("Param was null");
@@ -77,7 +77,7 @@ public class HelloBean implements HelloRemote {
     @Override
     public NonSerializableObject helloSerializableToNonSerializable(SerializableObject param)
             throws RemoteByReferenceException {
-        log.info("helloserializable("+ param +") = Hello " + param );
+        log.debug("helloserializable("+ param +") = Hello " + param );
 
         if(param == null)
             throw new RemoteByReferenceException("Param was null");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/securitydomain/EJBContextMultipleSDTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/securitydomain/EJBContextMultipleSDTestCase.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
-import java.util.logging.Logger;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -68,6 +67,7 @@ import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.SnapshotRestoreSetupTask;
 import org.jboss.as.test.shared.util.AssumeTestGroupUtil;
 import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -241,7 +241,7 @@ public class EJBContextMultipleSDTestCase {
 
         @Override
         public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
-            log.info("Installing modules and Security Domains");
+            log.debug("Installing modules and Security Domains");
 
             deployModule();
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/securitydomain/ejb/BaseHello.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/securitydomain/ejb/BaseHello.java
@@ -28,7 +28,8 @@ import javax.ejb.SessionContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+
+import org.jboss.logging.Logger;
 
 @PermitAll
 public abstract class BaseHello implements Hello {
@@ -57,8 +58,8 @@ public abstract class BaseHello implements Hello {
     @Override
     public Info sayHello(Info info) {
 
-        log.info("**** ejb-context =" + ejbContext);
-        log.info("**** session-context =" + stx);
+        log.debug("**** ejb-context =" + ejbContext);
+        log.debug("**** session-context =" + stx);
 
         return info.update(this.getClass().getSimpleName(), ejbContext, expectedPrincipalClassName);
     }
@@ -69,12 +70,12 @@ public abstract class BaseHello implements Hello {
         data = (HashMap<String, Object>) ejbContext.getContextData();
 
         for (Map.Entry<String, Object> entry : data.entrySet()) {
-            System.out.println(" key =" + entry.getKey() + "\t value =" + entry.getValue());
+            log.debug(" key =" + entry.getKey() + "\t value =" + entry.getValue());
         }
-        log.info("######## ejb context data =" + data.toString() + "\n\n");
+        log.debugf("######## ejb context data =%s%n%n", data);
 
-        log.info("**** ejb-context =" + ejbContext);
-        log.info("**** session-context =" + stx);
+        log.debug("**** ejb-context =" + ejbContext);
+        log.debug("**** session-context =" + stx);
 
         // update info with this step
         info.update(this.getClass().getSimpleName(), ejbContext, expectedPrincipalClassName);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/AbstractTimerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/AbstractTimerBean.java
@@ -51,7 +51,7 @@ public abstract class AbstractTimerBean {
         }
         for (int i = 0; i < NUMBER_OF_TIMERS; i++) {
             String name = getClass().getSimpleName() + "#" + i;
-            logger.infof("Starting timer %s", name);
+            logger.debugf("Starting timer %s", name);
             timerService.createTimer(100000, 100000, name); // doesn't really need any timeouts to happen
         }
     }
@@ -61,9 +61,9 @@ public abstract class AbstractTimerBean {
     }
 
     public void stopTimers() {
-        logger.infof("Stopping all timers.");
+        logger.debug("Stopping all timers.");
         for (Timer timer: timerService.getTimers()) {
-            logger.infof("Stopping timer %s.", timer.getInfo().toString());
+            logger.debugf("Stopping timer %s.", timer.getInfo().toString());
             timer.cancel();
         }
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionTestCase.java
@@ -136,7 +136,7 @@ public class LazyAssociationLocalTransactionTestCase extends LazyAssociationAbst
             assertTrue(lc1.isManagedConnectionSet());
             assertFalse(lc2.isManagedConnectionSet());
 
-            logger.infof("testTwoConnectionsWithoutEnlistment: After associate");
+            logger.debug("testTwoConnectionsWithoutEnlistment: After associate");
         } catch (Throwable t) {
             logger.error(t.getMessage(), t);
             status = false;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/tracer/StatelessBean.java
@@ -49,14 +49,14 @@ public class StatelessBean implements StatelessBeanRemote {
     public void insertToDB() {
         String sql = String.format("INSERT INTO %s (%s) VALUES (%s)", table, column, 1);
         executeUpdate(sql);
-        log.infof("sql '%s' executed", sql);
+        log.debugf("sql '%s' executed", sql);
     }
 
     @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
     public void createTable() {
         String sql = String.format("CREATE TABLE IF NOT EXISTS %s (%s int)", table, column);
         executeUpdate(sql);
-        log.infof("sql '%s' executed", sql);
+        log.debugf("sql '%s' executed", sql);
     }
 
     private void executeUpdate(String sql) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBean.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.integration.jsf.managedbean.gc;
 
 import java.io.Serializable;
-import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -31,6 +30,8 @@ import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.SessionScoped;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
+
+import org.jboss.logging.Logger;
 
 @ManagedBean
 @SessionScoped
@@ -47,19 +48,19 @@ public class CountBean implements Serializable {
 
     @PostConstruct
     public void init() {
-        LOG.info("CountBean#Initializing counter with @PostConstruct ...");
+        LOG.debug("CountBean#Initializing counter with @PostConstruct ...");
         count = initBean.getInit();
     }
 
     @PreDestroy
     public void destroy() {
-        LOG.info("Destroyed CountBean");
+        LOG.debug("Destroyed CountBean");
         TestResultsBean.setPreDestroySessionScoped(true);
     }
 
     public String invalidateGC() {
 
-        LOG.info("Running Garbage Collect and Invalidating Session");
+        LOG.debug("Running Garbage Collect and Invalidating Session");
 
         System.gc();
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBeanViewScoped.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/managedbean/gc/CountBeanViewScoped.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.integration.jsf.managedbean.gc;
 
 import java.io.Serializable;
-import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -31,6 +30,8 @@ import javax.faces.bean.ManagedProperty;
 import javax.faces.bean.ViewScoped;
 import javax.faces.context.ExternalContext;
 import javax.faces.context.FacesContext;
+
+import org.jboss.logging.Logger;
 
 @ManagedBean
 @ViewScoped
@@ -47,19 +48,19 @@ public class CountBeanViewScoped implements Serializable {
 
     @PostConstruct
     public void init() {
-        LOG.info("CountBeanViewScoped#Initializing counter with @PostConstruct ...");
+        LOG.debug("CountBeanViewScoped#Initializing counter with @PostConstruct ...");
         count = initBeanViewScoped.getInit();
     }
 
     @PreDestroy
     public void destroy() {
-        LOG.info("Destroyed View Scoped CountBean");
+        LOG.debug("Destroyed View Scoped CountBean");
         TestResultsBean.setPreDestroyViewScoped(true);
     }
 
     public String invalidateGC() {
 
-        LOG.info("Running View Scoped Garbage Collect, invalidate session so view will be destroyed");
+        LOG.debug("Running View Scoped Garbage Collect, invalidate session so view will be destroyed");
         System.gc();
 
         FacesContext facesContext = FacesContext.getCurrentInstance();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/expression/ExpressionSubstitutionInContainerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/expression/ExpressionSubstitutionInContainerTestCase.java
@@ -36,7 +36,6 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.as.test.integration.management.util.ModelUtil;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -57,7 +56,6 @@ import org.wildfly.test.api.Authentication;
  */
 @RunWith(Arquillian.class)
 public class ExpressionSubstitutionInContainerTestCase {
-    private static final Logger log = Logger.getLogger(ExpressionSubstitutionInContainerTestCase.class);
 
     private static final String ARCHIVE_NAME = "expression-substitution-test";
 
@@ -188,16 +186,13 @@ public class ExpressionSubstitutionInContainerTestCase {
     private void systemPropertyEvaluation() {
         // test resolution of expressions
         String result = bean.getJBossProperty(PROP_NAME);
-        log.infof("systemPropertyEvaluation: JBoss property %s was resolved to %s", PROP_NAME, result);
         Assert.assertEquals("jboss property " + PROP_NAME + " evaluation - value should be taken from system property", EXPRESSION_PROP_VALUE, result);
 
 
         result = bean.getSystemProperty(EXPRESSION_PROP_NAME);
-        log.infof("systemPropertyEvaluationsystemPropertyEvaluation: System property %s has value %s", EXPRESSION_PROP_NAME, result);
         Assert.assertEquals("system property " + EXPRESSION_PROP_NAME + " from directly defined system property", EXPRESSION_PROP_VALUE, result);
 
         result = bean.getSystemProperty(PROP_NAME);
-        log.infof("systemPropertyEvaluation:  System property %s has value %s", PROP_NAME, result);
         Assert.assertEquals("system property " + PROP_NAME + " from evaluated jboss property", EXPRESSION_PROP_VALUE, result);
     }
 
@@ -218,11 +213,9 @@ public class ExpressionSubstitutionInContainerTestCase {
         try {
             // evaluation the inner prop name in addition
             String result = bean.getJBossProperty(INNER_PROP_NAME);
-            log.infof("expressionEvaluation: JBoss property %s was resolved to %s", INNER_PROP_NAME, result);
             Assert.assertEquals("jboss property " + INNER_PROP_NAME + " substitution evaluation expected", EXPRESSION_PROP_VALUE, result);
 
             result = bean.getSystemProperty(INNER_PROP_NAME);
-            log.infof("expressionEvaluation: System property %s has value %s", INNER_PROP_NAME, result);
             Assert.assertEquals("system property " + INNER_PROP_NAME + " from substitued jboss property", EXPRESSION_PROP_VALUE, result);
 
             // then evaluation of the rest
@@ -262,21 +255,17 @@ public class ExpressionSubstitutionInContainerTestCase {
     }*/
     private void expresionEvaluation() {
         String result = bean.getJBossProperty(EXPRESSION_PROP_NAME);
-        log.infof("expressionEvaluation: JBoss property %s was resolved to %s", EXPRESSION_PROP_NAME, result);
         Assert.assertEquals("jboss property " + EXPRESSION_PROP_NAME + " defined directly", EXPRESSION_PROP_VALUE, result);
 
 
         result = bean.getJBossProperty(PROP_NAME);
-        log.infof("expressionEvaluation: JBoss property %s was resolved to %s", PROP_NAME, result);
         Assert.assertEquals("jboss property " + PROP_NAME + " substitution evaluation expected", EXPRESSION_PROP_VALUE, result);
 
 
         result = bean.getSystemProperty(EXPRESSION_PROP_NAME);
-        log.infof("expressionEvaluation: System property %s has value %s", EXPRESSION_PROP_NAME, result);
         Assert.assertEquals("system property " + EXPRESSION_PROP_NAME + " from directly defined jboss property", EXPRESSION_PROP_VALUE, result);
 
         result = bean.getSystemProperty(PROP_NAME);
-        log.infof("expressionEvaluation:  System property %s has value %s", PROP_NAME, result);
         Assert.assertEquals("system property " + PROP_NAME + " from evaluated jboss property", EXPRESSION_PROP_VALUE, result);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/MaximumTimeoutTestCase.java
@@ -230,8 +230,8 @@ public class MaximumTimeoutTestCase {
 
             op = executeForResult(managementClient.getControllerClient(), Util.getReadAttributeOperation(TX_ADDRESS, DEF_TIMEOUT_ATTR));
             defaultTimeout = op.asInt();
-            LOGGER.info("max timeout: " + maxTimeout);
-            LOGGER.info("default timeout: " + defaultTimeout);
+            LOGGER.debug("max timeout: " + maxTimeout);
+            LOGGER.debug("default timeout: " + defaultTimeout);
         }
 
         @Override

--- a/testsuite/integration/basic/src/test/resources/logging.properties
+++ b/testsuite/integration/basic/src/test/resources/logging.properties
@@ -21,9 +21,7 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
-logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=INFO
+loggers=sun.rmi,org.apache.directory
 logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
@@ -31,19 +29,10 @@ logger.sun.rmi.level=WARNING
 logger.level=INFO
 
 # Root logger handlers
-#logger.handlers=FILE, CONSOLE
-logger.handlers=CONSOLE
-
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
+logger.handlers=FILE
 
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -54,6 +43,3 @@ handler.FILE.append=true
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi=

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/AbstractClusteringTestCase.java
@@ -167,7 +167,7 @@ public abstract class AbstractClusteringTestCase {
                 // Even though we should be able to just stop the container object this currently fails with:
                 // WFARQ-47 Calling "container.stop();" always ends exceptionally "Caught exception closing ManagementClient: java.lang.NullPointerException"
                 this.stop(container.getName());
-                log.infof("Stopped container '%s' which was started but not requested for this test.", container.getName());
+                log.debugf("Stopped container '%s' which was started but not requested for this test.", container.getName());
             }
         });
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/affinity/RankedAffinityTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/affinity/RankedAffinityTestCase.java
@@ -133,7 +133,7 @@ public class RankedAffinityTestCase extends AbstractClusteringTestCase {
                 Map.Entry<String, String> entry = parseSessionRoute(response);
                 previousAffinities = entry.getValue().split("\\.");
 
-                log.info("Response #1:" + response);
+                log.debugf("Response #1: %s", response);
 
                 Assert.assertNotNull(entry);
                 Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
@@ -153,9 +153,9 @@ public class RankedAffinityTestCase extends AbstractClusteringTestCase {
                 PathAddress address = PathAddress.parseCLIStyleAddress(String.format("/subsystem=undertow/configuration=filter/mod-cluster=load-balancer/balancer=%s/node=%s", BALANCER_NAME, node));
                 operation.get(OP_ADDR).set(address.toModelNode());
                 ModelNode result = lbManagementClient.getControllerClient().execute(operation);
-                log.info("Running operation: " + operation.toJSONString(false));
+                log.debugf("Running operation: %s", operation.toJSONString(false));
                 Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
-                log.info("Operation result: " + result.toJSONString(false));
+                log.debugf("Operation result: %s", result.toJSONString(false));
 
                 operation = new ModelNode();
                 operation.get(OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
@@ -164,9 +164,9 @@ public class RankedAffinityTestCase extends AbstractClusteringTestCase {
                 operation.get(ModelDescriptionConstants.RECURSIVE).set(ModelNode.TRUE);
                 operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).set(ModelNode.TRUE);
                 result = lbManagementClient.getControllerClient().execute(operation);
-                log.info("Running operation: " + operation.toJSONString(false));
+                log.debugf("Running operation: %s", operation.toJSONString(false));
                 Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
-                log.info("Operation result: " + result.toJSONString(false));
+                log.debugf("Operation result: %s", result.toJSONString(false));
 
                 Thread.sleep(GRACE_TIME_TOPOLOGY_CHANGE);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/AbstractRemoteEJBForwardingTestCase.java
@@ -145,11 +145,11 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             RemoteStatefulSB bean = directory.lookupStateful(implementationClass, RemoteStatefulSB.class);
 
             // Allow sufficient time for client to receive full topology
-            logger.info("Waiting for clusters to form.");
+            logger.debug("Waiting for clusters to form.");
             Thread.sleep(FAILURE_FREE_TIME);
 
             int newSerialValue = bean.getSerialAndIncrement();
-            logger.infof("First invocation: serial = %d", newSerialValue);
+            logger.debugf("First invocation: serial = %d", newSerialValue);
 
             ClientInvocationTask client = new ClientInvocationTask(bean, newSerialValue);
 
@@ -160,40 +160,40 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
             Thread.sleep(FAILURE_FREE_TIME);
             client.assertNoExceptions("at the beginning of the test");
 
-            logger.info("------ Shutdown clusterA-node0 -----");
+            logger.debugf("------ Shutdown clusterA-node0 -----");
             stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_1);
             Thread.sleep(SERVER_DOWN_TIME);
             client.assertNoExceptions("after clusterA-node0 was shut down");
 
-            logger.info("------ Startup clusterA-node0 -----");
+            logger.debug("------ Startup clusterA-node0 -----");
             start(NODE_1);
             Thread.sleep(FAILURE_FREE_TIME);
             client.assertNoExceptions("after clusterA-node0 was brought up");
 
-            logger.info("----- Shutdown clusterA-node1 -----");
+            logger.debug("----- Shutdown clusterA-node1 -----");
             stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_2);
             Thread.sleep(SERVER_DOWN_TIME);
 
-            logger.info("------ Startup clusterA-node1 -----");
+            logger.debug("------ Startup clusterA-node1 -----");
             start(NODE_2);
             Thread.sleep(FAILURE_FREE_TIME);
             client.assertNoExceptions("after clusterA-node1 was brought back up");
 
-            logger.info("----- Shutdown clusterB-node0 -----");
+            logger.debug("----- Shutdown clusterB-node0 -----");
             stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_3);
             Thread.sleep(SERVER_DOWN_TIME);
             client.assertNoExceptions("after clusterB-node0 was shut down");
 
-            logger.info("------ Startup clusterB-node0 -----");
+            logger.debug("------ Startup clusterB-node0 -----");
             start(NODE_3);
             Thread.sleep(FAILURE_FREE_TIME);
             client.assertNoExceptions("after clusterB-node0 was brought back up");
 
-            logger.info("----- Shutdown clusterB-node1 -----");
+            logger.debug("----- Shutdown clusterB-node1 -----");
             stop(GRACEFUL_SHUTDOWN_TIMEOUT, NODE_4);
             Thread.sleep(SERVER_DOWN_TIME);
 
-            logger.info("------ Startup clusterB-node1 -----");
+            logger.debug("------ Startup clusterB-node1 -----");
             start(NODE_4);
             Thread.sleep(FAILURE_FREE_TIME);
 
@@ -231,7 +231,7 @@ public abstract class AbstractRemoteEJBForwardingTestCase extends AbstractCluste
 
             try {
                 int serial = this.bean.getSerialAndIncrement();
-                logger.infof("EJB client invocation #%d on bean, received serial #%d.", this.invocationCount, serial);
+                logger.debugf("EJB client invocation #%d on bean, received serial #%d.", this.invocationCount, serial);
 
                 if (serial != ++expectedSerial) {
                     logger.warnf("Expected (%d) and received serial (%d) numbers do not match! Resetting.", expectedSerial, serial);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/bean/common/CommonStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/bean/common/CommonStatefulSBImpl.java
@@ -38,12 +38,12 @@ public class CommonStatefulSBImpl implements CommonStatefulSB {
     @PostConstruct
     private void init() {
         serial = 0;
-        log.infof("New SFSB created: %s.", this);
+        log.debugf("New SFSB created: %s.", this);
     }
 
     @Override
     public int getSerialAndIncrement() {
-        log.infof("getSerialAndIncrement() called on non-forwarding node %s", getCurrentNode());
+        log.debugf("getSerialAndIncrement() called on non-forwarding node %s", getCurrentNode());
         return serial++;
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/bean/forwarding/AbstractForwardingStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/forwarding/bean/forwarding/AbstractForwardingStatefulSBImpl.java
@@ -47,7 +47,7 @@ public abstract class AbstractForwardingStatefulSBImpl {
             try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
                 bean = directory.lookupStateful("RemoteStatefulSBImpl", RemoteStatefulSB.class);
             } catch (Exception e) {
-                log.infof("exception occurred looking up ejb on forwarding node %s", getCurrentNode());
+                log.debugf("exception occurred looking up ejb on forwarding node %s", getCurrentNode());
                 throw new RuntimeException(e);
             }
         }
@@ -55,7 +55,7 @@ public abstract class AbstractForwardingStatefulSBImpl {
     }
 
     public int getSerialAndIncrement() {
-        log.infof("getSerialAndIncrement() called on forwarding node %s", getCurrentNode());
+        log.debugf("getSerialAndIncrement() called on forwarding node %s", getCurrentNode());
         return forward().getSerialAndIncrement();
     }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/byteman/LastNodeToLeaveRemoteEJBTestCase.java
@@ -130,7 +130,7 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
         public String selectNode(String clusterName, String[] connectedNodes, String[] totalAvailableNodes) {
             Set<String> connectedNodesSet = Arrays.asList(connectedNodes).stream().collect(Collectors.toSet());
             Set<String> totalNodesSet = Arrays.asList(totalAvailableNodes).stream().collect(Collectors.toSet());
-            LOGGER.infof("Calling ClusterNodeSelector.selectNode(%s,%s,%s)", clusterName, connectedNodesSet, totalNodesSet);
+            LOGGER.debugf("Calling ClusterNodeSelector.selectNode(%s,%s,%s)", clusterName, connectedNodesSet, totalNodesSet);
             return ClusterNodeSelector.DEFAULT.selectNode(clusterName, connectedNodes, totalAvailableNodes);
         }
     }
@@ -175,14 +175,14 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
     public void testDNRContentsAfterLastNodeToLeave() throws Exception {
 
         List<Future<?>> futures = new ArrayList<>(THREADS);
-        LOGGER.info("\n *** Starting test case test()\n");
-        LOGGER.info("*** Started nodes = " + getStartedNodes());
+        LOGGER.debugf("%n *** Starting test case test()%n");
+        LOGGER.debugf("*** Started nodes = %s", getStartedNodes());
 
         ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
         for (int i = 0; i < THREADS; ++i) {
             // start a client thread
             Runnable task = () -> {
-                LOGGER.infof("\n *** Starting test thread %s\n", Thread.currentThread().getName());
+                LOGGER.debugf("%s *** Starting test thread %s%s", Thread.currentThread().getName());
                 EJBClientContext oldContext = null;
                 try {
                     // install the correct EJB client context
@@ -193,28 +193,28 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
                     // look up the IncrementorBean and repeatedly invoke on it
                     try (NamingEJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
                         Incrementor bean = directory.lookupStateless(StatelessIncrementorBean.class, Incrementor.class);
-                        LOGGER.info("\n +++ Looked up bean for thread " + Thread.currentThread().getName() + " \n");
+                        LOGGER.debugf("%s +++ Looked up bean for thread %s%n", Thread.currentThread().getName());
 
                         while (!Thread.currentThread().isInterrupted()) {
                             try {
                                 // invoke on the incrementor bean and note where it executes
-                                LOGGER.info("\n +++ Thread " + Thread.currentThread().getName() + " invoking on bean...\n");
+                                LOGGER.debugf("%s +++ Thread %s invoking on bean...%n", Thread.currentThread().getName());
 
                                 Result<Integer> result = bean.increment();
                                 String target = result.getNode();
-                                LOGGER.info("\n +++ Thread " + Thread.currentThread().getName() + " got result " + result.getValue() + " from node " + target + "\n");
+                                LOGGER.debugf("%s +++ Thread %s got result %s from node %s%n", Thread.currentThread().getName(), result.getValue(), target);
                                 Thread.sleep(INVOCATION_WAIT);
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                             } catch (NoSuchEJBException e) {
-                                LOGGER.info("\n +++ Got NoSuchEJBException from node, skipping...\n");
+                                LOGGER.debugf("%n +++ Got NoSuchEJBException from node, skipping...%n");
                             }
                         }
                     } catch (NamingException | EJBException e) {
-                        System.out.println("\n +++ Exception looking up bean for thread " + Thread.currentThread().getName() + " \n");
+                        LOGGER.errorf("%n +++ Exception looking up bean for thread %s%n", Thread.currentThread().getName());
                         assertNull("Cause of EJBException has not been removed", e.getCause());
                     }
-                    LOGGER.infof("\n *** Stopping test thread %s\n", Thread.currentThread().getName());
+                    LOGGER.debugf("%n *** Stopping test thread %s%n", Thread.currentThread().getName());
                 } finally {
                     if (oldContext != null) {
                         EJBClientContext.getContextManager().setThreadDefault(null);
@@ -229,27 +229,27 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
 
         // now shutdown the entire cluster then start one node back up again, to check last node behaviour
 
-        LOGGER.info("\n *** Stopping node " + NODE_3 + "\n");
+        LOGGER.debugf("%n *** Stopping node %s%n", NODE_3);
         stop(NODE_3);
-        LOGGER.info("*** Started nodes = " + getStartedNodes());
+        LOGGER.debugf("*** Started nodes = %s", getStartedNodes());
         // Let the system stabilize
         Thread.sleep(GRACE_TIME_TO_MEMBERSHIP_CHANGE);
 
-        LOGGER.info("\n *** Stopping node " + NODE_2 + "\n");
+        LOGGER.debugf("%n*** Stopping node %s%n", NODE_2);
         stop(NODE_2);
-        LOGGER.info("*** Started nodes = " + getStartedNodes());
+        LOGGER.debugf("*** Started nodes = %s", getStartedNodes());
         // Let the system stabilize
         Thread.sleep(GRACE_TIME_TO_MEMBERSHIP_CHANGE);
 
-        LOGGER.info("\n *** Stopping node " + NODE_1 + "\n");
+        LOGGER.debugf("%n *** Stopping node %s%n", NODE_1);
         stop(NODE_1);
-        LOGGER.info("*** Started nodes = " + getStartedNodes());
+        LOGGER.debugf("*** Started nodes = %s", getStartedNodes());
         // Let the system stabilize
         Thread.sleep(GRACE_TIME_TO_MEMBERSHIP_CHANGE);
 
-        LOGGER.info("\n *** Starting node " + NODE_1 + "\n");
+        LOGGER.debugf("%n *** Starting node %s%n", NODE_1);
         start(NODE_1);
-        LOGGER.info("*** Started nodes = " + getStartedNodes());
+        LOGGER.debugf("*** Started nodes = %s", getStartedNodes());
         // Let the system stabilize
         Thread.sleep(GRACE_TIME_TO_MEMBERSHIP_CHANGE);
 
@@ -266,13 +266,13 @@ public class LastNodeToLeaveRemoteEJBTestCase extends AbstractClusteringTestCase
         // validate the test
         for (Map.Entry<String, List<List<Set<String>>>> entry: results.entrySet()) {
             String thread = entry.getKey();
-            LOGGER.infof("Collected data for thread: %s", thread);
+            LOGGER.debugf("Collected data for thread: %s", thread);
             List<List<Set<String>>> nodeEntries = entry.getValue();
             for (List<Set<String>> nodeEntry : nodeEntries) {
                 Set<String> startedNodes = nodeEntry.get(0);
                 Set<String> connectedNodes = nodeEntry.get(1);
                 Set<String> totalAvailableNodes = nodeEntry.get(2);
-                LOGGER.infof("started nodes = %s, connected nodes = %s, total available nodes = %s", startedNodes, connectedNodes, totalAvailableNodes);
+                LOGGER.debugf("started nodes = %s, connected nodes = %s, total available nodes = %s", startedNodes, connectedNodes, totalAvailableNodes);
 
                 Assert.assertTrue("Assertion violation: thread " + thread + " has stale nodes in discovered node registry(DNR): " +
                         " started = " + startedNodes + ", connected = " + connectedNodes + ", total available = " + totalAvailableNodes,

--- a/testsuite/integration/clustering/src/test/resources/logging.properties
+++ b/testsuite/integration/clustering/src/test/resources/logging.properties
@@ -21,10 +21,9 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.ejb.client,org.jboss.arquillian
-logger.org.jboss.arquillian.level=INFO
-logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.ejb.client.level=DEBUG
+loggers=sun.rmi,org.jboss.ejb.client,org.jboss.as.test.clustering,org.jboss.arquillian
+logger.org.jboss.ejb.client.level=${test.ejb.client.level:INFO}
+logger.org.jboss.as.test.clustering.level=${test.clustering.level:INFO}
 logger.sun.rmi.level=WARNING
 
 # Root logger level
@@ -33,16 +32,8 @@ logger.level=INFO
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=DEBUG
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log

--- a/testsuite/integration/elytron/src/test/resources/logging.properties
+++ b/testsuite/integration/elytron/src/test/resources/logging.properties
@@ -1,6 +1,6 @@
 #
 # JBoss, Home of Professional Open Source.
-# Copyright 2017, Red Hat, Inc., and individual contributors
+# Copyright 2020, Red Hat, Inc., and individual contributors
 # as indicated by the @author tags. See the copyright.txt file in the
 # distribution for a full listing of individual contributors.
 #
@@ -20,44 +20,24 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 
-# Additional loggers to configure (the root logger is always configured)
-loggers=com.arjuna,jacorb,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi,jacorb.config
+# Additional logger names to configure (root logger is always configured)
+loggers=
 
+# Root logger level
 logger.level=INFO
+
+# Root logger handlers
 logger.handlers=FILE
 
-logger.com.arjuna.level=WARN
-logger.com.arjuna.useParentHandlers=true
-
-logger.jacorb.level=WARN
-logger.jacorb.useParentHandlers=true
-
-logger.org.jboss.as.config.level=DEBUG
-logger.org.jboss.as.config.useParentHandlers=true
-
-logger.org.apache.directory.level=WARN
-logger.org.apache.directory.useParentHandlers=true
-
-logger.sun.rmi.level=WARN
-logger.sun.rmi.useParentHandlers=true
-
-logger.jacorb.config.level=ERROR
-logger.jacorb.config.useParentHandlers=true
-
-handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
-handler.FILE.level=ALL
-handler.FILE.formatter=PATTERN
-handler.FILE.properties=autoFlush,append,fileName,suffix
-handler.FILE.constructorProperties=fileName,append
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
 handler.FILE.append=true
-handler.FILE.fileName=${org.jboss.boot.log.file:target/boot.log}
-handler.FILE.suffix=.yyyy-MM-dd
 
-formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
-
+# Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/testsuite/integration/iiop/src/test/resources/logging.properties
+++ b/testsuite/integration/iiop/src/test/resources/logging.properties
@@ -31,16 +31,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=ALL
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -50,6 +42,3 @@ handler.FILE.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/legacy-ejb-client/src/test/resources/logging.properties
+++ b/testsuite/integration/legacy-ejb-client/src/test/resources/logging.properties
@@ -31,19 +31,10 @@ logger.sun.rmi.level=WARNING
 logger.level=WARN
 
 # Root logger handlers
-#logger.handlers=FILE, CONSOLE
-logger.handlers=CONSOLE
-
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
+logger.handlers=FILE
 
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -54,6 +45,3 @@ handler.FILE.append=true
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi=

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLRealmSetupTool.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLRealmSetupTool.java
@@ -120,7 +120,7 @@ public class SSLRealmSetupTool {
         operation.get(OP_ADDR).set(secRealmAddress);
         operation.get(OP).set(ADD);
         ModelNode result = managementClient.getControllerClient().execute(operation);
-        log.infof("Adding security realm %s with result %s", SECURITY_REALM_NAME, result);
+        log.debugf("Adding security realm %s with result %s", SECURITY_REALM_NAME, result);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // Adding SERVER IDENTITY
@@ -138,7 +138,7 @@ public class SSLRealmSetupTool {
         operation.get("keystore-path").set(KEYSTORES_ABSOLUTE_PATH + File.separator + SERVER_KEYSTORE_FILENAME);
         operation.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         result = managementClient.getControllerClient().execute(operation);
-        log.infof("Setting server-identity ssl for realm %s (password %s, keystore path %s) with result %s", SECURITY_REALM_NAME,
+        log.debugf("Setting server-identity ssl for realm %s (password %s, keystore path %s) with result %s", SECURITY_REALM_NAME,
                 SERVER_KEYSTORE_PASSWORD, KEYSTORES_ABSOLUTE_PATH, result.get(OUTCOME));
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
@@ -172,7 +172,7 @@ public class SSLRealmSetupTool {
         operation.get("connector-ref").set("https");
         operation.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         result = managementClient.getControllerClient().execute(operation);
-        log.infof("Adding HTTPS connector", result);
+        log.debugf("Adding HTTPS connector", result);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
     }
 
@@ -192,7 +192,7 @@ public class SSLRealmSetupTool {
         operation.get(OP).set(REMOVE);
         operation.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         ModelNode result = managementClient.getControllerClient().execute(operation);
-        log.infof("remove HTTPS connector", result);
+        log.debugf("remove HTTPS connector", result);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
         ServerReload.executeReloadAndWaitForCompletion(managementClient);
 
@@ -217,7 +217,7 @@ public class SSLRealmSetupTool {
         operation.get(OP).set(REMOVE);
         operation.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
         result = managementClient.getControllerClient().execute(operation);
-        log.infof("Removing security realm %s with result %s", SECURITY_REALM_NAME, result);
+        log.debugf("Removing security realm %s with result %s", SECURITY_REALM_NAME, result);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
         controller.stop(SSLEJBRemoteClientTestCase.DEFAULT_JBOSSAS);
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/jca/workmanager/distributed/AbstractDwmTestCase.java
@@ -138,7 +138,7 @@ public abstract class AbstractDwmTestCase {
         ModelNode operation = new ModelNode();
         operation.get(OP).set("take-snapshot");
         ModelNode result = execute(client, operation);
-        log.info("Snapshot of current configuration taken: " + result.asString());
+        log.debugf("Snapshot of current configuration taken: %s", result);
         return result.asString();
     }
 
@@ -326,7 +326,7 @@ public abstract class AbstractDwmTestCase {
     private void setUpServer(ModelControllerClient client ,String containerId) throws IOException {
         ModelControllerClient mcc = CONTAINER_0.equals(containerId) ? createClient1() : createClient2();
 
-        log.info("Setting up Policy/Selector: " + getPolicy() + "/" + getSelector() + " on server " + containerId);
+        log.debugf("Setting up Policy/Selector: %s/%s on server %s", getPolicy(), getSelector(), containerId);
         ModelNode addBasicDwm = addBasicDwm();
         ModelNode setUpPolicy = setUpPolicy(getPolicy());
         ModelNode setUpPolicyOptions = setUpWatermarkPolicyOption(getWatermarkPolicyOption());
@@ -339,10 +339,10 @@ public abstract class AbstractDwmTestCase {
         }
         ModelNode compositeOp = ModelUtil.createCompositeNode(operationList.toArray(new ModelNode[1]));
         ModelNode result = mcc.execute(compositeOp);
-        log.info("Setting up DWM on server " + containerId + ": " + result);
+        log.debugf("Setting up DWM on server %s: %s", containerId, result);
 
         result = mcc.execute(setUpCustomContext());
-        log.info("Setting up CustomContext on server " + containerId + ": " + result);
+        log.debugf("Setting up CustomContext on server %s: %s", containerId, result);
 
         mcc.close();
     }

--- a/testsuite/integration/manualmode/src/test/resources/logging.properties
+++ b/testsuite/integration/manualmode/src/test/resources/logging.properties
@@ -22,8 +22,7 @@
 
 # Additional logger names to configure (root logger is always configured)
 loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory,org.jboss.as.cli
-logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=DEBUG
+logger.org.jboss.as.test.level=${test.log.level:INFO}
 logger.org.apache.directory.level=WARNING
 logger.org.jboss.as.cli.level=WARNING
 logger.sun.rmi.level=WARNING
@@ -35,16 +34,8 @@ logger.level=INFO
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -54,6 +45,3 @@ handler.FILE.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
+++ b/testsuite/integration/microprofile-tck/fault-tolerance/src/test/java/org/wildfly/extension/microprofile/faulttolerance/tck/FaultToleranceApplicationArchiveProcessor.java
@@ -23,10 +23,10 @@ package org.wildfly.extension.microprofile.faulttolerance.tck;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.logging.Logger;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.Node;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -52,7 +52,7 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         if (!(applicationArchive instanceof ClassContainer)) {
-            LOGGER.warning(
+            LOGGER.warn(
                     "Unable to add additional classes - not a class/resource container: "
                             + applicationArchive);
             return;
@@ -81,7 +81,7 @@ public class FaultToleranceApplicationArchiveProcessor implements ApplicationArc
         }
         classContainer.addAsResource(new StringAsset(config), MP_CONFIG_PATH);
 
-        LOGGER.info("Added additional resources to " + applicationArchive.toString(true));
+        LOGGER.debug("Added additional resources to " + applicationArchive.toString(true));
     }
 
     private ByteArrayOutputStream readCurrentConfig(Archive<?> appArchive) {

--- a/testsuite/integration/multinode/src/test/resources/logging.properties
+++ b/testsuite/integration/multinode/src/test/resources/logging.properties
@@ -21,27 +21,24 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap
-logger.org.jboss.shrinkwrap.level=INFO
+loggers=sun.rmi
 logger.sun.rmi.level=WARNING
 
 # Root logger level
 logger.level=INFO
 
 # Root logger handlers
-logger.handlers=CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,append,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+handler.FILE.append=true
 
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/picketlink/src/test/resources/logging.properties
+++ b/testsuite/integration/picketlink/src/test/resources/logging.properties
@@ -21,26 +21,17 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=sun.rmi,org.jboss.shrinkwrap
-logger.org.jboss.shrinkwrap.level=INFO
+loggers=sun.rmi
 logger.sun.rmi.level=WARNING
 
 # Root logger level
-logger.level=OFF
+logger.level=INFO
 
 # Root logger handlers
-logger.handlers=FILE, CONSOLE
-
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
+logger.handlers=FILE
 
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log

--- a/testsuite/integration/rts/src/test/resources/logging.properties
+++ b/testsuite/integration/rts/src/test/resources/logging.properties
@@ -31,16 +31,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -50,6 +42,3 @@ handler.FILE.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/secman/src/test/resources/logging.properties
+++ b/testsuite/integration/secman/src/test/resources/logging.properties
@@ -23,7 +23,7 @@
 # Additional logger names to configure (root logger is always configured)
 loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
 logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=DEBUG
+logger.org.jboss.as.test.level=${test.log.level:INFO}
 logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
@@ -31,19 +31,17 @@ logger.sun.rmi.level=WARNING
 logger.level=WARN
 
 # Root logger handlers
-logger.handlers=CONSOLE
+logger.handlers=FILE
 
 # Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,append,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+handler.FILE.append=true
 
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/JMSListener.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/jms/auxiliary/JMSListener.java
@@ -6,9 +6,8 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import java.util.concurrent.CountDownLatch;
-import java.util.logging.Logger;
 
-import static java.util.logging.Level.SEVERE;
+import org.jboss.logging.Logger;
 
 @MessageDriven(
     activationConfig = {
@@ -37,12 +36,12 @@ public class JMSListener implements MessageListener {
     @Override
     public void onMessage(Message message) {
         try {
-            logger.info("Message received (async): " + message.getBody(String.class));
+            logger.debug("Message received (async): " + message.getBody(String.class));
 
             latch.countDown();
 
         } catch (JMSException ex) {
-            logger.log(SEVERE, null, ex);
+            logger.error("Error onMessage", ex);
         }
     }
 }

--- a/testsuite/integration/smoke/src/test/resources/logging.properties
+++ b/testsuite/integration/smoke/src/test/resources/logging.properties
@@ -32,16 +32,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -52,6 +44,3 @@ handler.FILE.append=true
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/web/src/test/resources/logging.properties
+++ b/testsuite/integration/web/src/test/resources/logging.properties
@@ -23,7 +23,7 @@
 # Additional logger names to configure (root logger is always configured)
 loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
 logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=DEBUG
+logger.org.jboss.as.test.level=${test.log.level:INFO}
 logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
@@ -33,16 +33,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -52,6 +44,3 @@ handler.FILE.formatter=PATTERN
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/ws/src/test/resources/logging.properties
+++ b/testsuite/integration/ws/src/test/resources/logging.properties
@@ -23,7 +23,7 @@
 # Additional logger names to configure (root logger is always configured)
 loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
 logger.org.jboss.shrinkwrap.level=INFO
-logger.org.jboss.as.test.level=DEBUG
+logger.org.jboss.as.test.level=${test.log.level:INFO}
 logger.org.apache.directory.level=WARNING
 logger.sun.rmi.level=WARNING
 
@@ -33,16 +33,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,append,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log
@@ -53,6 +45,3 @@ handler.FILE.append=true
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
 formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-logger.sun.rmi

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/AtomicTransactionExecutionService.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/AtomicTransactionExecutionService.java
@@ -59,7 +59,7 @@ public class AtomicTransactionExecutionService implements ExecutorService {
 
     @Override
     public void init(String activationServiceUrl, String remoteServiceUrl) {
-        LOGGER.infof("initialising with activationServiceUrl=%s and remoteServiceUrl=%s", activationServiceUrl,
+        LOGGER.debugf("initialising with activationServiceUrl=%s and remoteServiceUrl=%s", activationServiceUrl,
                 remoteServiceUrl);
 
         if (!wasInitialised) {
@@ -79,42 +79,42 @@ public class AtomicTransactionExecutionService implements ExecutorService {
     @Override
     public void begin() throws Exception {
         assert currentTransaction == null : "Transaction already started";
-        LOGGER.infof("trying to start a new transaction");
+        LOGGER.debugf("trying to start a new transaction");
 
         UserTransaction.getUserTransaction().begin();
         currentTransaction = TransactionManager.getTransactionManager().suspend();
 
-        LOGGER.infof("started transaction %s", currentTransaction);
+        LOGGER.debugf("started transaction %s", currentTransaction);
     }
 
     @Override
     public void commit() throws Exception {
         assert currentTransaction != null : "No active transaction";
-        LOGGER.infof("trying to commit transaction %s", currentTransaction);
+        LOGGER.debugf("trying to commit transaction %s", currentTransaction);
 
         TransactionManager.getTransactionManager().resume(currentTransaction);
         UserTransaction.getUserTransaction().commit();
         currentTransaction = null;
 
-        LOGGER.infof("committed transaction");
+        LOGGER.debugf("committed transaction");
     }
 
     @Override
     public void rollback() throws Exception {
         assert currentTransaction != null : "No active transaction";
-        LOGGER.infof("trying to rollback transaction %s", currentTransaction);
+        LOGGER.debugf("trying to rollback transaction %s", currentTransaction);
 
         TransactionManager.getTransactionManager().resume(currentTransaction);
         UserTransaction.getUserTransaction().rollback();
         currentTransaction = null;
 
-        LOGGER.infof("rolled back transaction");
+        LOGGER.debugf("rolled back transaction");
     }
 
     @Override
     public void enlistParticipant() throws Exception {
         assert currentTransaction != null : "No active transaction";
-        LOGGER.infof("trying to enlist participant to the transaction %s", currentTransaction);
+        LOGGER.debugf("trying to enlist participant to the transaction %s", currentTransaction);
 
         TransactionManager.getTransactionManager().resume(currentTransaction);
         String participantId = new Uid().stringForm();
@@ -122,20 +122,20 @@ public class AtomicTransactionExecutionService implements ExecutorService {
         TransactionManager.getTransactionManager().enlistForVolatileTwoPhase(transactionParticipant, participantId);
         currentTransaction = TransactionManager.getTransactionManager().suspend();
 
-        LOGGER.infof("enlisted participant %s", transactionParticipant);
+        LOGGER.debugf("enlisted participant %s", transactionParticipant);
     }
 
     @Override
     public void execute() throws Exception {
         assert remoteService != null : "Remote service was not initialised";
         assert currentTransaction != null : "No active transaction";
-        LOGGER.infof("trying to execute remote service in transaction %s", currentTransaction);
+        LOGGER.debugf("trying to execute remote service in transaction %s", currentTransaction);
 
         TransactionManager.getTransactionManager().resume(currentTransaction);
         remoteService.execute();
         currentTransaction = TransactionManager.getTransactionManager().suspend();
 
-        LOGGER.infof("executed remote service");
+        LOGGER.debugf("executed remote service");
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/AtomicTransactionRemoteService.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/AtomicTransactionRemoteService.java
@@ -44,7 +44,7 @@ public class AtomicTransactionRemoteService implements RemoteService {
 
     @Override
     public void execute() throws Exception {
-        LOGGER.infof("trying to enlist participant to the transaction %s",
+        LOGGER.debugf("trying to enlist participant to the transaction %s",
                 TransactionManager.getTransactionManager().currentTransaction());
 
         String participantId = new Uid().stringForm();
@@ -52,7 +52,7 @@ public class AtomicTransactionRemoteService implements RemoteService {
         TransactionManager.getTransactionManager().enlistForVolatileTwoPhase(transactionParticipant,
                 transactionParticipant.getId());
 
-        LOGGER.infof("enlisted participant %s", transactionParticipant);
+        LOGGER.debugf("enlisted participant %s", transactionParticipant);
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/TransactionParticipant.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsat/TransactionParticipant.java
@@ -49,12 +49,12 @@ public class TransactionParticipant implements Volatile2PCParticipant {
     }
 
     public static void resetInvocations() {
-        LOGGER.infof("resetting invocations %s", INVOCATIONS);
+        LOGGER.debugf("resetting invocations %s", INVOCATIONS);
         INVOCATIONS.clear();
     }
 
     public static List<String> getInvocations() {
-        LOGGER.infof("returning invocations %s", INVOCATIONS);
+        LOGGER.debugf("returning invocations %s", INVOCATIONS);
         return Collections.unmodifiableList(INVOCATIONS);
     }
 
@@ -65,32 +65,32 @@ public class TransactionParticipant implements Volatile2PCParticipant {
     @Override
     public Vote prepare() throws WrongStateException, SystemException {
         INVOCATIONS.add("prepare");
-        LOGGER.infof("preparing call on %s", this);
+        LOGGER.debugf("preparing call on %s", this);
         return new Prepared();
     }
 
     @Override
     public void commit() throws WrongStateException, SystemException {
         INVOCATIONS.add("commit");
-        LOGGER.infof("commit call on %s", this);
+        LOGGER.debugf("commit call on %s", this);
     }
 
     @Override
     public void rollback() throws WrongStateException, SystemException {
         INVOCATIONS.add("rollback");
-        LOGGER.infof("rollback call on %s", this);
+        LOGGER.debugf("rollback call on %s", this);
     }
 
     @Override
     public void unknown() throws SystemException {
         INVOCATIONS.add("unknown");
-        LOGGER.infof("unknown call on %s", this);
+        LOGGER.debugf("unknown call on %s", this);
     }
 
     @Override
     public void error() throws SystemException {
         INVOCATIONS.add("error");
-        LOGGER.infof("error call on %s", this);
+        LOGGER.debugf("error call on %s", this);
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityExecutionService.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityExecutionService.java
@@ -62,7 +62,7 @@ public class BusinessActivityExecutionService implements ExecutorService {
 
     @Override
     public void init(String activationServiceUrl, String remoteServiceUrl) {
-        LOGGER.infof("initialising with activationServiceUrl=%s and remoteServiceUrl=%s", activationServiceUrl,
+        LOGGER.debugf("initialising with activationServiceUrl=%s and remoteServiceUrl=%s", activationServiceUrl,
                 remoteServiceUrl);
 
         if (!wasInitialised) {
@@ -82,42 +82,42 @@ public class BusinessActivityExecutionService implements ExecutorService {
     @Override
     public void begin() throws Exception {
         assert currentActivity == null : "Business activity already started";
-        LOGGER.infof("trying to begin transaction on %s", XTSPropertyManager.getWSCEnvironmentBean().getCoordinatorURL11());
+        LOGGER.debugf("trying to begin transaction on %s", XTSPropertyManager.getWSCEnvironmentBean().getCoordinatorURL11());
 
         UserBusinessActivity.getUserBusinessActivity().begin();
         currentActivity = BusinessActivityManager.getBusinessActivityManager().suspend();
 
-        LOGGER.infof("started business activity %s", currentActivity);
+        LOGGER.debugf("started business activity %s", currentActivity);
     }
 
     @Override
     public void commit() throws Exception {
         assert currentActivity != null : "No active business activity";
-        LOGGER.infof("trying to close business activity %s", currentActivity);
+        LOGGER.debugf("trying to close business activity %s", currentActivity);
 
         BusinessActivityManager.getBusinessActivityManager().resume(currentActivity);
         UserBusinessActivity.getUserBusinessActivity().close();
         currentActivity = null;
 
-        LOGGER.infof("closed business activity");
+        LOGGER.debugf("closed business activity");
     }
 
     @Override
     public void rollback() throws Exception {
         assert currentActivity != null : "No active business activity";
-        LOGGER.infof("trying to cancel business activity %s", currentActivity);
+        LOGGER.debugf("trying to cancel business activity %s", currentActivity);
 
         BusinessActivityManager.getBusinessActivityManager().resume(currentActivity);
         UserBusinessActivity.getUserBusinessActivity().cancel();
         currentActivity = null;
 
-        LOGGER.infof("canceled business activity");
+        LOGGER.debugf("canceled business activity");
     }
 
     @Override
     public void enlistParticipant() throws Exception {
         assert currentActivity != null : "No active business activity";
-        LOGGER.infof("trying to enlist participant to the business activity %s", currentActivity);
+        LOGGER.debugf("trying to enlist participant to the business activity %s", currentActivity);
 
         BusinessActivityManager.getBusinessActivityManager().resume(currentActivity);
         BusinessActivityParticipant businessActivityParticipant = new BusinessActivityParticipant(new Uid().stringForm());
@@ -127,20 +127,20 @@ public class BusinessActivityExecutionService implements ExecutorService {
         participantManager.completed();
         currentActivity = BusinessActivityManager.getBusinessActivityManager().suspend();
 
-        LOGGER.infof("enlisted participant %s", businessActivityParticipant);
+        LOGGER.debugf("enlisted participant %s", businessActivityParticipant);
     }
 
     @Override
     public void execute() throws Exception {
         assert remoteService != null : "Remote service was not initialised";
         assert currentActivity != null : "No active business activity";
-        LOGGER.infof("trying to execute remote service in business activity %s", currentActivity);
+        LOGGER.debugf("trying to execute remote service in business activity %s", currentActivity);
 
         BusinessActivityManager.getBusinessActivityManager().resume(currentActivity);
         remoteService.execute();
         currentActivity = BusinessActivityManager.getBusinessActivityManager().suspend();
 
-        LOGGER.infof("executed remote service");
+        LOGGER.debugf("executed remote service");
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityParticipant.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityParticipant.java
@@ -49,12 +49,12 @@ public class BusinessActivityParticipant implements BusinessAgreementWithPartici
     }
 
     public static void resetInvocations() {
-        LOGGER.infof("resetting invocations %s", INVOCATIONS);
+        LOGGER.debugf("resetting invocations %s", INVOCATIONS);
         INVOCATIONS.clear();
     }
 
     public static List<String> getInvocations() {
-        LOGGER.infof("returning invocations %s", INVOCATIONS);
+        LOGGER.debugf("returning invocations %s", INVOCATIONS);
         return Collections.unmodifiableList(INVOCATIONS);
     }
 
@@ -65,38 +65,38 @@ public class BusinessActivityParticipant implements BusinessAgreementWithPartici
     @Override
     public void close() throws WrongStateException, SystemException {
         INVOCATIONS.add("close");
-        LOGGER.infof("close call on %s", this);
+        LOGGER.debugf("close call on %s", this);
     }
 
     @Override
     public void cancel() throws FaultedException, WrongStateException, SystemException {
         INVOCATIONS.add("cancel");
-        LOGGER.infof("cancel call on %s", this);
+        LOGGER.debugf("cancel call on %s", this);
     }
 
     @Override
     public void compensate() throws FaultedException, WrongStateException, SystemException {
         INVOCATIONS.add("compensate");
-        LOGGER.infof("compensate call on %s", this);
+        LOGGER.debugf("compensate call on %s", this);
     }
 
     @Override
     public String status() throws SystemException {
         INVOCATIONS.add("status");
-        LOGGER.infof("status call on %s", this);
+        LOGGER.debugf("status call on %s", this);
         return Status.STATUS_ACTIVE;
     }
 
     @Override
     public void unknown() throws SystemException {
         INVOCATIONS.add("unknown");
-        LOGGER.infof("unknown call on %s", this);
+        LOGGER.debugf("unknown call on %s", this);
     }
 
     @Override
     public void error() throws SystemException {
         INVOCATIONS.add("error");
-        LOGGER.infof("error call on %s", this);
+        LOGGER.debugf("error call on %s", this);
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityRemoteService.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/suspend/wsba/BusinessActivityRemoteService.java
@@ -47,7 +47,7 @@ public class BusinessActivityRemoteService implements RemoteService {
 
     @Override
     public void execute() throws Exception {
-        LOGGER.infof("trying to enlist participant to the business activity %s",
+        LOGGER.debugf("trying to enlist participant to the business activity %s",
                 BusinessActivityManager.getBusinessActivityManager().currentTransaction());
 
         String participantId = new Uid().stringForm();
@@ -57,7 +57,7 @@ public class BusinessActivityRemoteService implements RemoteService {
                         businessActivityParticipant.getId());
         participantManager.completed();
 
-        LOGGER.infof("enlisted participant %s", businessActivityParticipant);
+        LOGGER.debugf("enlisted participant %s", businessActivityParticipant);
     }
 
     @Override

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/wsat/service/ATDurableParticipant.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/wsat/service/ATDurableParticipant.java
@@ -86,7 +86,7 @@ public class ATDurableParticipant implements  Durable2PCParticipant, Serializabl
     // TODO: added option for System Exception would be thrown?
     public Vote prepare() throws WrongStateException, SystemException {
         eventLog.addEvent(eventLogName, EventLogEvent.PREPARE);
-        log.infof("[AT SERVICE] Durable participant prepare() - logged: %s", EventLogEvent.PREPARE);
+        log.debugf("[AT SERVICE] Durable participant prepare() - logged: %s", EventLogEvent.PREPARE);
 
         if(ServiceCommand.isPresent(ServiceCommand.VOTE_ROLLBACK, serviceCommands)) {
             log.trace("[AT SERVICE] Durable participant prepare(): " + Aborted.class.getSimpleName());

--- a/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/wsat/service/ATSuperService.java
+++ b/testsuite/integration/xts/src/test/java/org/jboss/as/test/xts/wsat/service/ATSuperService.java
@@ -64,7 +64,7 @@ public abstract class ATSuperService implements AT {
      */
     public void invokeWithCallName(String callName, ServiceCommand[] serviceCommands) throws TestApplicationException {
 
-        log.infof("[AT SERVICE] web method invoke(%s) with eventLog %s", callName, eventLog);
+        log.debugf("[AT SERVICE] web method invoke(%s) with eventLog %s", callName, eventLog);
         eventLog.foundEventLogName(callName);
         UserTransaction userTransaction;
 

--- a/testsuite/integration/xts/src/test/resources/logging.properties
+++ b/testsuite/integration/xts/src/test/resources/logging.properties
@@ -31,16 +31,8 @@ logger.level=WARN
 # Root logger handlers
 logger.handlers=FILE
 
-# Console handler configuration
-handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
-handler.CONSOLE.level=INFO
-handler.CONSOLE.autoFlush=true
-handler.CONSOLE.formatter=PATTERN
-
 # File handler configuration
 handler.FILE=org.jboss.logmanager.handlers.FileHandler
-handler.FILE.level=DEBUG
 handler.FILE.properties=autoFlush,fileName
 handler.FILE.autoFlush=true
 handler.FILE.fileName=./target/test.log

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/CLIServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/CLIServerSetupTask.java
@@ -83,20 +83,20 @@ public class CLIServerSetupTask implements ServerSetupTask {
 
             ModelNode result = managementClient.getControllerClient().execute(commandModel);
 
-            LOG.infof("Executed batch %s with result %s", commands, result.toJSONString(true));
+            LOG.debugf("Executed batch %s with result %s", commands, result.toJSONString(true));
             this.checkResult(result);
         } else {
             for (String command : commands) {
                 ModelNode commandModel = context.buildRequest(command);
                 ModelNode result = managementClient.getControllerClient().execute(commandModel);
 
-                LOG.infof("Executed single command %s with result %s", commands, result.toJSONString(true));
+                LOG.debugf("Executed single command %s with result %s", commands, result.toJSONString(true));
                 this.checkResult(result);
             }
         }
 
         if (reload) {
-            LOG.infof("Reloading server %s if its in a 'reload-required' state.", managementClient.getMgmtAddress());
+            LOG.debugf("Reloading server %s if its in a 'reload-required' state.", managementClient.getMgmtAddress());
             ServerReload.reloadIfRequired(managementClient);
         }
     }


### PR DESCRIPTION
…that log info messages to debug. Clean up the test logging configuration files.

https://issues.redhat.com/browse/WFLY-13489

There are some other log messages that could likely be removed. For now these are just the ones I did.

I've also contemplated removing the duplicate `logging.properties` files. If anyone else feels we should do that let me know and I'll create a single one in the base test suite.