### PR TITLE
[WFLY-13423] Remove the uses of AbstractOutboundConnectionService fro…

### DIFF
--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -100,6 +100,11 @@ vi:ts=4:sw=4:expandtab
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-network</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-request-controller</artifactId>
         </dependency>
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
@@ -38,7 +38,7 @@ import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.remote.EJBClientContextService;
 import org.jboss.as.ejb3.remote.RemotingProfileService;
-import org.jboss.as.remoting.AbstractOutboundConnectionService;
+import org.jboss.as.network.OutboundConnection;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -220,7 +220,8 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
         }
 
         private static AuthenticationContext transformOne(RemotingProfileService.ConnectionSpec connectionSpec, AuthenticationContext context) {
-            final AbstractOutboundConnectionService connectionService = connectionSpec.getInjector().getValue();
+            final OutboundConnection connectionService = connectionSpec.getInjector().getValue();
+
             AuthenticationConfiguration authenticationConfiguration = connectionService.getAuthenticationConfiguration();
             SSLContext sslContext = connectionService.getSSLContext();
             final URI destinationUri = connectionService.getDestinationUri();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
@@ -22,7 +22,11 @@
 
 package org.jboss.as.ejb3.remote;
 
-import org.jboss.as.remoting.AbstractOutboundConnectionService;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.network.OutboundConnection;
 import org.jboss.ejb.client.EJBTransportProvider;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -32,10 +36,6 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.discovery.ServiceURL;
 import org.xnio.OptionMap;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Service which contains the static configuration data found in an EJB Remoting profile, either in the subsystem or in a
@@ -87,11 +87,11 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
 
     public static final class ConnectionSpec {
         private final String connectionName;
-        private final InjectedValue<AbstractOutboundConnectionService> injector;
+        private final InjectedValue<OutboundConnection> injector;
         private final OptionMap connectOptions;
         private final long connectTimeout;
 
-        public ConnectionSpec(final String connectionName, final InjectedValue<AbstractOutboundConnectionService> injector, final OptionMap connectOptions, final long connectTimeout) {
+        public ConnectionSpec(final String connectionName, final InjectedValue<OutboundConnection> injector, final OptionMap connectOptions, final long connectTimeout) {
             this.connectionName = connectionName;
             this.injector = injector;
             this.connectOptions = connectOptions;
@@ -102,7 +102,7 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
             return connectionName;
         }
 
-        public InjectedValue<AbstractOutboundConnectionService> getInjector() {
+        public InjectedValue<OutboundConnection> getInjector() {
             return injector;
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.RuntimePackageDependency;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfiguration;
@@ -42,6 +43,7 @@ import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfigura
  * User: Jaikiran Pai
  */
 public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
+    private static final String JBOSS_AS_REMOTING = "org.jboss.as.remoting";
 
     public static final String EJB_REMOTE_CAPABILITY_NAME = "org.wildfly.ejb.remote";
 
@@ -99,5 +101,10 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
         super.registerChildren(resourceRegistration);
         // register channel-creation-options as sub model for EJB remote service
         resourceRegistration.registerSubModel(new RemoteConnectorChannelCreationOptionResource());
+    }
+
+    @Override
+    public void registerAdditionalRuntimePackages(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerAdditionalRuntimePackages(RuntimePackageDependency.required(JBOSS_AS_REMOTING));
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -55,7 +55,6 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
-import org.jboss.as.remoting.Attribute;
 import org.jboss.as.threads.ThreadsParser;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -620,7 +619,7 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         writer.writeStartElement(EJB3SubsystemXMLElement.CHANNEL_CREATION_OPTIONS.getLocalName());
         for (final Property optionPropertyModelNode : node.asPropertyList()) {
             writer.writeStartElement(EJB3SubsystemXMLElement.OPTION.getLocalName());
-            writer.writeAttribute(Attribute.NAME.getLocalName(), optionPropertyModelNode.getName());
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.NAME.getLocalName(), optionPropertyModelNode.getName());
             final ModelNode propertyValueModelNode = optionPropertyModelNode.getValue();
             RemoteConnectorChannelCreationOptionResource.CHANNEL_CREATION_OPTION_VALUE.marshallAsAttribute(propertyValueModelNode, writer);
             RemoteConnectorChannelCreationOptionResource.CHANNEL_CREATION_OPTION_TYPE.marshallAsAttribute(propertyValueModelNode, writer);

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -67,7 +67,7 @@
         <module name="org.wildfly.iiop-openjdk"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.jboss.as.remoting"/>
+        <module name="org.jboss.as.remoting" optional="true"/>
         <module name="org.jboss.as.security"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>


### PR DESCRIPTION
…m ejb3 subsystem

It requires a core upgrade. Depends on: https://github.com/wildfly/wildfly-core/pull/4213

- Provisions `org.jboss.as.remoting` always when EJB3RemoteResourceDefinition is present.
- Replaces the uses of `org.jboss.as.remoting.AbstractOutboundConnectionService` in favor of `org.jboss.as.network.OutboundConnection` and get it from the capability

Jira issue: https://issues.redhat.com/browse/WFLY-13423
