### PR TITLE
WFLY-13063: adjust sizes of id cache and confirmation window

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -35,7 +35,6 @@ import static org.jboss.dmr.ModelType.LONG;
 import static org.wildfly.extension.messaging.activemq.jms.Validators.noDuplicateElements;
 
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
-import org.apache.activemq.artemis.core.config.impl.FileConfiguration;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
@@ -104,8 +103,11 @@ public interface CommonAttributes {
             .addFlag(GAUGE_METRIC)
             .build();
 
+    /**
+     * @see ActiveMQDefaultConfiguration#DEFAULT_BRIDGE_CONFIRMATION_WINDOW_SIZE
+     */
     SimpleAttributeDefinition BRIDGE_CONFIRMATION_WINDOW_SIZE = create("confirmation-window-size", INT)
-            .setDefaultValue(new ModelNode(FileConfiguration.DEFAULT_CONFIRMATION_WINDOW_SIZE))
+            .setDefaultValue(new ModelNode(1024 * 1024 * 10))
             .setMeasurementUnit(BYTES)
             .setRequired(false)
             .setAllowExpression(true)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -100,7 +100,14 @@ import org.wildfly.extension.messaging.activemq.jms.ExternalPooledConnectionFact
  * Domain extension that integrates Apache ActiveMQ 6.
  *
  * <dl>
- * <dt><strong>Current</strong> - WildFly 20</dt>
+ * <dt><strong>Current</strong> - WildFly 21</dt>
+ *   <dd>
+ *     <ul>
+ *       <li>XML namespace: urn:jboss:domain:messaging-activemq:11.0
+ *       <li>Management model: 11.0.0
+ *     </ul>
+ *   </dd>
+ * <dt>WildFly 20</dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging-activemq:10.0
@@ -227,6 +234,7 @@ public class MessagingExtension implements Extension {
 
     static final String RESOURCE_NAME = MessagingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
+    protected static final ModelVersion VERSION_11_0_0 = ModelVersion.create(11, 0, 0);
     protected static final ModelVersion VERSION_10_0_0 = ModelVersion.create(10, 0, 0);
     protected static final ModelVersion VERSION_9_0_0 = ModelVersion.create(9, 0, 0);
     protected static final ModelVersion VERSION_8_0_0 = ModelVersion.create(8, 0, 0);
@@ -237,9 +245,9 @@ public class MessagingExtension implements Extension {
     protected static final ModelVersion VERSION_3_0_0 = ModelVersion.create(3, 0, 0);
     protected static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
     protected static final ModelVersion VERSION_1_0_0 = ModelVersion.create(1, 0, 0);
-    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_10_0_0;
+    private static final ModelVersion CURRENT_MODEL_VERSION = VERSION_11_0_0;
 
-    private static final MessagingSubsystemParser_10_0 CURRENT_PARSER = new MessagingSubsystemParser_10_0();
+    private static final MessagingSubsystemParser_11_0 CURRENT_PARSER = new MessagingSubsystemParser_11_0();
 
     // ARTEMIS-2273 introduced audit logging at a info level which is rather verbose. We need to use static loggers
     // to ensure the log levels are set to WARN and there is a strong reference to the loggers. This hack will likely
@@ -351,6 +359,7 @@ public class MessagingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_7_0.NAMESPACE, MessagingSubsystemParser_7_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_8_0.NAMESPACE, MessagingSubsystemParser_8_0::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_9_0.NAMESPACE, MessagingSubsystemParser_9_0::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_10_0.NAMESPACE, CURRENT_PARSER);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_10_0.NAMESPACE, MessagingSubsystemParser_10_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MessagingSubsystemParser_11_0.NAMESPACE, CURRENT_PARSER);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_11_0.java
@@ -1,0 +1,678 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.messaging.activemq;
+
+import static org.jboss.as.controller.PathElement.pathElement;
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.IN_VM_CONNECTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_ACCEPTOR;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.REMOTE_CONNECTOR;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
+import org.wildfly.extension.messaging.activemq.ha.LiveOnlyDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationColocatedDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationMasterDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ReplicationSlaveDefinition;
+import org.wildfly.extension.messaging.activemq.ha.ScaleDownAttributes;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreColocatedDefinition;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreMasterDefinition;
+import org.wildfly.extension.messaging.activemq.ha.SharedStoreSlaveDefinition;
+import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
+import org.wildfly.extension.messaging.activemq.jms.bridge.JMSBridgeDefinition;
+import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
+
+/**
+ * Parser and Marshaller for messaging-activemq's {@link #NAMESPACE}.
+ *
+ * <em>All resources and attributes must be listed explicitly and not through any collections.</em>
+ * This ensures that if the resource definitions change in later version (e.g. a new attribute is added),
+ * this will have no impact on parsing this specific version of the subsystem.
+ *
+ * @author Paul Ferraro
+ */
+public class MessagingSubsystemParser_11_0 extends PersistentResourceXMLParser {
+
+    static final String NAMESPACE = "urn:jboss:domain:messaging-activemq:11.0";
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+
+        final PersistentResourceXMLBuilder jgroupDiscoveryGroup = builder(JGroupsDiscoveryGroupDefinition.PATH)
+                .addAttributes(
+                        DiscoveryGroupDefinition.JGROUPS_CHANNEL_FACTORY,
+                        DiscoveryGroupDefinition.JGROUPS_CHANNEL,
+                        CommonAttributes.JGROUPS_CLUSTER,
+                        DiscoveryGroupDefinition.REFRESH_TIMEOUT,
+                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT);
+
+        final PersistentResourceXMLBuilder socketDiscoveryGroup = builder(SocketDiscoveryGroupDefinition.PATH)
+                .addAttributes(
+                        CommonAttributes.SOCKET_BINDING,
+                        DiscoveryGroupDefinition.REFRESH_TIMEOUT,
+                        DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT);
+
+        final PersistentResourceXMLBuilder remoteConnector = builder(pathElement(REMOTE_CONNECTOR))
+                .addAttributes(
+                        RemoteTransportDefinition.SOCKET_BINDING,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder httpConnector = builder(MessagingExtension.HTTP_CONNECTOR_PATH)
+                .addAttributes(
+                        HTTPConnectorDefinition.SOCKET_BINDING,
+                        HTTPConnectorDefinition.ENDPOINT,
+                        HTTPConnectorDefinition.SERVER_NAME,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder invmConnector = builder(pathElement(IN_VM_CONNECTOR))
+                .addAttributes(
+                        InVMTransportDefinition.SERVER_ID,
+                        CommonAttributes.PARAMS);
+
+        final PersistentResourceXMLBuilder connector = builder(pathElement(CONNECTOR))
+                .addAttributes(
+                        GenericTransportDefinition.SOCKET_BINDING,
+                        CommonAttributes.FACTORY_CLASS,
+                        CommonAttributes.PARAMS);
+
+        return builder(MessagingExtension.SUBSYSTEM_PATH, NAMESPACE)
+                .addAttributes(
+                        MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_THREAD_POOL_MAX_SIZE,
+                        MessagingSubsystemRootResourceDefinition.GLOBAL_CLIENT_SCHEDULED_THREAD_POOL_MAX_SIZE)
+                .addChild(httpConnector)
+                .addChild(remoteConnector)
+                .addChild(invmConnector)
+                .addChild(connector)
+                .addChild(jgroupDiscoveryGroup)
+                .addChild(socketDiscoveryGroup)
+                .addChild(builder(MessagingExtension.CONNECTION_FACTORY_PATH)
+                        .addAttributes(
+                                CommonAttributes.HA,
+                                ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
+                                ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                                ConnectionFactoryAttributes.Common.CONNECTORS,
+                                ConnectionFactoryAttributes.Common.ENTRIES,
+                                ConnectionFactoryAttributes.External.ENABLE_AMQ1_PREFIX,
+                                ConnectionFactoryAttributes.Common.USE_TOPOLOGY
+                        ))
+                .addChild(createPooledConnectionFactory(true))
+                .addChild(builder(MessagingExtension.EXTERNAL_JMS_QUEUE_PATH)
+                        .addAttributes(
+                                ConnectionFactoryAttributes.Common.ENTRIES
+                        ))
+                .addChild(builder(MessagingExtension.EXTERNAL_JMS_TOPIC_PATH)
+                        .addAttributes(
+                                ConnectionFactoryAttributes.Common.ENTRIES
+                        ))
+                .addChild(
+                        builder(MessagingExtension.SERVER_PATH)
+                                .addAttributes(// no attribute groups
+                                        ServerDefinition.PERSISTENCE_ENABLED,
+                                        ServerDefinition.PERSIST_ID_CACHE,
+                                        ServerDefinition.PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY,
+                                        ServerDefinition.ID_CACHE_SIZE,
+                                        ServerDefinition.PAGE_MAX_CONCURRENT_IO,
+                                        ServerDefinition.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                        ServerDefinition.THREAD_POOL_MAX_SIZE,
+                                        ServerDefinition.WILD_CARD_ROUTING_ENABLED,
+                                        ServerDefinition.CONNECTION_TTL_OVERRIDE,
+                                        ServerDefinition.ASYNC_CONNECTION_EXECUTION_ENABLED,
+                                        // security
+                                        ServerDefinition.SECURITY_ENABLED,
+                                        ServerDefinition.SECURITY_DOMAIN,
+                                        ServerDefinition.ELYTRON_DOMAIN,
+                                        ServerDefinition.SECURITY_INVALIDATION_INTERVAL,
+                                        ServerDefinition.OVERRIDE_IN_VM_SECURITY,
+                                        // cluster
+                                        ServerDefinition.CLUSTER_USER,
+                                        ServerDefinition.CLUSTER_PASSWORD,
+                                        ServerDefinition.CREDENTIAL_REFERENCE,
+                                        // management
+                                        ServerDefinition.MANAGEMENT_ADDRESS,
+                                        ServerDefinition.MANAGEMENT_NOTIFICATION_ADDRESS,
+                                        ServerDefinition.JMX_MANAGEMENT_ENABLED,
+                                        ServerDefinition.JMX_DOMAIN,
+                                        // journal
+                                        ServerDefinition.JOURNAL_TYPE,
+                                        ServerDefinition.JOURNAL_BUFFER_TIMEOUT,
+                                        ServerDefinition.JOURNAL_BUFFER_SIZE,
+                                        ServerDefinition.JOURNAL_SYNC_TRANSACTIONAL,
+                                        ServerDefinition.JOURNAL_SYNC_NON_TRANSACTIONAL,
+                                        ServerDefinition.LOG_JOURNAL_WRITE_RATE,
+                                        ServerDefinition.JOURNAL_FILE_SIZE,
+                                        ServerDefinition.JOURNAL_MIN_FILES,
+                                        ServerDefinition.JOURNAL_POOL_FILES,
+                                        ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT,
+                                        ServerDefinition.JOURNAL_COMPACT_PERCENTAGE,
+                                        ServerDefinition.JOURNAL_COMPACT_MIN_FILES,
+                                        ServerDefinition.JOURNAL_MAX_IO,
+                                        ServerDefinition.CREATE_BINDINGS_DIR,
+                                        ServerDefinition.CREATE_JOURNAL_DIR,
+                                        ServerDefinition.JOURNAL_DATASOURCE,
+                                        ServerDefinition.JOURNAL_MESSAGES_TABLE,
+                                        ServerDefinition.JOURNAL_BINDINGS_TABLE,
+                                        ServerDefinition.JOURNAL_JMS_BINDINGS_TABLE,
+                                        ServerDefinition.JOURNAL_LARGE_MESSAGES_TABLE,
+                                        ServerDefinition.JOURNAL_PAGE_STORE_TABLE,
+                                        ServerDefinition.JOURNAL_NODE_MANAGER_STORE_TABLE,
+                                        ServerDefinition.JOURNAL_DATABASE,
+                                        ServerDefinition.JOURNAL_JDBC_LOCK_EXPIRATION,
+                                        ServerDefinition.JOURNAL_JDBC_LOCK_RENEW_PERIOD,
+                                        ServerDefinition.JOURNAL_JDBC_NETWORK_TIMEOUT,
+                                        ServerDefinition.GLOBAL_MAX_DISK_USAGE,
+                                        ServerDefinition.DISK_SCAN_PERIOD,
+                                        ServerDefinition.GLOBAL_MAX_MEMORY_SIZE,
+                                        // statistics
+                                        ServerDefinition.STATISTICS_ENABLED,
+                                        ServerDefinition.MESSAGE_COUNTER_SAMPLE_PERIOD,
+                                        ServerDefinition.MESSAGE_COUNTER_MAX_DAY_HISTORY,
+                                        // transaction
+                                        ServerDefinition.TRANSACTION_TIMEOUT,
+                                        ServerDefinition.TRANSACTION_TIMEOUT_SCAN_PERIOD,
+                                        // message expiry
+                                        ServerDefinition.MESSAGE_EXPIRY_SCAN_PERIOD,
+                                        ServerDefinition.MESSAGE_EXPIRY_THREAD_PRIORITY,
+                                        // debug
+                                        ServerDefinition.PERF_BLAST_PAGES,
+                                        ServerDefinition.RUN_SYNC_SPEED_TEST,
+                                        ServerDefinition.SERVER_DUMP_INTERVAL,
+                                        ServerDefinition.MEMORY_MEASURE_INTERVAL,
+                                        ServerDefinition.MEMORY_WARNING_THRESHOLD,
+                                        CommonAttributes.INCOMING_INTERCEPTORS,
+                                        CommonAttributes.OUTGOING_INTERCEPTORS)
+                                .addChild(
+                                        builder(LiveOnlyDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(ReplicationMasterDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.CLUSTER_NAME,
+                                                        HAAttributes.GROUP_NAME,
+                                                        HAAttributes.CHECK_FOR_LIVE_SERVER,
+                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT))
+                                .addChild(
+                                        builder(ReplicationSlaveDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.CLUSTER_NAME,
+                                                        HAAttributes.GROUP_NAME,
+                                                        HAAttributes.ALLOW_FAILBACK,
+                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT,
+                                                        HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE,
+                                                        HAAttributes.RESTART_BACKUP,
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(ReplicationColocatedDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.REQUEST_BACKUP,
+                                                        HAAttributes.BACKUP_REQUEST_RETRIES,
+                                                        HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL,
+                                                        HAAttributes.MAX_BACKUPS,
+                                                        HAAttributes.BACKUP_PORT_OFFSET,
+                                                        HAAttributes.EXCLUDED_CONNECTORS)
+                                                .addChild(
+                                                        builder(ReplicationMasterDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.CLUSTER_NAME,
+                                                                        HAAttributes.GROUP_NAME,
+                                                                        HAAttributes.CHECK_FOR_LIVE_SERVER,
+                                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT))
+                                                .addChild(
+                                                        builder(ReplicationSlaveDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.CLUSTER_NAME,
+                                                                        HAAttributes.GROUP_NAME,
+                                                                        HAAttributes.ALLOW_FAILBACK,
+                                                                        HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT,
+                                                                        HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE,
+                                                                        HAAttributes.RESTART_BACKUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
+                                .addChild(
+                                        builder(SharedStoreMasterDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
+                                .addChild(
+                                        builder(SharedStoreSlaveDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.ALLOW_FAILBACK,
+                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
+                                                        HAAttributes.RESTART_BACKUP,
+                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS))
+                                .addChild(
+                                        builder(SharedStoreColocatedDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HAAttributes.REQUEST_BACKUP,
+                                                        HAAttributes.BACKUP_REQUEST_RETRIES,
+                                                        HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL,
+                                                        HAAttributes.MAX_BACKUPS,
+                                                        HAAttributes.BACKUP_PORT_OFFSET)
+                                                .addChild(
+                                                        builder(SharedStoreMasterDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN))
+                                                .addChild(
+                                                        builder(SharedStoreSlaveDefinition.CONFIGURATION_INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        HAAttributes.ALLOW_FAILBACK,
+                                                                        HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN,
+                                                                        HAAttributes.RESTART_BACKUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CLUSTER_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_GROUP_NAME,
+                                                                        ScaleDownAttributes.SCALE_DOWN_DISCOVERY_GROUP,
+                                                                        ScaleDownAttributes.SCALE_DOWN_CONNECTORS)))
+                                .addChild(
+                                        builder(PathDefinition.BINDINGS_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.BINDINGS_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.JOURNAL_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.JOURNAL_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.LARGE_MESSAGES_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.LARGE_MESSAGES_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(PathDefinition.PAGING_INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        PathDefinition.PATHS.get(CommonAttributes.PAGING_DIRECTORY),
+                                                        PathDefinition.RELATIVE_TO))
+                                .addChild(
+                                        builder(MessagingExtension.QUEUE_PATH)
+                                                .addAttributes(QueueDefinition.ADDRESS,
+                                                        CommonAttributes.DURABLE,
+                                                        CommonAttributes.FILTER,
+                                                        QueueDefinition.ROUTING_TYPE))
+                                .addChild(
+                                        builder(SecuritySettingDefinition.INSTANCE.getPathElement())
+                                                .addChild(
+                                                        builder(SecurityRoleDefinition.INSTANCE.getPathElement())
+                                                                .addAttributes(
+                                                                        SecurityRoleDefinition.SEND,
+                                                                        SecurityRoleDefinition.CONSUME,
+                                                                        SecurityRoleDefinition.CREATE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.DELETE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.MANAGE)))
+                                .addChild(
+                                        builder(AddressSettingDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        CommonAttributes.DEAD_LETTER_ADDRESS,
+                                                        CommonAttributes.EXPIRY_ADDRESS,
+                                                        AddressSettingDefinition.EXPIRY_DELAY,
+                                                        AddressSettingDefinition.REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.REDELIVERY_MULTIPLIER,
+                                                        AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS,
+                                                        AddressSettingDefinition.MAX_REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.MAX_SIZE_BYTES,
+                                                        AddressSettingDefinition.PAGE_SIZE_BYTES,
+                                                        AddressSettingDefinition.PAGE_MAX_CACHE_SIZE,
+                                                        AddressSettingDefinition.ADDRESS_FULL_MESSAGE_POLICY,
+                                                        AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT,
+                                                        AddressSettingDefinition.LAST_VALUE_QUEUE,
+                                                        AddressSettingDefinition.REDISTRIBUTION_DELAY,
+                                                        AddressSettingDefinition.SEND_TO_DLA_ON_NO_ROUTE,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_CHECK_PERIOD,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_POLICY,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD,
+                                                        AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES,
+                                                        AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES,
+                                                        AddressSettingDefinition.AUTO_CREATE_QUEUES,
+                                                        AddressSettingDefinition.AUTO_DELETE_QUEUES,
+                                                        AddressSettingDefinition.AUTO_CREATE_ADDRESSES,
+                                                        AddressSettingDefinition.AUTO_DELETE_ADDRESSES))
+                                .addChild(httpConnector)
+                                .addChild(remoteConnector)
+                                .addChild(invmConnector)
+                                .addChild(connector)
+                                .addChild(
+                                        builder(HTTPAcceptorDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        HTTPAcceptorDefinition.HTTP_LISTENER,
+                                                        HTTPAcceptorDefinition.UPGRADE_LEGACY,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(REMOTE_ACCEPTOR))
+                                                .addAttributes(
+                                                        RemoteTransportDefinition.SOCKET_BINDING,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(IN_VM_ACCEPTOR))
+                                                .addAttributes(
+                                                        InVMTransportDefinition.SERVER_ID,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(pathElement(ACCEPTOR))
+                                                .addAttributes(
+                                                        GenericTransportDefinition.SOCKET_BINDING,
+                                                        CommonAttributes.FACTORY_CLASS,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(MessagingExtension.JGROUPS_BROADCAST_GROUP_PATH)
+                                                .addAttributes(
+                                                        BroadcastGroupDefinition.JGROUPS_CHANNEL_FACTORY,
+                                                        BroadcastGroupDefinition.JGROUPS_CHANNEL,
+                                                        CommonAttributes.JGROUPS_CLUSTER,
+                                                        BroadcastGroupDefinition.BROADCAST_PERIOD,
+                                                        BroadcastGroupDefinition.CONNECTOR_REFS))
+                                .addChild(
+                                        builder(MessagingExtension.SOCKET_BROADCAST_GROUP_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.SOCKET_BINDING,
+                                                        BroadcastGroupDefinition.BROADCAST_PERIOD,
+                                                        BroadcastGroupDefinition.CONNECTOR_REFS))
+                                .addChild(jgroupDiscoveryGroup)
+                                .addChild(socketDiscoveryGroup)
+                                .addChild(
+                                        builder(MessagingExtension.CLUSTER_CONNECTION_PATH)
+                                                .addAttributes(
+                                                        ClusterConnectionDefinition.ADDRESS,
+                                                        ClusterConnectionDefinition.CONNECTOR_NAME,
+                                                        ClusterConnectionDefinition.CHECK_PERIOD,
+                                                        ClusterConnectionDefinition.CONNECTION_TTL,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        ClusterConnectionDefinition.CALL_FAILOVER_TIMEOUT,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
+                                                        ClusterConnectionDefinition.MAX_RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        ClusterConnectionDefinition.RECONNECT_ATTEMPTS,
+                                                        ClusterConnectionDefinition.USE_DUPLICATE_DETECTION,
+                                                        ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE,
+                                                        ClusterConnectionDefinition.MAX_HOPS,
+                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
+                                                        ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE,
+                                                        ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS,
+                                                        ClusterConnectionDefinition.NOTIFICATION_INTERVAL,
+                                                        ClusterConnectionDefinition.CONNECTOR_REFS,
+                                                        ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
+                                                        ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
+                                .addChild(
+                                        builder(GroupingHandlerDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        GroupingHandlerDefinition.TYPE,
+                                                        GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS,
+                                                        GroupingHandlerDefinition.TIMEOUT,
+                                                        GroupingHandlerDefinition.GROUP_TIMEOUT,
+                                                        GroupingHandlerDefinition.REAPER_PERIOD))
+                                .addChild(
+                                        builder(DivertDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        DivertDefinition.ROUTING_NAME,
+                                                        DivertDefinition.ADDRESS,
+                                                        DivertDefinition.FORWARDING_ADDRESS,
+                                                        CommonAttributes.FILTER,
+                                                        CommonAttributes.TRANSFORMER_CLASS_NAME,
+                                                        DivertDefinition.EXCLUSIVE))
+                                .addChild(
+                                        builder(MessagingExtension.BRIDGE_PATH)
+                                                .addAttributes(
+                                                        BridgeDefinition.QUEUE_NAME,
+                                                        BridgeDefinition.FORWARDING_ADDRESS,
+                                                        CommonAttributes.HA,
+                                                        CommonAttributes.FILTER,
+                                                        CommonAttributes.TRANSFORMER_CLASS_NAME,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CHECK_PERIOD,
+                                                        CommonAttributes.CONNECTION_TTL,
+                                                        CommonAttributes.RETRY_INTERVAL,
+                                                        CommonAttributes.RETRY_INTERVAL_MULTIPLIER,
+                                                        CommonAttributes.MAX_RETRY_INTERVAL,
+                                                        BridgeDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        BridgeDefinition.RECONNECT_ATTEMPTS,
+                                                        BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE,
+                                                        BridgeDefinition.USE_DUPLICATE_DETECTION,
+                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
+                                                        BridgeDefinition.PRODUCER_WINDOW_SIZE,
+                                                        BridgeDefinition.USER,
+                                                        BridgeDefinition.PASSWORD,
+                                                        BridgeDefinition.CREDENTIAL_REFERENCE,
+                                                        BridgeDefinition.CONNECTOR_REFS,
+                                                        BridgeDefinition.DISCOVERY_GROUP_NAME))
+                                .addChild(
+                                        builder(ConnectorServiceDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        CommonAttributes.FACTORY_CLASS,
+                                                        CommonAttributes.PARAMS))
+                                .addChild(
+                                        builder(MessagingExtension.JMS_QUEUE_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.DESTINATION_ENTRIES,
+                                                        CommonAttributes.SELECTOR,
+                                                        CommonAttributes.DURABLE,
+                                                        CommonAttributes.LEGACY_ENTRIES))
+                                .addChild(
+                                        builder(MessagingExtension.JMS_TOPIC_PATH)
+                                                .addAttributes(
+                                                        CommonAttributes.DESTINATION_ENTRIES,
+                                                        CommonAttributes.LEGACY_ENTRIES))
+                                .addChild(
+                                        builder(MessagingExtension.CONNECTION_FACTORY_PATH)
+                                                .addAttributes(
+                                                        ConnectionFactoryAttributes.Common.ENTRIES,
+                                                        // common
+                                                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                                                        ConnectionFactoryAttributes.Common.CONNECTORS,
+                                                        CommonAttributes.HA,
+                                                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
+                                                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
+                                                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        CommonAttributes.CLIENT_ID,
+                                                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
+                                                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND,
+                                                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
+                                                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
+                                                        CommonAttributes.MAX_RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
+                                                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                                                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
+                                                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                                                        ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
+                                                        ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
+                                                        ConnectionFactoryAttributes.Common.INITIAL_MESSAGE_PACKET_SIZE,
+                                                        ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
+                                                        ConnectionFactoryAttributes.Common.USE_TOPOLOGY))
+                                .addChild(
+                                        builder(LegacyConnectionFactoryDefinition.INSTANCE.getPathElement())
+                                                .addAttributes(
+                                                        LegacyConnectionFactoryDefinition.ENTRIES,
+                                                        LegacyConnectionFactoryDefinition.DISCOVERY_GROUP,
+                                                        LegacyConnectionFactoryDefinition.CONNECTORS,
+                                                        LegacyConnectionFactoryDefinition.AUTO_GROUP,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_ACKNOWLEDGE,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_DURABLE_SEND,
+                                                        LegacyConnectionFactoryDefinition.BLOCK_ON_NON_DURABLE_SEND,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        LegacyConnectionFactoryDefinition.CACHE_LARGE_MESSAGE_CLIENT,
+                                                        LegacyConnectionFactoryDefinition.CLIENT_FAILURE_CHECK_PERIOD,
+                                                        CommonAttributes.CLIENT_ID,
+                                                        LegacyConnectionFactoryDefinition.COMPRESS_LARGE_MESSAGES,
+                                                        LegacyConnectionFactoryDefinition.CONFIRMATION_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                                                        LegacyConnectionFactoryDefinition.CONNECTION_TTL,
+                                                        LegacyConnectionFactoryDefinition.CONSUMER_MAX_RATE,
+                                                        LegacyConnectionFactoryDefinition.CONSUMER_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.DUPS_OK_BATCH_SIZE,
+                                                        LegacyConnectionFactoryDefinition.FACTORY_TYPE,
+                                                        LegacyConnectionFactoryDefinition.FAILOVER_ON_INITIAL_CONNECTION,
+                                                        LegacyConnectionFactoryDefinition.GROUP_ID,
+                                                        LegacyConnectionFactoryDefinition.INITIAL_CONNECT_ATTEMPTS,
+                                                        LegacyConnectionFactoryDefinition.INITIAL_MESSAGE_PACKET_SIZE,
+                                                        LegacyConnectionFactoryDefinition.HA,
+                                                        LegacyConnectionFactoryDefinition.MAX_RETRY_INTERVAL,
+                                                        LegacyConnectionFactoryDefinition.MIN_LARGE_MESSAGE_SIZE,
+                                                        LegacyConnectionFactoryDefinition.PRE_ACKNOWLEDGE,
+                                                        LegacyConnectionFactoryDefinition.PRODUCER_MAX_RATE,
+                                                        LegacyConnectionFactoryDefinition.PRODUCER_WINDOW_SIZE,
+                                                        LegacyConnectionFactoryDefinition.RECONNECT_ATTEMPTS,
+                                                        LegacyConnectionFactoryDefinition.RETRY_INTERVAL,
+                                                        LegacyConnectionFactoryDefinition.RETRY_INTERVAL_MULTIPLIER,
+                                                        LegacyConnectionFactoryDefinition.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                                        LegacyConnectionFactoryDefinition.THREAD_POOL_MAX_SIZE,
+                                                        LegacyConnectionFactoryDefinition.TRANSACTION_BATCH_SIZE,
+                                                        LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS))
+                                .addChild(createPooledConnectionFactory(false)))
+                .addChild(
+                        builder(JMSBridgeDefinition.INSTANCE.getPathElement())
+                                .addAttributes(
+                                        JMSBridgeDefinition.MODULE,
+                                        JMSBridgeDefinition.QUALITY_OF_SERVICE,
+                                        JMSBridgeDefinition.FAILURE_RETRY_INTERVAL,
+                                        JMSBridgeDefinition.MAX_RETRIES,
+                                        JMSBridgeDefinition.MAX_BATCH_SIZE,
+                                        JMSBridgeDefinition.MAX_BATCH_TIME,
+                                        CommonAttributes.SELECTOR,
+                                        JMSBridgeDefinition.SUBSCRIPTION_NAME,
+                                        CommonAttributes.CLIENT_ID,
+                                        JMSBridgeDefinition.ADD_MESSAGE_ID_IN_HEADER,
+                                        JMSBridgeDefinition.SOURCE_CONNECTION_FACTORY,
+                                        JMSBridgeDefinition.SOURCE_DESTINATION,
+                                        JMSBridgeDefinition.SOURCE_USER,
+                                        JMSBridgeDefinition.SOURCE_PASSWORD,
+                                        JMSBridgeDefinition.SOURCE_CREDENTIAL_REFERENCE,
+                                        JMSBridgeDefinition.TARGET_CONNECTION_FACTORY,
+                                        JMSBridgeDefinition.TARGET_DESTINATION,
+                                        JMSBridgeDefinition.TARGET_USER,
+                                        JMSBridgeDefinition.TARGET_PASSWORD,
+                                        JMSBridgeDefinition.TARGET_CREDENTIAL_REFERENCE,
+                                        JMSBridgeDefinition.SOURCE_CONTEXT,
+                                        JMSBridgeDefinition.TARGET_CONTEXT))
+                .build();
+    }
+
+    private PersistentResourceXMLBuilder createPooledConnectionFactory(boolean external) {
+        PersistentResourceXMLBuilder builder = builder(MessagingExtension.POOLED_CONNECTION_FACTORY_PATH)
+                .addAttributes(
+                        ConnectionFactoryAttributes.Common.ENTRIES,
+                        // common
+                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
+                        ConnectionFactoryAttributes.Common.CONNECTORS,
+                        CommonAttributes.HA,
+                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
+                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
+                        CommonAttributes.CALL_TIMEOUT,
+                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
+                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
+                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
+                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
+                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
+                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
+                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                        CommonAttributes.CLIENT_ID,
+                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
+                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND,
+                        ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND,
+                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
+                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
+                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
+                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
+                        CommonAttributes.MAX_RETRY_INTERVAL,
+                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
+                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
+                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
+                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
+                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                        ConnectionFactoryAttributes.Common.DESERIALIZATION_BLACKLIST,
+                        ConnectionFactoryAttributes.Common.DESERIALIZATION_WHITELIST,
+                        ConnectionFactoryAttributes.Common.USE_TOPOLOGY,
+                        // pooled
+                        // inbound config
+                        ConnectionFactoryAttributes.Pooled.USE_JNDI,
+                        ConnectionFactoryAttributes.Pooled.JNDI_PARAMS,
+                        ConnectionFactoryAttributes.Pooled.REBALANCE_CONNECTIONS,
+                        ConnectionFactoryAttributes.Pooled.USE_LOCAL_TX,
+                        ConnectionFactoryAttributes.Pooled.SETUP_ATTEMPTS,
+                        ConnectionFactoryAttributes.Pooled.SETUP_INTERVAL,
+                        // outbound config
+                        ConnectionFactoryAttributes.Pooled.ALLOW_LOCAL_TRANSACTIONS,
+                        ConnectionFactoryAttributes.Pooled.TRANSACTION,
+                        ConnectionFactoryAttributes.Pooled.USER,
+                        ConnectionFactoryAttributes.Pooled.PASSWORD,
+                        ConnectionFactoryAttributes.Pooled.CREDENTIAL_REFERENCE,
+                        ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE,
+                        ConnectionFactoryAttributes.Pooled.USE_AUTO_RECOVERY,
+                        ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE,
+                        ConnectionFactoryAttributes.Pooled.MANAGED_CONNECTION_POOL,
+                        ConnectionFactoryAttributes.Pooled.ENLISTMENT_TRACE,
+                        ConnectionFactoryAttributes.Common.INITIAL_MESSAGE_PACKET_SIZE,
+                        ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS,
+                        ConnectionFactoryAttributes.Pooled.STATISTICS_ENABLED);
+        if (external) {
+            builder.addAttributes(ConnectionFactoryAttributes.External.ENABLE_AMQ1_PREFIX);
+        }
+        return builder;
+    }
+
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -70,6 +70,7 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
     public void registerTransformers(SubsystemTransformerRegistration registration) {
         ChainedTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
 
+        registerTransformers_WF_21(builder.createBuilder(MessagingExtension.VERSION_11_0_0, MessagingExtension.VERSION_10_0_0));
         registerTransformers_WF_20(builder.createBuilder(MessagingExtension.VERSION_10_0_0, MessagingExtension.VERSION_9_0_0));
         registerTransformers_WF_19(builder.createBuilder(MessagingExtension.VERSION_9_0_0, MessagingExtension.VERSION_8_0_0));
         registerTransformers_WF_18(builder.createBuilder(MessagingExtension.VERSION_8_0_0, MessagingExtension.VERSION_7_0_0));
@@ -83,7 +84,10 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
         builder.buildAndRegister(registration, new ModelVersion[] { MessagingExtension.VERSION_1_0_0, MessagingExtension.VERSION_2_0_0,
             MessagingExtension.VERSION_3_0_0, MessagingExtension.VERSION_4_0_0, MessagingExtension.VERSION_5_0_0,
             MessagingExtension.VERSION_6_0_0, MessagingExtension.VERSION_7_0_0, MessagingExtension.VERSION_8_0_0,
-            MessagingExtension.VERSION_9_0_0, MessagingExtension.VERSION_10_0_0});
+            MessagingExtension.VERSION_9_0_0, MessagingExtension.VERSION_10_0_0, MessagingExtension.VERSION_11_0_0});
+    }
+
+    private static void registerTransformers_WF_21(ResourceTransformationDescriptionBuilder subsystem) {
     }
 
     private static void registerTransformers_WF_20(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingTransformerRegistration.java
@@ -88,6 +88,15 @@ public class MessagingTransformerRegistration implements ExtensionTransformerReg
     }
 
     private static void registerTransformers_WF_21(ResourceTransformationDescriptionBuilder subsystem) {
+        ResourceTransformationDescriptionBuilder server = subsystem.addChildResource(MessagingExtension.SERVER_PATH);
+        ResourceTransformationDescriptionBuilder bridge = server.addChildResource(MessagingExtension.BRIDGE_PATH);
+        bridge.getAttributeBuilder()
+                .setValueConverter(AttributeConverter.DEFAULT_VALUE, CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE)
+                .end();
+        ResourceTransformationDescriptionBuilder clusterConnection = server.addChildResource(MessagingExtension.CLUSTER_CONNECTION_PATH);
+        clusterConnection.getAttributeBuilder()
+                .setValueConverter(AttributeConverter.DEFAULT_VALUE, CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE)
+                .end();
     }
 
     private static void registerTransformers_WF_20(ResourceTransformationDescriptionBuilder subsystem) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/legacy/LegacyConnectionFactoryDefinition.java
@@ -380,15 +380,21 @@ public class LegacyConnectionFactoryDefinition extends PersistentResourceDefinit
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient#DEFAULT_ACK_BATCH_SIZE
+     */
     public static final AttributeDefinition TRANSACTION_BATCH_SIZE = SimpleAttributeDefinitionBuilder.create("transaction-batch-size", INT)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_ACK_BATCH_SIZE))
+            .setDefaultValue(new ModelNode().set(1024 * 1024))
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()
             .build();
 
+    /**
+     * @see HornetQClient#DEFAULT_USE_GLOBAL_POOLS
+     */
     public static final AttributeDefinition USE_GLOBAL_POOLS = SimpleAttributeDefinitionBuilder.create("use-global-pools", BOOLEAN)
-            .setDefaultValue(new ModelNode().set(HornetQClient.DEFAULT_USE_GLOBAL_POOLS))
+            .setDefaultValue(ModelNode.TRUE)
             .setRequired(false)
             .setAllowExpression(true)
             .setRestartAllServices()

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_11_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_11_0.xsd
@@ -1,0 +1,996 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:messaging-activemq:11.0"
+           xmlns:credential-reference="urn:wildfly:credential-reference:1.1"
+           targetNamespace="urn:jboss:domain:messaging-activemq:11.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="11.0">
+
+    <xs:import namespace="urn:wildfly:credential-reference:1.1" schemaLocation="wildfly-credential-reference_1_1.xsd"/>
+
+    <xs:element name="subsystem">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="0" name="global-client">
+                    <xs:complexType>
+                        <xs:attribute name="thread-pool-max-size" type="xs:int" />
+                        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="http-connector" type="http-connectorType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="remote-connector" type="remote-connectorType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="in-vm-connector" minOccurs="0" maxOccurs="unbounded" type="in-vm-connectorType" />
+                <xs:element name="connector" minOccurs="0" maxOccurs="unbounded" type="connectorType" />
+                <xs:element name="jgroups-discovery-group" type="jgroups-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="socket-discovery-group" type="socket-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="connection-factory" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="ha" type="xs:boolean" use="optional" />
+                        <xs:attribute name="factory-type" type="connectionFactoryType" use="optional"/>
+                        <xs:attribute name="discovery-group" type="xs:string" use="optional"/>
+                        <xs:attribute name="connectors" type="xs:string" use="optional"/>
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                        <xs:attribute name="enable-amq1-prefix" type="xs:boolean" use="optional" />
+                        <xs:attribute name="use-topology-for-load-balancing" type="xs:boolean" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="pooled-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="inbound-config" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="use-jndi" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="jndi-params" type="xs:string" use="optional" />
+                                    <xs:attribute name="rebalance-connections" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="use-local-tx" type="xs:boolean" use="optional" />
+                                    <xs:attribute name="setup-attempts" type="xs:int" use="optional" />
+                                    <xs:attribute name="setup-interval" type="xs:long" use="optional" />
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="outbound-config" minOccurs="0" maxOccurs="1">
+                                <xs:complexType>
+                                    <xs:attribute name="allow-local-transactions" type="xs:boolean" use="optional" />
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Credential to be used by the configuration.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+
+                        <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                        <xs:attribute name="transaction" use="optional">
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                    <xs:enumeration value="xa"/>
+                                    <xs:enumeration value="local"/>
+                                    <xs:enumeration value="none"/>
+                                </xs:restriction>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="user" type="xs:string" use="optional" />
+                        <xs:attribute name="password" type="xs:string" use="optional" />
+                        <xs:attribute name="min-pool-size" type="xs:int" use="optional" />
+                        <xs:attribute name="use-auto-recovery" type="xs:boolean" use="optional" />
+                        <xs:attribute name="max-pool-size" type="xs:int" use="optional" />
+                        <xs:attribute name="managed-connection-pool" type="xs:string" use="optional" />
+                        <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional" />
+                        <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                        <xs:attribute name="statistics-enabled" type="xs:boolean" use="optional" />
+                        <xs:attribute name="enable-amq1-prefix" type="xs:boolean" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="external-jms-queue" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="external-jms-topic" minOccurs="0" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:attribute name="name" type="xs:string" use="required" />
+                        <xs:attribute name="entries" type="stringList" use="required" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="server" type="serverType" />
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="serverType">
+        <xs:sequence>
+
+            <xs:element name="incoming-interceptors" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="outgoing-interceptors" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="class" type="classType" minOccurs="1" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <!-- server attribute groups -->
+            <xs:element name="security" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="enabled" type="xs:boolean" />
+                    <xs:attribute name="domain" type="xs:string" />
+                    <xs:attribute name="elytron-domain" type="xs:string"/>
+                    <xs:attribute name="invalidation-interval" type="xs:long" />
+                    <xs:attribute name="override-in-vm-security" type="xs:boolean" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="cluster" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="user" type="xs:string" />
+                    <xs:attribute name="password" type="xs:string" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="management" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="address" type="xs:string" />
+                    <xs:attribute name="notification-address" type="xs:string" />
+                    <xs:attribute name="jmx-enabled" type="xs:boolean" />
+                    <xs:attribute name="jmx-domain" type="xs:string" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="journal" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="type">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="ASYNCIO"/>
+                                <xs:enumeration value="NIO"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="buffer-timeout" type="xs:long" />
+                    <xs:attribute name="buffer-size" type="xs:long" />
+                    <xs:attribute name="sync-transactional" type="xs:boolean" />
+                    <xs:attribute name="sync-non-transactional" type="xs:boolean" />
+                    <xs:attribute name="log-write-rate" type="xs:boolean" />
+                    <xs:attribute name="file-size" type="xs:long" />
+                    <xs:attribute name="min-files" type="xs:int" />
+                    <xs:attribute name="pool-files" type="xs:int" />
+                    <xs:attribute name="file-open-timeout" type="xs:int" />
+                    <xs:attribute name="compact-percentage" type="xs:int" />
+                    <xs:attribute name="compact-min-files" type="xs:int" />
+                    <xs:attribute name="max-io" type="xs:int" />
+                    <xs:attribute name="create-bindings-dir" type="xs:boolean" />
+                    <xs:attribute name="create-journal-dir" type="xs:boolean" />
+                    <xs:attribute name="datasource" type="xs:string" />
+                    <xs:attribute name="database" type="xs:string" />
+                    <xs:attribute name="messages-table" type="xs:string" />
+                    <xs:attribute name="bindings-table" type="xs:string" />
+                    <xs:attribute name="jms-bindings-table" type="xs:string" />
+                    <xs:attribute name="large-messages-table" type="xs:string" />
+                    <xs:attribute name="node-manager-store-table" type="xs:string" />
+                    <xs:attribute name="page-store-table" type="xs:string" />
+                    <xs:attribute name="jdbc-lock-expiration" type="xs:int" />
+                    <xs:attribute name="jdbc-lock-renew-period" type="xs:int" />
+                    <xs:attribute name="jdbc-network-timeout" type="xs:int" />
+                    <xs:attribute name="global-max-memory-size" type="xs:long" />
+                    <xs:attribute name="global-max-disk-usage" type="xs:int" />
+                    <xs:attribute name="disk-scan-period" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="statistics" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="enabled" type="xs:boolean" />
+                    <xs:attribute name="message-counter-sample-period" type="xs:long" />
+                    <xs:attribute name="message-counter-max-day-history" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="transaction" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="timeout" type="xs:long" />
+                    <xs:attribute name="scan-period" type="xs:long" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="message-expiry" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="scan-period" type="xs:long" />
+                    <xs:attribute name="thread-priority" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="debug" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="perf-blast-pages" type="xs:int" />
+                    <xs:attribute name="run-sync-speed-test" type="xs:boolean" />
+                    <xs:attribute name="server-dump-interval" type="xs:long" />
+                    <xs:attribute name="memory-measure-interval" type="xs:long" />
+                    <xs:attribute name="memory-warning-threshold" type="xs:int" />
+                </xs:complexType>
+            </xs:element>
+            <!-- end of server attribute groups -->
+
+            <xs:choice>
+                <xs:element name="live-only" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="replication-master" minOccurs="0" maxOccurs="1" type="replication-masterType" />
+                <xs:element name="replication-slave" minOccurs="0" maxOccurs="1" type="replication-slaveType" />
+                <xs:element name="replication-colocated" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="master" minOccurs="0" maxOccurs="1" type="replication-masterType" />
+                            <xs:element name="slave" minOccurs="0" maxOccurs="1" type="replication-slaveType" />
+                        </xs:sequence>
+
+                        <xs:attributeGroup ref="ha-policy-colocated-attributeGroup" />
+                        <xs:attribute name="excluded-connectors" type="xs:string" use="optional" />
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="shared-store-master" minOccurs="0" maxOccurs="1" type="shared-store-masterType" />
+                <xs:element name="shared-store-slave" minOccurs="0" maxOccurs="1"  type="shared-store-slaveType" />
+                <xs:element name="shared-store-colocated" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="master" minOccurs="0" maxOccurs="1" type="shared-store-masterType" />
+                            <xs:element name="slave" minOccurs="0" maxOccurs="1" type="shared-store-slaveType" />
+                        </xs:sequence>
+
+                        <xs:attributeGroup ref="ha-policy-colocated-attributeGroup" />
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+
+            <xs:element name="bindings-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="journal-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="large-messages-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+            <xs:element name="paging-directory" maxOccurs="1" minOccurs="0" type="directoryType" />
+
+            <xs:element name="queue" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+
+                    <xs:attribute name="address" type="xs:string" use="optional" />
+                    <xs:attribute name="filter" type="xs:string" use="optional" />
+                    <xs:attribute name="durable" type="xs:boolean" use="optional" />
+                    <xs:attribute name="routing-type" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="MULTICAST"/>
+                                <xs:enumeration value="ANYCAST"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="security-setting" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="role" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required" />
+
+                                <xs:attribute name="send" type="xs:string" use="optional" />
+                                <xs:attribute name="consume" type="xs:string" use="optional" />
+                                <xs:attribute name="create-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="delete-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="create-non-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="delete-non-durable-queue" type="xs:string" use="optional" />
+                                <xs:attribute name="manage" type="xs:string" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="address-setting" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+
+                    <xs:attribute name="dead-letter-address" type="xs:string" use="optional" />
+                    <xs:attribute name="expiry-address" type="xs:string" use="optional" />
+                    <xs:attribute name="expiry-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="redelivery-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="redelivery-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="max-delivery-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="max-redelivery-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="max-size-bytes" type="xs:long" use="optional" />
+                    <xs:attribute name="page-size-bytes" type="xs:int" use="optional" />
+                    <xs:attribute name="page-max-cache-size" type="xs:int" use="optional" />
+                    <xs:attribute name="address-full-policy" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="DROP"/>
+                                <xs:enumeration value="PAGE"/>
+                                <xs:enumeration value="BLOCK"/>
+                                <xs:enumeration value="FAIL"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="message-counter-history-day-limit" type="xs:int" use="optional" />
+                    <xs:attribute name="last-value-queue" type="xs:boolean" use="optional" />
+                    <xs:attribute name="redistribution-delay" type="xs:long" use="optional" />
+                    <xs:attribute name="send-to-dla-on-no-route" type="xs:boolean" use="optional" />
+                    <xs:attribute name="slow-consumer-check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="slow-consumer-policy" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="KILL"/>
+                                <xs:enumeration value="NOTIFY"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="slow-consumer-threshold" type="xs:long" use="optional" />
+                    <xs:attribute name="auto-create-jms-queues" type="xs:boolean">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use auto-create-queues and auto-create-addresses instead.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="auto-delete-jms-queues" type="xs:boolean">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use auto-delete-queues and auto-delete-addresses instead.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="auto-create-queues" type="xs:boolean" />
+                    <xs:attribute name="auto-delete-queues" type="xs:boolean" />
+                    <xs:attribute name="auto-create-addresses" type="xs:boolean" />
+                    <xs:attribute name="auto-delete-addresses" type="xs:boolean" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="http-connector" minOccurs="0" maxOccurs="unbounded" type="http-connectorType" />
+
+            <xs:element name="remote-connector" minOccurs="0" maxOccurs="unbounded" type="remote-connectorType" />
+
+            <xs:element name="in-vm-connector" minOccurs="0" maxOccurs="unbounded" type="in-vm-connectorType" />
+
+            <xs:element name="connector" minOccurs="0" maxOccurs="unbounded" type="connectorType" />
+
+            <xs:element name="http-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="upgrade-legacy" type="xs:boolean" use="optional" />
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="http-listener" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="remote-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="socket-binding" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="in-vm-acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="server-id" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="acceptor" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="factory-class" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+
+            <xs:element name="jgroups-broadcast-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="jgroups-stack" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>Deprecated. Use jgroups-channel instead.</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="jgroups-channel" type="xs:string" use="optional" />
+                    <xs:attribute name="jgroups-cluster" type="xs:string" use="optional" />
+                    <xs:attribute name="broadcast-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="socket-broadcast-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="socket-binding" type="xs:string" use="required" />
+                    <xs:attribute name="broadcast-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="jgroups-discovery-group" type="jgroups-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="socket-discovery-group" type="socket-discovery-groupType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="cluster-connection" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="address" type="xs:string" use="required" />
+                    <xs:attribute name="connector-name" type="xs:string" use="required" />
+
+                    <xs:attribute name="check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="use-duplicate-detection" type="xs:boolean" use="optional" />
+                    <xs:attribute name="message-load-balancing-type" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="OFF"/>
+                                <xs:enumeration value="STRICT"/>
+                                <xs:enumeration value="ON_DEMAND"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="max-hops" type="xs:int" use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="notification-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="notification-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="static-connectors" type="stringList" use="optional" />
+                    <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional" />
+                    <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="grouping-handler" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="type" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="LOCAL"/>
+                                <xs:enumeration value="REMOTE"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="address" type="xs:string" use="required" />
+
+                    <xs:attribute name="timeout" type="xs:int" use="optional" />
+                    <xs:attribute name="group-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="reaper-period" type="xs:long" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="divert" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="address" type="xs:string" use="required" />
+                    <xs:attribute name="forwarding-address" type="xs:string" use="required" />
+
+                    <xs:attribute name="routing-name" type="xs:string"  use="optional" />
+                    <xs:attribute name="filter" type="xs:string" use="optional" />
+                    <xs:attribute name="transformer-class-name" type="xs:string" use="optional" />
+                    <xs:attribute name="exclusive" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="bridge" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="queue-name" type="xs:string" use="required" />
+
+                    <xs:attribute name="forwarding-address" type="xs:string" use="optional" />
+                    <xs:attribute name="ha" type="xs:boolean"  use="optional" />
+                    <xs:attribute name="filter" type="xs:string"  use="optional" />
+                    <xs:attribute name="transformer-class-name" type="xs:string"  use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="check-period" type="xs:long"  use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long"  use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long"  use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double"  use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long"  use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int"  use="optional" />
+                    <xs:attribute name="reconnect-attempts-on-same-node" type="xs:int"  use="optional" />
+                    <xs:attribute name="use-duplicate-detection" type="xs:boolean"  use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int"  use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="user" type="xs:string"  use="optional" />
+                    <xs:attribute name="password" type="xs:string"  use="optional" />
+                    <xs:attribute name="static-connectors" type="stringList"  use="optional" />
+                    <xs:attribute name="discovery-group" type="xs:string"  use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="connector-service" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="factory-class" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="jms-queue" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attribute name="selector" type="xs:string" use="optional" />
+                    <xs:attribute name="durable" type="xs:string" use="optional" />
+                    <xs:attribute name="legacy-entries" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="jms-topic" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+                    <xs:attribute name="legacy-entries" type="stringList" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                    <xs:attribute name="factory-type" type="connectionFactoryType" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="legacy-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+                    <xs:attribute name="connectors" type="stringList" use="optional" />
+
+                    <xs:attribute name="auto-group" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-acknowledge" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-durable-send" type="xs:boolean" use="optional" />
+                    <xs:attribute name="block-on-non-durable-send" type="xs:boolean" use="optional" />
+                    <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+                    <xs:attribute name="cache-large-message-client" type="xs:boolean" use="optional" />
+                    <xs:attribute name="client-failure-check-period" type="xs:long" use="optional" />
+                    <xs:attribute name="client-id" type="xs:string" use="optional" />
+                    <xs:attribute name="compress-large-messages" type="xs:boolean" use="optional" />
+                    <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="connection-load-balancing-policy-class-name" type="xs:string" use="optional" />
+                    <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+                    <xs:attribute name="consumer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="consumer-max-rate" type="xs:int" use="optional" />
+                    <xs:attribute name="dups-ok-batch-size" type="xs:int" use="optional" />
+                    <xs:attribute name="factory-type" type="connectionFactoryType" use="optional" />
+                    <xs:attribute name="failover-on-initial-connection" type="xs:boolean" use="optional" />
+                    <xs:attribute name="group-id" type="xs:string" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="initial-message-packet-size" type="xs:int" use="optional" />
+                    <xs:attribute name="ha" type="xs:boolean" use="optional" />
+                    <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+                    <xs:attribute name="pre-acknowledge" type="xs:boolean" use="optional" />
+                    <xs:attribute name="producer-max-rate" type="xs:int" use="optional" />
+                    <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+                    <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+                    <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+                    <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+                    <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+                    <xs:attribute name="transaction-batch-size" type="xs:int" use="optional" />
+                    <xs:attribute name="use-global-pools" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="pooled-connection-factory" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="inbound-config" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="use-jndi" type="xs:boolean" use="optional" />
+                                <xs:attribute name="jndi-params" type="xs:string" use="optional" />
+                                <xs:attribute name="rebalance-connections" type="xs:boolean" use="optional" />
+                                <xs:attribute name="use-local-tx" type="xs:boolean" use="optional" />
+                                <xs:attribute name="setup-attempts" type="xs:int" use="optional" />
+                                <xs:attribute name="setup-interval" type="xs:long" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="outbound-config" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="allow-local-transactions" type="xs:boolean" use="optional" />
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="entries" type="stringList" use="required" />
+
+                    <xs:attributeGroup ref="common-connection-factory-attributeGroup" />
+                    <xs:attribute name="transaction" use="optional">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="xa"/>
+                                <xs:enumeration value="local"/>
+                                <xs:enumeration value="none"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                    <xs:attribute name="min-pool-size" type="xs:int" use="optional" />
+                    <xs:attribute name="use-auto-recovery" type="xs:boolean" use="optional" />
+                    <xs:attribute name="max-pool-size" type="xs:int" use="optional" />
+                    <xs:attribute name="managed-connection-pool" type="xs:string" use="optional" />
+                    <xs:attribute name="enlistment-trace" type="xs:boolean" use="optional" />
+                    <xs:attribute name="initial-connect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="statistics-enabled" type="xs:boolean" use="optional" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" use="required" />
+
+        <xs:attribute name="persistence-enabled" type="xs:boolean" use="optional" />
+        <xs:attribute name="persist-id-cache" type="xs:boolean" use="optional" />
+        <xs:attribute name="persist-delivery-count-before-delivery" type="xs:boolean" use="optional" />
+        <xs:attribute name="id-cache-size" type="xs:int" use="optional" />
+        <xs:attribute name="page-max-concurrent-io" type="xs:int" use="optional" />
+        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="wild-card-routing-enabled" type="xs:boolean" use="optional" />
+        <xs:attribute name="connection-ttl-override" type="xs:long" use="optional" />
+        <xs:attribute name="async-connection-execution-enabled" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:simpleType name="stringList">
+        <xs:restriction base="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ A list of string separated by whitespaces. ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="classType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="module" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="scale-downType">
+        <xs:attribute name="enabled" type="xs:boolean" use="required" />
+        <xs:attribute name="cluster-name" type="xs:string" use="required" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+        <xs:attribute name="connectors" type="xs:string" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="replication-masterType">
+        <xs:attribute name="cluster-name" type="xs:string" use="optional" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="check-for-live-server" type="xs:boolean" use="optional" />
+        <xs:attribute name="initial-replication-sync-timeout" type="xs:long" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="replication-slaveType">
+        <xs:sequence>
+            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+        </xs:sequence>
+
+        <xs:attribute name="cluster-name" type="xs:string" use="optional" />
+        <xs:attribute name="group-name" type="xs:string" use="optional" />
+        <xs:attribute name="allow-failback" type="xs:boolean" use="optional" />
+        <xs:attribute name="initial-replication-sync-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="restart-backup" type="xs:boolean" use="optional" />
+        <xs:attribute name="max-saved-replicated-journal-size" type="xs:int" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="shared-store-masterType">
+        <xs:attribute name="failover-on-server-shutdown" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:complexType name="shared-store-slaveType">
+        <xs:sequence>
+            <xs:element name="scale-down" minOccurs="0" maxOccurs="1" type="scale-downType" />
+        </xs:sequence>
+
+        <xs:attribute name="allow-failback" type="xs:boolean" use="optional" />
+        <xs:attribute name="failover-on-server-shutdown" type="xs:boolean" use="optional" />
+        <xs:attribute name="restart-backup" type="xs:boolean" use="optional" />
+    </xs:complexType>
+
+    <xs:attributeGroup name="ha-policy-colocated-attributeGroup">
+        <xs:attribute name="request-backup" type="xs:boolean" use="optional" />
+        <xs:attribute name="backup-request-retries" type="xs:int" use="optional" />
+        <xs:attribute name="backup-request-retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="max-backups" type="xs:int" use="optional" />
+        <xs:attribute name="backup-port-offset" type="xs:int" use="optional" />
+    </xs:attributeGroup>
+
+    <xs:complexType name="directoryType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                A directory location configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem pathname where the directory should be
+                located.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" />
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="value" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:attributeGroup name="common-connection-factory-attributeGroup">
+        <xs:attribute name="discovery-group" type="xs:string" use="optional" />
+        <xs:attribute name="connectors" type="xs:string" use="optional" />
+        <xs:attribute name="ha" type="xs:boolean" use="optional" />
+        <xs:attribute name="client-failure-check-period" type="xs:long" use="optional" />
+        <xs:attribute name="connection-ttl" type="xs:long" use="optional" />
+        <xs:attribute name="call-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="call-failover-timeout" type="xs:long" use="optional" />
+        <xs:attribute name="consumer-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="consumer-max-rate" type="xs:int" use="optional" />
+        <xs:attribute name="confirmation-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="producer-window-size" type="xs:int" use="optional" />
+        <xs:attribute name="producer-max-rate" type="xs:int" use="optional" />
+        <xs:attribute name="protocol-manager-factory" type="xs:string" use="optional" />
+        <xs:attribute name="compress-large-messages" type="xs:boolean" use="optional" />
+        <xs:attribute name="cache-large-message-client" type="xs:boolean" use="optional" />
+        <xs:attribute name="min-large-message-size" type="xs:int" use="optional" />
+        <xs:attribute name="client-id" type="xs:string" use="optional" />
+        <xs:attribute name="dups-ok-batch-size" type="xs:int" use="optional" />
+        <xs:attribute name="transaction-batch-size" type="xs:int" use="optional" />
+        <xs:attribute name="block-on-acknowledge" type="xs:boolean" use="optional" />
+        <xs:attribute name="block-on-non-durable-send" type="xs:boolean" use="optional" />
+        <xs:attribute name="block-on-durable-send" type="xs:boolean" use="optional" />
+        <xs:attribute name="auto-group" type="xs:boolean" use="optional" />
+        <xs:attribute name="pre-acknowledge" type="xs:boolean" use="optional" />
+        <xs:attribute name="retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
+        <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
+        <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+        <xs:attribute name="failover-on-initial-connection" type="xs:boolean" use="optional" />
+        <xs:attribute name="connection-load-balancing-policy-class-name" type="xs:string" use="optional" />
+        <xs:attribute name="use-global-pools" type="xs:boolean" use="optional" />
+        <xs:attribute name="scheduled-thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="thread-pool-max-size" type="xs:int" use="optional" />
+        <xs:attribute name="group-id" type="xs:string" use="optional" />
+        <xs:attribute name="deserialization-white-list" type="stringList" use="optional" />
+        <xs:attribute name="deserialization-black-list" type="stringList" use="optional" />
+        <xs:attribute name="initial-message-packet-size" type="xs:int" use="optional" />
+        <xs:attribute name="use-topology-for-load-balancing" type="xs:boolean" use="optional" />
+    </xs:attributeGroup>
+
+    <xs:simpleType name="connectionFactoryType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="GENERIC"/>
+            <xs:enumeration value="TOPIC"/>
+            <xs:enumeration value="QUEUE"/>
+            <xs:enumeration value="XA_GENERIC"/>
+            <xs:enumeration value="XA_QUEUE"/>
+            <xs:enumeration value="XA_TOPIC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="socket-discovery-groupType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string"  use="required" />
+        <xs:attribute name="refresh-timeout" type="xs:long" />
+        <xs:attribute name="initial-wait-timeout" type="xs:long" />
+    </xs:complexType>
+
+    <xs:complexType name="jgroups-discovery-groupType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="jgroups-stack" type="xs:string" >
+            <xs:annotation>
+                <xs:documentation>Deprecated. Use jgroups-channel instead.</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="jgroups-channel" type="xs:string" />
+        <xs:attribute name="jgroups-cluster" type="xs:string" />
+        <xs:attribute name="refresh-timeout" type="xs:long" />
+        <xs:attribute name="initial-wait-timeout" type="xs:long" />
+    </xs:complexType>
+
+    <xs:complexType name="remote-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="http-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="socket-binding" type="xs:string" use="required" />
+        <xs:attribute name="endpoint" type="xs:string" use="required" />
+        <xs:attribute name="server-name" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="in-vm-connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="server-id" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="connectorType">
+        <xs:sequence>
+            <xs:element name="param" minOccurs="0" maxOccurs="unbounded" type="paramType" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="factory-class" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="jms-bridgeType">
+        <xs:sequence>
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="source-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="source-credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration to connect to the source destination.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="target" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="target-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                        <xs:element name="target-credential-reference" type="credential-reference:credentialReferenceType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Credential to be used by the configuration to connect to the target destination.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="module" type="xs:string" use="required" />
+
+        <xs:attribute name="quality-of-service" use="optional" default="AT_MOST_ONCE">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="AT_MOST_ONCE"/>
+                    <xs:enumeration value="DUPLICATES_OK"/>
+                    <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="failure-retry-interval" type="xs:long" use="optional" default="5000" />
+        <xs:attribute name="max-retries" type="xs:int" use="optional" default="-1"/>
+        <xs:attribute name="max-batch-size" type="xs:int" use="optional" default="1"/>
+        <xs:attribute name="max-batch-time" type="xs:long" use="optional" default="-1"/>
+        <xs:attribute name="selector" type="xs:string" use="optional" />
+        <xs:attribute name="subscription-name" type="xs:string" use="optional" />
+        <xs:attribute name="client-id" type="xs:string" use="optional" />
+        <xs:attribute name="add-messageID-in-header" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="contextType">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="value" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+</xs:schema>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
@@ -3,7 +3,7 @@
 <config>
     <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
     <extension-module>org.wildfly.extension.messaging-activemq</extension-module>
-    <subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
         <server name="default"
                 persistence-enabled="true">
             <cluster password="${jboss.messaging.cluster.password:CHANGE ME!!}" />

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
     <extension-module>org.wildfly.extension.messaging-activemq</extension-module>
-    <subsystem xmlns="urn:jboss:domain:messaging-activemq:10.0">
+    <subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
 
         <server name="default">
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/AttributeDefaultsTest.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/AttributeDefaultsTest.java
@@ -1,0 +1,188 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.messaging.activemq;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
+import org.hornetq.api.core.client.HornetQClient;
+import org.jboss.as.subsystem.test.AbstractSubsystemTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.extension.messaging.activemq.ha.HAAttributes;
+import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
+import org.wildfly.extension.messaging.activemq.jms.legacy.LegacyConnectionFactoryDefinition;
+
+public class AttributeDefaultsTest extends AbstractSubsystemTest {
+
+    public AttributeDefaultsTest() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    @Test
+    public void testAttributeValues() {
+        Assert.assertNotEquals(ServerDefinition.GLOBAL_MAX_DISK_USAGE.getName(), ServerDefinition.GLOBAL_MAX_DISK_USAGE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMaxDiskUsage());
+        Assert.assertNotEquals(ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getName(), ServerDefinition.GLOBAL_MAX_MEMORY_SIZE.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMaxGlobalSize());
+        Assert.assertNotEquals(ServerDefinition.JOURNAL_POOL_FILES.getName(), ServerDefinition.JOURNAL_POOL_FILES.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalPoolFiles());
+
+        Assert.assertEquals(BridgeDefinition.INITIAL_CONNECT_ATTEMPTS.getName(), BridgeDefinition.INITIAL_CONNECT_ATTEMPTS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeInitialConnectAttempts());
+        Assert.assertEquals(BridgeDefinition.RECONNECT_ATTEMPTS.getName(), BridgeDefinition.RECONNECT_ATTEMPTS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeReconnectAttempts());
+        Assert.assertEquals(BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE.getName(), BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeConnectSameNode());
+        Assert.assertEquals(BridgeDefinition.USE_DUPLICATE_DETECTION.getName(), BridgeDefinition.USE_DUPLICATE_DETECTION.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultBridgeDuplicateDetection());
+
+        Assert.assertEquals(ClusterConnectionDefinition.CHECK_PERIOD.getName(), ClusterConnectionDefinition.CHECK_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultClusterFailureCheckPeriod());
+        Assert.assertEquals(ClusterConnectionDefinition.CONNECTION_TTL.getName(), ClusterConnectionDefinition.CONNECTION_TTL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultClusterConnectionTtl());
+        Assert.assertEquals(ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS.getName(), ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultClusterInitialConnectAttempts());
+        Assert.assertEquals(ClusterConnectionDefinition.MAX_HOPS.getName(), ClusterConnectionDefinition.MAX_HOPS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultClusterMaxHops());
+        Assert.assertEquals(ClusterConnectionDefinition.MAX_RETRY_INTERVAL.getName(), ClusterConnectionDefinition.MAX_RETRY_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultClusterMaxRetryInterval());
+        Assert.assertEquals(ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE.getName(), ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultClusterMessageLoadBalancingType());
+        Assert.assertEquals(ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS.getName(), ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultClusterNotificationAttempts());
+        Assert.assertEquals(ClusterConnectionDefinition.NOTIFICATION_INTERVAL.getName(), ClusterConnectionDefinition.NOTIFICATION_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultClusterNotificationInterval());
+        Assert.assertEquals(ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.getName(), ClusterConnectionDefinition.PRODUCER_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeProducerWindowSize());
+        Assert.assertEquals(ClusterConnectionDefinition.RECONNECT_ATTEMPTS.getName(), ClusterConnectionDefinition.RECONNECT_ATTEMPTS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultClusterReconnectAttempts());
+        Assert.assertEquals(ClusterConnectionDefinition.RETRY_INTERVAL.getName(), ClusterConnectionDefinition.RETRY_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultClusterRetryInterval());
+        Assert.assertEquals(ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER.getName(), ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER.getDefaultValue().asDouble(), ActiveMQDefaultConfiguration.getDefaultClusterRetryIntervalMultiplier(), 0);
+
+        Assert.assertEquals(CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE.getName(), CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultBridgeConfirmationWindowSize());
+        Assert.assertEquals(CommonAttributes.CALL_TIMEOUT.getName(), CommonAttributes.CALL_TIMEOUT.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_CALL_TIMEOUT);
+        Assert.assertEquals(CommonAttributes.CHECK_PERIOD.getName(), CommonAttributes.CHECK_PERIOD.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD);
+        Assert.assertEquals(CommonAttributes.CONNECTION_TTL.getName(), CommonAttributes.CONNECTION_TTL.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_CONNECTION_TTL);
+        Assert.assertEquals(CommonAttributes.HA.getName(), CommonAttributes.HA.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_HA);
+        Assert.assertEquals(CommonAttributes.MAX_RETRY_INTERVAL.getName(), CommonAttributes.MAX_RETRY_INTERVAL.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_MAX_RETRY_INTERVAL);
+        Assert.assertEquals(CommonAttributes.MIN_LARGE_MESSAGE_SIZE.getName(), CommonAttributes.MIN_LARGE_MESSAGE_SIZE.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE);
+        Assert.assertEquals(CommonAttributes.RETRY_INTERVAL.getName(), CommonAttributes.RETRY_INTERVAL.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_RETRY_INTERVAL);
+        Assert.assertEquals(CommonAttributes.RETRY_INTERVAL_MULTIPLIER.getName(), CommonAttributes.RETRY_INTERVAL_MULTIPLIER.getDefaultValue().asDouble(), ActiveMQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER, 0);
+
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.AUTO_GROUP.getName(), ConnectionFactoryAttributes.Common.AUTO_GROUP.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_AUTO_GROUP);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE.getName(), ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND.getName(), ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_BLOCK_ON_DURABLE_SEND);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND.getName(), ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT.getName(), ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES.getName(), ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_COMPRESS_LARGE_MESSAGES);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE.getName(), ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME.getName(), ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME.getDefaultValue().asString(), ActiveMQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE.getName(), ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_CONSUMER_MAX_RATE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE.getName(), ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE.getName(), ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_ACK_BATCH_SIZE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION.getName(), ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE.getName(), ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_PRE_ACKNOWLEDGE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE.getName(), ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_PRODUCER_MAX_RATE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE.getName(), ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_PRODUCER_WINDOW_SIZE);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS.getName(), ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS.getDefaultValue().asInt(), ActiveMQClient.DEFAULT_RECONNECT_ATTEMPTS);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE.getName(), ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize());
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS.getName(), ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_USE_GLOBAL_POOLS);
+        Assert.assertEquals(ConnectionFactoryAttributes.Common.USE_TOPOLOGY.getName(), ConnectionFactoryAttributes.Common.USE_TOPOLOGY.getDefaultValue().asBoolean(), ActiveMQClient.DEFAULT_USE_TOPOLOGY_FOR_LOADBALANCING);
+
+        Assert.assertEquals(DivertDefinition.EXCLUSIVE.getName(), DivertDefinition.EXCLUSIVE.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultDivertExclusive());
+
+        Assert.assertEquals(GroupingHandlerDefinition.GROUP_TIMEOUT.getName(), GroupingHandlerDefinition.GROUP_TIMEOUT.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultGroupingHandlerGroupTimeout());
+        Assert.assertEquals(GroupingHandlerDefinition.REAPER_PERIOD.getName(), GroupingHandlerDefinition.REAPER_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultGroupingHandlerReaperPeriod());
+        Assert.assertEquals(GroupingHandlerDefinition.TIMEOUT.getName(), GroupingHandlerDefinition.TIMEOUT.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultGroupingHandlerTimeout());
+
+        Assert.assertEquals(HAAttributes.ALLOW_FAILBACK.getName(), HAAttributes.ALLOW_FAILBACK.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultAllowAutoFailback());
+        Assert.assertEquals(HAAttributes.BACKUP_PORT_OFFSET.getName(), HAAttributes.BACKUP_PORT_OFFSET.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultHapolicyBackupPortOffset());
+        Assert.assertEquals(HAAttributes.BACKUP_REQUEST_RETRIES.getName(), HAAttributes.BACKUP_REQUEST_RETRIES.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetries());
+        Assert.assertEquals(HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL.getName(), HAAttributes.BACKUP_REQUEST_RETRY_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultHapolicyBackupRequestRetryInterval());
+        Assert.assertEquals(HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN.getName(), HAAttributes.FAILOVER_ON_SERVER_SHUTDOWN.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultFailoverOnServerShutdown());
+        Assert.assertEquals(HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT.getName(), HAAttributes.INITIAL_REPLICATION_SYNC_TIMEOUT.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultInitialReplicationSyncTimeout());
+        Assert.assertEquals(HAAttributes.MAX_BACKUPS.getName(), HAAttributes.MAX_BACKUPS.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultHapolicyMaxBackups());
+        Assert.assertEquals(HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE.getName(), HAAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMaxSavedReplicatedJournalsSize());
+        Assert.assertEquals(HAAttributes.REQUEST_BACKUP.getName(), HAAttributes.REQUEST_BACKUP.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultHapolicyRequestBackup());
+        Assert.assertEquals(HAAttributes.RESTART_BACKUP.getName(), HAAttributes.RESTART_BACKUP.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultRestartBackup());
+
+        Assert.assertEquals(JGroupsBroadcastGroupDefinition.BROADCAST_PERIOD.getName(), JGroupsBroadcastGroupDefinition.BROADCAST_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultBroadcastPeriod());
+
+        Assert.assertEquals(JGroupsDiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.getName(), JGroupsDiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT.getDefaultValue().asLong(), ActiveMQClient.DEFAULT_DISCOVERY_INITIAL_WAIT_TIMEOUT);
+        Assert.assertEquals(JGroupsDiscoveryGroupDefinition.REFRESH_TIMEOUT.getName(), JGroupsDiscoveryGroupDefinition.REFRESH_TIMEOUT.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultBroadcastRefreshTimeout());
+
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.AUTO_GROUP.getName(), LegacyConnectionFactoryDefinition.AUTO_GROUP.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_AUTO_GROUP);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.BLOCK_ON_ACKNOWLEDGE.getName(), LegacyConnectionFactoryDefinition.BLOCK_ON_ACKNOWLEDGE.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_BLOCK_ON_ACKNOWLEDGE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.BLOCK_ON_DURABLE_SEND.getName(), LegacyConnectionFactoryDefinition.BLOCK_ON_DURABLE_SEND.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_BLOCK_ON_DURABLE_SEND);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.BLOCK_ON_NON_DURABLE_SEND.getName(), LegacyConnectionFactoryDefinition.BLOCK_ON_NON_DURABLE_SEND.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_BLOCK_ON_NON_DURABLE_SEND);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CACHE_LARGE_MESSAGE_CLIENT.getName(), LegacyConnectionFactoryDefinition.CACHE_LARGE_MESSAGE_CLIENT.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_CACHE_LARGE_MESSAGE_CLIENT);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CLIENT_FAILURE_CHECK_PERIOD.getName(), LegacyConnectionFactoryDefinition.CLIENT_FAILURE_CHECK_PERIOD.getDefaultValue().asLong(), HornetQClient.DEFAULT_CLIENT_FAILURE_CHECK_PERIOD);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.COMPRESS_LARGE_MESSAGES.getName(), LegacyConnectionFactoryDefinition.COMPRESS_LARGE_MESSAGES.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_COMPRESS_LARGE_MESSAGES);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CONFIRMATION_WINDOW_SIZE.getName(), LegacyConnectionFactoryDefinition.CONFIRMATION_WINDOW_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_CONFIRMATION_WINDOW_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CONNECTION_LOAD_BALANCING_CLASS_NAME.getName(), LegacyConnectionFactoryDefinition.CONNECTION_LOAD_BALANCING_CLASS_NAME.getDefaultValue().asString(), HornetQClient.DEFAULT_CONNECTION_LOAD_BALANCING_POLICY_CLASS_NAME);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CONNECTION_TTL.getName(), LegacyConnectionFactoryDefinition.CONNECTION_TTL.getDefaultValue().asLong(), HornetQClient.DEFAULT_CONNECTION_TTL);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CONSUMER_MAX_RATE.getName(), LegacyConnectionFactoryDefinition.CONSUMER_MAX_RATE.getDefaultValue().asInt(), HornetQClient.DEFAULT_CONSUMER_MAX_RATE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.CONSUMER_WINDOW_SIZE.getName(), LegacyConnectionFactoryDefinition.CONSUMER_WINDOW_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_CONSUMER_WINDOW_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.DUPS_OK_BATCH_SIZE.getName(), LegacyConnectionFactoryDefinition.DUPS_OK_BATCH_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_ACK_BATCH_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.FAILOVER_ON_INITIAL_CONNECTION.getName(), LegacyConnectionFactoryDefinition.FAILOVER_ON_INITIAL_CONNECTION.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_FAILOVER_ON_INITIAL_CONNECTION);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.INITIAL_CONNECT_ATTEMPTS.getName(), LegacyConnectionFactoryDefinition.INITIAL_CONNECT_ATTEMPTS.getDefaultValue().asInt(), HornetQClient.INITIAL_CONNECT_ATTEMPTS);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.INITIAL_MESSAGE_PACKET_SIZE.getName(), LegacyConnectionFactoryDefinition.INITIAL_MESSAGE_PACKET_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_INITIAL_MESSAGE_PACKET_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.MAX_RETRY_INTERVAL.getName(), LegacyConnectionFactoryDefinition.MAX_RETRY_INTERVAL.getDefaultValue().asLong(), HornetQClient.DEFAULT_MAX_RETRY_INTERVAL);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.MIN_LARGE_MESSAGE_SIZE.getName(), LegacyConnectionFactoryDefinition.MIN_LARGE_MESSAGE_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_MIN_LARGE_MESSAGE_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.PRE_ACKNOWLEDGE.getName(), LegacyConnectionFactoryDefinition.PRE_ACKNOWLEDGE.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_PRE_ACKNOWLEDGE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.PRODUCER_MAX_RATE.getName(), LegacyConnectionFactoryDefinition.PRODUCER_MAX_RATE.getDefaultValue().asInt(), HornetQClient.DEFAULT_PRODUCER_MAX_RATE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.PRODUCER_WINDOW_SIZE.getName(), LegacyConnectionFactoryDefinition.PRODUCER_WINDOW_SIZE.getDefaultValue().asInt(), HornetQClient.DEFAULT_PRODUCER_WINDOW_SIZE);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.RECONNECT_ATTEMPTS.getName(), LegacyConnectionFactoryDefinition.RECONNECT_ATTEMPTS.getDefaultValue().asInt(), HornetQClient.DEFAULT_RECONNECT_ATTEMPTS);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.RETRY_INTERVAL.getName(), LegacyConnectionFactoryDefinition.RETRY_INTERVAL.getDefaultValue().asLong(), HornetQClient.DEFAULT_RETRY_INTERVAL);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.RETRY_INTERVAL_MULTIPLIER.getName(), LegacyConnectionFactoryDefinition.RETRY_INTERVAL_MULTIPLIER.getDefaultValue().asDouble(), HornetQClient.DEFAULT_RETRY_INTERVAL_MULTIPLIER, 0);
+        Assert.assertEquals(LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS.getName(), LegacyConnectionFactoryDefinition.USE_GLOBAL_POOLS.getDefaultValue().asBoolean(), HornetQClient.DEFAULT_USE_GLOBAL_POOLS);
+
+        Assert.assertEquals(ServerDefinition.ASYNC_CONNECTION_EXECUTION_ENABLED.getName(), ServerDefinition.ASYNC_CONNECTION_EXECUTION_ENABLED.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultAsyncConnectionExecutionEnabled());
+        Assert.assertEquals(ServerDefinition.CLUSTER_PASSWORD.getName(), ServerDefinition.CLUSTER_PASSWORD.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultClusterPassword());
+        Assert.assertEquals(ServerDefinition.CLUSTER_USER.getName(), ServerDefinition.CLUSTER_USER.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultClusterUser());
+        Assert.assertEquals(ServerDefinition.CONNECTION_TTL_OVERRIDE.getName(), ServerDefinition.CONNECTION_TTL_OVERRIDE.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultConnectionTtlOverride());
+        Assert.assertEquals(ServerDefinition.CREATE_BINDINGS_DIR.getName(), ServerDefinition.CREATE_BINDINGS_DIR.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultCreateBindingsDir());
+        Assert.assertEquals(ServerDefinition.CREATE_JOURNAL_DIR.getName(), ServerDefinition.CREATE_JOURNAL_DIR.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultCreateJournalDir());
+        Assert.assertEquals(ServerDefinition.DISK_SCAN_PERIOD.getName(), ServerDefinition.DISK_SCAN_PERIOD.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultDiskScanPeriod());
+        Assert.assertEquals(ServerDefinition.ID_CACHE_SIZE.getName(), ServerDefinition.ID_CACHE_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultIdCacheSize());
+        Assert.assertEquals(ServerDefinition.JMX_DOMAIN.getName(), ServerDefinition.JMX_DOMAIN.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultJmxDomain());
+        Assert.assertEquals(ServerDefinition.JOURNAL_BINDINGS_TABLE.getName(), ServerDefinition.JOURNAL_BINDINGS_TABLE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultBindingsTableName());
+        Assert.assertEquals(ServerDefinition.JOURNAL_COMPACT_MIN_FILES.getName(), ServerDefinition.JOURNAL_COMPACT_MIN_FILES.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalCompactMinFiles());
+        Assert.assertEquals(ServerDefinition.JOURNAL_COMPACT_PERCENTAGE.getName(), ServerDefinition.JOURNAL_COMPACT_PERCENTAGE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalCompactPercentage());
+        Assert.assertEquals(ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT.getName(), ServerDefinition.JOURNAL_FILE_OPEN_TIMEOUT.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalFileOpenTimeout());
+        Assert.assertEquals(ServerDefinition.JOURNAL_FILE_SIZE.getName(), ServerDefinition.JOURNAL_FILE_SIZE.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultJournalFileSize());
+        Assert.assertEquals(ServerDefinition.JOURNAL_JDBC_LOCK_EXPIRATION.getName(), ServerDefinition.JOURNAL_JDBC_LOCK_EXPIRATION.getDefaultValue().asInt() * 1000, ActiveMQDefaultConfiguration.getDefaultJdbcLockExpirationMillis());
+        Assert.assertEquals(ServerDefinition.JOURNAL_JDBC_LOCK_RENEW_PERIOD.getName(), ServerDefinition.JOURNAL_JDBC_LOCK_RENEW_PERIOD.getDefaultValue().asInt() * 1000, ActiveMQDefaultConfiguration.getDefaultJdbcLockRenewPeriodMillis());
+        Assert.assertEquals(ServerDefinition.JOURNAL_JDBC_NETWORK_TIMEOUT.getName(), ServerDefinition.JOURNAL_JDBC_NETWORK_TIMEOUT.getDefaultValue().asInt() * 1000, ActiveMQDefaultConfiguration.getDefaultJdbcNetworkTimeout());
+        Assert.assertEquals(ServerDefinition.JOURNAL_LARGE_MESSAGES_TABLE.getName(), ServerDefinition.JOURNAL_LARGE_MESSAGES_TABLE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultLargeMessagesTableName());
+        Assert.assertEquals(ServerDefinition.JOURNAL_MESSAGES_TABLE.getName(), ServerDefinition.JOURNAL_MESSAGES_TABLE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultMessageTableName());
+        Assert.assertEquals(ServerDefinition.JOURNAL_MIN_FILES.getName(), ServerDefinition.JOURNAL_MIN_FILES.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultJournalMinFiles());
+        Assert.assertEquals(ServerDefinition.JOURNAL_NODE_MANAGER_STORE_TABLE.getName(), ServerDefinition.JOURNAL_NODE_MANAGER_STORE_TABLE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultNodeManagerStoreTableName());
+        Assert.assertEquals(ServerDefinition.JOURNAL_PAGE_STORE_TABLE.getName(), ServerDefinition.JOURNAL_PAGE_STORE_TABLE.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultPageStoreTableName());
+        Assert.assertEquals(ServerDefinition.JOURNAL_SYNC_NON_TRANSACTIONAL.getName(), ServerDefinition.JOURNAL_SYNC_NON_TRANSACTIONAL.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultJournalSyncNonTransactional());
+        Assert.assertEquals(ServerDefinition.JOURNAL_SYNC_TRANSACTIONAL.getName(), ServerDefinition.JOURNAL_SYNC_TRANSACTIONAL.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultJournalSyncTransactional());
+        Assert.assertEquals(ServerDefinition.LOG_JOURNAL_WRITE_RATE.getName(), ServerDefinition.LOG_JOURNAL_WRITE_RATE.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultJournalLogWriteRate());
+        Assert.assertEquals(ServerDefinition.MANAGEMENT_ADDRESS.getName(), ServerDefinition.MANAGEMENT_ADDRESS.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultManagementAddress().toString());
+        Assert.assertEquals(ServerDefinition.MANAGEMENT_NOTIFICATION_ADDRESS.getName(), ServerDefinition.MANAGEMENT_NOTIFICATION_ADDRESS.getDefaultValue().asString(), ActiveMQDefaultConfiguration.getDefaultManagementNotificationAddress().toString());
+        Assert.assertEquals(ServerDefinition.MEMORY_MEASURE_INTERVAL.getName(), ServerDefinition.MEMORY_MEASURE_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMemoryMeasureInterval());
+        Assert.assertEquals(ServerDefinition.MEMORY_WARNING_THRESHOLD.getName(), ServerDefinition.MEMORY_WARNING_THRESHOLD.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMemoryWarningThreshold());
+        Assert.assertEquals(ServerDefinition.MESSAGE_COUNTER_MAX_DAY_HISTORY.getName(), ServerDefinition.MESSAGE_COUNTER_MAX_DAY_HISTORY.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMessageCounterMaxDayHistory());
+        Assert.assertEquals(ServerDefinition.MESSAGE_COUNTER_SAMPLE_PERIOD.getName(), ServerDefinition.MESSAGE_COUNTER_SAMPLE_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMessageCounterSamplePeriod());
+        Assert.assertEquals(ServerDefinition.MESSAGE_EXPIRY_SCAN_PERIOD.getName(), ServerDefinition.MESSAGE_EXPIRY_SCAN_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultMessageExpiryScanPeriod());
+        Assert.assertEquals(ServerDefinition.MESSAGE_EXPIRY_THREAD_PRIORITY.getName(), ServerDefinition.MESSAGE_EXPIRY_THREAD_PRIORITY.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMessageExpiryThreadPriority());
+        Assert.assertEquals(ServerDefinition.PAGE_MAX_CONCURRENT_IO.getName(), ServerDefinition.PAGE_MAX_CONCURRENT_IO.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultMaxConcurrentPageIo());
+        Assert.assertEquals(ServerDefinition.PERSISTENCE_ENABLED.getName(), ServerDefinition.PERSISTENCE_ENABLED.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultPersistenceEnabled());
+        Assert.assertEquals(ServerDefinition.PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY.getName(), ServerDefinition.PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultPersistDeliveryCountBeforeDelivery());
+        Assert.assertEquals(ServerDefinition.PERSIST_ID_CACHE.getName(), ServerDefinition.PERSIST_ID_CACHE.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultPersistIdCache());
+        Assert.assertEquals(ServerDefinition.SECURITY_ENABLED.getName(), ServerDefinition.SECURITY_ENABLED.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultSecurityEnabled());
+        Assert.assertEquals(ServerDefinition.SECURITY_INVALIDATION_INTERVAL.getName(), ServerDefinition.SECURITY_INVALIDATION_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultSecurityInvalidationInterval());
+        Assert.assertEquals(ServerDefinition.SERVER_DUMP_INTERVAL.getName(), ServerDefinition.SERVER_DUMP_INTERVAL.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultServerDumpInterval());
+        Assert.assertEquals(ServerDefinition.THREAD_POOL_MAX_SIZE.getName(), ServerDefinition.THREAD_POOL_MAX_SIZE.getDefaultValue().asInt(), ActiveMQDefaultConfiguration.getDefaultThreadPoolMaxSize());
+        Assert.assertEquals(ServerDefinition.TRANSACTION_TIMEOUT.getName(), ServerDefinition.TRANSACTION_TIMEOUT.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultTransactionTimeout());
+        Assert.assertEquals(ServerDefinition.TRANSACTION_TIMEOUT_SCAN_PERIOD.getName(), ServerDefinition.TRANSACTION_TIMEOUT_SCAN_PERIOD.getDefaultValue().asLong(), ActiveMQDefaultConfiguration.getDefaultTransactionTimeoutScanPeriod());
+        Assert.assertEquals(ServerDefinition.WILD_CARD_ROUTING_ENABLED.getName(), ServerDefinition.WILD_CARD_ROUTING_ENABLED.getDefaultValue().asBoolean(), ActiveMQDefaultConfiguration.isDefaultWildcardRoutingEnabled());
+    }
+}

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_11_0_TestCase.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingActiveMQSubsystem_11_0_TestCase.java
@@ -74,20 +74,20 @@ import org.wildfly.extension.messaging.activemq.jms.ConnectionFactoryAttributes;
 /**
  *  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012 Red Hat inc
  */
