### PR TITLE
[WFLY-12342] Add server probes for readiness health check

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/subsystem-configuration/MicroProfile_Health.adoc
@@ -19,18 +19,45 @@ element to the xml or by using the following CLI operation:
 [standalone@localhost:9990 /]/extension=org.wildfly.extension.microprofile.health-smallrye:add
 ----
 
-== Management Operation
+== Management Operations
 
-The healthiness of the application server can be queried by calling the `check`:
+The healthiness of the application server can be queried by calling 3 different operations:
+
+* `check` to check both the liveness and readiness of the runtime
+* `check-live` to check only the liveness of the runtime
+* `check-ready` to check only the readiness of the runtime
+
 
 [source,options="nowrap"]
 ----
 [standalone@localhost:9990 /] /subsystem=microprofile-health-smallrye:check
 {
-    "outcome" => "success", <1>
+    "outcome" => "success",
     "result" => {
-        "outcome" => "UP", <2>
-        "checks" => []
+        "status" => "UP",
+        "checks" => [
+            {
+                "name" => "empty-liveness-checks",
+                "status" => "UP"
+            },
+            {
+                "name" => "server-state",
+                "status" => "UP",
+                "data" => {"value" => "running"}
+            },
+            {
+                "name" => "boot-errors",
+                "status" => "UP"
+            },
+            {
+                "name" => "deployments-status",
+                "status" => "UP"
+            },
+            {
+                "name" => "empty-readiness-checks",
+                "status" => "UP"
+            }
+        ]
     }
 }
 ----
@@ -40,6 +67,7 @@ The healthiness of the application server can be queried by calling the `check`:
 == HTTP Endpoints
 
 The MicroProfile Health Check specifications defines three HTTP endpoints:
+
 * `/health` to test both the liveness and readiness of the runtime.
 * `/health/live` to test the liveness of the runtime.
 * `/health/ready` to test the readiness of the runtime.
@@ -58,7 +86,7 @@ If the application server is healthy, it will return a `200 OK` response:
 $ curl -v http://localhost:9990/health
 < HTTP/1.1 200 OK
 ...
-{"outcome":"UP","checks":[]}
+{"status":"UP","checks":[{"name":"empty-liveness-checks","status":"UP"},{"name":"server-state","status":"UP","data":{"value":"running"}},{"name":"boot-errors","status":"UP"},{"name":"deployments-status","status":"UP"},{"name":"empty-readiness-checks","status":"UP"}]}
 ----
 
 If the application server (and its deployment) is not healthy, it returns `503 Service Unavailable`
@@ -79,28 +107,44 @@ created by the `add-user` script. For example:
 $ curl -v --digest -u myadminuser:myadminpassword http://localhost:9990/health
 < HTTP/1.1 200 OK
 ...
-{"outcome":"UP","checks":[]}
+{"status":"UP","checks":[{"name":"empty-liveness-checks","status":"UP"},{"name":"server-state","status":"UP","data":{"value":"running"}},{"name":"boot-errors","status":"UP"},{"name":"deployments-status","status":"UP"},{"name":"empty-readiness-checks","status":"UP"}]}
 ----
 
 If the authentication fails, the  server will reply with a `401 NOT AUTHORIZED` response.
 
-=== Global Status when probes are not defined
+=== Default Server Procedures
 
-By default, the HTTP endpoints will return `UP` if there are no health check probes defined by the application.
+WildFly provides some readiness procedures that are checked to determine if the application server is ready to serve requests:
 
