### PR TITLE
WFLY-13503 [GSS](7.3.z) Websphere MQ Resource Adapter Configuration Does Not Take Effect Until Reboot

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/AdminObjectAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/AdminObjectAdd.java
@@ -128,5 +128,9 @@ public class AdminObjectAdd extends AbstractAddStepHandler {
         final Resource aoResource = new IronJacamarResource.IronJacamarRuntimeResource();
 
         resource.registerChild(peAO, aoResource);
+
+        if(!context.isBooting()){
+            context.reloadRequired();
+        }
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
@@ -228,6 +228,9 @@ public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
 
             resource.registerChild(peExtended, extendedResource);
 
+            if(!context.isBooting()){
+                context.reloadRequired();
+            }
 
         } catch (Exception e) {
             throw new OperationFailedException(e, new ModelNode().set(ConnectorLogger.ROOT_LOGGER.failedToCreate("ConnectionDefinition", operation, e.getLocalizedMessage())));

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/afterresourcecreation/AfterResourceCreationDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/afterresourcecreation/AfterResourceCreationDeploymentTestCase.java
@@ -39,6 +39,7 @@ import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsyst
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
@@ -95,6 +96,7 @@ public class AfterResourceCreationDeploymentTestCase extends ContainerResourceMg
         operation.get(OP).set("activate");
         operation.get(OP_ADDR).set(address);
         executeOperation(operation);
+        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
 
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/configproperty/ConfigPropertyTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyAdminObjectInterface;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyConnection;
 import org.jboss.as.test.smoke.deployment.rar.configproperty.ConfigPropertyConnectionFactory;
@@ -126,6 +127,8 @@ public class ConfigPropertyTestCase {
             operationConfigConn.get(OP_ADDR).set(addressConfigConn);
             operationConfigConn.get("value").set("B");
             executeOperation(operationConfigConn);
+
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/earpackage/EarPackagedDeploymentTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsyst
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
@@ -61,6 +62,7 @@ public class EarPackagedDeploymentTestCase {
             String xml = FileUtils.readFile(EarPackagedDeploymentTestCase.class, "ear_packaged.xml");
             List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
             executeOperation(operationListToCompositeOperation(operations));
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiactivation/MultipleActivationTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
@@ -63,6 +64,7 @@ public class MultipleActivationTestCase {
             String xml = FileUtils.readFile(MultipleActivationTestCase.class, "simple.xml");
             List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
             executeOperation(operationListToCompositeOperation(operations));
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectactivation/MultipleObjectActivationTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject2;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
@@ -64,6 +65,7 @@ public class MultipleObjectActivationTestCase {
             String xml = FileUtils.readFile(MultipleObjectActivationTestCase.class, "multiple.xml");
             List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
             executeOperation(operationListToCompositeOperation(operations));
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/multiobjectpartialactivation/MultipleObjectPartialActivationTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask
 import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
@@ -62,6 +63,7 @@ public class MultipleObjectPartialActivationTestCase {
             String xml = FileUtils.readFile(MultipleObjectPartialActivationTestCase.class, "multiple_part.xml");
             List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
             executeOperation(operationListToCompositeOperation(operations));
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/raconnection/RaTestConnectionTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsyst
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -68,6 +69,7 @@ public class RaTestConnectionTestCase extends ContainerResourceMgmtTestBase {
             String xml = FileUtils.readFile(RaTestConnectionTestCase.class, "testcon_multiple.xml");
             List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
             executeOperation(operationListToCompositeOperation(operations));
+            ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
         }
 
         @Override

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/deployment/rar/tests/redeployment/ReDeploymentTestCase.java
@@ -41,6 +41,7 @@ import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsyst
 import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1;
 import org.jboss.as.test.smoke.deployment.rar.MultipleConnectionFactory1;
 import org.jboss.dmr.ModelNode;
@@ -99,6 +100,7 @@ public class ReDeploymentTestCase extends ContainerResourceMgmtTestBase {
         operation.get(OP).set("activate");
         operation.get(OP_ADDR).set(address);
         executeOperation(operation);
+        ServerReload.executeReloadAndWaitForCompletion(getModelControllerClient());
 
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13503