-public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemBaseTest {
+public class MessagingActiveMQSubsystem_11_0_TestCase extends AbstractSubsystemBaseTest {
 
-    public MessagingActiveMQSubsystem_10_0_TestCase() {
+    public MessagingActiveMQSubsystem_11_0_TestCase() {
         super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_10_0.xml");
+        return readResource("subsystem_11_0.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws IOException {
-        return "schema/wildfly-messaging-activemq_10_0.xsd";
+        return "schema/wildfly-messaging-activemq_11_0.xsd";
     }
 
     @Override
@@ -106,9 +106,10 @@ public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemB
         return properties;
     }
 
-   @Override
-    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
-        return super.standardSubsystemTest(configId, false);
+    @Test
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        super.testSchemaOfSubsystemTemplates();
     }
 
     @Test
@@ -131,25 +132,24 @@ public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemB
 
     @Test
     public void testHAPolicyConfiguration() throws Exception {
-        standardSubsystemTest("subsystem_10_0_ha-policy.xml");
+        standardSubsystemTest("subsystem_11_0_ha-policy.xml");
     }
 
     ///////////////////////
     // Transformers test //
     ///////////////////////
     @Test
-    public void testTransformersWildfly18() throws Exception {
-        testTransformers(ModelTestControllerVersion.MASTER, MessagingExtension.VERSION_8_0_0);
+    public void testTransformersWildfly20() throws Exception {
+        testTransformers(ModelTestControllerVersion.MASTER, MessagingExtension.VERSION_10_0_0);
+    }
+    @Test
+    public void testTransformersWildfly19() throws Exception {
+        testTransformers(ModelTestControllerVersion.MASTER, MessagingExtension.VERSION_9_0_0);
     }
 
     @Test
-    public void testTransformersWildfly17() throws Exception {
-        testTransformers(ModelTestControllerVersion.MASTER, MessagingExtension.VERSION_7_0_0);
-    }
-
-    @Test
-    public void testTransformersWildfly16() throws Exception {
-        testTransformers(ModelTestControllerVersion.MASTER, MessagingExtension.VERSION_6_0_0);
+    public void testTransformersEAP_7_3_0() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_3_0, MessagingExtension.VERSION_8_0_0);
     }
 
     @Test
@@ -185,7 +185,7 @@ public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemB
     private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion) throws Exception {
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
-                .setSubsystemXmlResource("subsystem_10_0_transform.xml");
+                .setSubsystemXmlResource("subsystem_11_0_transform.xml");
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, messagingVersion)
                 .addMavenResourceURL(getMessagingActiveMQGAV(controllerVersion))
                 .addMavenResourceURL(getActiveMQDependencies(controllerVersion))
@@ -225,7 +225,7 @@ public class MessagingActiveMQSubsystem_10_0_TestCase extends AbstractSubsystemB
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(messagingVersion).isSuccessfulBoot());
 
