### PR TITLE
[WFLY-13439] - CVE-2020-6950 jsf-impl: Mojarra: Path traversal via ei…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/ForbiddenUrlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/ForbiddenUrlTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * UnallowedUrlTestCase
+ * For more information visit <a href="https://issues.redhat.com/browse/WFLY-13439">https://issues.redhat.com/browse/WFLY-13439</a>
+ * @author Petr Adamec
+ */
+package org.jboss.as.test.integration.jsf.testurl;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+/**
+ * Test if 404 is returned for url address which isn't allowed
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ForbiddenUrlTestCase {
+    private static final String ALLOWED_URL = "faces/javax.faces.resource/lala.js?con=lala";
+    private static final String FORBIDDEN_URL = "faces/javax.faces.resource/lala.js?con=lala/../lala";
+    private static final int ALLOWED_STATUS_CODE = 200;
+    private static final int FORBIDDEN_STATUS_CODE = 404;
+
+    @ArquillianResource
+    private URL url;
+
+
+    @Deployment
+    public static Archive<?> deploy() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "jsf-resources.war");
+        war.addAsWebInfResource(ForbiddenUrlTestCase.class.getPackage(), "web.xml", "web.xml");
+        war.addAsWebResource(ForbiddenUrlTestCase.class.getPackage(), "index.xhtml", "index.xhtml");
+        war.addAsWebResource(ForbiddenUrlTestCase.class.getPackage(), "lala.jsp", "lala.jsp");
+        war.addAsWebResource(ForbiddenUrlTestCase.class.getPackage(), "lala.js", "contracts/lala/lala.js");
+        return war;
+    }
+
+    /**
+     * Test if 200 is returned for allowed url
+     * <br /> For more information see https://issues.redhat.com/browse/WFLY-13439.
+     * @throws Exception
+     */
+    @Test
+    public void testAllowedUrl() throws Exception {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+        try(CloseableHttpClient client = httpClientBuilder.build()) {
+
+            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + ALLOWED_URL);
+            try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
+                int statusCode = getVarResponse.getStatusLine().getStatusCode();
+                Assert.assertEquals("Status code should be " + ALLOWED_STATUS_CODE + ", but is " + statusCode + ". For more information see JBEAP-18842. ", ALLOWED_STATUS_CODE, statusCode);
+            }
+        }
+    }
+
+    /**
+     * Test id 404 is returned fot forbidden url.
+     * <br /> For more information see https://issues.redhat.com/browse/WFLY-13439
+     * @throws Exception
+     */
+    @Test
+    public void testForbiddenUrl() throws Exception {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+
+        try(CloseableHttpClient client = httpClientBuilder.build()) {
+
+            HttpUriRequest getVarRequest = new HttpGet(url.toExternalForm() + FORBIDDEN_URL);
+            try (CloseableHttpResponse getVarResponse = client.execute(getVarRequest)) {
+                int statusCode = getVarResponse.getStatusLine().getStatusCode();
+                Assert.assertEquals("Status code should be " + FORBIDDEN_STATUS_CODE + ", but is " + statusCode + ". For more information see JBEAP-18842. ", FORBIDDEN_STATUS_CODE, statusCode);
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/index.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/index.xhtml
@@ -1,0 +1,24 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns = "http://www.w3.org/1999/xhtml"
+   xmlns:f = "http://java.sun.com/jsf/core"    
+   xmlns:h = "http://java.sun.com/jsf/html">
+   
+   <h:head>
+      <title>JSF Tutorial!</title>
+      <h:outputStylesheet library="default" name="css/bootstrap.css"/> 
+      <h:outputScript library="default" name="js/jquery-3.4.1.js"/>
+   </h:head>
+   
+   <h:body>
+      <h2>h:outputStylesheet example</h2>
+      <hr />
+      <h:form>
+         <div class = "message">Hello World!</div>
+      </h:form> 		
+   </h:body>
+
+   <h:outputLink value = "index.xhtml" >refresh</h:outputLink> 
+
+</html> 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/lala.js
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/lala.js
@@ -1,0 +1,1 @@
+// nothing

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/lala.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/lala.jsp
@@ -1,0 +1,17 @@
+<%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@taglib prefix="f" uri="http://java.sun.com/jsf/core"%>
+<%@taglib prefix="h" uri="http://java.sun.com/jsf/html"%>
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<html>
+  <head>
+      <title>JSF Tutorial!</title>
+  </head>
+   
+   <body>
+      <f:view>
+          <h:form>
+              <h:outputText value="Some text..."></h:outputText>
+          </h:form>
+      </f:view>
+   </body>
+</html> 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsf/testurl/web.xml
@@ -1,0 +1,69 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<web-app version="3.1" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd">
+
+    <!--<security-constraint>
+        <display-name>Security Constraint on Conversation</display-name>
+        <web-resource-collection>
+            <web-resource-name>exampleWebApp</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-constraint>
+        <display-name>Security Constraint on Conversation</display-name>
+        <web-resource-collection>
+            <web-resource-name>exampleWebApp</web-resource-name>
+            <url-pattern>/javax.faces.resource/*</url-pattern>
+        </web-resource-collection>
+    </security-constraint>
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>BASIC</realm-name>
+    </login-config>-->
+
+    <welcome-file-list>
+        <welcome-file>faces/index.xhtml</welcome-file>
+    </welcome-file-list>
+
+    <security-role>
+        <description>Role required to log in to the Application</description>
+        <role-name>*</role-name>
+    </security-role>
+	
+   <!-- 
+      FacesServlet is main servlet responsible to handle all request. 
+      It acts as central controller.
+      This servlet initializes the JSF components before the JSP is displayed.
+   -->
+	
+   <servlet>
+      <servlet-name>Faces Servlet</servlet-name>
+      <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+      <load-on-startup>1</load-on-startup>
+   </servlet>
+	
+   <servlet-mapping>
+      <servlet-name>Faces Servlet</servlet-name>
+      <url-pattern>/faces/*</url-pattern>
+   </servlet-mapping>
+	
+   <servlet-mapping>
+      <servlet-name>Faces Servlet</servlet-name>
+      <url-pattern>*.jsf</url-pattern>
+   </servlet-mapping>
+	
+   <servlet-mapping>
+      <servlet-name>Faces Servlet</servlet-name>
+      <url-pattern>*.faces</url-pattern>
+   </servlet-mapping>
+	
+   <servlet-mapping>
+      <servlet-name>Faces Servlet</servlet-name>
+      <url-pattern>*.xhtml</url-pattern>
+   </servlet-mapping>
+	
+</web-app>


### PR DESCRIPTION
ENTSWM-771 - CVE-2020-6950 jsf-impl: Mojarra: Path traversal via either the loc parameter or the con parameter, incomplete fix of CVE-2018-14371 [thorntail-2]

EAP Issue: https://issues.redhat.com/browse/ENTSWM-771
