### PR TITLE
[WFLY-13421] / [WFLY-13553] JSF Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>2.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>2.0.0.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>2.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
-        <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.3_spec>3.0.0.SP02</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.3_spec>
+        <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.3_spec>3.0.0.SP03</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.3_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>2.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>
         <version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>2.0.0.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <version.com.squareup.okhttp3>3.9.0</version.com.squareup.okhttp3>
         <version.com.squareup.okio>1.13.0</version.com.squareup.okio>
         <version.com.sun.activation.jakarta.activation>1.2.1</version.com.sun.activation.jakarta.activation>
-        <version.com.sun.faces>2.3.9.SP09</version.com.sun.faces>
+        <version.com.sun.faces>2.3.9.SP10</version.com.sun.faces>
         <version.com.sun.istack>3.0.10</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.13</version.com.sun.xml.fastinfoset>
         <version.commons-beanutils>1.9.4</version.commons-beanutils>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13421
https://issues.redhat.com/browse/WFLY-13553

Mojarra 2.3.9.SP10 includes the following bug fixes:
* [[WFLY-13497](https://issues.redhat.com/browse/WFLY-13497)] - Wrong behaviour in JSF UIInput's component
* [[WFLY-13556](https://issues.redhat.com/browse/WFLY-13556)] - Memory leak in FlashScope - expired elements are not cleared

jboss-jsf-api 3.0.0.SP03 includes the following bug fix:
* [[WFLY-13497](https://issues.redhat.com/browse/WFLY-13497)] - Wrong behaviour in JSF UIInput's component
