### PR TITLE
WFLY-13641 Do not try to index beans if module from jboss-deployment-…

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracingDependencyProcessor.java
@@ -93,7 +93,12 @@ public class TracingDependencyProcessor implements DeploymentUnitProcessor {
             moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, false, true, false));
         }
         for (String module : EXPORTED_MODULES) {
-            moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, false, true, true, false));
+            ModuleDependency modDep = new ModuleDependency(moduleLoader, module, false, true, true, false);
+            // io.opentracing.contrib.opentracing-interceptors needs to be processed by ExternalBeanArchiveProcessor
+            if (module.contains("opentracing-interceptors")) {
+                modDep.addImportFilter(s -> s.equals("META-INF"), true);
+            }
+            moduleSpecification.addSystemDependency(modDep);
         }
         for (String module : WildFlyTracerFactory.getModules()) {
             moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, module, true, false, true, false));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/config/LoggingConfigSharedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/config/LoggingConfigSharedTestCase.java
@@ -138,7 +138,7 @@ public class LoggingConfigSharedTestCase extends AbstractConfigTestCase {
                 "<jboss-deployment-structure>\n" +
                         "   <deployment>\n" +
                         "       <dependencies>\n" +
-                        "           <module name=\"deployment." + EJB_DEPLOYMENT_NAME + "\" />\n" +
+                        "           <module name=\"deployment." + EJB_DEPLOYMENT_NAME + "\" meta-inf=\"import\" />\n" +
                         "       </dependencies>\n" +
                         "   </deployment>\n" +
                         "</jboss-deployment-structure>");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/config/LoggingProfileSharedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/config/LoggingProfileSharedTestCase.java
@@ -143,7 +143,7 @@ public class LoggingProfileSharedTestCase extends AbstractConfigTestCase {
                 "<jboss-deployment-structure>\n" +
                         "   <deployment>\n" +
                         "       <dependencies>\n" +
-                        "           <module name=\"deployment." + EJB_DEPLOYMENT_NAME + "\" />\n" +
+                        "           <module name=\"deployment." + EJB_DEPLOYMENT_NAME + "\" meta-inf=\"import\" />\n" +
                         "       </dependencies>\n" +
                         "   </deployment>\n" +
                         "</jboss-deployment-structure>");

--- a/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/ExternalBeanArchiveProcessor.java
+++ b/weld/subsystem/src/main/java/org/jboss/as/weld/deployment/processors/ExternalBeanArchiveProcessor.java
@@ -199,6 +199,14 @@ public class ExternalBeanArchiveProcessor implements DeploymentUnitProcessor {
                             continue;
                         }
 
+                        /*
+                         * check if the dependency processes META-INF, if it doesn't we don't want to pick up beans
+                         * See https://docs.wildfly.org/17/Developer_Guide.html#CDI_Reference
+                         */
+                        if (!dep.getImportFilter().accept("META-INF")) {
+                            continue;
+                        }
+
                         WeldLogger.DEPLOYMENT_LOGGER.debugf("Found external beans.xml: %s", beansXmlUrl.toString());
                         final BeansXml beansXml = parseBeansXml(beansXmlUrl, parser, deploymentUnit);
 


### PR DESCRIPTION
…structure doesnt include META-INF.

JIRA - https://issues.redhat.com/browse/WFLY-13641

The processor in this PR goes over all dependencies and tries to scan for beans based on presence of `beans.xml` and the appropriate discovery mode. However, if a dependency is added via `jboss-deployment-structure`, it needs to have `meta-inf="import"` declared for CDI beans to be picked up. See https://docs.wildfly.org/17/Developer_Guide.html#CDI_Reference
This contract is currently not honored and you would see warning when Weld fails to index those classes.

This PR attempts to fix it. I am not 100% sure this is correct solution, e.g. if it couldn't be solved at some earlier point so that `ExternalBeanArchiveProcessor` wouldn't see that dependency at all. I have ran this against the issue reproducer and with basic WFLY tests (leaving full TS to PR checks).

Also, there is no test attached because the original issue reports warning being logged (and no hard failure) when this wasn't in place.

As usual, I am open to comments and suggestions :)