### PR TITLE
[WFLY-13550] Upgrade WildFly Core 12.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.0.Beta4</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.20.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.12.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13550

Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/12.0.0.Beta4...12.0.0.Final

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

## Release Notes - WildFly Core - Version 12.0.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4899'>WFCORE-4899</a>] -         Upgrade jboss-modules from 1.10.0.Final to 1.10.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4988'>WFCORE-4988</a>] -         Upgrade Undertow from 2.1.1.Final to 2.1.2.Final
</li>
</ul>
                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4950'>WFCORE-4950</a>] -         Regression: Legacy Ldap Realm securing EJB with JDK8 not working
</li>
</ul>
                                            