### PR TITLE
[20.x] WFLY-13590 JGroups subsystem logs "version is missing in the configuration file" warning on startup

### DIFF
--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -42,6 +42,25 @@
     <name>WildFly: JGroups Subsystem</name>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>jgroups-defaults.xml</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*</include>
+                </includes>
+                <excludes>
+                    <exclude>jgroups-defaults.xml</exclude>
+                </excludes>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -22,7 +22,7 @@
   -->
 <!-- N.B. This is *not* a usable protocol stack -->
 <!-- This file supplies the internal defaults per protocol -->
-<config xmlns="urn:org:jgroups">
+<config xmlns="urn:org:jgroups" xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd" version="${version.org.jgroups}">
     <UDP
         ip_ttl="2"
         mcast_recv_buf_size="25m"


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13590

Backported from master.