-However, it is possible to change this behaviour.
-The `/health/live` HTTP endpoint (as well as the `check-live` management operation) can return `DOWN` when there are no liveness check probes by setting the `empty-liveness-checks-status` attribute
-on the `subsystem` resource to `DOWN`.
-Similarly, the `/health/ready` HTTP endpoint (as well as the `check-ready` management operation) can return `DOWN` when there are no readiness check probes by setting the `empty-readiness-checks-status` attribute
-on the `subsystem` resource to `DOWN`.
+* `boot-errors` checks that there were no errors during the server boot sequence
+* `deployments-status` checks that all deployments were deployed without errors
+* `server-state` checks that the server state is `running`
+* `empty-readiness-checks` determines the status when there are no readiness check procedures deployed to the server. The outcome of this procedure is determined by the `empty-readiness-checks-status` attribute. If the attribute is
+   `UP` (by default), the server can be ready when there are no readiness checks in the deployments. Setting the `empty-readiness-checks-status` attribute to `DOWN` will make this procedure fail when there are no readiness checks in the deployments.
 
-This allows application to ensure that the HTTP liveness and readiness endpoints will return `DOWN` until their probes are deployed and used to determine the actual
-liveness and readiness state of the application.
+If a deployment does not provide any readiness checks, WildFly will automatically add one for each deployment (named `ready-<deployment name>`) which always returns `UP`.
 
 [NOTE]
