### PR TITLE
[WFLY-13526] Upgrade WildFly Core 12.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13526

Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/12.0.0.Beta3...12.0.0.Beta4

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

## Release Notes - WildFly Core - Version 12.0.0.Beta4
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4937'>WFCORE-4937</a>] -         Upgrade FasterXML from 2.10.3 to 2.10.4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4986'>WFCORE-4986</a>] -         Upgrade WildFly Elytron to 1.12.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4955'>WFCORE-4955</a>] -         Create a wildfly-network OutboundConnection interface from AbstractOutboundConnectionService; expose via capabilities
</li>
</ul>
                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4976'>WFCORE-4976</a>] -         Where ModelControllerClient is initialised in process with CBH AuthenticationConfiguration takes priority.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4982'>WFCORE-4982</a>] -         Remove streaming from DeploymentUnitPhaseService
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4983'>WFCORE-4983</a>] -         Fix bootable jar failing tests
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4974'>WFCORE-4974</a>] -         Test runner Server start and stop timeouts are too low
</li>
</ul>
                                    