### PR TITLE
[WFLY-13490] Add Galleon layer for web console

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -165,6 +165,10 @@ Layers that you combine with "use-case tailored" layers to extend the capabiliti
 * _observability_: Support for MicroProfile monitoring and configuration features. 
 Includes Health support (optional), _microprofile-config_ (optional), _microprofile-metrics_ (optional) and _open-tracing_ (optional).
 
+Tools layers:
+
+* _web-console_: Support for HAL web console.
+
 ==== WildFly servlet layers
 
 Basic layers:

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/web-console/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/web-console/layer-spec.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="web-console">
+    <dependencies>
+        <layer name="secure-management"/>
+    </dependencies>
+    <packages>
+        <package name="org.jboss.as.console"/>
+    </packages>
+</layer-spec>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1201,6 +1201,84 @@
                                 </configuration>
                             </execution>
 
+                            <!-- Provision a server with Web Console -->
+                            <execution>
+                                <id>web-console-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-web-console</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>web-console</layer>
+                                                <layer>datasources-web-server</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+
+                            <!-- Provision a server with Web Console combined with cloud-server to configure metrics -->
+                            <execution>
+                                <id>web-console-cloud-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-web-console-cloud</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>web-console</layer>
+                                                <layer>cloud-server</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+
                         </executions>
                     </plugin>
                     <plugin>
@@ -1363,6 +1441,61 @@
                                         <include>org/jboss/as/test/integration/jpa/**/NonTransactionalEmTestCase.java</include>
                                         <!-- WebJPATestCase is currently the only test that does not need EJB -->
                                         <include>org/jboss/as/test/integration/jpa/**/WebJPATestCase.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+
+                            <!-- Tests against a server provisioned with the Web Console -->
+                            <execution>
+                                <id>web-console-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-web-console</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-web-console</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-web-console</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-web-console</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-web-console</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-web-console/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-web-console</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                                    <includes>
+                                        <!-- notice HttpManagementConstantHeadersTestCase#testHeadersOverrideNonManagementEndpoint will be ignored because the provisioning don't configure metrics -->
+                                        <include>org/jboss/as/test/integration/management/console/*TestCase.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+
+                            <!-- Tests against a server provisioned with the Web Console -->
+                            <execution>
+                                <id>web-console-cloud-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-web-console-cloud</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-web-console-cloud</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-web-console-cloud</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-web-console-cloud</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-web-console-cloud</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-web-console-cloud/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-web-console-cloud</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/management/console/*TestCase.java</include>
                                     </includes>
                                 </configuration>
                             </execution>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2115,6 +2115,42 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>web-console-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/web-console</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>web-console</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>all-layers-provisioning-full</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -2196,6 +2232,7 @@
                                                 <layer>undertow-load-balancer</layer>
                                                 <layer>vault</layer>
                                                 <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
                                                 <layer>web-server</layer>
                                             </layers>
                                         </config>
@@ -2203,7 +2240,7 @@
                                 </configuration>
                             </execution>
 
-                            <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
+                           <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
                             <execution>
                                 <id>all-layers-jpa-distributed-provisioning-full</id>
                                 <goals>
@@ -2286,6 +2323,7 @@
                                                 <layer>undertow-load-balancer</layer>
                                                 <layer>vault</layer>
                                                 <layer>web-clustering</layer>
+                                                <layer>web-console</layer>
                                                 <layer>web-server</layer>
                                             </layers>
                                             <excluded-layers>


### PR DESCRIPTION
This supersedes: https://github.com/wildfly/wildfly/pull/13302

It is the same PR but this one includes the integration tests available on WildFly tests suite for the Web Console.

One of those tests is ignored in the case of layers is enabled. The ignored test verifies header overriding for a non management endpoint, using the metrics endpoint. However when the web console is supplied via a Galleon Layer there is no other non management endpoint, so the test is ignored for layers provisioning.

Jira issue: https://issues.redhat.com/browse/WFLY-13490
Proposal: https://github.com/wildfly/wildfly-proposals/pull/312