### PR TITLE
[WFLY-13495] Add missing dependencies for last json-patch update

### DIFF
--- a/ee-galleon-pack/pom.xml
+++ b/ee-galleon-pack/pom.xml
@@ -287,14 +287,44 @@
 
         <dependency>
             <groupId>com.github.fge</groupId>
-            <artifactId>json-patch</artifactId>
+            <artifactId>btf</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>jackson-coreutils</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>json-patch</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>msg-simple</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -220,12 +220,40 @@
 
         <dependency>
             <groupId>com.github.fge</groupId>
-            <artifactId>json-patch</artifactId>
+            <artifactId>btf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>jackson-coreutils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>json-patch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>msg-simple</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -124,6 +124,17 @@
     </dependency>
     <dependency>
       <groupId>com.github.fge</groupId>
+      <artifactId>btf</artifactId>
+      <licenses>
+        <license>
+          <name>GNU Lesser General Public License v3.0 or later</name>
+          <url>https://spdx.org/licenses/LGPL-3.0+.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>com.github.fge</groupId>
       <artifactId>jackson-coreutils</artifactId>
       <licenses>
         <license>
@@ -142,6 +153,17 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
           <distribution>repo</distribution>
         </license>
+        <license>
+          <name>GNU Lesser General Public License v3.0 or later</name>
+          <url>https://spdx.org/licenses/LGPL-3.0+.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>com.github.fge</groupId>
+      <artifactId>msg-simple</artifactId>
+      <licenses>
         <license>
           <name>GNU Lesser General Public License v3.0 or later</name>
           <url>https://spdx.org/licenses/LGPL-3.0+.html</url>

--- a/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/btf/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/btf/main/module.xml
@@ -22,21 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.jackson-coreutils">
+<module xmlns="urn:jboss:module:1.7" name="com.github.fge.btf">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.github.fge:jackson-coreutils}"/>
+        <artifact name="${com.github.fge:btf}"/>
     </resources>
 
-    <dependencies>
-        <module name="com.github.fge.msg-simple" export="true"/>
-        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
-        <module name="com.fasterxml.jackson.core.jackson-core"/>
-        <module name="com.fasterxml.jackson.core.jackson-databind"/>
-        <module name="com.google.guava"/>
-    </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/msg-simple/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/github/fge/msg-simple/main/module.xml
@@ -22,21 +22,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.7" name="com.github.fge.jackson-coreutils">
+<module xmlns="urn:jboss:module:1.7" name="com.github.fge.msg-simple">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${com.github.fge:jackson-coreutils}"/>
+        <artifact name="${com.github.fge:msg-simple}"/>
     </resources>
 
     <dependencies>
-        <module name="com.github.fge.msg-simple" export="true"/>
-        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
-        <module name="com.fasterxml.jackson.core.jackson-core"/>
-        <module name="com.fasterxml.jackson.core.jackson-databind"/>
-        <module name="com.google.guava"/>
+        <module name="com.github.fge.btf" export="true"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -260,8 +260,10 @@
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.10.4</version.com.fasterxml.jackson>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
-        <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
+        <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
+        <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.9</version.com.github.fge.json-patch>
+        <version.com.github.fge.msg-simple>1.1</version.com.github.fge.msg-simple>
         <version.com.github.spullara.mustache>0.9.6</version.com.github.spullara.mustache>
         <version.com.google.code.gson>2.8.6</version.com.google.code.gson>
         <version.com.google.guava>25.0-jre</version.com.google.guava>
@@ -1431,6 +1433,12 @@
 
             <dependency>
                 <groupId>com.github.fge</groupId>
+                <artifactId>btf</artifactId>
+                <version>${version.com.github.fge.btf}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.fge</groupId>
                 <artifactId>jackson-coreutils</artifactId>
                 <version>${version.com.github.fge.jackson-coreutils}</version>
             </dependency>
@@ -1439,6 +1447,12 @@
                 <groupId>com.github.fge</groupId>
                 <artifactId>json-patch</artifactId>
                 <version>${version.com.github.fge.json-patch}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.fge</groupId>
+                <artifactId>msg-simple</artifactId>
+                <version>${version.com.github.fge.msg-simple}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -52,7 +52,6 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <wildfly.dir>${basedir}/target/${wildfly.instance.name}</wildfly.dir>
 
-        <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
         <version.org.hsqldb.hsqldb>2.5.0</version.org.hsqldb.hsqldb>
         <version.org.mock-server.mockserver>5.6.1</version.org.mock-server.mockserver>
         <version.org.mock-server.mockserver-netty>5.6.1</version.org.mock-server.mockserver-netty>
@@ -208,7 +207,6 @@
         <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>jackson-coreutils</artifactId>
-            <version>${version.com.github.fge.jackson-coreutils}</version>
         </dependency>
         <!-- /crl and ocsp -->
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13495

This is a follow up for https://github.com/wildfly/wildfly/pull/12818

By updating to json-patch 1.9 we also need other dependencies to be added which was missed in the original PR. Details are explained at https://issues.redhat.com/browse/RESTEASY-2126

I checked that these changes fix the problem reported at jira, what I am not sure about is whether I layouted the modules changes correctly so I kindly ask someone to confirm that.
Open questions:
* Do we need exclusions on maven dependencies? I can see that current changes generate unexpected license record for com.google.code.findbugs:jsr305 
* Does the order on ee-galleon-pack/pom.xml matter? 

The alternative simplified version without additional modules (as we just need these new dependencies on "classpath" and don't use them in other modules) is proposed at https://github.com/wildfly/wildfly/compare/master...jbliznak:wfly-13495-fix-fge-modules-flatten (this is basically how it is tested on RESTEasy now).

