### PR TITLE
WFLY-13590, WFLY-13591 JGroups subsystem fixes

### DIFF
--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -42,6 +42,25 @@
     <name>WildFly: JGroups Subsystem</name>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>jgroups-defaults.xml</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+                <excludes>
+                    <exclude>jgroups-defaults.xml</exclude>
+                </excludes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -30,6 +30,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.util.Map;
 
 import org.jboss.as.network.SocketBinding;
@@ -149,6 +151,20 @@ public class ManagedSocketFactory implements SocketFactory {
         if (address == null) return this.createMulticastSocket(name);
         String socketBindingName = this.getSocketBindingName(name);
         return this.manager.createMulticastSocket(socketBindingName, address);
+    }
+
+    @Override
+    public SocketChannel createSocketChannel(String name) throws IOException {
+        SocketChannel channel = SocketChannel.open();
+        this.manager.getNamedRegistry().registerChannel(name, channel);
+        return channel;
+    }
+
+    @Override
+    public ServerSocketChannel createServerSocketChannel(String name) throws IOException {
+        ServerSocketChannel channel = ServerSocketChannel.open();
+        this.manager.getNamedRegistry().registerChannel(name, channel);
+        return channel;
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationServiceConfigurator.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationServiceConfigurator.java
@@ -125,7 +125,7 @@ public class TransportConfigurationServiceConfigurator<T extends TP> extends Abs
     public Map<String, SocketBinding> getSocketBindings() {
         Map<String, SocketBinding> bindings = new HashMap<>();
         SocketBinding binding = this.getSocketBinding();
-        for (String serviceName : Arrays.asList("jgroups.udp.mcast_sock", "jgroups.udp.sock", "jgroups.tcp.server", "jgroups.nio.server", "jgroups.tunnel.ucast_sock")) {
+        for (String serviceName : Arrays.asList("jgroups.udp.mcast_sock", "jgroups.udp.sock", "jgroups.tcp.server", "jgroups.nio.client", "jgroups.nio.server", "jgroups.tunnel.ucast_sock")) {
             bindings.put(serviceName, binding);
         }
         bindings.put("jgroups.tp.diag.mcast_sock", this.diagnosticsSocketBinding.get());

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -76,6 +76,8 @@
     />
     <pbcast.GMS print_local_addr="false"/>
     <UFC max_credits="2m"/>
+    <UFC_NB max_credits="3m"/>
     <MFC max_credits="2m"/>
+    <MFC_NB max_credits="3m"/>
     <FRAG2 frag_size="30k"/>
 </config>

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -22,7 +22,7 @@
   -->
 <!-- N.B. This is *not* a usable protocol stack -->
 <!-- This file supplies the internal defaults per protocol -->
-<config xmlns="urn:org:jgroups">
+<config xmlns="urn:org:jgroups" xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd" version="${version.org.jgroups}">
     <UDP
         ip_ttl="2"
         mcast_recv_buf_size="25m"


### PR DESCRIPTION
JGroups subsystem logs "version is missing in the configuration file" warning on startup
https://issues.redhat.com/browse/WFLY-13590

TCP_NIO2 sockets are not registered with socket binding manager
https://issues.redhat.com/browse/WFLY-13591