### PR TITLE
[WFLY-12171] toss the ejb-xa-recovery file permissions out of ejb client tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/client/descriptor/EJBClientDescriptorTestCase.java
@@ -22,12 +22,10 @@
 
 package org.jboss.as.test.integration.ejb.client.descriptor;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+
 import javax.ejb.EJBException;
 import javax.naming.Context;
 
@@ -111,10 +109,7 @@ public class EJBClientDescriptorTestCase {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_ONE + ".jar");
         jar.addPackage(EchoBean.class.getPackage());
-        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return jar;
     }
 
@@ -123,10 +118,7 @@ public class EJBClientDescriptorTestCase {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JBOSS_EJB_CLIENT_1_2_MODULE_NAME + ".jar");
         jar.addPackage(EchoBean.class.getPackage());
-        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client_1_2.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client_1_2.xml", "jboss-ejb-client.xml");
         return jar;
     }
 
@@ -135,10 +127,7 @@ public class EJBClientDescriptorTestCase {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_TWO + ".jar");
         jar.addPackage(EchoBean.class.getPackage());
-        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "no-ejb-receiver-jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "no-ejb-receiver-jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return jar;
     }
 
@@ -147,10 +136,7 @@ public class EJBClientDescriptorTestCase {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME_THREE + ".jar");
         jar.addPackage(EchoBean.class.getPackage());
-        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "local-and-remote-receiver-jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "local-and-remote-receiver-jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return jar;
     }
 
@@ -160,10 +146,7 @@ public class EJBClientDescriptorTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JBOSS_EJB_CLIENT_WITH_PROPERTIES_1_2_MODULE_NAME + ".jar");
         jar.addPackage(EchoBean.class.getPackage());
         jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client_with_properties_1_2.xml", "jboss-ejb-client.xml");
-        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client_with_properties_1_2.properties", "jboss.properties")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+        jar.addAsManifestResource(EJBClientDescriptorTestCase.class.getPackage(), "jboss-ejb-client_with_properties_1_2.properties", "jboss.properties");
 
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/propagation/RunAsWithElytronEJBContextPropagationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/propagation/RunAsWithElytronEJBContextPropagationTestCase.java
@@ -21,9 +21,6 @@
  */
 package org.jboss.as.test.integration.ejb.security.runas.propagation;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-
 import java.io.File;
 import java.util.Properties;
 
@@ -85,10 +82,7 @@ public class RunAsWithElytronEJBContextPropagationTestCase extends AbstractCliTe
         final JavaArchive ejbClientJar = ShrinkWrap.create(JavaArchive.class, EJB_TEST_MODULE_NAME + ".jar");
         ejbClientJar.addClass(IntermediateCallerInRole.class).addClass(IntermediateCallerInRoleRemote.class)
                 .addClass(CallerInRole.class).addClass(ServerCallerInRole.class).addAsManifestResource(
-                        IntermediateCallerInRole.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery"),
-                        createFilePermission("read,write", "standalone", "data", "ejb-xa-recovery", "-")
-                ), "permissions.xml");
+                        IntermediateCallerInRole.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return ejbClientJar;
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/RemoteOutboundConnectionReconnectTestCase.java
@@ -22,13 +22,10 @@
 
 package org.jboss.as.test.manualmode.ejb.client.outbound.connection;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Properties;
+
 import javax.naming.Context;
 import javax.naming.NamingException;
 
@@ -104,12 +101,7 @@ public class RemoteOutboundConnectionReconnectTestCase {
     public static Archive<?> createContainer2Deployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, SERVER_ONE_MODULE_NAME + ".jar");
         ejbJar.addClasses(EchoOnServerOne.class, RemoteEcho.class, IndependentBean.class);
