### PR TITLE
[WFLY-13618] Upgrade WildFly Core 13.0.0.Beta1

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:13.0">
+<domain xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="master">
+<host xmlns="urn:jboss:domain:14.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0">
+<host xmlns="urn:jboss:domain:14.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="master">
+<host xmlns="urn:jboss:domain:14.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:13.0">
+<server xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:13.0">
+<server xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/feature-pack/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:13.0">
+<server xmlns="urn:jboss:domain:14.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>12.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:13.0">
+<domain xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="master">
+<host xmlns="urn:jboss:domain:14.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0">
+<host xmlns="urn:jboss:domain:14.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="master">
+<host xmlns="urn:jboss:domain:14.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:13.0">
+<server xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0"
+<domain xmlns="urn:jboss:domain:14.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0">
+<domain xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0"
+<domain xmlns="urn:jboss:domain:14.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0">
+<domain xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0">
+<domain xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="master">
+<host xmlns="urn:jboss:domain:14.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:13.0" name="slave">
+<host xmlns="urn:jboss:domain:14.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:13.0"
+<host xmlns="urn:jboss:domain:14.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:13.0">
+<server xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:13.0"
+<domain xmlns="urn:jboss:domain:14.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:13.0">
+<host name="master" xmlns="urn:jboss:domain:14.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:13.0">
+<host name="master" xmlns="urn:jboss:domain:14.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13618

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.0.Beta1
Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/12.0.1.Final...13.0.0.Beta1

---


        Release Notes - WildFly Core - Version 13.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4863'>WFCORE-4863</a>] -         Upgrade PicketBox to 5.0.3.Final-redhat-00006
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4984'>WFCORE-4984</a>] -         Upgrade tests to use wildfly-jar-maven-plugin 2.0.0.Alpha3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4991'>WFCORE-4991</a>] -         Upgrade jboss-logmanager from 2.1.15.Final to 2.1.16.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4996'>WFCORE-4996</a>] -         Upgrade WildFly Galleon Plugins from 4.2.6.Final to 4.2.8.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5001'>WFCORE-5001</a>] -         Upgrade WildFly Elytron to 1.13.0.CR1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5008'>WFCORE-5008</a>] -         Upgrade WildFly maven-plugins to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5017'>WFCORE-5017</a>] -         Upgrade jakarta.inject-api 1.0.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5018'>WFCORE-5018</a>] -         Upgrade woodstox:stax2-api to 4.2.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5019'>WFCORE-5019</a>] -         Upgrade jboss-invocation 1.5.3.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5006'>WFCORE-5006</a>] -         Improve readability of domain host controller server logs in tests
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5022'>WFCORE-5022</a>] -         The /subsystem=elytron/policy=* can be simplified a lot further
</li>
</ul>
                                                                                                                    
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4484'>WFCORE-4484</a>] -         Support SSH authentication for Git persistence
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4748'>WFCORE-4748</a>] -         Expose the ability to add jboss-modules specific arguments
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-944'>WFCORE-944</a>] -         truststore path is ignored if provider is not JKS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4707'>WFCORE-4707</a>] -         OperationContext.getCapabilityServiceName(String, String...) generates wrong ServiceName if capability is not registered and dynamic part contains a DOT
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4972'>WFCORE-4972</a>] -         LayersTest doesn&#39;t follow module aliases
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5004'>WFCORE-5004</a>] -         TlsTestCase#testReloadTrustManager fails on IBM Java 8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5011'>WFCORE-5011</a>] -         Remove licenses for artifact wildfly-jar-boot that is not in the distribution
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5014'>WFCORE-5014</a>] -         Log files truncated when jboss.as.management.blocking.timeout error happens on startup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5020'>WFCORE-5020</a>] -         Although elytron has module for JACC factory it is not used for JACC
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4981'>WFCORE-4981</a>] -         Add DeploymentUnit Phases for Undertow to resolve the security domain early.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4987'>WFCORE-4987</a>] -         Bump the Elytron subsystem version
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4992'>WFCORE-4992</a>] -         Create tests to ensure log file rotation works when the security manager is enabled
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4993'>WFCORE-4993</a>] -         Organize feature pack code to facilitate separate EE 8 and EE 9 variants
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4995'>WFCORE-4995</a>] -         Bump the kernel management API version to 14.0.0 and the xsd to 14.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4999'>WFCORE-4999</a>] -         Remove Zanata configuration
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5002'>WFCORE-5002</a>] -         Require a minimum of Maven 3.6.0 and default to 3.6.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5016'>WFCORE-5016</a>] -         Have the feature pack &#39;source modules&#39; produce zip artifacts
</li>
</ul>
                                        
