### PR TITLE
[WFLY-12190]: Add EjbOverHttpWrongCredentialsTestCase

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EJB3.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/EJB3.adoc
@@ -46,7 +46,17 @@ of each
       <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
     </data-stores>
   </timer-service>
-  <remote connector-ref="remoting-connector" thread-pool-name="default"/>
+  <remote connector-ref="remoting-connector" thread-pool-name="default">
+    <profiles>
+        <profile name="profile">
+          <static-ejb-discovery>
+            <module uri="http://localhost:8180/wildfly-services" module-name="foo" app-name="bar" distinct-name="baz"/>
+          </static-ejb-discovery>
+          <remote-http-connection name="connection" uri="http://localhost:8180/wildfly-services"/>
+          <remoting-ejb-receiver name="receiver" outbound-connection-ref="remote-ejb-connection"/>
+        </profile>
+    </profiles>
+  </remote>
   <thread-pools>
     <thread-pool name="default">
       <max-threads count="10"/>
@@ -167,6 +177,51 @@ information is saved to.
 This is used to enable remote EJB invocations. It specifies the remoting
 connector to use (as defined in the remoting subsystem configuration),
 and the thread pool to use for remote invocations.
+
+[[profile]]
+=== <profile>
+
+Remote profile specificies a configuration of remote invocations that can
+be referenced by many deployments. EJBs that are meant to be invoked can
+be discovered in either static or dynamic way.
+
+Static discovery decides which remote node to connect based on the information
+provided by the user.
+
+Dynamic discovery is responsible for monitoring available EJBs on all the
+nodes to which connections are configured and decides which remote node to
+connect based on gathered data.
+
+[[static-ejb-discovery]]
+==== <static-ejb-discovery>
+
+Static ejb discovery allows to explicitly specify on which remote nodes
+given EJBs are located. `module` tag is used to define it:
+
+* `module-name` the name of EJB module
+* `app-name` the name of EJB app
+* `distinct-name` the distinct name EJB
+* `uri` the address on which given EJB is located
+
+[[remoting-ejb-receiver]]
+==== <remoting-ejb-receiver>
+
+`remoting-ejb-receiver` tag is used to define dynamic discovery based on
+the remoting procol:
+
+* `name` name of the remote connection
+* `outbound-connection-ref` reference to outbound connection defined in
+the remoting subsystem
+* `connection-timeout` the timeout of the connection
+
+[[remote-http-connection]]
+==== <remote-http-connection>
+
+`remote-http-connection` tag is used to define dynamic discovery based on
+HTTP procol:
+
+* `name` name of the HTTP connection
+* `uri` URI of the connection
 
 [[thread-pools]]
 == <thread-pools>

