### PR TITLE
[WFLY-13567] Do not run the MPScriptTestCase if the example configura…

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/MPScriptTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/wildfly/test/manual/management/MPScriptTestCase.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import org.jboss.dmr.ModelNode;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -73,6 +74,7 @@ public class MPScriptTestCase {
     @Before
     public void check() {
         AssumeTestGroupUtil.assumeElytronProfileEnabled();
+        Assume.assumeTrue(String.format("Configuration file %s not found. Skipping these tests.", SCRIPT_FILE), Files.exists(SCRIPT_FILE));
     }
 
     @Test


### PR DESCRIPTION
…tion file does not exist. This can happen when the -Dtestsuite.default.build.project.prefix=ee- system property is passed.

https://issues.redhat.com/browse/WFLY-13567