### PR TITLE
WFLY-13546 Upgrade smallrye-open-api to 2.0.3

### DIFF
--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -207,7 +207,18 @@
 
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-open-api</artifactId>
+            <artifactId>smallrye-open-api-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-jaxrs</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/galleon-pack/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
+++ b/galleon-pack/src/main/resources/modules/system/layers/base/io/smallrye/openapi/main/module.xml
@@ -28,7 +28,8 @@
     </properties>
 
     <resources>
-        <artifact name="${io.smallrye:smallrye-open-api}"/>
+        <artifact name="${io.smallrye:smallrye-open-api-core}"/>
+        <artifact name="${io.smallrye:smallrye-open-api-jaxrs}"/>
     </resources>
 
     <dependencies>

--- a/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
+++ b/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
@@ -64,5 +64,6 @@
 
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.extension.undertow"/>
+        <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/microprofile/openapi-smallrye/pom.xml
+++ b/microprofile/openapi-smallrye/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-open-api</artifactId>
+            <artifactId>smallrye-open-api-core</artifactId>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
@@ -171,6 +171,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIHttpHandler.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIHttpHandler.java
@@ -42,8 +42,8 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.jboss.resteasy.util.AcceptParser;
 
+import io.smallrye.openapi.runtime.io.Format;
 import io.smallrye.openapi.runtime.io.OpenApiSerializer;
-import io.smallrye.openapi.runtime.io.OpenApiSerializer.Format;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HeaderMap;

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.open-api>1.2.3</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.0.3</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>
@@ -1941,7 +1941,12 @@
 
             <dependency>
                 <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-open-api</artifactId>
+                <artifactId>smallrye-open-api-core</artifactId>
+                <version>${version.io.smallrye.open-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye</groupId>
+                <artifactId>smallrye-open-api-jaxrs</artifactId>
                 <version>${version.io.smallrye.open-api}</version>
             </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13546

Resolves:
* Smallrye OpenAPI throws java.lang.NullPointerException because of null parameter schema
https://issues.redhat.com/browse/WFLY-13587
* Smallrye OpenAPI throws java.lang.NullPointerException when processing JAX-RS resources which define methods acception a SortedSet type parameter
https://issues.redhat.com/browse/WFLY-13547
* Smallrye OpenAPI annotaton scanner throws StackOverflowError when processing JAX-RS resource classes which implement a locator that will return the class itself
https://issues.redhat.com/browse/WFLY-13545
* Log messages from io.smallrye.openapi don't have message ID
https://issues.redhat.com/browse/WFLY-12992
