### PR TITLE
full-feature-pack-licenses: add missing license for com.github.fge:jackson-coreutils

### DIFF
--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -138,6 +138,11 @@
       <artifactId>jackson-coreutils</artifactId>
       <licenses>
         <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
           <name>GNU Lesser General Public License v3.0 or later</name>
           <url>https://spdx.org/licenses/LGPL-3.0+.html</url>
           <distribution>repo</distribution>


### PR DESCRIPTION
See license file: https://github.com/fge/jackson-coreutils/blob/1.8/LICENSE