### PR TITLE
[WFLY-13647] Annotation processing error sun.reflect.annotation.TypeNotPresentExceptionProxy does not indicate issue

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3222,4 +3222,7 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 520, value = "Legacy host does not support multiple values for attributes: %s")
     String multipleValuesNotSupported(Set<String> attributes);
+
+    @Message(id = 521, value = "Some classes referenced by annotation: %s in class: %s are missing.")
+    DeploymentUnitProcessingException missingClassInAnnotation(String anCls, String resCls);
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -416,4 +416,7 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 103, value = "The time zone id %s is invalid.")
     OperationFailedException invalidTimeZoneId(String zoneId);
+
+    @Message(id = 104, value = "Some classes referenced by annotation: %s in class: %s are missing.")
+    DeploymentUnitProcessingException missingClassInAnnotation(String anCls, String resCls);
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13647

There is a bug with `Class.getAnnotation()` call in `JDK < 11` [1]  which throws `ArrayStoreException` when the annotation refers to some classes not found in current class path. The `ArrayStoreException` confuses user why it failed because the root cause is missing.

This PR tries to catch the exception and give more readable feedback in this case.

[1] https://bugs.openjdk.java.net/browse/JDK-7183985