### PR TITLE
WFLY-13653 Upgrade smallrye-health to 2.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <version.io.rest-assured>3.0.6</version.io.rest-assured>
         <version.io.smallrye.smallrye-config>1.6.2</version.io.smallrye.smallrye-config>
         <version.io.smallrye.smallrye-fault-tolerance>4.2.1</version.io.smallrye.smallrye-fault-tolerance>
-        <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
+        <version.io.smallrye.smallrye-health>2.2.2</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>1.2.3</version.io.smallrye.open-api>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13653

The implementation was rewritten to be fully reactive (based on Mutiny).