-There is a specific behaviour for deployments that provides no _readiness_ probes. In that the case, WildFly automatically adds a readiness probe for the deployment that always return
-`UP`. This allows existing deployments that do not provide readiness probes to configure WildFly so it will not be ready until this deployment is actually deployed.
+====
+This allows applications that does not provide readiness checks to still be able to inform cloud containers when they are ready to serve requests.
+Setting empty-readiness-checks-status` to `DOWN` ensures that the server will not be ready until the application is deployed. At that time, the `ready-<deployment name>`
+will be added (which returns `UP`) and the `empty-readiness-checks` procedure will no longer be checked as there is no a readiness check procedure provided by the deployment.
+====
 
+WildFly also provide a liveness procedure that is checked to determine if the application server is live:
+
+* `empty-liveness-checks` determines the status when there are no liveness check procedures deployed to the server. The outcome of this procedure is determined by the `empty-liveness-checks-status` attribute. If the attribute is
+`UP` (by default), the server can be live when there are no liveness checks in the deployments.  Setting the `empty-liveness-checks-status` attribute to `DOWN` will make this procedure fail when there are no liveness checks in the deployments.
+
+It is possible to disable all these server procedures by using the MicroProfile Config property `mp.health.disable-default-procedures`.
+
+[NOTE]
+====
+The MicroProfile Config property `mp.health.disable-default-procedures` is read at 2 different times:
+
+1. __When the server starts__, to determine if its server procedures should be disabled or enabled. It can be set using the system property `mp.health.disable-default-procedures` or the environment variable `MP_HEALTH_DISABLE_DEFAULT_PROCEDURES`. Setting this property in a deployment is ignored at that time.
+2. __When an application is deployed__, to determine if WildFly should add a readiness check if the deployment does not provide any. At that time, setting this property in a `microprofile-config.properties` file in the deployment would be taken into account. (with the usual priority rules for MicroProfile Config properties).
+====
 
 == Component Reference
 

--- a/microprofile/health-smallrye/pom.xml
+++ b/microprofile/health-smallrye/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
             <exclusions>
                 <exclusion>
@@ -127,11 +131,6 @@
         <dependency>
             <groupId>org.projectodd.vdx</groupId>
             <artifactId>vdx-wildfly</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/MicroProfileHealthSubsystemDefinition.java
@@ -44,9 +44,12 @@ public class MicroProfileHealthSubsystemDefinition extends PersistentResourceDef
 
     static final String HEALTH_REPORTER_CAPABILITY = "org.wildfly.microprofile.health.reporter";
 
+    static final String CLIENT_FACTORY_CAPABILITY ="org.wildfly.management.model-controller-client-factory";
+    static final String MANAGEMENT_EXECUTOR ="org.wildfly.management.executor";
+
     static final RuntimeCapability<Void> HEALTH_REPORTER_RUNTIME_CAPABILITY =
             RuntimeCapability.Builder.of(HEALTH_REPORTER_CAPABILITY, HealthReporter.class)
-                    .addRequirements(WELD_CAPABILITY_NAME)
+                    .addRequirements(WELD_CAPABILITY_NAME, CLIENT_FACTORY_CAPABILITY, MANAGEMENT_EXECUTOR)
                     .build();
 
     public static final ServiceName HEALTH_REPORTER_SERVICE = ServiceName.parse(HEALTH_REPORTER_CAPABILITY);

--- a/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/ServerReadinessProbes.java
+++ b/microprofile/health-smallrye/src/main/java/org/wildfly/extension/microprofile/health/ServerReadinessProbes.java
@@ -1,0 +1,180 @@
+package org.wildfly.extension.microprofile.health;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERRORS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATUS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
+import java.util.List;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.jboss.as.controller.LocalModelControllerClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+
+class ServerReadinessProbes {
+
+    private static final ModelNode READ_SERVER_STATE_ATTRIBUTE;
+    private static final ModelNode READ_BOOT_ERRORS;
+    private static final ModelNode READ_DEPLOYMENTS_STATUS;
+
+    static {
+        READ_SERVER_STATE_ATTRIBUTE = new ModelNode();
+        READ_SERVER_STATE_ATTRIBUTE.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        READ_SERVER_STATE_ATTRIBUTE.get(OP_ADDR).set(new ModelNode());
+        READ_SERVER_STATE_ATTRIBUTE.get(NAME).set("server-state");
+
+        READ_BOOT_ERRORS = new ModelNode();
+        READ_BOOT_ERRORS.get(OP).set("read-boot-errors");
+        READ_BOOT_ERRORS.get(OP_ADDR).add(CORE_SERVICE, MANAGEMENT);
+
+        READ_DEPLOYMENTS_STATUS = new ModelNode();
+        READ_DEPLOYMENTS_STATUS.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        READ_DEPLOYMENTS_STATUS.get(OP_ADDR).add(DEPLOYMENT, "*");
+        READ_DEPLOYMENTS_STATUS.get(NAME).set(STATUS);
+
+    }
+
+    /**
+     * Check that the server-state attribute value is "running"
+     */
+    static class ServerStateCheck implements HealthCheck {
+
+        private LocalModelControllerClient modelControllerClient;
+
+        ServerStateCheck(LocalModelControllerClient modelControllerClient) {
+            this.modelControllerClient = modelControllerClient;
+        }
+
+        @Override
+        public HealthCheckResponse call() {
+            ModelNode response = modelControllerClient.execute(READ_SERVER_STATE_ATTRIBUTE);
+
+            HealthCheckResponseBuilder check = HealthCheckResponse.named("server-state");
+
+            if (!SUCCESS.equals(response.get(OUTCOME).asStringOrNull())) {
+                return check.down().build();
+            }
+            if (response.hasDefined(FAILURE_DESCRIPTION)) {
+                return check.down()
+                        .withData(FAILURE_DESCRIPTION, response.get(FAILURE_DESCRIPTION).asString())
+                        .build();
+            }
+            ModelNode result = response.get(RESULT);
+            if (!result.isDefined()) {
+                return check.down().build();
+            }
+            String value = result.asString();
+            return check.state("running".equals(value))
+                    .withData(VALUE, value)
+                    .build();
+        }
+    }
+
+    /**
+     * Check that /core-service=management:read-boot-errors does not report any errors.
+     */
+    static class NoBootErrorsCheck implements HealthCheck {
+
+        private LocalModelControllerClient modelControllerClient;
+
+        NoBootErrorsCheck(LocalModelControllerClient modelControllerClient) {
+            this.modelControllerClient = modelControllerClient;
+        }
+
+        @Override
+        public HealthCheckResponse call() {
+            ModelNode response = modelControllerClient.execute(READ_BOOT_ERRORS);
+            HealthCheckResponseBuilder check = HealthCheckResponse.named(BOOT_ERRORS);
+
+            if (!SUCCESS.equals(response.get(OUTCOME).asStringOrNull())) {
+                return check.down().build();
+            }
+            if (response.hasDefined(FAILURE_DESCRIPTION)) {
+                return check.down()
+                        .withData(FAILURE_DESCRIPTION, response.get(FAILURE_DESCRIPTION).asString())
+                        .build();
+            }
+            ModelNode result = response.get(RESULT);
+            if (!result.isDefined()) {
+                return check.down().build();
+            }
+            List<ModelNode> errors = result.asList();
+            if (errors.isEmpty()) {
+                return check.up().build();
+            }
+            return check.down()
+                    .withData(BOOT_ERRORS, result.toJSONString(true))
+                    .build();
+        }
+    }
+
+    /**
+     * Check that all deployments status are OK
+     */
+    static class DeploymentsStatusCheck implements HealthCheck {
+
+        private LocalModelControllerClient modelControllerClient;
+
+        DeploymentsStatusCheck(LocalModelControllerClient modelControllerClient) {
+            this.modelControllerClient = modelControllerClient;
+        }
+
+        @Override
+        public HealthCheckResponse call() {
+            ModelNode responses = modelControllerClient.execute(READ_DEPLOYMENTS_STATUS);
+            HealthCheckResponseBuilder check = HealthCheckResponse.named("deployments-status");
+
+            if (!SUCCESS.equals(responses.get(OUTCOME).asStringOrNull())) {
+                return check.down().build();
+            }
+            if (!responses.get(RESULT).isDefined()) {
+                return check.down().build();
+            }
+
+            boolean globalStatus = true;
+            for (ModelNode response : responses.get(RESULT).asList()) {
+                boolean deploymentUp = false;
+                String data = null;
+
+                if (!SUCCESS.equals(response.get(OUTCOME).asStringOrNull())) {
+                    data = "DMR Query failed";
+                } else if (response.hasDefined(FAILURE_DESCRIPTION)) {
+                    data = response.get(FAILURE_DESCRIPTION).asString();
+                }
+                ModelNode result = response.get(RESULT);
+                if (!result.isDefined()) {
+                    data = "status undefined";
+                }
+                String value = result.asString();
+                if ("OK".equals(value)) {
+                    deploymentUp = true;
+                }
+                if (data == null) {
+                    data = value;
+                }
+
+                PathAddress address = PathAddress.pathAddress(response.get(OP_ADDR));
+                String deploymentName = address.getElement(0).getValue();
+                check.withData(deploymentName, data);
+                globalStatus = globalStatus && deploymentUp;
+            }
+
+            return check.state(globalStatus)
+                    .build();
+        }
+    }
+
+}

--- a/microprofile/health-smallrye/src/main/resources/org/wildfly/extension/microprofile/health/LocalDescriptions.properties
+++ b/microprofile/health-smallrye/src/main/resources/org/wildfly/extension/microprofile/health/LocalDescriptions.properties
@@ -5,5 +5,5 @@ microprofile-health-smallrye.check=Check both the liveness and readiness of the 
 microprofile-health-smallrye.check-live=Check the liveness of the application server and its deployments
 microprofile-health-smallrye.check-ready=Check the readiness of the application server and its deployments
 microprofile-health-smallrye.security-enabled=True if authentication is required to access the HTTP endpoints on the HTTP management interface.
-microprofile-health-smallrye.empty-liveness-checks-status=Defines the global status returned by the Health checks endpoints if no liveness probes have been defined.
-microprofile-health-smallrye.empty-readiness-checks-status=Defines the global status returned by the Health checks endpoints if no readiness probes have been defined.
+microprofile-health-smallrye.empty-liveness-checks-status=Defines the global status returned by the Health checks endpoints if no liveness probes have been defined in deployments.
+microprofile-health-smallrye.empty-readiness-checks-status=Defines the global status returned by the Health checks endpoints if no readiness probes have been defined in deployments.

--- a/microprofile/health-smallrye/src/test/java/org/wildfly/extension/microprofile/health/Subsystem_2_0_ParsingTestCase.java
+++ b/microprofile/health-smallrye/src/test/java/org/wildfly/extension/microprofile/health/Subsystem_2_0_ParsingTestCase.java
@@ -26,6 +26,7 @@ import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 import static org.junit.Assert.assertTrue;
 import static org.wildfly.extension.microprofile.health.MicroProfileHealthExtension.VERSION_1_0_0;
 import static org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition.HTTP_EXTENSIBILITY_CAPABILITY;
+import static org.wildfly.extension.microprofile.health.MicroProfileHealthSubsystemDefinition.MANAGEMENT_EXECUTOR;
 
 import java.io.IOException;
 import java.util.List;
@@ -110,7 +111,8 @@ public class Subsystem_2_0_ParsingTestCase extends AbstractSubsystemBaseTest {
     protected AdditionalInitialization createAdditionalInitialization() {
         return AdditionalInitialization.withCapabilities(
                 HTTP_EXTENSIBILITY_CAPABILITY,
-                WELD_CAPABILITY_NAME);
+                WELD_CAPABILITY_NAME,
+                MANAGEMENT_EXECUTOR);
     }
 
     private void testRejectingTransformers(ModelTestControllerVersion controllerVersion, ModelVersion healthVersion) throws Exception {

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationReadyHTTPEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationReadyHTTPEndpointTestCase.java
@@ -55,10 +55,11 @@ public class MicroProfileHealthApplicationReadyHTTPEndpointTestCase extends Micr
         try (CloseableHttpClient client = HttpClients.createDefault()) {
 
             CloseableHttpResponse resp = client.execute(new HttpGet(healthURL));
-            assertEquals(mustBeUP ? 200 : 503, resp.getStatusLine().getStatusCode());
-
             String content = EntityUtils.toString(resp.getEntity());
             resp.close();
+
+            assertEquals(content, mustBeUP ? 200 : 503, resp.getStatusLine().getStatusCode());
+
 
             try (
                     JsonReader jsonReader = Json.createReader(new StringReader(content))

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationReadySetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationReadySetupTask.java
@@ -34,7 +34,7 @@ public class MicroProfileHealthApplicationReadySetupTask implements ServerSetupT
     public void setup(ManagementClient managementClient, String containerId) throws Exception {
         final ModelNode address = Operations.createAddress("subsystem", "microprofile-health-smallrye");
         final ModelNode op = Operations.createWriteAttributeOperation(address, "empty-readiness-checks-status", "DOWN" );
-        ModelNode result = managementClient.getControllerClient().execute(op);
+        managementClient.getControllerClient().execute(op);
 
         ServerReload.reloadIfRequired(managementClient);
     }

--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessHTTPEndpointTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/microprofile/health/MicroProfileHealthApplicationWithoutReadinessHTTPEndpointTestCase.java
@@ -43,7 +43,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2019 Red Hat inc.
  */
-public class MicroProfileHealthApplicationWitouhtReadinessHTTPEndpointTestCase extends MicroProfileHealthApplicationWithoutReadinessTestBase {
+public class MicroProfileHealthApplicationWithoutReadinessHTTPEndpointTestCase extends MicroProfileHealthApplicationWithoutReadinessTestBase {
 
     void checkGlobalOutcome(ManagementClient managementClient, String operation, boolean mustBeUP, String probeName) throws IOException {
 

--- a/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian.xml
+++ b/testsuite/integration/microprofile-tck/health/src/test/resources/arquillian.xml
@@ -5,7 +5,7 @@
     <container qualifier="jboss" default="true" >
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">${microprofile.jvm.args}</property>
+            <property name="javaVmArguments">${microprofile.jvm.args} -Dmp.health.disable-default-procedures=true</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-microprofile.xml}</property>
             <property name="managementAddress">127.0.0.1</property>
             <property name="managementPort">9990</property>


### PR DESCRIPTION
[WFLY-12342] Add server probes for readiness health check

Add 3 healthcheck probes to determine the readiness of the server:

* server-state returns UP when the server is "running"
* boot-errors returns UP if there were no boot-errors
* deployments-status returns UP if all deployments status are OK

JIRA: https://issues.jboss.org/browse/WFLY-12342