-        ejbJar.addAsManifestResource(EchoOnServerOne.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "basedir"
-                        , Arrays.asList("target", "jbossas-with-remote-outbound-connection", "standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write", "basedir"
-                                , Arrays.asList("target", "jbossas-with-remote-outbound-connection", "standalone", "data", "ejb-xa-recovery", "-"))
-                ), "permissions.xml");
+        ejbJar.addAsManifestResource(EchoOnServerOne.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return ejbJar;
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ElytronRemoteOutboundConnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/security/ElytronRemoteOutboundConnectionTestCase.java
@@ -22,8 +22,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SSL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +29,6 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.security.Provider;
-import java.util.Arrays;
 import java.util.Properties;
 
 import javax.ejb.NoSuchEJBException;
@@ -190,12 +187,7 @@ public class ElytronRemoteOutboundConnectionTestCase {
         final JavaArchive ejbClientJar = ShrinkWrap.create(JavaArchive.class, OUTBOUND_CONNECTION_MODULE_NAME + ".jar");
         ejbClientJar.addClass(WhoAmI.class)
                 .addClass(IntermediateWhoAmI.class)
-                .addAsManifestResource(IntermediateWhoAmI.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "basedir"
-                         , Arrays.asList("target", OUTBOUND_CONNECTION_SERVER, "standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write", "basedir"
-                                , Arrays.asList("target", OUTBOUND_CONNECTION_SERVER, "standalone", "data", "ejb-xa-recovery", "-"))
-                ), "permissions.xml");
+                .addAsManifestResource(IntermediateWhoAmI.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         return ejbClientJar;
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/transaction/preparehalt/TransactionPropagationPrepareHaltTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/outbound/connection/transaction/preparehalt/TransactionPropagationPrepareHaltTestCase.java
@@ -100,11 +100,7 @@ public class TransactionPropagationPrepareHaltTestCase {
             .addPackage(TestXAResource.class.getPackage())
             .addAsManifestResource(EchoOnServerOne.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml")
             .addAsManifestResource(createPermissionsXmlAsset(
-                new RuntimePermission("exitVM", "none"),
-                createFilePermission("read,write", "basedir",
-                    Arrays.asList("target", "jbossas-with-remote-outbound-connection", "standalone", "data", "ejb-xa-recovery")),
-                createFilePermission("read,write", "basedir",
-                    Arrays.asList("target", "jbossas-with-remote-outbound-connection", "standalone", "data", "ejb-xa-recovery", "-"))
+                new RuntimePermission("exitVM", "none")
                 ), "permissions.xml")
             .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts\n"), "MANIFEST.MF");
         return jar;
@@ -118,8 +114,9 @@ public class TransactionPropagationPrepareHaltTestCase {
             .addPackages(true, TestXAResource.class.getPackage())
             .addAsManifestResource(createPermissionsXmlAsset(
                 new PropertyPermission("jboss.server.data.dir", "read"),
-                createFilePermission("read,write", "basedir", Arrays.asList("target", "wildfly", "standalone", "data")),
-                createFilePermission("read,write", "basedir", Arrays.asList("target", "wildfly", "standalone", "data", "-"))
+                // PersistentTestXAResource requires the following permissions
+                createFilePermission("read", "basedir", Arrays.asList("target", "wildfly", "standalone", "data")),
+                createFilePermission("read,write", "basedir", Arrays.asList("target", "wildfly", "standalone", "data", "PersistentTestXAResource"))
             ), "permissions.xml")
             .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts\n"), "MANIFEST.MF");
         return jar;

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/RemoteCallClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/RemoteCallClientInterceptorTestCase.java
@@ -22,10 +22,8 @@
 
 package org.jboss.as.test.multinode.clientinterceptor;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import java.security.SecurityPermission;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -75,11 +73,7 @@ public class RemoteCallClientInterceptorTestCase {
         jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         jar.addAsManifestResource(
                 createPermissionsXmlAsset(
-                        new SecurityPermission("putProviderProperty.WildFlyElytron"),createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
-
+                        new SecurityPermission("putProviderProperty.WildFlyElytron")),
                 "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/multiple/MultipleClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/multiple/MultipleClientInterceptorTestCase.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.test.multinode.clientinterceptor.multiple;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.fail;
 import java.security.SecurityPermission;
@@ -83,11 +82,7 @@ public class MultipleClientInterceptorTestCase {
         jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         jar.addAsManifestResource(
                 createPermissionsXmlAsset(
-                        new SecurityPermission("putProviderProperty.WildFlyElytron"),createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
-
+                        new SecurityPermission("putProviderProperty.WildFlyElytron")),
                 "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/protocol/RemoteProtocolChangeClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/protocol/RemoteProtocolChangeClientInterceptorTestCase.java
@@ -22,10 +22,8 @@
 package org.jboss.as.test.multinode.clientinterceptor.protocol;
 
 import static org.jboss.as.test.shared.TestSuiteEnvironment.getSystemProperty;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import java.security.SecurityPermission;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
@@ -86,10 +84,7 @@ public class RemoteProtocolChangeClientInterceptorTestCase {
         jar.addAsManifestResource(RemoteProtocolChangeClientInterceptorTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
         jar.addAsManifestResource(
                 createPermissionsXmlAsset(
-                        new SecurityPermission("putProviderProperty.WildFlyElytron"),createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
+                        new SecurityPermission("putProviderProperty.WildFlyElytron"),
                         new PropertyPermission("management.address", "read"),
                         new PropertyPermission("node0", "read"),
                         new PropertyPermission("jboss.http.port", "read"),

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/secured/SecuredBeanClientInterceptorTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/clientinterceptor/secured/SecuredBeanClientInterceptorTestCase.java
@@ -21,10 +21,8 @@
  */
 package org.jboss.as.test.multinode.clientinterceptor.secured;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import java.security.SecurityPermission;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -92,14 +90,10 @@ public class SecuredBeanClientInterceptorTestCase {
         war.addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
         war.addAsManifestResource(
                 createPermissionsXmlAsset(
-                        new SecurityPermission("putProviderProperty.WildFlyElytron"),createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-")),
+                        new SecurityPermission("putProviderProperty.WildFlyElytron"),
                         new ElytronPermission("getSecurityDomain"),
                         new RuntimePermission("getProtectionDomain"),
                         new AuthPermission("modifyPrincipals")),
-
                 "permissions.xml");
         return war;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
@@ -29,10 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
-import java.util.Arrays;
 import javax.ejb.EJBException;
 import javax.naming.InitialContext;
 
@@ -127,12 +124,7 @@ public class RemoteLocalCallProfileTestCase {
     public static Archive<?> deployment1() {
         JavaArchive jar = createJar(ARCHIVE_NAME_CLIENT);
         jar.addClasses(RemoteLocalCallProfileTestCase.class);
-        jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
-                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
-                        "permissions.xml");
+        jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml");
         return jar;
     }
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallTestCase.java
@@ -22,11 +22,9 @@
 
 package org.jboss.as.test.multinode.remotecall;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.security.SecurityPermission;
-import java.util.Arrays;
 import javax.ejb.EJBException;
 import javax.naming.InitialContext;
 
@@ -75,11 +73,7 @@ public class RemoteLocalCallTestCase {
         jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         jar.addAsManifestResource(
                 createPermissionsXmlAsset(
-                        new SecurityPermission("putProviderProperty.WildFlyElytron"),createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
-
+                        new SecurityPermission("putProviderProperty.WildFlyElytron")),
                 "permissions.xml");
         return jar;
     }

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/TransactionInvocationTestCase.java
@@ -22,19 +22,6 @@
 
 package org.jboss.as.test.multinode.transaction;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
-
-import java.io.IOException;
-import java.util.Arrays;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.transaction.HeuristicMixedException;
-import javax.transaction.HeuristicRollbackException;
-import javax.transaction.NotSupportedException;
-import javax.transaction.RollbackException;
-import javax.transaction.SystemException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -44,6 +31,15 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.NotSupportedException;
+import javax.transaction.RollbackException;
+import javax.transaction.SystemException;
+import java.io.IOException;
 
 /**
  * A simple EJB Remoting transaction context propagation in JTS style from one AS7 server to another.
@@ -72,11 +68,7 @@ public class TransactionInvocationTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, CLIENT_DEPLOYMENT + ".jar");
         jar.addClasses(ClientEjb.class, TransactionalRemote.class, TransactionInvocationTestCase.class,
                 TransactionalStatefulRemote.class);
-        jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write", "jbossas.multinode.client",
-                        Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write", "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))
-                ), "permissions.xml");
+        jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         return jar;
     }
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/async/TransactionPropagationTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/transaction/async/TransactionPropagationTestCase.java
@@ -22,12 +22,6 @@
 
 package org.jboss.as.test.multinode.transaction.async;
 
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
-import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
-
-import java.util.Arrays;
-import javax.naming.InitialContext;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -37,6 +31,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import javax.naming.InitialContext;
 
 /**
  * <p>
@@ -64,12 +59,7 @@ public class TransactionPropagationTestCase {
     public static Archive<?> clientDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, CLIENT_DEPLOYMENT + ".jar");
         jar.addPackage(TransactionPropagationTestCase.class.getPackage());
-        jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml")
-                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
-                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
-                        createFilePermission("read,write",
-                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
-                        "permissions.xml");
+        jar.addAsManifestResource("META-INF/jboss-ejb-client-receivers.xml", "jboss-ejb-client.xml");
         return jar;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
@@ -23,17 +23,10 @@
 package org.jboss.as.test.shared.integration.ejb.security;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FilePermission;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.Permission;
-import java.util.Arrays;
-import java.util.Iterator;
 
 import nu.xom.Attribute;
 import nu.xom.Document;
@@ -46,7 +39,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class PermissionUtils {
-
     public static Asset createPermissionsXmlAsset(Permission... permissions) {
         final Element permissionsElement = new Element("permissions");
         permissionsElement.setNamespaceURI("http://xmlns.jcp.org/xml/ns/javaee");
@@ -80,77 +72,6 @@ public final class PermissionUtils {
         } catch (IOException e) {
             throw new IllegalStateException("Generating permissions.xml failed", e);
         }
-    }
-
-    /**
-     * Creates a new {@link FilePermission} with the base path of the system property {@code jboss.inst}.
-     *
-     * @param action the actions required
-     * @param paths  the relative parts of the path
-     *
-     * @return the new file permission
-     *
-     * @see FilePermission
-     * @see #createFilePermission(String, String, Iterable)
-     */
-    public static FilePermission createFilePermission(final String action, final String... paths) {
-        return createFilePermission(action, "jboss.inst", Arrays.asList(paths));
-    }
-
-    /**
-     * Creates a new {@link FilePermission}.
-     * <p>
-     * The paths are iterated with a {@link java.io.File#separatorChar} be placed after each path portion. The
-     * {@code sysPropKey} is used to resolve the base directory which the {@code paths} will be appended to.
-     * </p>
-     * <p>
-     * The base path is validated and must exist as well as be a directory. The path is converted to an
-     * {@linkplain Path#toAbsolutePath() absolute} path as well as {@linkplain Path#normalize() normalized}.
-     * </p>
-     * <pre>
-     * {@code
-     * // The following produces the absolute path of target/wildfly/standalone/tmp/example/*
-     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "tmp", "example", "*"));
-     *
-     * // The following produces the absolute path of target/wildfly/standalone/data/-
-     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "data", "-"));
-     *
-     * // The following produces the absolute path of target/wildfly/standalone/data/example
-     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "data", "example"));
-     * }
-     * </pre>
-     *
-     * @param action     the actions required
-     * @param sysPropKey the system property key to resolve the base directory
-     * @param paths      the relative parts of the path to be appended to the base directory
-     *
-     * @return the new file permission
-     *
-     * @see FilePermission
-     */
-    public static FilePermission createFilePermission(final String action, final String sysPropKey, final Iterable<String> paths) {
-        final String prop = System.getProperty(sysPropKey);
-        if (prop == null) {
-            throw new IllegalArgumentException(String.format("Could not find the system property %s", sysPropKey));
-        }
-        final Path base = Paths.get(prop);
-        if (Files.notExists(base)) {
-            throw new RuntimeException(String.format("The system property %s resolved to %s which does not exist.", sysPropKey, base));
-        }
-        if (!Files.isDirectory(base)) {
-            throw new RuntimeException(String.format("The system property %s resolved to %s which is not a directory.", sysPropKey, base));
-        }
-        final StringBuilder path = new StringBuilder(256)
-                .append(base.toAbsolutePath().normalize())
-                .append(File.separatorChar);
-        final Iterator<String> iter = paths.iterator();
-        while (iter.hasNext()) {
-            path.append(iter.next());
-            if (iter.hasNext()) {
-                path.append(File.separatorChar);
-            }
-        }
-        return new FilePermission(path.toString(), action);
     }
 
     static class NiceSerializer extends Serializer {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
@@ -23,10 +23,17 @@
 package org.jboss.as.test.shared.integration.ejb.security;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FilePermission;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Permission;
+import java.util.Arrays;
+import java.util.Iterator;
 
 import nu.xom.Attribute;
 import nu.xom.Document;
@@ -39,6 +46,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class PermissionUtils {
+
     public static Asset createPermissionsXmlAsset(Permission... permissions) {
         final Element permissionsElement = new Element("permissions");
         permissionsElement.setNamespaceURI("http://xmlns.jcp.org/xml/ns/javaee");
@@ -72,6 +80,77 @@ public final class PermissionUtils {
         } catch (IOException e) {
             throw new IllegalStateException("Generating permissions.xml failed", e);
         }
+    }
+
+    /**
+     * Creates a new {@link FilePermission} with the base path of the system property {@code jboss.inst}.
+     *
+     * @param action the actions required
+     * @param paths  the relative parts of the path
+     *
+     * @return the new file permission
+     *
+     * @see FilePermission
+     * @see #createFilePermission(String, String, Iterable)
+     */
+    public static FilePermission createFilePermission(final String action, final String... paths) {
+        return createFilePermission(action, "jboss.inst", Arrays.asList(paths));
+    }
+
+    /**
+     * Creates a new {@link FilePermission}.
+     * <p>
+     * The paths are iterated with a {@link java.io.File#separatorChar} be placed after each path portion. The
+     * {@code sysPropKey} is used to resolve the base directory which the {@code paths} will be appended to.
+     * </p>
+     * <p>
+     * The base path is validated and must exist as well as be a directory. The path is converted to an
+     * {@linkplain Path#toAbsolutePath() absolute} path as well as {@linkplain Path#normalize() normalized}.
+     * </p>
+     * <pre>
+     * {@code
+     * // The following produces the absolute path of target/wildfly/standalone/tmp/example/*
+     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "tmp", "example", "*"));
+     *
+     * // The following produces the absolute path of target/wildfly/standalone/data/-
+     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "data", "-"));
+     *
+     * // The following produces the absolute path of target/wildfly/standalone/data/example
+     * createFilePermission("read", "jboss.inst", Arrays.asList("standalone", "data", "example"));
+     * }
+     * </pre>
+     *
+     * @param action     the actions required
+     * @param sysPropKey the system property key to resolve the base directory
+     * @param paths      the relative parts of the path to be appended to the base directory
+     *
+     * @return the new file permission
+     *
+     * @see FilePermission
+     */
+    public static FilePermission createFilePermission(final String action, final String sysPropKey, final Iterable<String> paths) {
+        final String prop = System.getProperty(sysPropKey);
+        if (prop == null) {
+            throw new IllegalArgumentException(String.format("Could not find the system property %s", sysPropKey));
+        }
+        final Path base = Paths.get(prop);
+        if (Files.notExists(base)) {
+            throw new RuntimeException(String.format("The system property %s resolved to %s which does not exist.", sysPropKey, base));
+        }
+        if (!Files.isDirectory(base)) {
+            throw new RuntimeException(String.format("The system property %s resolved to %s which is not a directory.", sysPropKey, base));
+        }
+        final StringBuilder path = new StringBuilder(256)
+                .append(base.toAbsolutePath().normalize())
+                .append(File.separatorChar);
+        final Iterator<String> iter = paths.iterator();
+        while (iter.hasNext()) {
+            path.append(iter.next());
+            if (iter.hasNext()) {
+                path.append(File.separatorChar);
+            }
+        }
+        return new FilePermission(path.toString(), action);
     }
 
     static class NiceSerializer extends Serializer {


### PR DESCRIPTION
Please don't merge this yet, it needs to be properly tested first.

https://issues.redhat.com/browse/WFLY-12171