### PR TITLE
[WFLY-13581]: The multicast queue stats are not correct.

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/DestinationConfiguration.java
@@ -138,7 +138,7 @@ public class DestinationConfiguration {
             connection.start();
             QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
             Message m = session.createMessage();
-            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createQueue", topicName, topicName, isDurable(), RoutingType.MULTICAST.name());
+            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "createAddress", topicName, RoutingType.MULTICAST.name());
             Message reply = requestor.request(m);
             ROOT_LOGGER.infof("Creating topic %s returned %s", topicName, reply);
             if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
@@ -157,7 +157,7 @@ public class DestinationConfiguration {
             connection.start();
             QueueRequestor requestor = new QueueRequestor((QueueSession) session, managementQueue);
             Message m = session.createMessage();
-            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "destroyQueue", topicName, true, true);
+            org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putOperationInvocation(m, ResourceNames.BROKER, "deleteAddress", topicName, true);
             Message reply = requestor.request(m);
             ROOT_LOGGER.debugf("Deleting topic " + topicName + " returned " + reply);
             if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {


### PR DESCRIPTION
* When creating a remote jms topic only the address is to be created not
  the subscription queue. Removing the queue creation in this case and
  only creating the address.

Jira: https://issues.redhat.com/browse/WFLY-13581