### PR TITLE
[WFLY-13558] Upgrade WildFly Core 12.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13558

Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/12.0.0.Final...12.0.1.Final

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---


## Release Notes - WildFly Core - Version 12.0.1.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4989'>WFCORE-4989</a>] -         Upgrade WildFly Elytron to 1.12.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4990'>WFCORE-4990</a>] -         Upgrade Undertow to 2.1.3.Final
</li>
</ul>
                                                                                                                                                                        