--- a/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/EJBClientDescriptorMetaData.java
@@ -22,10 +22,12 @@
 
 package org.jboss.as.ee.metadata;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -45,6 +47,7 @@ public class EJBClientDescriptorMetaData {
     private String profile;
 
     private Map<String, RemotingReceiverConfiguration> remotingReceiverConfigurations = new HashMap<String, RemotingReceiverConfiguration>();
+    private List<HttpConnectionConfiguration> httpConnectionConfigurations = new ArrayList<>();
     private Set<ClusterConfig> clusterConfigs = new HashSet<ClusterConfig>();
 
 
@@ -71,6 +74,10 @@ public class EJBClientDescriptorMetaData {
      */
     public Collection<RemotingReceiverConfiguration> getRemotingReceiverConfigurations() {
         return this.remotingReceiverConfigurations.values();
+    }
+
+    public List<HttpConnectionConfiguration> getHttpConnectionConfigurations() {
+        return httpConnectionConfigurations;
     }
 
     /**
@@ -337,6 +344,18 @@ public class EJBClientDescriptorMetaData {
         @Override
         public int hashCode() {
             return outboundConnectionRef != null ? outboundConnectionRef.hashCode() : 0;
+        }
+    }
+
+    public class HttpConnectionConfiguration {
+        private final String uri;
+
+        HttpConnectionConfiguration(final String uri) {
+            this.uri = uri;
+        }
+
+        public String getUri() {
+            return uri;
         }
     }
 }

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -217,6 +217,11 @@ projects that depend on this project.-->
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.wildfly-http-client</groupId>
+            <artifactId>wildfly-http-ejb-client</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/DiscoveryRegistrationProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/DiscoveryRegistrationProcessor.java
@@ -39,6 +39,7 @@ import org.jboss.msc.service.ServiceName;
 import org.wildfly.discovery.Discovery;
 import org.wildfly.discovery.impl.StaticDiscoveryProvider;
 import org.wildfly.discovery.spi.DiscoveryProvider;
+import org.wildfly.httpclient.ejb.HttpDiscoveryConfigurator;
 
 /**
  * Processor responsible for ensuring that the discovery service for each deployment unit exists.
@@ -76,6 +77,9 @@ public final class DiscoveryRegistrationProcessor implements DeploymentUnitProce
                 providerInjector.uninject();
             }
         });
+
+        providerInjector = discoveryService.getDiscoveryProviderInjector();
+        new HttpDiscoveryConfigurator().configure(providerInjector::inject, registryProvider -> {});
 
         // only add association service dependency if the context is configured to use the local EJB receiver & we are not app client
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
@@ -180,7 +180,7 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
                             AuthenticationContext transformed = finalAuthenticationContext;
                             // now transform it
                             if (profileService != null) {
-                                for (RemotingProfileService.ConnectionSpec connectionSpec : profileService.getConnectionSpecs()) {
+                                for (RemotingProfileService.RemotingConnectionSpec connectionSpec : profileService.getConnectionSpecs()) {
                                     transformed = transformOne(connectionSpec, transformed);
                                 }
                             }
@@ -219,7 +219,7 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
             return null;
         }
 
-        private static AuthenticationContext transformOne(RemotingProfileService.ConnectionSpec connectionSpec, AuthenticationContext context) {
+        private static AuthenticationContext transformOne(RemotingProfileService.RemotingConnectionSpec connectionSpec, AuthenticationContext context) {
             final AbstractOutboundConnectionService connectionService = connectionSpec.getInjector().getValue();
             AuthenticationConfiguration authenticationConfiguration = connectionService.getAuthenticationConfiguration();
             SSLContext sslContext = connectionService.getSSLContext();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientContextService.java
@@ -110,11 +110,18 @@ public final class EJBClientContextService implements Service<EJBClientContextSe
         }
 
         final RemotingProfileService profileService = profileServiceInjector.getOptionalValue();
-        if (profileService != null) for (RemotingProfileService.ConnectionSpec spec : profileService.getConnectionSpecs()) {
-            final EJBClientConnection.Builder connBuilder = new EJBClientConnection.Builder();
-            connBuilder.setDestination(spec.getInjector().getValue().getDestinationUri());
-            // connBuilder.setConnectionTimeout(timeout);
-            builder.addClientConnection(connBuilder.build());
+        if (profileService != null) {
+            for (RemotingProfileService.RemotingConnectionSpec spec : profileService.getConnectionSpecs()) {
+                final EJBClientConnection.Builder connBuilder = new EJBClientConnection.Builder();
+                connBuilder.setDestination(spec.getInjector().getValue().getDestinationUri());
+                // connBuilder.setConnectionTimeout(timeout);
+                builder.addClientConnection(connBuilder.build());
+            }
+            for (RemotingProfileService.HttpConnectionSpec spec : profileService.getHttpConnectionSpecs()) {
+                final EJBClientConnection.Builder connBuilder = new EJBClientConnection.Builder();
+                connBuilder.setDestination(spec.getUri());
+                builder.addClientConnection(connBuilder.build());
+            }
         }
         if(appClientUri.getOptionalValue() != null) {
             final EJBClientConnection.Builder connBuilder = new EJBClientConnection.Builder();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
@@ -33,6 +33,7 @@ import org.jboss.msc.value.InjectedValue;
 import org.wildfly.discovery.ServiceURL;
 import org.xnio.OptionMap;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -52,12 +53,15 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
      * There URLs are used to allow discovery to find these connections.
      */
     private final List<ServiceURL> serviceUrls;
-    private final Map<String, ConnectionSpec> connectionSpecMap;
+    private final Map<String, RemotingConnectionSpec> remotingConnectionSpecMap;
+    private final List<HttpConnectionSpec> httpConnectionSpecs;
     private final InjectedValue<EJBTransportProvider> localTransportProviderInjector = new InjectedValue<>();
 
-    public RemotingProfileService(final List<ServiceURL> serviceUrls, final Map<String, ConnectionSpec> connectionSpecMap) {
+    public RemotingProfileService(final List<ServiceURL> serviceUrls, final Map<String, RemotingConnectionSpec> remotingConnectionSpecMap,
+                                  final List<HttpConnectionSpec> httpConnectionSpecs) {
         this.serviceUrls = serviceUrls;
-        this.connectionSpecMap = connectionSpecMap;
+        this.remotingConnectionSpecMap = remotingConnectionSpecMap;
+        this.httpConnectionSpecs = httpConnectionSpecs;
     }
 
     @Override
@@ -73,8 +77,12 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
     public void stop(StopContext context) {
     }
 
-    public Collection<ConnectionSpec> getConnectionSpecs() {
-        return connectionSpecMap.values();
+    public Collection<RemotingConnectionSpec> getConnectionSpecs() {
+        return remotingConnectionSpecMap.values();
+    }
+
+    public Collection<HttpConnectionSpec> getHttpConnectionSpecs() {
+        return httpConnectionSpecs;
     }
 
     public List<ServiceURL> getServiceUrls() {
@@ -85,13 +93,13 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
         return localTransportProviderInjector;
     }
 
-    public static final class ConnectionSpec {
+    public static final class RemotingConnectionSpec {
         private final String connectionName;
         private final InjectedValue<AbstractOutboundConnectionService> injector;
         private final OptionMap connectOptions;
         private final long connectTimeout;
 
-        public ConnectionSpec(final String connectionName, final InjectedValue<AbstractOutboundConnectionService> injector, final OptionMap connectOptions, final long connectTimeout) {
+        public RemotingConnectionSpec(final String connectionName, final InjectedValue<AbstractOutboundConnectionService> injector, final OptionMap connectOptions, final long connectTimeout) {
             this.connectionName = connectionName;
             this.injector = injector;
             this.connectOptions = connectOptions;
@@ -112,6 +120,22 @@ public class RemotingProfileService implements Service<RemotingProfileService> {
 
         public long getConnectTimeout() {
             return connectTimeout;
+        }
+    }
+
+    public static final class HttpConnectionSpec {
+        private final String uri;
+
+        public HttpConnectionSpec(final String uri) {
+            this.uri = uri;
+        }
+
+        public URI getUri() {
+            try {
+                return new URI(uri);
+            } catch(Exception e) {
+                return null;
+            }
         }
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem50Parser.java
@@ -264,7 +264,7 @@ public class EJB3Subsystem50Parser extends EJB3Subsystem40Parser {
         }
     }
 
-    private ModelNode parseStaticEjbDiscoveryType(final XMLExtendedStreamReader reader) throws XMLStreamException {
+    protected ModelNode parseStaticEjbDiscoveryType(final XMLExtendedStreamReader reader) throws XMLStreamException {
         ModelNode staticDiscovery = new ModelNode();
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (EJB3SubsystemXMLElement.forName(reader.getLocalName())) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -96,6 +96,7 @@ public interface EJB3SubsystemModel {
     String OUTBOUND_CONNECTION_REF= "outbound-connection-ref";
     String CONNECT_TIMEOUT= "connect-timeout";
     String CLIENT_MAPPINGS_CLUSTER_NAME = "cluster";
+    String REMOTE_HTTP_CONNECTION = "remote-http-connection";
 
     String TIMER = "timer";
     String TIMER_SERVICE = "timer-service";
@@ -171,5 +172,6 @@ public interface EJB3SubsystemModel {
     String CLASS = "class";
     String BINDING = "binding";
 
+    String URI = "uri";
 
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLElement.java
@@ -79,6 +79,7 @@ public enum EJB3SubsystemXMLElement {
 
     REMOTE("remote"),
     REMOTING_EJB_RECEIVER("remoting-ejb-receiver"),
+    REMOTE_HTTP_CONNECTION("remote-http-connection"),
     RESOURCE_ADAPTER_NAME("resource-adapter-name"),
     RESOURCE_ADAPTER_REF("resource-adapter-ref"),
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -41,6 +41,7 @@ import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.IN_VM_REMOTE_INTERF
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.LOG_SYSTEM_EXCEPTIONS;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.PROFILE;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTE_HTTP_CONNECTION;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTING_EJB_RECEIVER;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTING_PROFILE;
 import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVER_INTERCEPTORS;
@@ -635,6 +636,9 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
             if(profileNode.hasDefined(REMOTING_EJB_RECEIVER)){
                 writeRemotingEjbReceivers(writer, profileNode);
             }
+            if(profileNode.hasDefined(REMOTE_HTTP_CONNECTION)){
+                writeRemoteHttpConnection(writer, profileNode);
+            }
             StaticEJBDiscoveryDefinition.INSTANCE.marshallAsElement(profileNode, writer);
             writer.writeEndElement();
         }
@@ -652,6 +656,18 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
             if (receiverNode.hasDefined(CHANNEL_CREATION_OPTIONS)) {
                 writeChannelCreationOptions(writer, receiverNode.get(CHANNEL_CREATION_OPTIONS));
             }
+            writer.writeEndElement();
+        }
+    }
+
+    private void writeRemoteHttpConnection(final XMLExtendedStreamWriter writer, final ModelNode profileNode)
+            throws XMLStreamException {
+        final List<Property> connections = profileNode.get(REMOTE_HTTP_CONNECTION).asPropertyList();
+        for (final Property property : connections) {
+            writer.writeStartElement(REMOTE_HTTP_CONNECTION);
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.NAME.getLocalName(), property.getName());
+            final ModelNode connectionNode = property.getValue();
+            RemoteHttpConnectionDefinition.URI.marshallAsAttribute(connectionNode, writer);
             writer.writeEndElement();
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemoteHttpConnectionDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemoteHttpConnectionDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+public class RemoteHttpConnectionDefinition extends SimpleResourceDefinition {
+
+    public static final SimpleAttributeDefinition URI = new SimpleAttributeDefinitionBuilder(
+            EJB3SubsystemModel.URI, ModelType.STRING).setRequired(true).setAllowExpression(true)
+            .build();
+
+    private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{URI};
+
+    public static final RemoteHttpConnectionDefinition INSTANCE = new RemoteHttpConnectionDefinition();
+
+    private RemoteHttpConnectionDefinition() {
+        super(PathElement.pathElement(EJB3SubsystemModel.REMOTE_HTTP_CONNECTION), EJB3Extension
+                .getResourceDescriptionResolver(EJB3SubsystemModel.REMOTE_HTTP_CONNECTION), new RemotingProfileChildResourceAddHandler(
+                ATTRIBUTES), new RemotingProfileChildResourceRemoveHandler());
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        for (final AttributeDefinition attr : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(attr, null, new RemotingProfileResourceChildWriteAttributeHandler(attr));
+        }
+    }
+}
+

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceDefinition.java
@@ -60,6 +60,7 @@ public class RemotingProfileResourceDefinition extends SimpleResourceDefinition 
     @Override
     public void registerChildren(ManagementResourceRegistration subsystemRegistration) {
         subsystemRegistration.registerSubModel(RemotingEjbReceiverDefinition.INSTANCE);
+        subsystemRegistration.registerSubModel(RemoteHttpConnectionDefinition.INSTANCE);
     }
 
     @Override

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -341,6 +341,10 @@ remoting-ejb-receiver.add=Adds a remoting ejb receiver reference to the profile
 remoting-ejb-receiver.remove=Removes a remoting ejb receiver reference from the profile
 remoting-ejb-receiver.outbound-connection-ref=Name of outbound connection that will be used by the ejb receiver
 remoting-ejb-receiver.connect-timeout=Remoting ejb receiver connect timeout
+remote-http-connection=Remote connection using HTTP protocol
+remote-http-connection.add=Add remote HTTP connection
+remote-http-connection.remove=Remove remote HTTP connection
+remote-http-connection.uri=Remote HTTP connection URI
 
 
 mdb-delivery-group=Delivery group to manage delivery for mdbs

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -31,7 +31,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.http-client.ejb" />
+        <module name="org.wildfly.http-client.ejb" services="import"/>
         <module name="javax.annotation.api"/>
         <module name="javax.api"/>
         <module name="javax.ejb.api"/>
@@ -109,5 +109,6 @@
 
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.transaction.client"/>
+        <module name="org.wildfly.http-client.ejb"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/http-client/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/http-client/ejb/main/module.xml
@@ -45,5 +45,6 @@
         <module name="org.wildfly.http-client.transaction" />
         <module name="org.wildfly.transaction.client" />
         <module name="org.jboss.xnio"/>
+        <module name="org.wildfly.discovery"/>
     </dependencies>
 </module>

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.http;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import java.util.Arrays;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+/**
+ * This test che
+ *
+ * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(EjbOverHttpTestCase.EjbOverHttpTestCaseServerSetup.class)
+public class EjbOverHttpTestCase {
+    private static final Logger log = Logger.getLogger(EjbOverHttpTestCase.class);
+    public static final String ARCHIVE_NAME_CLIENT = "ejboverhttp-test-client";
+    public static final String ARCHIVE_NAME_SERVER = "ejboverhttp-test-server";
+
+    static class EjbOverHttpTestCaseServerSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+            final ModelNode address = new ModelNode();
+            address.add("subsystem", "ejb3");
+            address.add("remoting-profile", "test-profile");
+            address.protect();
+
+            final ModelNode op1 = new ModelNode();
+            op1.get(OP).set("add");
+            op1.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
+            op1.get(OP_ADDR).add("remoting-profile", "test-profile");
+            op1.get(OP_ADDR).set(address);
+
+            op1.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op1);
+
+            ModelNode op2 = new ModelNode();
+            op2.get(OP).set(ADD);
+            op2.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
+            op2.get(OP_ADDR).add("remoting-profile", "test-profile");
+            op2.get(OP_ADDR).add("remote-http-connection", "test-connection");
+
+            op2.get("uri").set("http://localhost:8180/wildfly-services");
+
+            op2.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op2);
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+             ModelNode op = new ModelNode();
+             op.get(OP).set(REMOVE);
+             op.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
+             op.get(OP_ADDR).add("remoting-profile", "test-profile");
+             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+    }
+
+    @BeforeClass
+    public static void printSysProps() {
+        log.trace("System properties:\n" + System.getProperties());
+    }
+
+    @Deployment(name = "server")
+    @TargetsContainer("multinode-server")
+    public static Archive<?> deployment0() {
+        JavaArchive jar = createJar(ARCHIVE_NAME_SERVER);
+        return jar;
+    }
+
+    @Deployment(name = "client")
+    @TargetsContainer("multinode-client")
+    public static Archive<?> deployment1() {
+        JavaArchive jar = createJar(ARCHIVE_NAME_CLIENT);
+        jar.addClasses(EjbOverHttpTestCase.class);
+        jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml")
+                .addAsManifestResource("ejb-http-wildfly-config.xml", "wildfly-config.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
+                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
+                        createFilePermission("read,write",
+                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
+                        "permissions.xml");
+        return jar;
+    }
+
+    private static JavaArchive createJar(String archiveName) {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar");
+        jar.addClasses(StatelessBean.class, StatelessLocal.class, StatelessRemote.class);
+        return jar;
+    }
+
+    @Test
+    @OperateOnDeployment("client")
+    public void testBasicInvocation(@ArquillianResource InitialContext ctx) throws Exception {
+        StatelessRemote bean = (StatelessRemote) ctx.lookup("java:module/" + StatelessBean.class.getSimpleName() + "!"
+                + StatelessRemote.class.getName());
+        Assert.assertNotNull(bean);
+
+        int methodCount = bean.remoteCall();
+        Assert.assertEquals(1, methodCount);
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/EjbOverHttpWrongCredentialsTestCase.java
@@ -1,0 +1,79 @@
+package org.jboss.as.test.multinode.ejb.http;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createFilePermission;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import java.util.Arrays;
+import javax.naming.InitialContext;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * EJB over HTTP remote call should fail with incorrect wildfly-config.xml credentials
+ *
+ * @author <a href="mailto:szhantem@redhat.com">Sultan Zhantemirov</a>
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(EjbOverHttpTestCase.EjbOverHttpTestCaseServerSetup.class)
+public class EjbOverHttpWrongCredentialsTestCase {
+
+    public static final String ARCHIVE_NAME_SERVER = "ejboverhttp-test-server";
+    public static final String ARCHIVE_NAME_CLIENT_WRONG_CREDENTIALS = "ejboverhttp-test-client-wrong-credentials";
+
+    @Deployment(name = "server")
+    @TargetsContainer("multinode-server")
+    public static Archive<?> deployment0() {
+        JavaArchive jar = createJar(ARCHIVE_NAME_SERVER);
+        return jar;
+    }
+
+    @Deployment(name = "client-wrong-credentials")
+    @TargetsContainer("multinode-client")
+    public static Archive<?> deployment1() {
+        JavaArchive jar = createClientJar();
+        return jar;
+    }
+
+    private static JavaArchive createJar(String archiveName) {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, archiveName + ".jar");
+        jar.addClasses(StatelessBean.class, StatelessLocal.class, StatelessRemote.class);
+        return jar;
+    }
+
+    private static JavaArchive createClientJar() {
+        JavaArchive jar = createJar(EjbOverHttpWrongCredentialsTestCase.ARCHIVE_NAME_CLIENT_WRONG_CREDENTIALS);
+        jar.addClasses(EjbOverHttpTestCase.class);
+        jar.addAsManifestResource("META-INF/jboss-ejb-client-profile.xml", "jboss-ejb-client.xml")
+                .addAsManifestResource("ejb-http-wildfly-config-wrong.xml", "wildfly-config.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(createFilePermission("read,write",
+                        "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery")),
+                        createFilePermission("read,write",
+                                "jbossas.multinode.client", Arrays.asList("standalone", "data", "ejb-xa-recovery", "-"))),
+                        "permissions.xml");
+        return jar;
+    }
+
+    @Test
+    @OperateOnDeployment("client-wrong-credentials")
+    public void testBasicInvocationWithWrongCredentials(@ArquillianResource InitialContext ctx) throws Exception {
+        StatelessRemote bean = (StatelessRemote) ctx.lookup("java:module/" + StatelessBean.class.getSimpleName() + "!"
+                + StatelessRemote.class.getName());
+        Assert.assertNotNull(bean);
+
+        try {
+            int methodCount = bean.remoteCall();
+            Assert.assertEquals(EjbOverHttpTestCase.NO_EJB_RETURN_CODE, methodCount);
+        } catch (javax.naming.AuthenticationException e) {
+            // expected
+        }
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessBean.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessBean.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.multinode.ejb.http;
 import org.jboss.logging.Logger;
 
 import javax.ejb.Local;
+import javax.ejb.NoSuchEJBException;
 import javax.ejb.Remote;
 import javax.ejb.Stateless;
 import javax.naming.Context;
@@ -53,7 +54,11 @@ public class StatelessBean {
         log.trace("Calling Remote... " + jndiContext.getEnvironment());
         StatelessRemote stateless = (StatelessRemote) jndiContext.lookup("ejb:/" +EjbOverHttpTestCase.ARCHIVE_NAME_SERVER
                 + "//" + StatelessBean.class.getSimpleName() + "!" + StatelessRemote.class.getName());
-        return stateless.method();
+        try {
+            return stateless.method();
+        } catch (NoSuchEJBException e) {
+            return EjbOverHttpTestCase.NO_EJB_RETURN_CODE;
+        }
     }
 
     public int method() throws Exception {

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessBean.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessBean.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.http;
+
+import org.jboss.logging.Logger;
+
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+@Stateless
+@Local(StatelessLocal.class)
+@Remote(StatelessRemote.class)
+public class StatelessBean {
+    private static final Logger log = Logger.getLogger(StatelessBean.class);
+
+    private static int methodCount = 0;
+
+    private InitialContext getInitialContext() throws NamingException {
+        final Properties props = new Properties();
+        // setup the ejb: namespace URL factory
+        props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        return new InitialContext(props);
+    }
+
+    public int remoteCall() throws Exception {
+        ++methodCount;
+        InitialContext jndiContext = getInitialContext();
+        log.trace("Calling Remote... " + jndiContext.getEnvironment());
+        StatelessRemote stateless = (StatelessRemote) jndiContext.lookup("ejb:/" +EjbOverHttpTestCase.ARCHIVE_NAME_SERVER
+                + "//" + StatelessBean.class.getSimpleName() + "!" + StatelessRemote.class.getName());
+        return stateless.method();
+    }
+
+    public int method() throws Exception {
+        ++methodCount;
+        log.trace("Method called " + methodCount);
+        return methodCount;
+    }
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessLocal.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessLocal.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.http;
+
+public interface StatelessLocal extends javax.ejb.EJBLocalObject {
+    int method() throws Exception;
+}

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessRemote.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/http/StatelessRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.multinode.ejb.http;
+
+/**
+ * @author <a href="mailto:bdecoste@jboss.com">William DeCoste</a>
+ */
+public interface StatelessRemote extends javax.ejb.EJBObject {
+    int remoteCall() throws Exception;
+    int method() throws Exception;
+}

--- a/testsuite/integration/multinode/src/test/resources/ejb-http-wildfly-config-wrong.xml
+++ b/testsuite/integration/multinode/src/test/resources/ejb-http-wildfly-config-wrong.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <authentication-rules>
+            <rule use-configuration="jta">
+                <match-protocol name="http"/>
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="jta">
+                <sasl-mechanism-selector selector="DIGEST-MD5"/>
+                <providers>
+                    <use-service-loader />
+                </providers>
+                <set-user-name name="remoteejbuser"/>
+                <credentials>
+                    <clear-password password="wrong-password"/>
+                </credentials>
+                <set-mechanism-realm name="ApplicationRealm" />
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>

--- a/testsuite/integration/multinode/src/test/resources/ejb-http-wildfly-config.xml
+++ b/testsuite/integration/multinode/src/test/resources/ejb-http-wildfly-config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <authentication-rules>
+            <rule use-configuration="jta">
+                <match-protocol name="http"/>
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="jta">
+                <sasl-mechanism-selector selector="DIGEST-MD5"/>
+                <providers>
+                    <use-service-loader />
+                </providers>
+                <set-user-name name="remoteejbuser"/>
+                <credentials>
+                    <clear-password password="rem@teejbpasswd1"/>
+                </credentials>
+                <set-mechanism-realm name="ApplicationRealm" />
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>


### PR DESCRIPTION
_EJB over HTTP discovery configuration_

https://issues.redhat.com/browse/EAP7-1236
https://issues.redhat.com/browse/WFLY-12190

Based on https://github.com/wildfly/wildfly/pull/12887/ PR. The latest commit here can be cherry-picked afterwards. 

Changes: 

- basic invocation test has been extended with failed discovery and rediscovery checks.
- added test scenario with incorrect wildfly-config.xml authentication credentials.

@tadamski 