-        List<ModelNode> ops = builder.parseXmlResource("subsystem_10_0_reject_transform.xml");
+        List<ModelNode> ops = builder.parseXmlResource("subsystem_11_0_reject_transform.xml");
         System.out.println("ops = " + ops);
         PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM_PATH);
 

--- a/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingDependencies.java
+++ b/messaging-activemq/src/test/java/org/wildfly/extension/messaging/activemq/MessagingDependencies.java
@@ -35,8 +35,16 @@ public class MessagingDependencies {
 
     private static final Map<ModelTestControllerVersion, String[]> ACTIVEMQ_DEPENDENCIES;
     static {
-        Map<ModelTestControllerVersion, String[]> map = new HashMap<ModelTestControllerVersion, String[]>();
-
+        Map<ModelTestControllerVersion, String[]> map = new HashMap<>();
+        map.put(ModelTestControllerVersion.EAP_7_3_0, new String[] {
+                "org.apache.activemq:artemis-commons:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-journal:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-server:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-jms-server:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-core-client:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-jms-client:2.9.0.redhat-00005",
+                "org.apache.activemq:artemis-ra:2.9.0.redhat-00005",
+        });
         map.put(ModelTestControllerVersion.EAP_7_2_0, new String[] {
                 "org.apache.activemq:artemis-commons:2.6.3.redhat-00014",
                 "org.apache.activemq:artemis-journal:2.6.3.redhat-00014",

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0.xml
@@ -1,0 +1,704 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
+    <global-client thread-pool-max-size="${global.client.thread-pool-max-size:32}"
+                   scheduled-thread-pool-max-size="${global.client.scheduled.thread-pool-max-size:54}" />
+
+    <http-connector name="client-http"
+                    socket-binding="http"
+                    endpoint="http"
+                    server-name="=foo">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </http-connector>
+
+    <remote-connector name="client-netty-throughput"
+                      socket-binding="messaging-throughput">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </remote-connector>
+
+    <in-vm-connector name="in-vm-client"
+                     server-id="${my.server-id:0}"/>
+
+    <connector name="myconnector-client"
+               factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+        <param name="host" value="192.168.1.2"/>
+        <param name="port" value="5445"/>
+        <param name="key-store-path" value="path/to/server.jks"/>
+        <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+    </connector>
+
+    <jgroups-discovery-group name="client-discovery-group-2"
+                     jgroups-channel="ee"
+                     jgroups-cluster="activemq-cluster"
+                     refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                     initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+    <socket-discovery-group name="client-discovery-group-1"
+                     socket-binding="group-t-binding"/>
+
+    <connection-factory name="InVmConnectionFactory"
+                        connectors="in-vm client"
+                        entries="${connection-factory.entries.entry:java:/ClientConnectionFactory}"
+                        enable-amq1-prefix="true"
+                        use-topology-for-load-balancing="true" />
+
+    <connection-factory name="RemoteClientConnectionFactory"
+                        factory-type="XA_QUEUE"
+                        connectors="client-http client-netty-throughput"
+                        entries="RemoteClientConnectionFactory java:/global/jms/RemoteClientConnectionFactory" />
+
+    <connection-factory name="otherClientConnectionFactory"
+                        discovery-group="client-discovery-group-1"
+                        ha="${ha:true}"
+                        entries="otherClientConnectionFactory"
+                        use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="hornetq-ra-local"
+                               transaction="local"
+                               user="alice"
+                               password="alicepassword"
+                               use-auto-recovery="${use.auto.recovery:true}"
+                               connectors="in-vm-client"
+                               entries="java:/JmsLocal"
+                               enable-amq1-prefix="true"
+                               use-topology-for-load-balancing="true" />
+
+    <pooled-connection-factory name="activemq-ra-none"
+                               transaction="none"
+                               user="alice"
+                               password="alicepassword"
+                               connectors="in-vm-client"
+                               entries="java:/JmsNone"
+                               use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="activemq-ra"
+                               transaction="${transaction:xa}"
+                               user="${user:alice}"
+                               password="${password:alicepassword}"
+                               min-pool-size="${min.pool.size:42}"
+                               max-pool-size="${max.pool.size:242}"
+                               managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                               enlistment-trace="${enlistment.trace:false}"
+                               initial-message-packet-size="${initial.message.packet.size:9876}"
+                               initial-connect-attempts="${initial.connect.attempts:5432}"
+                               connectors="in-vm-client"
+                               entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                               ha="${ha:true}"
+                               client-failure-check-period="${client.failure.check.period:12345}"
+                               connection-ttl="${connection.ttl:6789}"
+                               call-timeout="${call.timeout:123}"
+                               call-failover-timeout="${call.failover.timeout:456}"
+                               consumer-window-size="${consumer.window.size:456}"
+                               consumer-max-rate="${consumer.max.rate:789}"
+                               confirmation-window-size="${confirmation.window.size:-1}"
+                               producer-window-size="${producer.window.size:-1}"
+                               producer-max-rate="${producer.max.rate:1024}"
+                               protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                               compress-large-messages="${compress.large.messages:true}"
+                               cache-large-message-client="${cache.large.message.client:false}"
+                               min-large-message-size="${min.large.message.size:2048}"
+                               client-id="${client.id:myClientID}"
+                               dups-ok-batch-size="${dups.ok.batch.size:256}"
+                               transaction-batch-size="${transaction.batch.size:512}"
+                               block-on-acknowledge="${block.on.acknowledge:false}"
+                               block-on-non-durable-send="${block.on.non.durable.send:false}"
+                               block-on-durable-send="${block.on.durable.send:false}"
+                               auto-group="${auto.group:true}"
+                               pre-acknowledge="${pre.acknowledge:true}"
+                               retry-interval="${retry.interval:500}"
+                               retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                               max-retry-interval="${max.retry.interval:10000}"
+                               reconnect-attempts="${reconnect.attempts:2}"
+                               failover-on-initial-connection="${failover.on.initial.connection:true}"
+                               connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                               use-global-pools="${use.global.pools:true}"
+                               scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                               thread-pool-max-size="${thread.pool.max.size:48}"
+                               group-id="${group.id:myGroup}"
+                               deserialization-black-list="org.foo.Bar org.foo.Baz"
+                               deserialization-white-list="org.bar.Bar org.baz.Baz"
+                               statistics-enabled="${pcf.statistics-enabled:true}">
+        <inbound-config
+            use-jndi="${use.jndi:false}"
+            jndi-params="${jndi.params:whatever}"
+            rebalance-connections="${inbound.rebalance-connections:true}"
+            use-local-tx="${use.local.tx:true}"
+            setup-attempts="${setup-attempts:123}"
+            setup-interval="${setup-interval:456}" />
+        <outbound-config
+            allow-local-transactions="${allow.local.transactions:true}" />
+    </pooled-connection-factory>
+
+    <pooled-connection-factory name="pcf-with-credential-reference"
+                               entries="java:/JmsLocal2"
+                               connectors="in-vm-client"
+                               user="foo">
+        <credential-reference clear-text="passwordOut!"/>
+    </pooled-connection-factory>
+
+    <external-jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/client-test}"/>
+    <external-jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/client-test2"/>
+    <external-jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/client-test}"/>
+
+    <server name="default"
+            persistence-enabled="${persistence.enabled:false}"
+            persist-id-cache="${persist.id.cache:false}"
+            persist-delivery-count-before-delivery="${persist.delivery.count.before.delivery:true}"
+            id-cache-size="${id.cache.size:102030}"
+            page-max-concurrent-io="${page.max.concurrent.io:10}"
+            scheduled-thread-pool-max-size="${messaging.scheduled.thread.pool.max.size:6}"
+            thread-pool-max-size="${messaging.thread.pool.max.size:5}"
+            wild-card-routing-enabled="${wild.card.routing.enabled:false}"
+            connection-ttl-override="${connection.ttl.override:5432}"
+            async-connection-execution-enabled="${async.connection.execution.enabled:false}">
+
+        <incoming-interceptors>
+            <class name="org.foo.incoming.myInterceptor" module="org.foo" />
+            <class name="org.bar.incoming.myOtherInterceptor" module="org.bar" />
+        </incoming-interceptors>
+
+        <outgoing-interceptors>
+            <class name="org.foo.outgoing.myInterceptor" module="org.foo" />
+            <class name="org.bar.outgoing.myOtherInterceptor" module="org.bar" />
+        </outgoing-interceptors>
+
+        <security
+            enabled="${security.enabled:false}"
+            elytron-domain="elytronDomain"
+            invalidation-interval="${security.invalidation.interval:1234}"
+            override-in-vm-security="${override.in-vm.security:false}"/>
+
+        <cluster
+            user="${messaging.cluster.user.name}"
+            password="${messaging.cluster.user.password}"/>
+
+        <management
+            address="${management.address:my.management.address}"
+            notification-address="${management.notification.address:my.management.notif.address}"
+            jmx-enabled="${jmx.management.enabled:false}"
+            jmx-domain="${jmx.domain:my.jmx.domain}"/>
+
+        <journal
+                type="${journal.type:NIO}"
+                buffer-timeout="${journal.buffer.timeout:1357}"
+                buffer-size="${journal.buffer.size:2468}"
+                sync-transactional="${journal.sync.transactional:false}"
+                sync-non-transactional="${journal.sync.non.transactional:true}"
+                log-write-rate="${log.journal.write.rate:true}"
+                file-size="${journal.file.size:102400}"
+                min-files="${journal.min.files:2}"
+                pool-files="${journal.pool.files:5}"
+                compact-percentage="${journal.compact.percentage:83}"
+                file-open-timeout="${journal.file.open.timeout:7}"
+                compact-min-files="${journal.compact.min.files:2}"
+                max-io="${journal.max.io:50}"
+                create-bindings-dir="${create.bindings.dir:false}"
+                create-journal-dir="${create.journal.dir:true}"
+                datasource="fooDS"
+                database="mysql"
+                jdbc-lock-expiration="${journal.jdbc.lock.expiration:891}"
+                jdbc-lock-renew-period="${journal.jdbc.lock.renew.period:892}"
+                jdbc-network-timeout="${journal.jdbc.network.timeout:4567}"
+                messages-table="${journal.message.table:MESSAGES}"
+                bindings-table="${journal.bindings.table:BINDINGS}"
+                jms-bindings-table="${journal.jms.bindings.table:JMS_BINDINGS}"
+                large-messages-table="${journal.large-messages.table:LARGE_MESSAGES}"
+                page-store-table="${journal.page-store.table:PAGE_STORE}"
+                node-manager-store-table="${journal.node-manager-store-table:NODE_MANAGER_STORE}" />
+
+        <statistics
+            enabled="${statistics.enabled:true}"
+            message-counter-sample-period="${message.counter.sample.period:7654}"
+            message-counter-max-day-history="${message.counter.max.day.history:23}"/>
+
+        <transaction
+            timeout="${transaction.timeout:4321}"
+            scan-period="${transaction.timeout.scan.period:5432}"/>
+
+        <message-expiry
+            scan-period="${message.expiry.scan.period:7654}"
+            thread-priority="${message.expiry.thread.priority:7}"/>
+
+        <debug
+            perf-blast-pages="${perf.blast.pages:70}"
+            run-sync-speed-test="${run.sync.speed.test:false}"
+            server-dump-interval="${server.dump.interval:8642}"
+            memory-warning-threshold="${memory.warning.threshold:1024}"
+            memory-measure-interval="${memory.measure.interval:2048}"/>
+
+        <bindings-directory path="${my.bindings.dir:test}" relative-to="test"/>
+        <journal-directory path="${my.journal.dir:test}" relative-to="test"/>
+        <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test"/>
+        <paging-directory path="${my.paging.dir:test}" relative-to="test"/>
+
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+
+        <queue name="coreQueueB" address="addressB"
+               routing-type="ANYCAST" />
+
+        <security-setting name="#">
+            <role name="guest"
+                  send="true"
+                  consume="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"/>
+            <role name="admin"
+                  send="true"
+                  consume="true"
+                  create-durable-queue="true"
+                  delete-durable-queue="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"
+                  manage="true"/>
+        </security-setting>
+
+        <address-setting name="#"
+                         dead-letter-address="${dead.letter.address:jms.queue.DLQ}"
+                         expiry-address="${expiry.address:jms.queue.ExpiryQueue}"
+                         expiry-delay="${expiry.delay:12345}"
+                         redelivery-delay="${redelivery.delay:0}"
+                         redelivery-multiplier="${redelivery.multiplier:1.0}"
+                         max-delivery-attempts="${max.delivery.attempts:5}"
+                         max-redelivery-delay="${max.redelivery.delay:234}"
+                         max-size-bytes="${max.size.bytes:10485760}"
+                         page-size-bytes="${page.size.bytes:10485760}"
+                         page-max-cache-size="${page.max.cache.size:7}"
+                         address-full-policy="${address.full.policy:BLOCK}"
+                         message-counter-history-day-limit="${message.counter.history.day.limit:10}"
+                         last-value-queue="${last.value.queue:false}"
+                         redistribution-delay="${redistribution.delay:0}"
+                         send-to-dla-on-no-route="${send.to.dla.on.no.route:false}"
+                         slow-consumer-check-period="${slow.consumer.check.period:123}"
+                         slow-consumer-policy="${slow.consumer.policy:KILL}"
+                         slow-consumer-threshold="${slow.consumer.threshold:456}"
+                         auto-create-jms-queues="${auto.create.jms.queue:true}"
+                         auto-delete-jms-queues="${auto.delete.jms.queue:true}"
+                         auto-create-queues="${auto.create.queues:true}"
+                         auto-delete-queues="${auto.delete.queues:true}"
+                         auto-create-addresses="${auto.create.addresses:true}"
+                         auto-delete-addresses="${auto.delete.addresses:true}" />
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http"
+                        server-name="=foo">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+        <remote-connector name="netty"
+                          socket-binding="messaging"/>
+        <remote-connector name="netty-throughput"
+                          socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <connector name="myconnector"
+                   factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="host" value="192.168.1.2"/>
+            <param name="port" value="5445"/>
+            <param name="key-store-path" value="path/to/server.jks"/>
+            <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+        </connector>
+
+        <http-acceptor name="http"
+                       http-listener="default"
+                       upgrade-legacy="${upgrade.legacy:true}">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-acceptor>
+        <remote-acceptor name="netty"
+                         socket-binding="messaging"/>
+        <remote-acceptor name="netty-throughput"
+                         socket-binding="messaging-throughput">
+            <param name="batch-delay" value="50"/>
+            <param name="direct-deliver" value="false"/>
+        </remote-acceptor>
+        <in-vm-acceptor name="in-vm"
+                        server-id="${my.server-id:0}"/>
+        <acceptor name="myacceptor"
+                  factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="batchDelay" value="${batch.delay:50}"/>
+        </acceptor>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         broadcast-period="${broadcast.group.period:1234}"
+                         connectors="http netty"/>
+
+        <socket-broadcast-group name="groupS"
+                         socket-binding="group-s-binding"
+                         connectors="in-vm"/>
+
+        <jgroups-discovery-group name="groupU"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                         initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+        <socket-discovery-group name="groupT"
+                         socket-binding="group-t-binding"/>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            check-period="${check.period:2345}"
+                            connection-ttl="${connection.ttl:1234}"
+                            min-large-message-size="${min.large.message.size:10245}"
+                            call-timeout="${call.timeout:3456}"
+                            call-failover-timeout="${call.failover.timeout:7890}"
+                            retry-interval="${retry.interval:987}"
+                            retry-interval-multiplier="${retry.interval.multiplier:3.0}"
+                            max-retry-interval="${max.retry.interval:3600}"
+                            reconnect-attempts="${reconnect.attempts:-1}"
+                            use-duplicate-detection="${use.duplicate.detection:true}"
+                            message-load-balancing-type="${message.load.balancing.type:STRICT}"
+                            max-hops="${max.hops:7}"
+                            confirmation-window-size="${confirmation.windows.size:459}"
+                            producer-window-size="${producer.windows.size:5678}"
+                            notification-attempts="${notification.attempts:2}"
+                            notification-interval="${notification.interval:1}"
+                            static-connectors="in-vm netty" />
+        <cluster-connection name="cc2"
+                            address="cc2-address"
+                            connector-name="netty"
+                            static-connectors="in-vm netty"
+                            allow-direct-connections-only="true" />
+        <cluster-connection name="cc3"
+                            address="cc3-address"
+                            connector-name="netty"
+                            discovery-group="groupC"/>
+        <cluster-connection name="cc4"
+                            address="cc4-address"
+                            connector-name="netty-throughput"
+                            static-connectors="in-vm netty" />
+
+        <grouping-handler name="grouping-handler"
+                          type="${grouping.type:LOCAL}"
+                          address="${address:handler-address}"
+                          timeout="${timeout:5000}"
+                          group-timeout="${group-timeout:1234}"
+                          reaper-period="${reaper-period:5678}" />
+
+        <divert name="testDivert1"
+                routing-name="${routing.name:routing}"
+                address="${address:address1}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                filter="${filter:afilter}"
+                transformer-class-name="org.jboss.test.Transformer"
+                exclusive="${exclusive:true}"/>
+        <divert name="testDivert2"
+                address="address2"
+                forwarding-address="forwardingaddress2"/>
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                ha="${ha:true}"
+                filter="${filter:afilter}"
+                transformer-class-name="foo.bar"
+                min-large-message-size="${min.large.message.size:10240}"
+                check-period="${check.period:666}"
+                connection-ttl="${connection.tt:36000}"
+                retry-interval="${retry.interval:750}"
+                retry-interval-multiplier="${retry.interval.multiplier:2}"
+                max-retry-interval="${max.retry.interval:3000}"
+                reconnect-attempts="${reconnect-attempts:3}"
+                reconnect-attempts-on-same-node="${reconnect-attempts-on-same-node:5}"
+                use-duplicate-detection="${use.duplicate.detection:true}"
+                confirmation-window-size="${confirmation.window.size:350}"
+                producer-window-size="${producer.windows.size:5678}"
+                user="${user:Brian}"
+                password="${password:secret}"
+                static-connectors="in-vm netty" />
+        <bridge name="bridge2"
+                queue-name="coreQueueB"
+                discovery-group="groupC" />
+
+        <connector-service name="b"
+                           factory-class="bar.foo">
+            <param name="foo"
+                   value="${connector.value:bar}"/>
+            <param name="bar"
+                   value="2"/>
+        </connector-service>
+
+
+        <jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/test}"
+                   selector="${selector:color='red'}"
+                   durable="${durable:true}" />
+        <jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/test2"
+                   legacy-entries="java:/global/queue/legacy/test java:/global/queue/legacy/test2" />
+        <jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/test}"
+                   legacy-entries="${jms-topic.entry:topic/legacy/test}" />
+
+        <connection-factory name="InVmConnectionFactory"
+                            connectors="in-vm netty"
+                            entries="${connection-factory.entries.entry:java:/ConnectionFactory}"
+                            use-topology-for-load-balancing="true" />
+        <connection-factory name="RemoteConnectionFactory"
+                            factory-type="XA_QUEUE"
+                            client-id="testClient"
+                            connectors="http netty"
+                            entries="RemoteConnectionFactory java:/global/jms/RemoteConnectionFactory"
+                            use-topology-for-load-balancing="false" />
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            ha="${ha:true}"
+                            client-failure-check-period="${client.failure.check.period:12345}"
+                            connection-ttl="${connection.ttl:56789}"
+                            call-timeout="${call.timeout:123}"
+                            call-failover-timeout="${call.failover.timeout:456}"
+                            consumer-window-size="${consumer.window.size:456}"
+                            consumer-max-rate="${consumer.max.rate:789}"
+                            confirmation-window-size="${confirmation.window.size:-1}"
+                            producer-window-size="${producer.window.size:-1}"
+                            producer-max-rate="${producer.max.rate:1024}"
+                            protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                            compress-large-messages="${compress.large.messages:true}"
+                            cache-large-message-client="${cache.large.message.client:false}"
+                            min-large-message-size="${min.large.message.size:2048}"
+                            client-id="${client.id:myClientID}"
+                            dups-ok-batch-size="${dups.ok.batch.size:256}"
+                            transaction-batch-size="${transaction.batch.size:512}"
+                            block-on-acknowledge="${block.on.acknowledge:false}"
+                            block-on-non-durable-send="${block.on.non.durable.send:false}"
+                            block-on-durable-send="${block.on.durable.send:false}"
+                            auto-group="${auto.group:true}"
+                            pre-acknowledge="${pre.acknowledge:true}"
+                            retry-interval="${retry.interval:500}"
+                            retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                            max-retry-interval="${max.retry.interval:10000}"
+                            reconnect-attempts="${reconnect.attempts:2}"
+                            failover-on-initial-connection="${failover.on.initial.connection:true}"
+                            connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                            use-global-pools="${use.global.pools:true}"
+                            scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                            thread-pool-max-size="${thread.pool.max.size:48}"
+                            group-id="${group.id:myGroup}"
+                            deserialization-black-list="org.foo.Bar org.foo.Baz"
+                            deserialization-white-list="org.bar.Bar org.baz.Baz"
+                            initial-message-packet-size="${initial.message.packet.size:456}" />
+        <legacy-connection-factory name="legacyConnectionFactory-discovery"
+                                   entries="legacy/RemoteConnectionFactory java:/global/jms/legacy/RemoteConnectionFactory"
+                                   discovery-group="groupT"
+                                   auto-group="${auto.group:true}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   call-timeout="${call.timeout:123}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   client-id="${client.id:myClientID}"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                                   connection-ttl="${connection.ttl:56789}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   factory-type="${legacy.connection.factory.factory-type:XA_QUEUE}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   group-id="${group.id:myGroup}"
+                                   ha="${legacy.connection.factory.ha:true}"
+                                   initial-connect-attempts="${initial.connect.attemps:123}"
+                                   initial-message-packet-size="${initial.message.packet.size:456}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   use-global-pools="${use.global.pools:true}" />
+        <legacy-connection-factory name="legacyConnectionFactory-connectors"
+                                   entries="legacy/RemoteConnectionFactory2 java:/global/jms/legacy/RemoteConnectionFactory2"
+                                   connectors="netty http" />
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"
+                                   use-topology-for-load-balancing="true" />
+        <pooled-connection-factory name="activemq-ra-none"
+                                   transaction="none"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsNone"
+                                   use-topology-for-load-balancing="false" />
+        <pooled-connection-factory name="activemq-ra"
+                                   transaction="${transaction:xa}"
+                                   user="${user:alice}"
+                                   password="${password:alicepassword}"
+                                   min-pool-size="${min.pool.size:42}"
+                                   max-pool-size="${max.pool.size:242}"
+                                   managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                                   enlistment-trace="${enlistment.trace:false}"
+                                   initial-message-packet-size="${initial.message.packet.size:9876}"
+                                   initial-connect-attempts="${initial.connect.attempts:5432}"
+                                   connectors="in-vm netty"
+                                   entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                                   ha="${ha:true}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   connection-ttl="${connection.ttl:6789}"
+                                   call-timeout="${call.timeout:123}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   client-id="${client.id:myClientID}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   auto-group="${auto.group:true}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                                   use-global-pools="${use.global.pools:true}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   group-id="${group.id:myGroup}"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz"
+                                   statistics-enabled="${pcf.statistics-enabled:true}">
+            <inbound-config
+                use-jndi="${use.jndi:false}"
+                jndi-params="${jndi.params:whatever}"
+                rebalance-connections="${inbound.rebalance-connections:true}"
+                use-local-tx="${use.local.tx:true}"
+                setup-attempts="${setup-attempts:123}"
+                setup-interval="${setup-interval:456}" />
+            <outbound-config
+                allow-local-transactions="${allow.local.transactions:true}" />
+        </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
+    </server>
+
+    <server name="empty"/>
+
+    <jms-bridge name="default"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser"
+                password="myPassword"/>
+
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser"
+                password="myPassword"/>
+    </jms-bridge>
+
+    <jms-bridge name="another-bridge"
+                module="org.another.mq.broker"
+                quality-of-service="ONCE_AND_ONLY_ONCE"
+                failure-retry-interval="-1"
+                max-retries="-1"
+                max-batch-size="1"
+                max-batch-time="-1"
+                selector="${selector:color='red'}"
+                subscription-name="${subscription.name:mySubscription}"
+                client-id="${client.id:myClientID}"
+                add-messageID-in-header="${add.messageID.in.header:true}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/sourceTopic"
+                user="myUser"
+                password="myPassword">
+            <source-context>
+                <property name="java.naming.factory.initial"
+                          value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property name="java.naming.provider.url"
+                          value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property name="java.naming.factory.url.pkgs"
+                          value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+            </source-context>
+        </source>
+        <target connection-factory="anotherAS7/jms/cf/targetCF"
+                destination="anotherAS7/jms/queue/targetQueue"
+                user="${userInExpression:user}"
+                password="${passwordInExpression:password}">
+            <target-context>
+                <property name="java.naming.factory.initial"
+                          value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property name="java.naming.provider.url"
+                          value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property name="java.naming.factory.url.pkgs"
+                          value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+            </target-context>
+        </target>
+    </jms-bridge>
+
+    <jms-bridge name="bridge-with-credential-reference"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser">
+            <source-credential-reference clear-text="passwordOut!"/>
+        </source>
+
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser">
+            <target-credential-reference alias="bob" store="jms-bridge-store" />
+        </target>
+    </jms-bridge>
+
+    <jms-bridge name="default-bridge"
+                module="org.default.mq.broker"
+                selector="${selector:color='red'}"
+                subscription-name="${subscription.name:mySubscription}"
+                client-id="${client.id:myClientID}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/sourceTopic"
+                user="myUser"
+                password="myPassword">
+        </source>
+        <target connection-factory="anotherAS7/jms/cf/targetCF"
+                destination="anotherAS7/jms/queue/targetQueue"
+                user="${userInExpression:user}"
+                password="${passwordInExpression:password}">
+        </target>
+    </jms-bridge>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_ha-policy.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_ha-policy.xml
@@ -1,0 +1,92 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
+    <server name="ha-policy-live-only-scale-down-discovery-group">
+        <live-only>
+            <scale-down enabled="${scale-down.enabled:true}"
+                        cluster-name="${scale-down.cluster-name:mycluster}"
+                        group-name="${scale-down.group-name:mygroup}"
+                        discovery-group="groupC"/>
+        </live-only>
+    </server>
+    <server name="ha-policy-live-only-scale-down-connectors">
+        <live-only>
+            <scale-down enabled="${scale-down.enabled:true}"
+                        cluster-name="${scale-down.cluster-name:mycluster}"
+                        group-name="${scale-down.group-name:mygroup}"
+                        connectors="netty in-vm"/>
+        </live-only>
+    </server>
+    <server name="ha-policy-replication-master">
+        <replication-master
+                cluster-name="${replication-master.cluster-name:mycluster}"
+                group-name="${replication-master.cluster-name:mygroup}"
+                check-for-live-server="${replication-master.check-for-live-server:false}"
+                initial-replication-sync-timeout="${replication-master.initial-replication-sync-timeout:1234}"/>
+    </server>
+    <server name="ha-policy-replication-slave">
+        <replication-slave
+                cluster-name="${replication-slave.cluster-name:mycluster}"
+                group-name="${replication-slave.cluster-name:mygroup}"
+                allow-failback="${replication-slave.allow-failback:true}"
+                initial-replication-sync-timeout="${replication-master.initial-replication-sync-timeout:1234}"
+                restart-backup="${replication-slave.restart-backup:true}"
+                max-saved-replicated-journal-size="${replication-slave.max-saved-replicated-journal-size:24}">
+            <scale-down enabled="${replication-slave-scale-down.enabled:true}"
+                        cluster-name="${replication-slave-scale-down.cluster-name:mycluster}"
+                        group-name="${replication-slave-scale-down.group-name:mygroup}"
+                        connectors="netty"/>
+        </replication-slave>
+    </server>
+    <server name="ha-policy-replication-colocated">
+        <replication-colocated request-backup="${replication-colocated.request-backup:false}"
+                               backup-request-retries="${replication-colocated.backup-request-retries:-1}"
+                               backup-request-retry-interval="${replication-colocated.backup-request-retry-interval:5098}"
+                               max-backups="${replication-colocated.max-backups:5}"
+                               backup-port-offset="${replication-colocated.backup-port-offset:500}"
+                               excluded-connectors="netty">
+            <master cluster-name="${replication-colocated-master.cluster-name:mycluster}"
+                    group-name="${replication-colocated-master.cluster-name:mygroup}"
+                    check-for-live-server="${replication-colocated-master.check-for-live-server:false}" />
+            <slave cluster-name="${replication-colocated-slave.cluster-name:mycluster}"
+                   group-name="${replication-colocated-slave.cluster-name:mygroup}"
+                   allow-failback="${replication-colocated-slave.allow-failback:true}"
+                   initial-replication-sync-timeout="${replication-colocated-slave.initial-replication-sync-timeout:1234}"
+                   restart-backup="${replication-colocated-slave.restart-backup:true}"
+                   max-saved-replicated-journal-size="${replication-colocated-slave.max-saved-replicated-journal-size:24}">
+                <scale-down enabled="${replication-colocated-slave-scale-down.enabled:true}"
+                            cluster-name="${replication-colocated-slave-scale-down.cluster-name:mycluster}"
+                            group-name="${replication-colocated-slave-scale-down.group-name:mygroup}"
+                            connectors="netty"/>
+            </slave>
+        </replication-colocated>
+    </server>
+    <server name="ha-policy-shared-store-master">
+        <shared-store-master failover-on-server-shutdown="${shared-store-master.failover-on-server-shutdown:true}" />
+    </server>
+    <server name="ha-policy-shared-store-slave">
+        <shared-store-slave allow-failback="${shared-store-slave.allow-failback:false}"
+                            failover-on-server-shutdown="${shared-store-slave.failover-on-server-shutdown:true}"
+                            restart-backup="${shared-store-slave.restart-backup:false}">
+            <scale-down enabled="${shared-store-slave-scale-down.enabled:true}"
+                        cluster-name="${shared-store-slave-scale-down.cluster-name:mycluster}"
+                        group-name="${shared-store-slave-slave-scale-down.group-name:mygroup}"
+                        connectors="netty" />
+        </shared-store-slave>
+    </server>
+    <server name="ha-policy-shared-store-colocated">
+        <shared-store-colocated request-backup="${shared-store-colocated.request-backup:false}"
+                                backup-request-retries="${shared-store-colocated.backup-request-retries:-1}"
+                                backup-request-retry-interval="${shared-store-colocated.backup-request-retry-interval:5098}"
+                                max-backups="${shared-store-colocated.max-backups:5}"
+                                backup-port-offset="${shared-store-colocated.backup-port-offset:500}">
+            <master failover-on-server-shutdown="${shared-store-colocated-master.failover-on-server-shutdown:true}" />
+            <slave allow-failback="${shared-store-colocated-slave.allow-failback:false}"
+                   failover-on-server-shutdown="${shared-store-colocated-slave.failover-on-server-shutdown:true}"
+                   restart-backup="${shared-store-colocated-slave.restart-backup:false}">
+                <scale-down enabled="${shared-store-colocated-slave-scale-down.enabled:true}"
+                            cluster-name="${shared-store-colocated-slave-scale-down.cluster-name:mycluster}"
+                            group-name="${shared-store-colocated-slave-slave-scale-down.group-name:mygroup}"
+                            connectors="netty" />
+            </slave>
+        </shared-store-colocated>
+    </server>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_reject_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_reject_transform.xml
@@ -1,0 +1,222 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
+    <global-client thread-pool-max-size="${global.client.thread-pool-max-size:32}"
+                   scheduled-thread-pool-max-size="${global.client.scheduled.thread-pool-max-size:54}" />
+
+    <http-connector name="client-http"
+                    socket-binding="http"
+                    endpoint="http"
+                    server-name="=foo">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </http-connector>
+
+    <remote-connector name="client-netty-throughput"
+                      socket-binding="messaging-throughput">
+        <param name="batch-delay" value="${batch.delay:50}"/>
+    </remote-connector>
+
+    <in-vm-connector name="in-vm-client"
+                     server-id="${my.server-id:0}"/>
+
+    <connector name="myconnector-client"
+               factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+        <param name="host" value="192.168.1.2"/>
+        <param name="port" value="5445"/>
+        <param name="key-store-path" value="path/to/server.jks"/>
+        <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+    </connector>
+
+    <socket-discovery-group name="client-discovery-group-1"
+                     socket-binding="group-t-binding"/>
+
+    <connection-factory name="InVmConnectionFactory"
+                        connectors="in-vm-client"
+                        entries="${connection-factory.entries.entry:java:/ClientConnectionFactory}"
+                        enable-amq1-prefix="false"
+                        use-topology-for-load-balancing="false" />
+
+    <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm-client"
+                                   entries="java:/JmsLocal"
+                                   enable-amq1-prefix="false"/>
+
+    <external-jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/client-test}"/>
+    <external-jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/client-test2"/>
+    <external-jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/client-test}"/>
+
+    <server name="default">
+
+        <security elytron-domain="elytronDomain"/>
+        <cluster user="testuser">
+            <credential-reference store="cs1" alias="testuser"/>
+        </cluster>
+        <journal datasource="fooDS"
+                 database="mysql"
+                 jdbc-lock-expiration="891"
+                 jdbc-lock-renew-period="892"
+                 jdbc-network-timeout="4567"
+                 messages-table="MY_MESSAGES"
+                 bindings-table="MY_BINDINGS"
+                 jms-bindings-table="MY_JMS_BINDINGS"
+                 large-messages-table="MY_LARGE_MESSAGES"
+                 node-manager-store-table="MY_NODE_MANAGER_STORE"
+                 page-store-table="MY_PAGE_STORE"
+                 global-max-disk-usage="70"
+                 global-max-memory-size="100000"
+                 disk-scan-period="10000"
+                 file-open-timeout="7"/>
+
+        <replication-colocated>
+            <master />
+        </replication-colocated>
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"
+               routing-type="ANYCAST" />
+
+        <queue name="coreQueueB" address="addressB" routing-type="ANYCAST" />
+
+        <address-setting name="#"
+                         auto-create-queues="true"
+                         auto-delete-queues="true"
+                         auto-create-addresses="false"
+                         auto-delete-addresses="false" />
+
+        <remote-connector name="netty"
+                                           socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+
+        <in-vm-connector name="in-vm"
+                                          server-id="${my.server-id:0}"/>
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http"
+                        server-name="=foo">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            producer-window-size="${producer.windows.size:5678}"
+                            static-connectors="in-vm netty" />
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}">
+            <credential-reference clear-text="secret1"/>
+        </bridge>
+        <bridge name="bridge2"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}"
+                password="${password:secret}">
+        </bridge>
+
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            deserialization-black-list="org.foo.Bar org.foo.Baz"
+                            deserialization-white-list="org.bar.Bar org.baz.Baz"
+                            initial-message-packet-size="${initial.message.packet.size:12345}"/>
+
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"
+                                   statistics-enabled="true"
+                                   use-topology-for-load-balancing="false">
+            <inbound-config
+                    rebalance-connections="true" />
+            <outbound-config
+                    allow-local-transactions="true" />
+
+        </pooled-connection-factory>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz">
+            <credential-reference clear-text="passwordOut!"/>
+        </pooled-connection-factory>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"
+                         connectors="http"/>
+
+        <jgroups-discovery-group name="groupU"
+                         jgroups-channel="ee"
+                         jgroups-cluster="activemq-cluster"/>
+    </server>
+    <server name="server1">
+        <security elytron-domain="elytronDomain"/>
+        <cluster user="testuser">
+            <credential-reference store="cs1" alias="testuser" clear-text="clusterpass"/>
+        </cluster>
+    </server>
+    <server name="server2">
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+        <bridge name="bridge2"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                producer-window-size="${producer.windows.size:5678}"
+                static-connectors="in-vm netty"
+                user="${user:Brian}">
+            <credential-reference store="cs1" clear-text="bridgepass"/>
+        </bridge>
+    </server>
+    <server name="server3">
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <pooled-connection-factory name="pcf-with-credential-reference"
+                                   entries="java:/JmsLocal2"
+                                   connectors="in-vm"
+                                   user="foo"
+                                   deserialization-black-list="org.foo.Bar org.foo.Baz"
+                                   deserialization-white-list="org.bar.Bar org.baz.Baz">
+            <credential-reference store="cs1" clear-text="pooledpass"/>
+        </pooled-connection-factory>
+    </server>
+    <jms-bridge name="bridge-with-credential-reference"
+                module="com.foo.bar"
+                quality-of-service="${quality.of.service:AT_MOST_ONCE}"
+                failure-retry-interval="${failure.retry.interval:45678}"
+                max-retries="${max.retries:7890}"
+                max-batch-size="${max.batch.size:12345}"
+                max-batch-time="${max.batch.time:10000}">
+        <source connection-factory="/cf/sourceCF"
+                destination="/topic/anotherSourceTopic"
+                user="myUser">
+            <source-credential-reference store="cs1" clear-text="sourcepass"/>
+        </source>
+        <target connection-factory="/cf/targetCF"
+                destination="anotherMQ/jms/queue/anotherTargetQueue"
+                user="myUser">
+            <target-credential-reference alias="bob" store="jms-bridge-store" clear-text="targetpass"/>
+        </target>
+    </jms-bridge>
+    <server name="other">
+        <replication-master />
+    </server>
+</subsystem>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_transform.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_11_0_transform.xml
@@ -1,0 +1,416 @@
+<subsystem xmlns="urn:jboss:domain:messaging-activemq:11.0">
+    <server name="default"
+            persistence-enabled="${persistence.enabled:false}"
+            persist-id-cache="${persist.id.cache:false}"
+            persist-delivery-count-before-delivery="${persist.delivery.count.before.delivery:true}"
+            id-cache-size="${id.cache.size:102030}"
+            page-max-concurrent-io="${page.max.concurrent.io:10}"
+            scheduled-thread-pool-max-size="${messaging.scheduled.thread.pool.max.size:6}"
+            thread-pool-max-size="${messaging.thread.pool.max.size:5}"
+            wild-card-routing-enabled="${wild.card.routing.enabled:false}"
+            connection-ttl-override="${connection.ttl.override:5432}"
+            async-connection-execution-enabled="${async.connection.execution.enabled:false}">
+
+        <security
+                enabled="${security.enabled:false}"
+                domain="someDomain"
+                invalidation-interval="${security.invalidation.interval:1234}"
+                override-in-vm-security="${override.in-vm.security:false}"/>
+
+        <cluster
+                user="${messaging.cluster.user.name:myClusterUser}"
+                password="${messaging.cluster.user.password:myClusterPassword}"/>
+
+        <management
+                address="${management.address:my.management.address}"
+                notification-address="${management.notification.address:my.management.notif.address}"
+                jmx-enabled="${jmx.management.enabled:false}"
+                jmx-domain="${jmx.domain:my.jmx.domain}"/>
+
+        <journal
+                type="${journal.type:NIO}"
+                buffer-timeout="${journal.buffer.timeout:1357}"
+                buffer-size="${journal.buffer.size:2468}"
+                sync-transactional="${journal.sync.transactional:false}"
+                sync-non-transactional="${journal.sync.non.transactional:true}"
+                log-write-rate="${log.journal.write.rate:true}"
+                file-size="${journal.file.size:102400}"
+                min-files="${journal.min.files:2}"
+                pool-files="${journal.pool.files:5}"
+                compact-percentage="${journal.compact.percentage:83}"
+                compact-min-files="${journal.compact.min.files:2}"
+                max-io="${journal.max.io:50}"
+                create-bindings-dir="${create.bindings.dir:false}"
+                create-journal-dir="${create.journal.dir:true}"
+                global-max-disk-usage="100"
+                disk-scan-period="5000"
+                global-max-memory-size="-1"/>
+
+        <statistics
+                enabled="${statistics.enabled:true}"
+                message-counter-sample-period="${message.counter.sample.period:7654}"
+                message-counter-max-day-history="${message.counter.max.day.history:23}"/>
+
+        <transaction
+                timeout="${transaction.timeout:4321}"
+                scan-period="${transaction.timeout.scan.period:5432}"/>
+
+        <message-expiry
+                scan-period="${message.expiry.scan.period:7654}"
+                thread-priority="${message.expiry.thread.priority:7}"/>
+
+        <debug
+                perf-blast-pages="${perf.blast.pages:70}"
+                run-sync-speed-test="${run.sync.speed.test:false}"
+                server-dump-interval="${server.dump.interval:8642}"
+                memory-warning-threshold="${memory.warning.threshold:1024}"
+                memory-measure-interval="${memory.measure.interval:2048}"/>
+
+        <bindings-directory path="${my.bindings.dir:test}" relative-to="test"/>
+        <journal-directory path="${my.journal.dir:test}" relative-to="test"/>
+        <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test"/>
+        <paging-directory path="${my.paging.dir:test}" relative-to="test"/>
+
+        <queue name="coreQueueA"
+               address="${address:addressA}"
+               filter="${filter:afilter}"
+               durable="${durable:true}"/>
+
+        <queue name="coreQueueB"
+               address="addressB"/>
+
+        <security-setting name="#">
+            <role name="guest"
+                  send="true"
+                  consume="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"/>
+            <role name="admin"
+                  send="true"
+                  consume="true"
+                  create-durable-queue="true"
+                  delete-durable-queue="true"
+                  create-non-durable-queue="true"
+                  delete-non-durable-queue="true"
+                  manage="true"/>
+        </security-setting>
+
+        <address-setting name="#"
+                         dead-letter-address="${dead.letter.address:jms.queue.DLQ}"
+                         expiry-address="${expiry.address:jms.queue.ExpiryQueue}"
+                         expiry-delay="${expiry.delay:12345}"
+                         redelivery-delay="${redelivery.delay:0}"
+                         redelivery-multiplier="${redelivery.multiplier:1.0}"
+                         max-delivery-attempts="${max.delivery.attempts:5}"
+                         max-redelivery-delay="${max.redelivery.delay:234}"
+                         max-size-bytes="${max.size.bytes:10485760}"
+                         page-size-bytes="${page.size.bytes:10485760}"
+                         page-max-cache-size="${page.max.cache.size:7}"
+                         address-full-policy="${address.full.policy:BLOCK}"
+                         message-counter-history-day-limit="${message.counter.history.day.limit:10}"
+                         last-value-queue="${last.value.queue:false}"
+                         redistribution-delay="${redistribution.delay:0}"
+                         send-to-dla-on-no-route="${send.to.dla.on.no.route:false}"
+                         slow-consumer-check-period="${slow.consumer.check.period:123}"
+                         slow-consumer-policy="${slow.consumer.policy:KILL}"
+                         slow-consumer-threshold="${slow.consumer.threshold:456}"
+                         auto-create-jms-queues="${auto.create.jms.queue:true}"
+                         auto-delete-jms-queues="${auto.delete.jms.queue:true}"
+                         auto-create-queues="false"
+                         auto-delete-queues="false"
+                         auto-create-addresses="true"
+                         auto-delete-addresses="true"/>
+
+        <address-setting name="test"
+                         page-size-bytes="100"/>
+
+        <http-connector name="http"
+                        socket-binding="http"
+                        endpoint="http">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-connector>
+        <remote-connector name="netty"
+                          socket-binding="messaging"/>
+        <remote-connector name="netty-throughput"
+                          socket-binding="messaging-throughput">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </remote-connector>
+        <in-vm-connector name="in-vm"
+                         server-id="${my.server-id:0}"/>
+        <connector name="myconnector"
+                   factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="host" value="192.168.1.2"/>
+            <param name="port" value="5445"/>
+            <param name="key-store-path" value="path/to/server.jks"/>
+            <param name="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+        </connector>
+
+        <http-acceptor name="http"
+                       http-listener="default"
+                       upgrade-legacy="${upgrade.legacy:true}">
+            <param name="batch-delay" value="${batch.delay:50}"/>
+        </http-acceptor>
+        <remote-acceptor name="netty"
+                         socket-binding="messaging"/>
+        <remote-acceptor name="netty-throughput"
+                         socket-binding="messaging-throughput">
+            <param name="batch-delay" value="50"/>
+            <param name="direct-deliver" value="false"/>
+        </remote-acceptor>
+        <in-vm-acceptor name="in-vm"
+                        server-id="${my.server-id:0}"/>
+        <acceptor name="myacceptor"
+                  factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
+            <param name="batchDelay" value="${batch.delay:50}"/>
+        </acceptor>
+
+        <jgroups-broadcast-group name="groupT"
+                         jgroups-cluster="activemq-cluster"
+                         broadcast-period="${broadcast.group.period:1234}"
+                         connectors="http netty"/>
+        <jgroups-discovery-group name="groupU"
+                         jgroups-cluster="activemq-cluster"
+                         refresh-timeout="${discovery.group.refresh.timeout:2345}"
+                         initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
+
+        <cluster-connection name="cc1"
+                            address="${address:cc1-address}"
+                            connector-name="netty"
+                            check-period="${check.period:2345}"
+                            connection-ttl="${connection.ttl:1234}"
+                            min-large-message-size="${min.large.message.size:10245}"
+                            call-timeout="${call.timeout:3456}"
+                            call-failover-timeout="${call.failover.timeout:7890}"
+                            retry-interval="${retry.interval:987}"
+                            retry-interval-multiplier="${retry.interval.multiplier:3.0}"
+                            max-retry-interval="${max.retry.interval:3600}"
+                            reconnect-attempts="${reconnect.attempts:-1}"
+                            use-duplicate-detection="${use.duplicate.detection:true}"
+                            message-load-balancing-type="${message.load.balancing.type:STRICT}"
+                            max-hops="${max.hops:7}"
+                            confirmation-window-size="${confirmation.windows.size:459}"
+                            producer-window-size="-1"
+                            notification-attempts="${notification.attempts:2}"
+                            notification-interval="${notification.interval:1}"
+                            static-connectors="in-vm netty" />
+        <cluster-connection name="cc2"
+                            address="cc2-address"
+                            connector-name="netty"
+                            static-connectors="in-vm netty"
+                            allow-direct-connections-only="true" />
+        <cluster-connection name="cc3"
+                            address="cc3-address"
+                            connector-name="netty"
+                            discovery-group="groupC"/>
+        <cluster-connection name="cc4"
+                            address="cc4-address"
+                            connector-name="netty-throughput"
+                            static-connectors="in-vm netty" />
+
+        <grouping-handler name="grouping-handler"
+                          type="${grouping.type:LOCAL}"
+                          address="${address:handler-address}"
+                          timeout="${timeout:5000}"
+                          group-timeout="${group-timeout:1234}"
+                          reaper-period="${reaper-period:5678}" />
+
+        <divert name="testDivert1"
+                routing-name="${routing.name:routing}"
+                address="${address:address1}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                filter="${filter:afilter}"
+                transformer-class-name="org.jboss.test.Transformer"
+                exclusive="${exclusive:true}"/>
+        <divert name="testDivert2"
+                address="address2"
+                forwarding-address="forwardingaddress2"/>
+
+        <bridge name="bridge1"
+                queue-name="${queue.name:coreQueueA}"
+                forwarding-address="${forwarding.address:forwardingaddress1}"
+                ha="${ha:true}"
+                filter="${filter:afilter}"
+                transformer-class-name="foo.bar"
+                min-large-message-size="${min.large.message.size:10240}"
+                check-period="${check.period:666}"
+                connection-ttl="${connection.tt:36000}"
+                retry-interval="${retry.interval:750}"
+                retry-interval-multiplier="${retry.interval.multiplier:2}"
+                max-retry-interval="${max.retry.interval:3000}"
+                reconnect-attempts="${reconnect-attempts:3}"
+                reconnect-attempts-on-same-node="${reconnect-attempts-on-same-node:5}"
+                use-duplicate-detection="${use.duplicate.detection:true}"
+                confirmation-window-size="${confirmation.window.size:350}"
+                producer-window-size="-1"
+                user="${user:Brian}"
+                password="${password:secret}"
+                static-connectors="in-vm netty" />
+        <bridge name="bridge2"
+                queue-name="coreQueueB"
+                discovery-group="groupC" />
+        <jms-queue name="testQueue"
+                   entries="${jms-queue.entry:queue/test}"
+                   selector="${selector:color='red'}"
+                   durable="${durable:true}" />
+        <jms-queue name="testQueue2"
+                   entries="java:/global/queue/test java:/global/queue/test2"
+                   legacy-entries="java:/global/queue/legacy/test java:/global/queue/legacy/test2" />
+        <jms-topic name="testTopic"
+                   entries="${jms-topic.entry:topic/test}"
+                   legacy-entries="${jms-topic.entry:topic/legacy/test}" />
+
+        <connection-factory name="InVmConnectionFactory"
+                            connectors="in-vm netty"
+                            entries="${connection-factory.entries.entry:java:/ConnectionFactory}" />
+        <connection-factory name="RemoteConnectionFactory"
+                            factory-type="XA_QUEUE"
+                            client-id="testClient"
+                            connectors="http netty"
+                            entries="RemoteConnectionFactory java:/global/jms/RemoteConnectionFactory" />
+        <connection-factory name="otherConnectionFactory"
+                            discovery-group="groupC"
+                            entries="otherConnectionFactory"
+                            ha="${ha:true}"
+                            client-failure-check-period="${client.failure.check.period:12345}"
+                            connection-ttl="${connection.ttl:56789}"
+                            call-timeout="${call.timeout:123}"
+                            call-failover-timeout="${call.failover.timeout:456}"
+                            consumer-window-size="${consumer.window.size:456}"
+                            consumer-max-rate="${consumer.max.rate:789}"
+                            confirmation-window-size="${confirmation.window.size:-1}"
+                            producer-window-size="${producer.window.size:-1}"
+                            producer-max-rate="${producer.max.rate:1024}"
+                            protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                            compress-large-messages="${compress.large.messages:true}"
+                            cache-large-message-client="${cache.large.message.client:false}"
+                            min-large-message-size="${min.large.message.size:2048}"
+                            client-id="${client.id:myClientID}"
+                            dups-ok-batch-size="${dups.ok.batch.size:256}"
+                            transaction-batch-size="${transaction.batch.size:512}"
+                            block-on-acknowledge="${block.on.acknowledge:false}"
+                            block-on-non-durable-send="${block.on.non.durable.send:false}"
+                            block-on-durable-send="${block.on.durable.send:false}"
+                            auto-group="${auto.group:true}"
+                            pre-acknowledge="${pre.acknowledge:true}"
+                            retry-interval="${retry.interval:500}"
+                            retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                            max-retry-interval="${max.retry.interval:10000}"
+                            reconnect-attempts="${reconnect.attempts:2}"
+                            failover-on-initial-connection="${failover.on.initial.connection:true}"
+                            connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                            use-global-pools="${use.global.pools:true}"
+                            scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                            thread-pool-max-size="${thread.pool.max.size:48}"
+                            group-id="${group.id:myGroup}"
+                            use-topology-for-load-balancing="true" />
+        <legacy-connection-factory name="legacyConnectionFactory-discovery"
+                                   entries="legacy/RemoteConnectionFactory java:/global/jms/legacy/RemoteConnectionFactory"
+                                   discovery-group="groupT"
+                                   auto-group="${auto.group:true}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   call-timeout="${call.timeout:123}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   client-id="${client.id:myClientID}"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancy.policy.class"
+                                   connection-ttl="${connection.ttl:56789}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   factory-type="${legacy.connection.factory.factory-type:XA_QUEUE}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   group-id="${group.id:myGroup}"
+                                   ha="${legacy.connection.factory.ha:true}"
+                                   initial-connect-attempts="${initial.connect.attemps:123}"
+                                   initial-message-packet-size="${initial.message.packet.size:456}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   use-global-pools="${use.global.pools:true}" />
+        <legacy-connection-factory name="legacyConnectionFactory-connectors"
+                                   entries="legacy/RemoteConnectionFactory2 java:/global/jms/legacy/RemoteConnectionFactory2"
+                                   connectors="netty http" />
+        <pooled-connection-factory name="hornetq-ra-local"
+                                   transaction="local"
+                                   user="alice"
+                                   password="alicepassword"
+                                   use-auto-recovery="${use.auto.recovery:true}"
+                                   connectors="in-vm"
+                                   entries="java:/JmsLocal"/>
+        <pooled-connection-factory name="activemq-ra-none"
+                                   transaction="none"
+                                   user="alice"
+                                   password="alicepassword"
+                                   connectors="in-vm"
+                                   entries="java:/JmsNone"/>
+        <pooled-connection-factory name="activemq-ra"
+                                   transaction="${transaction:xa}"
+                                   user="${user:alice}"
+                                   password="${password:alicepassword}"
+                                   min-pool-size="${min.pool.size:42}"
+                                   max-pool-size="${max.pool.size:242}"
+                                   managed-connection-pool="${managed.connection.pool:org.foo.bar.ConnectionPool}"
+                                   enlistment-trace="${enlistment.trace:false}"
+                                   initial-message-packet-size="${initial.message.packet.size:9876}"
+                                   initial-connect-attempts="${initial.connect.attempts:5432}"
+                                   connectors="in-vm netty"
+                                   entries="${pooled-connection-factory.entries.entry:java:/JmsXA}"
+                                   ha="${ha:true}"
+                                   client-failure-check-period="${client.failure.check.period:12345}"
+                                   connection-ttl="${connection.ttl:6789}"
+                                   call-timeout="${call.timeout:123}"
+                                   call-failover-timeout="${call.failover.timeout:456}"
+                                   consumer-window-size="${consumer.window.size:456}"
+                                   consumer-max-rate="${consumer.max.rate:789}"
+                                   confirmation-window-size="${confirmation.window.size:-1}"
+                                   producer-window-size="${producer.window.size:-1}"
+                                   producer-max-rate="${producer.max.rate:1024}"
+                                   protocol-manager-factory="com.foo.bar.ProtocolManagerFactory"
+                                   compress-large-messages="${compress.large.messages:true}"
+                                   cache-large-message-client="${cache.large.message.client:false}"
+                                   min-large-message-size="${min.large.message.size:2048}"
+                                   client-id="${client.id:myClientID}"
+                                   dups-ok-batch-size="${dups.ok.batch.size:256}"
+                                   transaction-batch-size="${transaction.batch.size:512}"
+                                   block-on-acknowledge="${block.on.acknowledge:false}"
+                                   block-on-non-durable-send="${block.on.non.durable.send:false}"
+                                   block-on-durable-send="${block.on.durable.send:false}"
+                                   auto-group="${auto.group:true}"
+                                   pre-acknowledge="${pre.acknowledge:true}"
+                                   retry-interval="${retry.interval:500}"
+                                   retry-interval-multiplier="${retry.interval.multiplier:2.5}"
+                                   max-retry-interval="${max.retry.interval:10000}"
+                                   reconnect-attempts="${reconnect.attempts:2}"
+                                   failover-on-initial-connection="${failover.on.initial.connection:true}"
+                                   connection-load-balancing-policy-class-name="connection.load.balancing.policy.class"
+                                   use-global-pools="${use.global.pools:true}"
+                                   scheduled-thread-pool-max-size="${scheduled.thread.pool.max.size:24}"
+                                   thread-pool-max-size="${thread.pool.max.size:48}"
+                                   group-id="${group.id:myGroup}"
+                                   statistics-enabled="false"
+                                   use-topology-for-load-balancing="true">
+            <inbound-config
+                    use-jndi="${use.jndi:false}"
+                    jndi-params="${jndi.params:whatever}"
+                    rebalance-connections="false"
+                    use-local-tx="${use.local.tx:true}"
+                    setup-attempts="${setup-attempts:123}"
+                    setup-interval="${setup-interval:456}" />
+            <outbound-config
+                    allow-local-transactions="false" />
+        </pooled-connection-factory>
+    </server>
+</subsystem>


### PR DESCRIPTION
Issue: [WFLY-13063](https://issues.redhat.com/browse/WFLY-13063)

`id-cache-size` value is the same, I just changed it not to be hard-coded on our end

`confirmation-window-size` changed from 1048576 to 10485760, as this seems to be intended default value as per [ARTEMIS-1261](https://issues.apache.org/jira/browse/ARTEMIS-1261)
