### PR TITLE
[WFLY-13579] adjust testsuite waiting times with the timeout factor

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbInvocationStatisticsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbInvocationStatisticsTestCase.java
@@ -48,6 +48,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.shrinkwrap.api.Archive;
@@ -220,7 +221,7 @@ public class EjbInvocationStatisticsTestCase {
                 bean2.doIt();
 
                 // Eviction is asynchronous, so wait a bit for this to take effect
-                Thread.sleep(500);
+                Thread.sleep(TimeoutUtil.adjust(500));
 
                 result = executeOperation(managementClient, ModelDescriptionConstants.READ_RESOURCE_OPERATION, address);
                 assertEquals(1L, result.get("cache-size").asLong());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbJarRuntimeResourceTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/EjbJarRuntimeResourceTestBase.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -112,6 +113,7 @@ public class EjbJarRuntimeResourceTestBase {
     public static Archive<?> getEJBJar() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, JAR_NAME);
         jar.addPackage(EjbJarRuntimeResourcesTestCase.class.getPackage());
+        jar.addClass(TimeoutUtil.class);
         jar.addAsManifestResource(EjbJarRuntimeResourcesTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         jar.addAsManifestResource(EjbJarRuntimeResourcesTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
         return jar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/WaitTimeSingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/WaitTimeSingletonBean.java
@@ -37,6 +37,7 @@ import javax.ejb.TimerService;
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
 
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.logging.Logger;
 
 @Singleton
@@ -83,7 +84,7 @@ public class WaitTimeSingletonBean implements BusinessInterface {
         final Serializable info = timer.getInfo();
         logger.info("Entering timeout method for " + info);
         try {
-            Thread.sleep(50);
+            Thread.sleep(TimeoutUtil.adjust(50));
         } catch (InterruptedException e) {
             Thread.interrupted();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessagingUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessagingUtil.java
@@ -23,6 +23,8 @@
 package org.jboss.as.test.integration.ejb.mdb;
 
 
+import org.jboss.as.test.shared.TimeoutUtil;
+
 import java.io.Serializable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -92,10 +94,10 @@ public class JMSMessagingUtil {
         this.sendMessage(replyMsg, destination, null);
     }
 
-    public Message receiveMessage(final Destination destination, final long waitInMillis) throws JMSException {
+    public Message receiveMessage(final Destination destination, final int waitInMillis) throws JMSException {
         MessageConsumer consumer = this.session.createConsumer(destination);
         try {
-            return consumer.receive(waitInMillis);
+            return consumer.receive(TimeoutUtil.adjust(waitInMillis));
         } finally {
             consumer.close();
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
@@ -49,6 +50,7 @@ import org.junit.runner.RunWith;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.FilePermission;
+import java.util.PropertyPermission;
 
 /**
  * Tests MDB deployments
@@ -108,7 +110,7 @@ public class MDBTestCase {
     public static Archive getDeployment() {
 
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "MDBTestCase.jar");
-        ejbJar.addClasses(DDBasedMDB.class, BMTSLSB.class, JMSMessagingUtil.class, AnnoBasedMDB.class);
+        ejbJar.addClasses(DDBasedMDB.class, BMTSLSB.class, JMSMessagingUtil.class, AnnoBasedMDB.class, TimeoutUtil.class);
         ejbJar.addPackage(JMSOperations.class.getPackage());
         ejbJar.addClass(JmsQueueSetup.class);
         ejbJar.addAsManifestResource(MDBTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
@@ -116,7 +118,8 @@ public class MDBTestCase {
         ejbJar.addAsManifestResource(createPermissionsXmlAsset(
                 new RemotingPermission("createEndpoint"),
                 new RemotingPermission("connect"),
-                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read")
+                new FilePermission(System.getProperty("jboss.inst") + "/standalone/tmp/auth/*", "read"),
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")
         ), "permissions.xml");
 
         return ejbJar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBCdiIntegrationTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -44,6 +45,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that the CDI request scope is active in MDB invocations.
@@ -91,10 +96,13 @@ public class MDBCdiIntegrationTestCase {
     public static Archive getDeployment() {
 
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "mdb-cdi-integration-test.jar");
-        ejbJar.addClasses(CdiIntegrationMDB.class, RequestScopedCDIBean.class, JMSMessagingUtil.class, MDBCdiIntegrationTestCase.class, JmsQueueSetup.class)
+        ejbJar.addClasses(CdiIntegrationMDB.class, RequestScopedCDIBean.class, JMSMessagingUtil.class, MDBCdiIntegrationTestCase.class,
+                JmsQueueSetup.class, TimeoutUtil.class)
            .addPackage(JMSOperations.class.getPackage());
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ejbJar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cdi/MDBRAScopeCdiIntegrationTestCase.java
@@ -24,10 +24,12 @@ package org.jboss.as.test.integration.ejb.mdb.cdi;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.IOException;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.PropertyPermission;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -51,6 +53,7 @@ import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -180,8 +183,8 @@ public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestB
         ResourceAdapterArchive raa = createRAR();
         JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "xxx-ejbs.jar");
         ejbJar.addClasses(/* MDBRAScopeCdiIntegrationTestCase.class, */CdiIntegrationMDB.class, RequestScopedCDIBean.class,
-                MDBProxy.class, MDBProxyBean.class, JMSMessagingUtil.class, JmsQueueSetup.class).addPackage(
-                JMSOperations.class.getPackage());
+                MDBProxy.class, MDBProxyBean.class, JMSMessagingUtil.class, JmsQueueSetup.class, TimeoutUtil.class)
+                .addPackage(JMSOperations.class.getPackage());
         ejbJar.addAsManifestResource(new StringAsset(
                 "Dependencies: org.jboss.as.controller-client, org.jboss.as.controller, org.jboss.dmr \n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
@@ -189,6 +192,8 @@ public class MDBRAScopeCdiIntegrationTestCase extends ContainerResourceMgmtTestB
         final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentName);
         ear.addAsModule(raa);
         ear.addAsModule(ejbJar);
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ear;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedrivencontext/SetMessageDrivenContextInvocationTestCase.java
@@ -36,12 +36,17 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that the {@link javax.ejb.MessageDrivenBean#setMessageDrivenContext(javax.ejb.MessageDrivenContext)}
@@ -90,8 +95,10 @@ public class SetMessageDrivenContextInvocationTestCase {
     public static Archive createDeployment() {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "set-message-driven-context-invocation-test.jar");
-        jar.addClasses(SimpleMDB.class, JMSMessagingUtil.class, JmsQueueSetup.class);
+        jar.addClasses(SimpleMDB.class, JMSMessagingUtil.class, JmsQueueSetup.class, TimeoutUtil.class);
         jar.addPackage(JMSOperations.class.getPackage());
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/MessageListenerInClassHierarchyTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -42,6 +43,10 @@ import javax.ejb.EJB;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.TextMessage;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that if a message listener interface is implemented by the base class of a message driven bean, then
@@ -91,8 +96,10 @@ public class MessageListenerInClassHierarchyTestCase {
     @Deployment
     public static Archive createDeployment() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "message-listener-in-class-hierarchy-test.jar");
-        jar.addClasses(ConcreteMDB.class, CommonBase.class, JMSMessagingUtil.class, JmsQueueSetup.class);
+        jar.addClasses(ConcreteMDB.class, CommonBase.class, JMSMessagingUtil.class, JmsQueueSetup.class, TimeoutUtil.class);
         jar.addPackage(JMSOperations.class.getPackage());
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/objectmessage/unit/ObjectMessageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/objectmessage/unit/ObjectMessageTestCase.java
@@ -23,6 +23,7 @@
 package org.jboss.as.test.integration.ejb.mdb.objectmessage.unit;
 
 import java.util.Arrays;
+import java.util.PropertyPermission;
 
 import javax.annotation.Resource;
 import javax.ejb.EJB;
@@ -41,6 +42,7 @@ import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
 import org.jboss.as.test.integration.ejb.mdb.objectmessage.MDBAcceptingObjectMessage;
 import org.jboss.as.test.integration.ejb.mdb.objectmessage.MDBAcceptingObjectMessageOfArrayType;
 import org.jboss.as.test.integration.ejb.mdb.objectmessage.SimpleMessageInEarLibJar;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -49,6 +51,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests that a MDB can get hold of the underlying Object from a {@link ObjectMessage} without any classloading issues.
@@ -121,7 +125,8 @@ public class ObjectMessageTestCase {
     public static Archive getDeployment() {
 
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar");
-        ejbJar.addClasses(MDBAcceptingObjectMessageOfArrayType.class, JMSMessagingUtil.class, ObjectMessageTestCase.class, MDBAcceptingObjectMessage.class);
+        ejbJar.addClasses(MDBAcceptingObjectMessageOfArrayType.class, JMSMessagingUtil.class, ObjectMessageTestCase.class,
+                MDBAcceptingObjectMessage.class, TimeoutUtil.class);
 
         final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "util.jar");
         libJar.addClasses(SimpleMessageInEarLibJar.class);
@@ -133,6 +138,8 @@ public class ObjectMessageTestCase {
         ear.addAsLibraries(libJar);
 
         ear.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ear;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ConfiguredResourceAdapterNameTestCase.java
@@ -14,6 +14,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -21,6 +22,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 @RunWith(Arquillian.class)
 @ServerSetup({ConfiguredResourceAdapterNameTestCase.JmsQueueSetup.class})
@@ -63,10 +68,12 @@ public class ConfiguredResourceAdapterNameTestCase {
     public static Archive<JavaArchive> getDeployment() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "configured-resource-adapter-name-mdb-test.jar")
                 .addClasses(ConfiguredResourceAdapterNameMDB.class, JMSMessagingUtil.class, ConfiguredResourceAdapterNameTestCase.class,
-                        JmsQueueSetup.class)
+                        JmsQueueSetup.class, TimeoutUtil.class)
                 .addPackage(JMSOperations.class.getPackage())
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF")
-                .addAsManifestResource(ConfiguredResourceAdapterNameTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
+                .addAsManifestResource(ConfiguredResourceAdapterNameTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                    new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ejbJar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/resourceadapter/ResourceAdapterNameTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -43,6 +44,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * User: jpai
@@ -89,9 +94,11 @@ public class ResourceAdapterNameTestCase {
 
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "resource-adapter-name-mdb-test.jar");
         ejbJar.addClasses(OverriddenResourceAdapterNameMDB.class, JMSMessagingUtil.class, ResourceAdapterNameTestCase.class,
-                JmsQueueSetup.class);
+                JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addPackage(JMSOperations.class.getPackage());
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ejbJar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/MDBWhichDependsOnTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/MDBWhichDependsOnTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.ejb.mdb.JMSMessagingUtil;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,6 +43,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * WFLY-2732 - test if MDB can access @DependsOn ejbs in @PostConstruct and @PreDestroy annotated methods.
@@ -75,10 +80,12 @@ public class MDBWhichDependsOnTestCase {
         jar.addClass(CallCounterSingleton.class);
         jar.addClass(MDBWhichDependsOnTestCase.class);
         jar.addClass(Constants.class);
-        jar.addClass(JMSMessagingUtil.class);
+        jar.addClasses(JMSMessagingUtil.class, TimeoutUtil.class);
         jar.addClasses(JmsQueueServerSetupTask.class, SetupModuleServerSetupTask.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, "
                 + Constants.TEST_MODULE_NAME_FULL + "\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return jar;
     }
 
@@ -87,12 +94,14 @@ public class MDBWhichDependsOnTestCase {
 
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, Constants.DEPLOYMENT_JAR_NAME_MDB);
         jar.addPackage(JMSOperations.class.getPackage());
-        jar.addClass(JMSMessagingUtil.class);
+        jar.addClasses(JMSMessagingUtil.class, TimeoutUtil.class);
         jar.addClass(MDBWhichDependsOn.class);
         jar.addClass(Constants.class);
         jar.addClass(CallCounterProxy.class);
         jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, "
                 + Constants.TEST_MODULE_NAME_FULL + "\n"), "MANIFEST.MF");
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
@@ -38,6 +38,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -86,6 +87,7 @@ public class SecurityAuthCommandsTestCase {
     public static void setup() throws Exception {
         // Create ctx, used to setup the test and do the final reload.
         CommandContextConfiguration.Builder configBuilder = new CommandContextConfiguration.Builder();
+        configBuilder.setConnectionTimeout(TimeoutUtil.adjust(5000)); // default from org.jboss.as.cli.impl.CliConfigImpl
         configBuilder.setConsoleOutput(consoleOutput).setInitConsole(true).
                 setController("remote+http://" + TestSuiteEnvironment.getServerAddress()
                         + ":" + TestSuiteEnvironment.getServerPort());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -82,6 +83,7 @@ public class SecurityCommandsTestCase {
     public static void setup() throws Exception {
         // Create ctx, used to setup the test and do the final reload.
         CommandContextConfiguration.Builder configBuilder = new CommandContextConfiguration.Builder();
+        configBuilder.setConnectionTimeout(TimeoutUtil.adjust(5000)); // default from org.jboss.as.cli.impl.CliConfigImpl
         configBuilder.setConsoleOutput(consoleOutput).
                 setController("remote+http://" + TestSuiteEnvironment.getServerAddress()
                         + ":" + TestSuiteEnvironment.getServerPort());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/BeanManagedMessageConsumer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/BeanManagedMessageConsumer.java
@@ -40,6 +40,7 @@ import javax.jms.JMSDestinationDefinitions;
 import javax.jms.JMSRuntimeException;
 import javax.transaction.UserTransaction;
 
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.junit.Assert;
 
 /**
@@ -72,14 +73,14 @@ public class BeanManagedMessageConsumer {
         transaction.begin();
 
         JMSConsumer consumer = context.createConsumer(destination);
-        String text = consumer.receiveBody(String.class, 1000);
+        String text = consumer.receiveBody(String.class, TimeoutUtil.adjust(1000));
         assertNotNull(text);
         assertEquals(expectedText, text);
 
         transaction.commit();
 
         try {
-            consumer.receiveBody(String.class, 1000);
+            consumer.receiveBody(String.class, TimeoutUtil.adjust(1000));
             Assert.fail("call must fail as the injected JMSContext is closed when the transaction is committed");
         } catch (JMSRuntimeException e) {
             // exception is expected

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/auditing/SecurityAuditingTestCase.java
@@ -53,6 +53,7 @@ import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.ServerSnapshot;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -218,7 +219,7 @@ public class SecurityAuditingTestCase extends AnnSBTest {
         Pattern successPattern = Pattern.compile(regex);
 
         // we'll be actively waiting for a given INTERVAL for the record to appear
-        final long INTERVAL = 5000;
+        final long INTERVAL = TimeoutUtil.adjust(5000);
         long startTime = System.currentTimeMillis();
         String line;
         search_for_log:

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/ApplicationContextLifecycleTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -37,7 +38,10 @@ import org.junit.runner.RunWith;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.util.PropertyPermission;
 import java.util.concurrent.TimeUnit;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests possible deployment scenarios for CDI ApplicationScoped events, and usage of other EE technologies in such event handlers.
@@ -58,7 +62,9 @@ public class ApplicationContextLifecycleTestCase {
     @Deployment(name = TEST_BEANS_EJB_JAR, managed = false)
     public static Archive<JavaArchive> deployJar() {
         final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, TEST_BEANS_EJB_JAR +".jar")
-                .addClasses(Ejb.class, Bean.class, Mdb.class, TestResults.class, Utils.class);
+                .addClasses(Ejb.class, Bean.class, Mdb.class, TestResults.class, Utils.class, TimeoutUtil.class)
+                .addAsManifestResource(createPermissionsXmlAsset(
+                    new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return ejbJar;
     }
 
@@ -87,7 +93,9 @@ public class ApplicationContextLifecycleTestCase {
     @Deployment
     public static Archive<?> deployTestResults() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, TEST_RESULTS +".jar");
-        jar.addClasses(TestResultsBean.class, TestResults.class);
+        jar.addClasses(TestResultsBean.class, TestResults.class, TimeoutUtil.class);
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission(TimeoutUtil.FACTOR_SYS_PROP, "read")), "permissions.xml");
         return jar;
     }
 
@@ -102,7 +110,7 @@ public class ApplicationContextLifecycleTestCase {
         // deploy app
         deployer.deploy(TEST_BEANS_EJB_JAR);
         // await and assert initialized results
-        testResults.await(5, TimeUnit.SECONDS);
+        testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         Assert.assertTrue(testResults.isCdiBeanInitialized());
         Assert.assertTrue(testResults.isEjbBeanInitialized());
         // NOTE: before destroyed and destroyed atm only guaranteed for web deployments, uncomment all once that's solved
@@ -111,7 +119,7 @@ public class ApplicationContextLifecycleTestCase {
         // undeploy app
         deployer.undeploy(TEST_BEANS_EJB_JAR);
         // await and assert before destroyed and destroyed results
-        //testResults.await(5, TimeUnit.SECONDS);
+        //testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         //Assert.assertTrue(testResults.isCdiBeanBeforeDestroyed());
         //Assert.assertTrue(testResults.isCdiBeanDestroyed());
         //Assert.assertTrue(testResults.isEjbBeanBeforeDestroyed());
@@ -126,7 +134,7 @@ public class ApplicationContextLifecycleTestCase {
         // deploy app
         deployer.deploy(TEST_BEANS_EAR);
         // await and assert initialized results
-        testResults.await(5, TimeUnit.SECONDS);
+        testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         Assert.assertTrue(testResults.isCdiBeanInitialized());
         Assert.assertTrue(testResults.isEjbBeanInitialized());
         // NOTE: before destroyed and destroyed atm only guaranteed for web deployments, uncomment all once that's solved
@@ -135,7 +143,7 @@ public class ApplicationContextLifecycleTestCase {
         // undeploy app
         deployer.undeploy(TEST_BEANS_EAR);
         // await and assert before destroyed and destroyed results
-        //testResults.await(5, TimeUnit.SECONDS);
+        //testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         //Assert.assertTrue(testResults.isCdiBeanBeforeDestroyed());
         //Assert.assertTrue(testResults.isCdiBeanDestroyed());
         //Assert.assertTrue(testResults.isEjbBeanBeforeDestroyed());
@@ -150,7 +158,7 @@ public class ApplicationContextLifecycleTestCase {
         // deploy app
         deployer.deploy(TEST_BEANS_WAR);
         // await and assert initialized results
-        testResults.await(5, TimeUnit.SECONDS);
+        testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         Assert.assertTrue(testResults.isCdiBeanInitialized());
         Assert.assertTrue(testResults.isServletInitialized());
         // setup before destroyed and destroyed test
@@ -158,7 +166,7 @@ public class ApplicationContextLifecycleTestCase {
         // undeploy app
         deployer.undeploy(TEST_BEANS_WAR);
         // await and assert before destroyed and destroyed results
-        testResults.await(5, TimeUnit.SECONDS);
+        testResults.await(TimeoutUtil.adjust(5), TimeUnit.SECONDS);
         Assert.assertTrue(testResults.isCdiBeanBeforeDestroyed());
         Assert.assertTrue(testResults.isCdiBeanDestroyed());
         Assert.assertTrue(testResults.isServletBeforeDestroyed());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/TestResultsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/context/application/lifecycle/TestResultsBean.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.weld.context.application.lifecycle;
 
+import org.jboss.as.test.shared.TimeoutUtil;
+
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import java.util.concurrent.CountDownLatch;
@@ -147,7 +149,7 @@ public class TestResultsBean implements TestResults {
             throw new IllegalStateException();
         }
         try {
-            latch.await(timeout, timeUnit);
+            latch.await(TimeoutUtil.adjust(Long.valueOf(timeout).intValue()), timeUnit);
         } finally {
             latch = null;
         }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/cdi/CdiJsfWebServicesTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/cdi/CdiJsfWebServicesTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -72,7 +73,8 @@ public class CdiJsfWebServicesTestCase {
     @Test
     public void testWebServicesDoNotBreakCDI() throws IOException, ExecutionException, TimeoutException {
         URL webRoot = new URL(baseUrl, "/");
-        Assert.assertEquals("<html><body>" + MyBean.MESSAGE + "</body></html>", HttpRequest.get(webRoot.toString() + ARCHIVE_NAME + "/index.jsf", 20, TimeUnit.SECONDS));
+        Assert.assertEquals("<html><body>" + MyBean.MESSAGE + "</body></html>",
+                HttpRequest.get(webRoot.toString() + ARCHIVE_NAME + "/index.jsf", TimeoutUtil.adjust(20), TimeUnit.SECONDS));
     }
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13579

Making the `Thread.sleep` and other timeout calls in testsuite to be parametrized by timeout factor (defined in {{TimeoutUtil}} shared testsuite config class).