### PR TITLE
[WFLY-13433] Improve capability support in EJB3 subsystem

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponentDescription.java
@@ -30,6 +30,7 @@ import javax.ejb.TransactionManagementType;
 import javax.resource.spi.ResourceAdapter;
 
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentConfiguration;
@@ -50,7 +51,6 @@ import org.jboss.as.ejb3.component.EJBViewDescription;
 import org.jboss.as.ejb3.component.MethodIntf;
 import org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor;
 import org.jboss.as.ejb3.component.pool.PoolConfig;
-import org.jboss.as.ejb3.component.pool.StrictMaxPoolConfigService;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
 import org.jboss.as.ejb3.tx.CMTTxInterceptor;
 import org.jboss.as.ejb3.tx.EjbBMTInterceptor;
@@ -75,6 +75,10 @@ import org.jboss.msc.service.ServiceName;
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class MessageDrivenComponentDescription extends EJBComponentDescription {
+
+    private static final String STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME = "org.wildfly.ejb3.pool-config";
+    private static final String DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME = "org.wildfly.ejb3.pool-config.mdb-default";
+
     private final Properties activationProps;
     private String resourceAdapterName;
     private boolean deliveryActive;
@@ -132,12 +136,57 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
         }
         mdbComponentConfiguration.setComponentCreateServiceFactory(new MessageDrivenComponentCreateServiceFactory(messageListenerInterface));
 
-        // setup the configurator to inject the PoolConfig in the MessageDrivenComponentCreateService
         final MessageDrivenComponentDescription mdbComponentDescription = (MessageDrivenComponentDescription) mdbComponentConfiguration.getComponentDescription();
-        mdbComponentConfiguration.getCreateDependencies().add(new PoolInjectingConfigurator(mdbComponentDescription));
 
-        // setup the configurator to inject the resource adapter
-        mdbComponentConfiguration.getCreateDependencies().add(new ResourceAdapterInjectingConfiguration());
+        // setup a configurator to inject the PoolConfig in the MessageDrivenComponentCreateService
+        getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
+                //get CapabilitySupport to resolve service names
+                final CapabilityServiceSupport support = context.getDeploymentUnit().getAttachment(CAPABILITY_SERVICE_SUPPORT);
+
+                MessageDrivenComponentDescription mdbDescription = (MessageDrivenComponentDescription) description;
+                configuration.getCreateDependencies().add(new DependencyConfigurator<Service<Component>>() {
+                    @Override
+                    public void configureDependency(ServiceBuilder<?> serviceBuilder, Service<Component> service) throws DeploymentUnitProcessingException {
+                        // add any dependencies here
+                        final MessageDrivenComponentCreateService mdbComponentCreateService = (MessageDrivenComponentCreateService) service;
+                        final String poolName = mdbComponentDescription.getPoolConfigName();
+                        // if no pool name has been explicitly set, then inject the *optional* "default mdb pool config"
+                        // If the default mdb pool config itself is not configured, then pooling is disabled for the bean
+                        if (poolName == null) {
+                            if (mdbComponentDescription.isDefaultMdbPoolAvailable()) {
+                                ServiceName defaultPoolConfigServiceName = support.getCapabilityServiceName(DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME);
+                                serviceBuilder.addDependency(defaultPoolConfigServiceName, PoolConfig.class, mdbComponentCreateService.getPoolConfigInjector());
+                            }
+                        } else {
+                            // pool name has been explicitly set so the pool config is a required dependency
+                            ServiceName poolConfigServiceName = support.getCapabilityServiceName(STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME, poolName);
+                            serviceBuilder.addDependency(poolConfigServiceName, PoolConfig.class, mdbComponentCreateService.getPoolConfigInjector());
+                        }
+                    }
+                });
+            }
+        });
+
+        // set up a configurator to inject ResourceAdapterService dependencies into the MessageDrivenComponentCreateService
+        getConfigurators().add(new ComponentConfigurator() {
+            @Override
+            public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
+                //get CapabilitySupport to resolve service names
+                final CapabilityServiceSupport support = context.getDeploymentUnit().getAttachment(CAPABILITY_SERVICE_SUPPORT);
+                configuration.getCreateDependencies().add(new DependencyConfigurator<MessageDrivenComponentCreateService>() {
+                    @Override
+                    public void configureDependency(ServiceBuilder<?> serviceBuilder, MessageDrivenComponentCreateService service) throws DeploymentUnitProcessingException {
+                        final ServiceName raServiceName =
+                                ConnectorServices.getResourceAdapterServiceName(MessageDrivenComponentDescription.this.resourceAdapterName);
+                        // add the dependency on the RA service
+                        serviceBuilder.addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class, service.getResourceAdapterRepositoryInjector());
+                        serviceBuilder.addDependency(raServiceName, ResourceAdapter.class, service.getResourceAdapterInjector());
+                    }
+                });
+            }
+        });
 
         getConfigurators().add(new ComponentConfigurator() {
             @Override
@@ -154,7 +203,7 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
             }
         });
 
-        // add the bmt interceptor
+        // add the BMT interceptor
         if (TransactionManagementType.BEAN.equals(this.getTransactionManagementType())) {
             getConfigurators().add(new ComponentConfigurator() {
                 @Override
@@ -319,49 +368,6 @@ public class MessageDrivenComponentDescription extends EJBComponentDescription {
 
     public String getMessageListenerInterfaceName() {
         return messageListenerInterfaceName;
-    }
-
-    private static class PoolInjectingConfigurator implements DependencyConfigurator<Service<Component>> {
-
-        private final MessageDrivenComponentDescription mdbComponentDescription;
-
-        PoolInjectingConfigurator(final MessageDrivenComponentDescription mdbComponentDescription) {
-            this.mdbComponentDescription = mdbComponentDescription;
-        }
-
-        @Override
-        public void configureDependency(ServiceBuilder<?> serviceBuilder, Service<Component> service) {
-            final MessageDrivenComponentCreateService mdbComponentCreateService = (MessageDrivenComponentCreateService) service;
-            final String poolName = this.mdbComponentDescription.getPoolConfigName();
-            // if no pool name has been explicitly set, then inject the *optional* "default mdb pool config"
-            // If the default mdb pool config itself is not configured, then pooling is disabled for the bean
-            if (poolName == null) {
-                if (mdbComponentDescription.isDefaultMdbPoolAvailable()) {
-                    serviceBuilder.addDependency(StrictMaxPoolConfigService.DEFAULT_MDB_POOL_CONFIG_SERVICE_NAME,
-                            PoolConfig.class, mdbComponentCreateService.getPoolConfigInjector());
-                }
-            } else {
-                // pool name has been explicitly set so the pool config is a required dependency
-                serviceBuilder.addDependency(StrictMaxPoolConfigService.EJB_POOL_CONFIG_BASE_SERVICE_NAME.append(poolName),
-                        PoolConfig.class, mdbComponentCreateService.getPoolConfigInjector());
-            }
-        }
-    }
-
-    /**
-     * A dependency configurator which adds a dependency/injection into the {@link MessageDrivenComponentCreateService}
-     * for the appropriate resource adapter service
-     */
-    private class ResourceAdapterInjectingConfiguration implements DependencyConfigurator<MessageDrivenComponentCreateService> {
-
-        @Override
-        public void configureDependency(ServiceBuilder<?> serviceBuilder, MessageDrivenComponentCreateService service) {
-            final ServiceName raServiceName =
-                ConnectorServices.getResourceAdapterServiceName(MessageDrivenComponentDescription.this.resourceAdapterName);
-            // add the dependency on the RA service
-            serviceBuilder.addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class, service.getResourceAdapterRepositoryInjector());
-            serviceBuilder.addDependency(raServiceName, ResourceAdapter.class, service.getResourceAdapterInjector());
-        }
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/pool/StrictMaxPoolConfigService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/pool/StrictMaxPoolConfigService.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -37,14 +36,6 @@ import org.jboss.msc.value.InjectedValue;
  * User: jpai
  */
 public class StrictMaxPoolConfigService implements Service<StrictMaxPoolConfig> {
-
-    public static final ServiceName EJB_POOL_CONFIG_BASE_SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("pool-config");
-
-    public static final ServiceName DEFAULT_SLSB_POOL_CONFIG_SERVICE_NAME = EJB_POOL_CONFIG_BASE_SERVICE_NAME.append("slsb-default");
-
-    public static final ServiceName DEFAULT_MDB_POOL_CONFIG_SERVICE_NAME = EJB_POOL_CONFIG_BASE_SERVICE_NAME.append("mdb-default");
-
-    public static final ServiceName DEFAULT_ENTITY_POOL_CONFIG_SERVICE_NAME = EJB_POOL_CONFIG_BASE_SERVICE_NAME.append("entity-default");
 
     private final StrictMaxPoolConfig poolConfig;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -93,6 +93,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
 
     private static final String INTERNAL_REMOTING_PROFILE = "internal-remoting-profile";
     private static final String OUTBOUND_CONNECTION_CAPABILITY_NAME = "org.wildfly.remoting.outbound-connection";
+    private static final String REMOTING_PROFILE_CAPABILITY_NAME = "org.wildfly.ejb3.remoting-profile";
 
     private final boolean appclient;
 
@@ -112,9 +113,11 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
             return;
         }
 
+        // support for using capabilities to resolve service names
+        CapabilityServiceSupport capabilityServiceSupport = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
+
         // check for EJB client interceptor configuration
         final List<EJBClientInterceptor> deploymentEjbClientInterceptors = getClassPathInterceptors(module.getClassLoader());
-
         List<EJBClientInterceptor> staticEjbClientInterceptors = deploymentUnit.getAttachment(org.jboss.as.ejb3.subsystem.Attachments.STATIC_EJB_CLIENT_INTERCEPTORS);
 
         List<EJBClientInterceptor> ejbClientInterceptors = new ArrayList<>();
@@ -129,8 +132,8 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
 
         final boolean interceptorsDefined = ejbClientInterceptors != null && ! ejbClientInterceptors.isEmpty();
 
-        final EJBClientDescriptorMetaData ejbClientDescriptorMetaData = deploymentUnit
-                .getAttachment(Attachments.EJB_CLIENT_METADATA);
+        final EJBClientDescriptorMetaData ejbClientDescriptorMetaData = deploymentUnit.getAttachment(Attachments.EJB_CLIENT_METADATA);
+
         // no explicit EJB client configuration in this deployment, so nothing to do
         if (ejbClientDescriptorMetaData == null && ! interceptorsDefined) {
             return;
@@ -176,7 +179,9 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
             final String profile = ejbClientDescriptorMetaData.getProfile();
             final ServiceName profileServiceName;
             if (profile != null) {
-                profileServiceName = RemotingProfileService.BASE_SERVICE_NAME.append(profile);
+                // set up a service for the named remoting profile
+                profileServiceName = capabilityServiceSupport.getCapabilityServiceName(REMOTING_PROFILE_CAPABILITY_NAME, profile);
+                // why below?
                 serviceBuilder.addDependency(profileServiceName, RemotingProfileService.class, profileServiceInjector);
                 serviceBuilder.addDependency(profileServiceName, RemotingProfileService.class, service.getProfileServiceInjector());
             } else {
@@ -185,14 +190,14 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                 profileServiceName = ejbClientContextServiceName.append(INTERNAL_REMOTING_PROFILE);
                 final Map<String, RemotingProfileService.ConnectionSpec> map = new HashMap<>();
                 final RemotingProfileService profileService = new RemotingProfileService(Collections.emptyList(), map);
-                final ServiceBuilder<RemotingProfileService> profileServiceBuilder = serviceTarget.addService(profileServiceName,
-                        profileService);
+                final ServiceBuilder<RemotingProfileService> profileServiceBuilder = serviceTarget.addService(profileServiceName, profileService);
+
                 if (ejbClientDescriptorMetaData.isLocalReceiverExcluded() != Boolean.TRUE) {
                     final Boolean passByValue = ejbClientDescriptorMetaData.isLocalReceiverPassByValue();
                     profileServiceBuilder.addDependency(passByValue == Boolean.FALSE ? LocalTransportProvider.BY_REFERENCE_SERVICE_NAME : LocalTransportProvider.BY_VALUE_SERVICE_NAME, EJBTransportProvider.class, profileService.getLocalTransportProviderInjector());
                 }
                 final Collection<EJBClientDescriptorMetaData.RemotingReceiverConfiguration> receiverConfigurations = ejbClientDescriptorMetaData.getRemotingReceiverConfigurations();
-                final CapabilityServiceSupport support = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
+
                 for (EJBClientDescriptorMetaData.RemotingReceiverConfiguration receiverConfiguration : receiverConfigurations) {
                     final String connectionRef = receiverConfiguration.getOutboundConnectionRef();
                     final long connectTimeout = receiverConfiguration.getConnectionTimeout();
@@ -200,7 +205,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                     final OptionMap optionMap = getOptionMapFromProperties(channelCreationOptions, EJBClientDescriptorMetaDataProcessor.class.getClassLoader());
 
                     final InjectedValue<OutboundConnection> injector = new InjectedValue<>();
-                    final ServiceName internalServiceName = support.getCapabilityServiceName(OUTBOUND_CONNECTION_CAPABILITY_NAME, connectionRef);
+                    final ServiceName internalServiceName = capabilityServiceSupport.getCapabilityServiceName(OUTBOUND_CONNECTION_CAPABILITY_NAME, connectionRef);
                     profileServiceBuilder.addDependency(internalServiceName, OutboundConnection.class, injector);
 
                     final RemotingProfileService.ConnectionSpec connectionSpec = new RemotingProfileService.ConnectionSpec(connectionRef, injector, optionMap, connectTimeout);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBDefaultSecurityDomainProcessor.java
@@ -114,7 +114,7 @@ public class EJBDefaultSecurityDomainProcessor implements DeploymentUnitProcesso
             final CapabilityServiceSupport support = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.CAPABILITY_SERVICE_SUPPORT);
             ServiceName serviceName = deploymentUnit.getServiceName().append(EJBSecurityDomainService.SERVICE_NAME);
             final ServiceBuilder<Void> builder = phaseContext.getServiceTarget().addService(serviceName, ejbSecurityDomainService)
-                    .addDependency(support.getCapabilityServiceName(ApplicationSecurityDomainDefinition.APPLICATION_SECURITY_DOMAIN_CAPABILITY, knownSecurityDomainName),
+                    .addDependency(support.getCapabilityServiceName(ApplicationSecurityDomainDefinition.APPLICATION_SECURITY_DOMAIN_CAPABILITY_NAME, knownSecurityDomainName),
                             ApplicationSecurityDomain.class, ejbSecurityDomainService.getApplicationSecurityDomainInjector());
             builder.install();
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
@@ -91,17 +91,14 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
 
-
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         if (!IIOPDeploymentMarker.isIIOPDeployment(deploymentUnit)) {
             return;
         }
 
-        final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
         if (!EjbDeploymentMarker.isEjbDeployment(deploymentUnit)) {
             return;
         }
-
 
         // a bean-name -> IIOPMetaData map, reflecting the assembly descriptor IIOP configuration.
         Map<String, IIOPMetaData> iiopMetaDataMap = new HashMap<String, IIOPMetaData>();
@@ -116,6 +113,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         }
 
         final DeploymentReflectionIndex deploymentReflectionIndex = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.REFLECTION_INDEX);
+        final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
         final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);
         if (moduleDescription != null) {
             for (final ComponentDescription componentDescription : moduleDescription.getComponentDescriptions()) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3225,4 +3225,8 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 521, value = "Some classes referenced by annotation: %s in class: %s are missing.")
     DeploymentUnitProcessingException missingClassInAnnotation(String anCls, String resCls);
+
+    @LogMessage(level = WARN)
+    @Message(id = 522, value = "The default pool name %s could not be resolved from its value: %s")
+    void defaultPoolExpressionCouldNotBeResolved(String defaultPoolName, String defaultPoolValue);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingProfileService.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.jboss.as.network.OutboundConnection;
 import org.jboss.ejb.client.EJBTransportProvider;
 import org.jboss.msc.service.Service;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -45,8 +44,6 @@ import org.xnio.OptionMap;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public class RemotingProfileService implements Service<RemotingProfileService> {
-
-    public static final ServiceName BASE_SERVICE_NAME = ServiceName.JBOSS.append("ejb3", "profile");
 
     /**
      * There URLs are used to allow discovery to find these connections.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/CacheFactoryAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/CacheFactoryAdd.java
@@ -43,6 +43,8 @@ import org.wildfly.clustering.service.IdentityServiceConfigurator;
 import org.wildfly.clustering.service.ServiceConfigurator;
 
 /**
+ * Configure, build and install CacheFactoryBuilders to support SFSB usage.
+ *
  * @author Paul Ferraro
  */
 public class CacheFactoryAdd extends AbstractAddStepHandler {
@@ -61,8 +63,11 @@ public class CacheFactoryAdd extends AbstractAddStepHandler {
         final Collection<String> unwrappedAliasValues = CacheFactoryResourceDefinition.ALIASES.unwrap(context,model);
         final Set<String> aliases = unwrappedAliasValues != null ? new HashSet<>(unwrappedAliasValues) : Collections.<String>emptySet();
         ServiceTarget target = context.getServiceTarget();
-        ServiceConfigurator configurator = (passivationStore != null) ? new IdentityServiceConfigurator<>(new CacheFactoryBuilderServiceNameProvider(name).getServiceName(), new DistributableCacheFactoryBuilderServiceNameProvider(passivationStore).getServiceName()) : new SimpleCacheFactoryBuilderServiceConfigurator<>(name);
+        // set up the CacheFactoryBuilder service
+        ServiceConfigurator configurator = (passivationStore != null) ? new IdentityServiceConfigurator<>(new CacheFactoryBuilderServiceNameProvider(name).getServiceName(),
+                new DistributableCacheFactoryBuilderServiceNameProvider(passivationStore).getServiceName()) : new SimpleCacheFactoryBuilderServiceConfigurator<>(name);
         ServiceBuilder<?> builder = configurator.build(target);
+        // set up aliases to the CacheFactoryBuilder service
         for (String alias: aliases) {
             new IdentityServiceConfigurator<>(new CacheFactoryBuilderServiceNameProvider(alias).getServiceName(), configurator.getServiceName()).build(target).install();
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/CacheFactoryResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/CacheFactoryResourceDefinition.java
@@ -34,9 +34,17 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelType;
 
 /**
+ * Defines a CacheFactoryBuilder instance which, during deployment, is used to configure, build and install a CacheFactory for the SFSB being deployed.
+ * The CacheFactory resource instances defined here produce bean caches which are either:
+ * - distributed and have passivation-enabled
+ * - non distributed and do not have passivation-enabled
+ * For passivation enabled CacheFactoryBuilders, the PassivationStoreResourceDefinition must define a supporting passivation store.
+ *
  * @author Paul Ferraro
  */
 public class CacheFactoryResourceDefinition extends SimpleResourceDefinition {
+
+    // capabilities not required as although we install CacheFactoryBuilder services, these do not depend on any defined clustering resources
 
     public static final StringListAttributeDefinition ALIASES = new StringListAttributeDefinition.Builder(EJB3SubsystemModel.ALIASES)
             .setXmlName(EJB3SubsystemXMLAttribute.ALIASES.getLocalName())

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3AsyncResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3AsyncResourceDefinition.java
@@ -28,9 +28,13 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.threads.ThreadsServices;
 import org.jboss.dmr.ModelType;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * A {@link org.jboss.as.controller.ResourceDefinition} for the EJB async service
@@ -39,19 +43,29 @@ import org.jboss.dmr.ModelType;
  */
 public class EJB3AsyncResourceDefinition extends SimpleResourceDefinition {
 
+    // this is an unregistered copy of the capability defined and registered in /subsystem=ejb3/thread-pool=*
+    // needed due to the unorthodox way in which the thread pools are defined in ejb3 subsystem
+    protected static final String THREAD_POOL_CAPABILITY_NAME = ThreadsServices.createCapability(EJB3SubsystemModel.BASE_EJB_THREAD_POOL_NAME, ExecutorService.class).getName();
+
+    public static final String ASYNC_SERVICE_CAPABILITY_NAME = "org.wildfly.ejb3.async";
+    public static final RuntimeCapability<Void> ASYNC_SERVICE_CAPABILITY =
+            RuntimeCapability.Builder.of(ASYNC_SERVICE_CAPABILITY_NAME).build();
+
     static final SimpleAttributeDefinition THREAD_POOL_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.THREAD_POOL_NAME, ModelType.STRING, true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setCapabilityReference(THREAD_POOL_CAPABILITY_NAME, ASYNC_SERVICE_CAPABILITY)
                     .build();
 
     private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { THREAD_POOL_NAME };
     public static final EJB3AsyncResourceDefinition INSTANCE = new EJB3AsyncResourceDefinition();
 
     private EJB3AsyncResourceDefinition() {
-        super(EJB3SubsystemModel.ASYNC_SERVICE_PATH,
-                EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.ASYNC),
-                new EJB3AsyncServiceAdd(ATTRIBUTES), ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(EJB3SubsystemModel.ASYNC_SERVICE_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.ASYNC))
+                .setAddHandler(new EJB3AsyncServiceAdd(ATTRIBUTES))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setCapabilities(ASYNC_SERVICE_CAPABILITY));
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3AsyncServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3AsyncServiceAdd.java
@@ -34,6 +34,8 @@ import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
+import java.util.concurrent.Executor;
+
 /**
  * A {@link org.jboss.as.controller.AbstractBoottimeAddStepHandler} to handle the add operation for the EJB
  * remote service, in the EJB subsystem
@@ -51,7 +53,9 @@ public class EJB3AsyncServiceAdd extends AbstractBoottimeAddStepHandler {
     protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
         final String threadPoolName = EJB3AsyncResourceDefinition.THREAD_POOL_NAME.resolveModelAttribute(context, model).asString();
-        final ServiceName threadPoolServiceName = EJB3SubsystemModel.BASE_THREAD_POOL_SERVICE_NAME.append(threadPoolName);
+
+        final ServiceName threadPoolServiceName = context.getCapabilityServiceName(EJB3AsyncResourceDefinition.THREAD_POOL_CAPABILITY_NAME, threadPoolName, Executor.class);
+
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 ROOT_LOGGER.debug("Adding EJB @Asynchronous support");

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPAdd.java
@@ -57,6 +57,6 @@ public class EJB3IIOPAdd extends AbstractBoottimeAddStepHandler {
             }
         }, OperationContext.Stage.RUNTIME);
 
-        context.getServiceTarget().addService(IIOPSettingsService.SERVICE_NAME, settingsService).install();
+        context.getCapabilityServiceTarget().addCapability(EJB3IIOPResourceDefinition.EJB3_IIOP_SETTINGS_CAPABILITY, settingsService).install();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3IIOPResourceDefinition.java
@@ -31,20 +31,26 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 
 /**
- * A {@link org.jboss.as.controller.ResourceDefinition} for the EJB async service
+ * A {@link org.jboss.as.controller.ResourceDefinition} for the EJB IIOP resource definition
  * <p/>
  *
  * @author Stuart Douglas
  */
 public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
+
+    public static final String EJB3_IIOP_SETTINGS_CAPABILITY_NAME = "org.wildfly.ejb3.iiop.settings-service";
+    public static final RuntimeCapability<Void> EJB3_IIOP_SETTINGS_CAPABILITY =
+            RuntimeCapability.Builder.of(EJB3_IIOP_SETTINGS_CAPABILITY_NAME, IIOPSettingsService.class).build();
 
     static final SimpleAttributeDefinition USE_QUALIFIED_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.USE_QUALIFIED_NAME, ModelType.BOOLEAN)
@@ -64,9 +70,10 @@ public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
     public static final EJB3IIOPResourceDefinition INSTANCE = new EJB3IIOPResourceDefinition();
 
     private EJB3IIOPResourceDefinition() {
-        super(EJB3SubsystemModel.IIOP_PATH,
-                EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.IIOP),
-                new EJB3IIOPAdd(ATTRIBUTES), ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(new SimpleResourceDefinition.Parameters(EJB3SubsystemModel.IIOP_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.IIOP))
+                .setAddHandler(new EJB3IIOPAdd(ATTRIBUTES))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setCapabilities(EJB3_IIOP_SETTINGS_CAPABILITY));
     }
 
     @Override
@@ -111,7 +118,8 @@ public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
 
         private void applyModelToRuntime(OperationContext context, final ModelNode model) throws OperationFailedException {
             final ServiceRegistry serviceRegistry = context.getServiceRegistry(true);
-            ServiceController<IIOPSettingsService> controller = (ServiceController<IIOPSettingsService>) serviceRegistry.getService(IIOPSettingsService.SERVICE_NAME);
+            ServiceName iiopSettingsServiceName = context.getCapabilityServiceName(EJB3_IIOP_SETTINGS_CAPABILITY_NAME, IIOPSettingsService.class);
+            ServiceController<IIOPSettingsService> controller = (ServiceController<IIOPSettingsService>) serviceRegistry.getService(iiopSettingsServiceName);
             if (controller != null) {
                 IIOPSettingsService service = controller.getValue();
                 applySetting(service, context, model);
@@ -119,6 +127,5 @@ public class EJB3IIOPResourceDefinition extends SimpleResourceDefinition {
         }
 
         abstract void applySetting(final IIOPSettingsService service, final OperationContext context, final ModelNode model) throws OperationFailedException;
-
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -56,18 +56,29 @@ import java.util.List;
  *
  */
 public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
-    private static final String JBOSS_AS_REMOTING = "org.jboss.as.remoting";
 
-    public static final String CONNECTOR_CAPABILITY_NAME = "org.wildfly.remoting.connector";
+    private static final String JBOSS_AS_REMOTING = "org.jboss.as.remoting";
+    // todo: add in connector capability reference when connector resources are converted to use capabilities (WFCORE-5055)
+    protected static final String CONNECTOR_CAPABILITY_NAME = "org.wildfly.remoting.connector";
+    protected static final String INFINISPAN_CACHE_CONTAINER_CAPABILITY_NAME = "org.wildfly.clustering.infinispan.cache-container";
+    protected static final String REMOTE_TRANSACTION_SERVICE_CAPABILITY_NAME = "org.wildfly.transactions.remote-transaction-service";
+    protected static final String REMOTING_ENDPOINT_CAPABILITY_NAME = "org.wildfly.remoting.endpoint";
+    protected static final String THREAD_POOL_CAPABILITY_NAME = "org.wildfly.threads.executor.ejb3";
+
     public static final String EJB_REMOTE_CAPABILITY_NAME = "org.wildfly.ejb.remote";
 
-    static final RuntimeCapability<Void> EJB_REMOTE_CAPABILITY = RuntimeCapability.Builder.of(EJB_REMOTE_CAPABILITY_NAME).setServiceType(Void.class).build();
+    static final RuntimeCapability<Void> EJB_REMOTE_CAPABILITY = RuntimeCapability.Builder.of(EJB_REMOTE_CAPABILITY_NAME)
+            .setServiceType(Void.class)
+            .addRequirements(REMOTING_ENDPOINT_CAPABILITY_NAME)
+            .build();
 
     static final SimpleAttributeDefinition CLIENT_MAPPINGS_CLUSTER_NAME =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME, ModelType.STRING, true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setDefaultValue(new ModelNode(BeanManagerFactoryServiceConfiguratorConfiguration.DEFAULT_CONTAINER_NAME))
+                    // TODO: replace this with a Requirement reference when the ejb-spi module for clustering is available
+                    .setCapabilityReference(INFINISPAN_CACHE_CONTAINER_CAPABILITY_NAME, EJB_REMOTE_CAPABILITY)
                     .build();
 
     @Deprecated
@@ -92,6 +103,7 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.THREAD_POOL_NAME, ModelType.STRING, true)
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setCapabilityReference(THREAD_POOL_CAPABILITY_NAME, EJB_REMOTE_CAPABILITY)
                     .build();
 
     static final SimpleAttributeDefinition EXECUTE_IN_WORKER =

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -148,6 +148,9 @@ public interface EJB3SubsystemModel {
     PathElement IIOP_PATH = PathElement.pathElement(SERVICE, IIOP);
     PathElement FILE_DATA_STORE_PATH = PathElement.pathElement(FILE_DATA_STORE);
     PathElement DATABASE_DATA_STORE_PATH = PathElement.pathElement(DATABASE_DATA_STORE);
+    PathElement MDB_DELIVERY_GROUP_PATH = PathElement.pathElement(MDB_DELIVERY_GROUP);
+    PathElement STRICT_MAX_BEAN_INSTANCE_POOL_PATH = PathElement.pathElement(STRICT_MAX_BEAN_INSTANCE_POOL);
+    PathElement REMOTING_PROFILE_PATH = PathElement.pathElement(REMOTING_PROFILE);
 
     String BASE_EJB_THREAD_POOL_NAME = "ejb3";
     ServiceName BASE_THREAD_POOL_SERVICE_NAME = ThreadsServices.EXECUTOR.append(BASE_EJB_THREAD_POOL_NAME);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
@@ -25,7 +25,16 @@ package org.jboss.as.ejb3.subsystem;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.dmr.ModelNode;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_MDB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_SLSB_POOL_CONFIG_CAPABILITY_NAME;
+import static org.jboss.as.ejb3.subsystem.StrictMaxPoolResourceDefinition.STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME;
 
 /**
  * Handler for removing the EJB3 subsystem.
@@ -37,6 +46,45 @@ public class EJB3SubsystemRemove extends AbstractRemoveStepHandler {
     public static final EJB3SubsystemRemove INSTANCE = new EJB3SubsystemRemove();
 
     private EJB3SubsystemRemove() {
+    }
+
+    /*
+     * handle conditionally-defined capabilities for default bean instance pools
+     */
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        ModelNode model = resource.getModel();
+
+        // de-register the capability we are exporting as well as its capability requirement on the strict-max-pool that supports it
+        if (model.hasDefined(DEFAULT_SLSB_INSTANCE_POOL)) {
+            context.deregisterCapability(DEFAULT_SLSB_POOL_CONFIG_CAPABILITY_NAME);
+
+            try {
+                // need to resolve the attribute value before using it
+                String resolvedDefaultSLSBPoolName = context.resolveExpressions(model.get(DEFAULT_SLSB_INSTANCE_POOL)).asString();
+                String defaultSLSBPoolRequirementName = RuntimeCapability.buildDynamicCapabilityName(STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME, resolvedDefaultSLSBPoolName);
+
+                context.deregisterCapabilityRequirement(defaultSLSBPoolRequirementName, DEFAULT_SLSB_POOL_CONFIG_CAPABILITY_NAME, DEFAULT_SLSB_INSTANCE_POOL);
+            } catch(OperationFailedException ofe) {
+                EjbLogger.ROOT_LOGGER.defaultPoolExpressionCouldNotBeResolved(DEFAULT_SLSB_INSTANCE_POOL, model.get(DEFAULT_SLSB_INSTANCE_POOL).asString());
+            }
+        }
+
+        if (model.hasDefined(DEFAULT_MDB_INSTANCE_POOL)) {
+            context.deregisterCapability(DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME);
+
+            try {
+                // need to resolve the attribute value before using it
+                String resolvedDefaultMDBPoolName = context.resolveExpressions(model.get(DEFAULT_MDB_INSTANCE_POOL)).asString();
+                String defaultMDBPoolRequirementName = RuntimeCapability.buildDynamicCapabilityName(STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME, resolvedDefaultMDBPoolName);
+
+                context.deregisterCapabilityRequirement(defaultMDBPoolRequirementName, DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME, DEFAULT_MDB_INSTANCE_POOL);
+            } catch(OperationFailedException ofe) {
+                EjbLogger.ROOT_LOGGER.defaultPoolExpressionCouldNotBeResolved(DEFAULT_MDB_INSTANCE_POOL, model.get(DEFAULT_MDB_INSTANCE_POOL).asString());
+            }
+        }
+
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.ejb3.component.pool.PoolConfig;
 import org.jboss.as.ejb3.deployment.processors.EJBDefaultSecurityDomainProcessor;
 import org.jboss.as.ejb3.deployment.processors.merging.MissingMethodPermissionsDenyAccessMergingProcessor;
 import org.jboss.as.ejb3.logging.EjbLogger;
@@ -69,6 +70,17 @@ import org.jboss.dmr.ModelType;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinition {
+
+    // TODO: put capability definitions up here
+    public static final String DEFAULT_SLSB_POOL_CONFIG_CAPABILITY_NAME = "org.wildfly.ejb3.pool-config.slsb-default";
+    public static final String DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME = "org.wildfly.ejb3.pool-config.mdb-default";
+    public static final String DEFAULT_ENTITY_POOL_CONFIG_CAPABILITY_NAME = "org.wildfly.ejb3.pool-config.entity-default";
+
+    private static final String EJB_CAPABILITY_NAME = "org.wildfly.ejb3";
+    private static final String EJB_CLIENT_CONFIGURATOR_CAPABILITY_NAME = "org.wildfly.ejb3.remote.client-configurator";
+    private static final String CLUSTERED_SINGLETON_CAPABILITY_NAME = "org.wildfly.ejb3.clustered.singleton";
+    private static final String TRANSACTION_GLOBAL_DEFAULT_LOCAL_PROVIDER_CAPABILITY_NAME = "org.wildfly.transactions.global-default-local-provider";
+
     static final SimpleAttributeDefinition DEFAULT_SLSB_INSTANCE_POOL =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_SLSB_INSTANCE_POOL, ModelType.STRING, true)
                     .setAllowExpression(true).build();
@@ -226,18 +238,31 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
             .build();
 
     public static final RuntimeCapability<Void> CLUSTERED_SINGLETON_CAPABILITY =  RuntimeCapability.Builder.of(
-            "org.wildfly.ejb3.clustered.singleton", Void.class).build();
+            CLUSTERED_SINGLETON_CAPABILITY_NAME, Void.class).build();
 
-    public static final RuntimeCapability<Void> EJB_CAPABILITY =  RuntimeCapability.Builder.of("org.wildfly.ejb3", Void.class)
+    public static final RuntimeCapability<Void> EJB_CAPABILITY =  RuntimeCapability.Builder.of(EJB_CAPABILITY_NAME, Void.class)
             // EJBComponentDescription adds a create dependency on the local tx provider to all components,
-            // so in the absence of relevant finer grained EJB capabilities, we'll say that EJB overall
-            // requires the local provider
-            .addRequirements("org.wildfly.transactions.global-default-local-provider")
+            // so in the absence of relevant finer grained EJB capabilities, we'll say that EJB overall requires the local provider
+            .addRequirements(TRANSACTION_GLOBAL_DEFAULT_LOCAL_PROVIDER_CAPABILITY_NAME)
             .build();
 
     //We don't want to actually expose the service, we just want to use optional deps
-    public static final RuntimeCapability<Void>  EJB_CLIENT_CONFIGURATOR = RuntimeCapability.Builder.of("org.wildfly.ejb3.remote.client-configurator", Void.class)
+    public static final RuntimeCapability<Void> EJB_CLIENT_CONFIGURATOR_CAPABILITY = RuntimeCapability.Builder.of(EJB_CLIENT_CONFIGURATOR_CAPABILITY_NAME, Void.class)
             .build();
+
+    // default pool capabilities, defined here but registered conditionally
+    // TODO: these are not guaranteed to be defined but their use as dependants is guarded by predicate which knows if the pool is available or not
+    public static final RuntimeCapability<Void> DEFAULT_SLSB_POOL_CONFIG_CAPABILITY =
+            RuntimeCapability.Builder.of(DEFAULT_SLSB_POOL_CONFIG_CAPABILITY_NAME, PoolConfig.class)
+                    .build();
+
+    public static final RuntimeCapability<Void> DEFAULT_MDB_POOL_CONFIG_CAPABILITY =
+            RuntimeCapability.Builder.of(DEFAULT_MDB_POOL_CONFIG_CAPABILITY_NAME, PoolConfig.class)
+                    .build();
+
+    public static final RuntimeCapability<Void> DEFAULT_ENTITY_POOL_CONFIG_CAPABILITY =
+            RuntimeCapability.Builder.of(DEFAULT_ENTITY_POOL_CONFIG_CAPABILITY_NAME, PoolConfig.class)
+                    .build();
 
     private static final ApplicationSecurityDomainDefinition APPLICATION_SECURITY_DOMAIN = ApplicationSecurityDomainDefinition.INSTANCE;
     private static final IdentityResourceDefinition IDENTITY = IdentityResourceDefinition.INSTANCE;
@@ -245,10 +270,8 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
             APPLICATION_SECURITY_DOMAIN.getKnownSecurityDomainFunction(), IDENTITY.getOutflowSecurityDomainsConfiguredSupplier());
     private static final MissingMethodPermissionsDenyAccessMergingProcessor missingMethodPermissionsDenyAccessMergingProcessor = new MissingMethodPermissionsDenyAccessMergingProcessor();
 
-
     private final boolean registerRuntimeOnly;
     private final PathManager pathManager;
-
 
     EJB3SubsystemRootResourceDefinition(boolean registerRuntimeOnly, PathManager pathManager) {
         super(new Parameters(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME), EJB3Extension.getResourceDescriptionResolver(EJB3Extension.SUBSYSTEM_NAME))
@@ -256,7 +279,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                 .setRemoveHandler(EJB3SubsystemRemove.INSTANCE)
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
-                .setCapabilities(CLUSTERED_SINGLETON_CAPABILITY, EJB_CLIENT_CONFIGURATOR, EJB_CAPABILITY)
+                .setCapabilities(CLUSTERED_SINGLETON_CAPABILITY, EJB_CLIENT_CONFIGURATOR_CAPABILITY, EJB_CAPABILITY)
         );
         this.registerRuntimeOnly = registerRuntimeOnly;
         this.pathManager = pathManager;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreAdd.java
@@ -41,6 +41,7 @@ public class FilePassivationStoreAdd extends PassivationStoreAdd {
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws IllegalArgumentException, OperationFailedException {
         int initialMaxSize = FilePassivationStoreResourceDefinition.MAX_SIZE.resolveModelAttribute(context, model).asInt();
         String containerName = PassivationStoreResourceDefinition.CACHE_CONTAINER.getDefaultValue().asString();
+        // despite being called file passivation store, this sets up a cache factory based on the default cache container and cache name "passivation"
         this.install(context, operation, initialMaxSize, containerName, "passivation");
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreResourceDefinition.java
@@ -40,6 +40,8 @@ import org.jboss.dmr.ModelType;
 @Deprecated
 public class FilePassivationStoreResourceDefinition extends LegacyPassivationStoreResourceDefinition {
 
+    // this actually has a dependency on a cache factory using default cache container and cache name "passivation"
+    // but no attributes to set requirements for !?
     @Deprecated
     public static final SimpleAttributeDefinition MAX_SIZE = MAX_SIZE_BUILDER.build();
     @Deprecated
@@ -79,6 +81,7 @@ public class FilePassivationStoreResourceDefinition extends LegacyPassivationSto
             .setDeprecated(DEPRECATED_VERSION)
             .build()
     ;
+
 
     private static final AttributeDefinition[] ATTRIBUTES = { IDLE_TIMEOUT, IDLE_TIMEOUT_UNIT, MAX_SIZE, RELATIVE_TO, GROUPS_PATH, SESSIONS_PATH, SUBDIRECTORY_COUNT };
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/LegacyPassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/LegacyPassivationStoreResourceDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.operations.validation.TimeUnitValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -81,6 +82,17 @@ public abstract class LegacyPassivationStoreResourceDefinition extends SimpleRes
 
     LegacyPassivationStoreResourceDefinition(String element, OperationStepHandler addHandler, OperationStepHandler removeHandler, OperationEntry.Flag addRestartLevel, OperationEntry.Flag removeRestartLevel, AttributeDefinition... attributes) {
         super(PathElement.pathElement(element), EJB3Extension.getResourceDescriptionResolver(element), addHandler, removeHandler, addRestartLevel, removeRestartLevel, new DeprecationData(DEPRECATED_VERSION));
+        this.attributes = attributes;
+    }
+
+    LegacyPassivationStoreResourceDefinition(String element, OperationStepHandler addHandler, OperationStepHandler removeHandler, OperationEntry.Flag addRestartLevel, OperationEntry.Flag removeRestartLevel, RuntimeCapability capability, AttributeDefinition... attributes) {
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(element), EJB3Extension.getResourceDescriptionResolver(element))
+                .setAddHandler(addHandler)
+                .setRemoveHandler(removeHandler)
+                .setAddRestartLevel(addRestartLevel)
+                .setRemoveRestartLevel(removeRestartLevel)
+                .setDeprecationData(new DeprecationData(DEPRECATED_VERSION))
+                .setCapabilities(capability));
         this.attributes = attributes;
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupAdd.java
@@ -23,15 +23,12 @@
 package org.jboss.as.ejb3.subsystem;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
-
-import static org.jboss.as.ejb3.subsystem.MdbDeliveryGroupResourceDefinition.getDeliveryGroupServiceName;
 
 /**
  * Adds a mdb delivery group.
@@ -52,10 +49,11 @@ public class MdbDeliveryGroupAdd extends AbstractAddStepHandler {
     }
 
     protected void installServices(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        final String groupName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.ADDRESS)).getLastElement()
-                .getValue();
         final boolean active = MdbDeliveryGroupResourceDefinition.ACTIVE.resolveModelAttribute(context, model).asBoolean();
-        context.getServiceTarget().addService(getDeliveryGroupServiceName(groupName), Service.NULL)
-                .setInitialMode(active? ServiceController.Mode.ACTIVE: ServiceController.Mode.NEVER).install();
+
+        CapabilityServiceTarget serviceTarget = context.getCapabilityServiceTarget();
+        serviceTarget.addCapability(MdbDeliveryGroupResourceDefinition.MDB_DELIVERY_GROUP_CAPABILITY, Service.NULL)
+                .setInitialMode(active? ServiceController.Mode.ACTIVE: ServiceController.Mode.NEVER)
+                .install();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
@@ -25,14 +25,15 @@ package org.jboss.as.ejb3.subsystem;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.Service;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
@@ -43,22 +44,22 @@ import org.jboss.msc.service.ServiceName;
  */
 public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition {
 
-    private static final ServiceName DELIVERY_GROUP_SERVICE_NAME = ServiceName.of("org", "wildfly", "ejb3", "mdb", "delivery", "group");
-    public static final SimpleAttributeDefinition ACTIVE = new SimpleAttributeDefinitionBuilder(
-            EJB3SubsystemModel.MDB_DELVIERY_GROUP_ACTIVE, ModelType.BOOLEAN, true).setAllowExpression(true)
+    public static final String MDB_DELIVERY_GROUP_CAPABILITY_NAME = "org.wildfly.ejb3.mdb-delivery-group";
+    public static final RuntimeCapability<Void> MDB_DELIVERY_GROUP_CAPABILITY =
+            RuntimeCapability.Builder.of(MDB_DELIVERY_GROUP_CAPABILITY_NAME, true, Service.NULL.getClass()).build();
+
+    public static final SimpleAttributeDefinition ACTIVE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.MDB_DELVIERY_GROUP_ACTIVE, ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
             .setDefaultValue(ModelNode.TRUE)
             .build();
 
     public static final MdbDeliveryGroupResourceDefinition INSTANCE = new MdbDeliveryGroupResourceDefinition();
 
     private MdbDeliveryGroupResourceDefinition() {
-        super(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP),
-                EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.MDB_DELIVERY_GROUP), MdbDeliveryGroupAdd.INSTANCE,
-                new ReloadRequiredRemoveStepHandler());
-    }
-
-    public static ServiceName getDeliveryGroupServiceName(String deliveryGroupName) {
-        return DELIVERY_GROUP_SERVICE_NAME.append(deliveryGroupName);
+        super(new SimpleResourceDefinition.Parameters(EJB3SubsystemModel.MDB_DELIVERY_GROUP_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.MDB_DELIVERY_GROUP))
+                .setAddHandler(MdbDeliveryGroupAdd.INSTANCE)
+                .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
+                .setCapabilities(MDB_DELIVERY_GROUP_CAPABILITY));
     }
 
     @Override
@@ -84,9 +85,12 @@ public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition
                         if (currentValue.equals(resolvedValue)) {
                             return;
                         }
-                        String groupName = context.getCurrentAddress().getLastElement().getValue();
-                        context.getServiceRegistry(true).getRequiredService(getDeliveryGroupServiceName(groupName)).setMode(
-                                resolvedValue.asBoolean() ? ServiceController.Mode.ACTIVE : ServiceController.Mode.NEVER);
+
+                        String groupName = context.getCurrentAddressValue();
+                        ServiceName deliveryGroupServiceName = context.getCapabilityServiceName(MdbDeliveryGroupResourceDefinition.MDB_DELIVERY_GROUP_CAPABILITY_NAME, Service.NULL.getClass(), groupName);
+
+                        context.getServiceRegistry(true).getRequiredService(deliveryGroupServiceName)
+                                .setMode(resolvedValue.asBoolean() ? ServiceController.Mode.ACTIVE : ServiceController.Mode.NEVER);
                     }
                 });
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreRemove.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreRemove.java
@@ -23,21 +23,106 @@
 package org.jboss.as.ejb3.subsystem;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ejb3.cache.distributable.DistributableCacheFactoryBuilderServiceNameProvider;
+import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
+ * Handler to remove resource at /subsystem=ejb3/passivation-store=X
+ *
+ * In order to work with capabilities from org.wildfly.clustering.infinispan.spi, the handler is modified
+ * to remove capabilities for the resource before the resource itself is removed.
+ *
  * @author Paul Ferraro
  */
 public class PassivationStoreRemove extends ServiceRemoveStepHandler {
 
+    private final Set<RuntimeCapability> unavailableCapabilities;
+
     public PassivationStoreRemove(final AbstractAddStepHandler addOperation) {
-        super(null, addOperation);
+        super(addOperation);
+        this.unavailableCapabilities = new LinkedHashSet<>();
+    }
+
+    public PassivationStoreRemove(final AbstractAddStepHandler addOperation, RuntimeCapability ...  unavailableCapabilities) {
+        super(addOperation, unavailableCapabilities);
+        this.unavailableCapabilities = new LinkedHashSet<>(Arrays.asList(unavailableCapabilities));
     }
 
     @Override
     protected ServiceName serviceName(final String name) {
         return new DistributableCacheFactoryBuilderServiceNameProvider(name).getServiceName();
+    }
+
+    /**
+     *  Override AbstractRemoveStepHandler.performRemove() to remove capabilities before removing child resources
+     */
+    @Override
+    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+
+        Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+
+        if (removeInCurrentStep(resource)) {
+            // We need to remove capabilities *before* removing the resource, since the capability reference resolution might involve reading the resource
+            Set<RuntimeCapability> capabilitySet = unavailableCapabilities.isEmpty() ? context.getResourceRegistration().getCapabilities() : unavailableCapabilities;
+            PathAddress address = context.getCurrentAddress();
+
+            // deregister capabilities which will no longer be available after remove
+            for (RuntimeCapability capability : capabilitySet) {
+                if (capability.isDynamicallyNamed()) {
+                    context.deregisterCapability(capability.getDynamicName(context.getCurrentAddress()));
+                } else {
+                    context.deregisterCapability(capability.getName());
+                }
+            }
+
+            // remove capability requiremnts for attributes which will no longer be required after remove
+            ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
+            for (String attributeName : registration.getAttributeNames(PathAddress.EMPTY_ADDRESS)) {
+                AttributeDefinition attribute = registration.getAttributeAccess(PathAddress.EMPTY_ADDRESS, attributeName).getAttributeDefinition();
+                if (attribute.hasCapabilityRequirements()) {
+                    attribute.removeCapabilityRequirements(context, resource, model.get(attributeName));
+                }
+            }
+
+            // remove capability requiremnts for reference recorders which will no longer be required
+            for (CapabilityReferenceRecorder recorder : registration.getRequirements()) {
+                recorder.removeCapabilityRequirements(context, resource, null);
+            }
+
+        }
+        super.performRemove(context, operation, model);
+    }
+
+    /*
+     * Determines whether resource removal happens in this step, or a subsequent step
+     */
+    private static boolean removeInCurrentStep(Resource resource) {
+        for (String childType : resource.getChildTypes()) {
+            for (Resource.ResourceEntry entry : resource.getChildren(childType)) {
+                if (!entry.isRuntime() && resource.hasChild(entry.getPathElement())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        // we already unregistered our capabilities in performRemove(...)
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
@@ -4,6 +4,7 @@
  */
 package org.jboss.as.ejb3.subsystem;
 
+import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -11,6 +12,7 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -18,11 +20,26 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.ejb.BeanManagerFactoryServiceConfiguratorConfiguration;
+import org.wildfly.clustering.infinispan.spi.InfinispanCacheRequirement;
+import org.wildfly.clustering.infinispan.spi.InfinispanDefaultCacheRequirement;
 
 /**
+ * Definies a CacheFactoryBuilder instance which, during deployment, is used to configure, build and install a CacheFactory for the SFSB being deployed.
+ * The CacheFactory produces bean caches which are distributable and have passivation enabled. Used to support CacheFactoryResourceDefinition.
+ *
  * @author Paul Ferraro
  */
 public class PassivationStoreResourceDefinition extends SimpleResourceDefinition {
+
+    public static final String PASSIVATION_STORE_CAPABILITY_NAME = "org.wildfly.ejb.passivation-store";
+
+    // use these to avoid pulling in ISPN SPI module
+    protected static final String INFINISPAN_DEFAULT_CACHE_CONFIGURATION_CAPABILITY_NAME = "org.wildfly.clustering.infinispan.default-cache-configuration";
+    protected static final String INFINISPAN_CACHE_CONFIGURATION_CAPABILITY_NAME = "org.wildfly.clustering.infinispan.cache-configuration";
+
+    static final RuntimeCapability<Void> PASSIVATION_STORE_CAPABILITY = RuntimeCapability.Builder.of(PASSIVATION_STORE_CAPABILITY_NAME, true)
+            .setServiceType(Void.class)
+            .build();
 
     static final SimpleAttributeDefinition MAX_SIZE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.MAX_SIZE, ModelType.INT, true)
             .setXmlName(EJB3SubsystemXMLAttribute.MAX_SIZE.getLocalName())
@@ -30,21 +47,24 @@ public class PassivationStoreResourceDefinition extends SimpleResourceDefinition
             .setAllowExpression(true)
             .setValidator(new LongRangeValidator(0, Integer.MAX_VALUE, true, true))
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .build()
-    ;
+            .build();
+
     static final SimpleAttributeDefinition CACHE_CONTAINER = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CACHE_CONTAINER, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.CACHE_CONTAINER.getLocalName())
             .setDefaultValue(new ModelNode(BeanManagerFactoryServiceConfiguratorConfiguration.DEFAULT_CONTAINER_NAME))
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .build()
-    ;
+            // a CapabilityReference to a UnaryRequirement
+            .setCapabilityReference(new CapabilityReference(()->PASSIVATION_STORE_CAPABILITY, InfinispanDefaultCacheRequirement.CONFIGURATION))
+            .build();
+
     static final SimpleAttributeDefinition BEAN_CACHE = new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.BEAN_CACHE, ModelType.STRING, true)
             .setXmlName(EJB3SubsystemXMLAttribute.BEAN_CACHE.getLocalName())
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .build()
-    ;
+            // a CapabilityReference to a BinaryRequirement (including a parent attribute)
+            .setCapabilityReference(new CapabilityReference(()->PASSIVATION_STORE_CAPABILITY, InfinispanCacheRequirement.CONFIGURATION, ()->CACHE_CONTAINER))
+            .build();
 
     static final AttributeDefinition[] ATTRIBUTES = { MAX_SIZE, CACHE_CONTAINER, BEAN_CACHE };
 
@@ -55,8 +75,9 @@ public class PassivationStoreResourceDefinition extends SimpleResourceDefinition
     private PassivationStoreResourceDefinition(String element, AttributeDefinition... attributes) {
         super(new Parameters(PathElement.pathElement(element), EJB3Extension.getResourceDescriptionResolver(element))
                 .setAddHandler(ADD_HANDLER)
-                .setRemoveHandler(new PassivationStoreRemove(ADD_HANDLER))
-                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES));
+                .setRemoveHandler(new PassivationStoreRemove(ADD_HANDLER, PASSIVATION_STORE_CAPABILITY))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setCapabilities(PASSIVATION_STORE_CAPABILITY));
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceHandlerBase.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileChildResourceHandlerBase.java
@@ -26,21 +26,20 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RestartParentResourceHandlerBase;
-import org.jboss.as.ejb3.remote.RemotingProfileService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
 public abstract class RemotingProfileChildResourceHandlerBase extends RestartParentResourceHandlerBase {
+
      protected RemotingProfileChildResourceHandlerBase() {
-        super(EJB3SubsystemModel.REMOTING_PROFILE);
+         super(EJB3SubsystemModel.REMOTING_PROFILE);
     }
 
     @Override
-    protected void recreateParentService(final OperationContext context, final PathAddress parentAddress,
-            final ModelNode parentModel) throws OperationFailedException {
-        switch(context.getCurrentStage()){
+    protected void recreateParentService(final OperationContext context, final PathAddress parentAddress, final ModelNode parentModel) throws OperationFailedException {
+
+        switch(context.getCurrentStage()) {
             case RUNTIME:
                 // service installation in another step: when interruption is thrown then it is handled by RollbackHandler
                 // declared in RestartParentResourceHandlerBase
@@ -60,18 +59,11 @@ public abstract class RemotingProfileChildResourceHandlerBase extends RestartPar
 
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
-        String profileName = null;
-        for (final PathElement element : parentAddress) {
-            if (element.getKey().equals(EJB3SubsystemModel.REMOTING_PROFILE)) {
-                profileName = element.getValue();
-            }
-        }
-        return RemotingProfileService.BASE_SERVICE_NAME.append(profileName);
+       return RemotingProfileResourceDefinition.REMOTING_PROFILE_CAPABILITY.getCapabilityServiceName(parentAddress);
     }
 
     @Override
-    protected void removeServices(OperationContext context, ServiceName parentService, ModelNode parentModel)
-            throws OperationFailedException {
+    protected void removeServices(OperationContext context, ServiceName parentService, ModelNode parentModel) throws OperationFailedException {
         super.removeServices(context, parentService, parentModel);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceChildWriteAttributeHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceChildWriteAttributeHandler.java
@@ -26,9 +26,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
-import org.jboss.as.ejb3.remote.RemotingProfileService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
@@ -44,19 +42,12 @@ public class RemotingProfileResourceChildWriteAttributeHandler extends RestartPa
     }
 
     @Override
-    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel)
-            throws OperationFailedException {
+    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
         RemotingProfileResourceDefinition.ADD_HANDLER.installServices(context, parentAddress, parentModel);
     }
 
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
-        String profileName = null;
-        for (final PathElement element : parentAddress) {
-            if (element.getKey().equals(EJB3SubsystemModel.REMOTING_PROFILE)) {
-                profileName = element.getValue();
-            }
-        }
-        return RemotingProfileService.BASE_SERVICE_NAME.append(profileName);
+        return RemotingProfileResourceDefinition.REMOTING_PROFILE_CAPABILITY.getCapabilityServiceName(parentAddress);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/RemotingProfileResourceDefinition.java
@@ -23,11 +23,11 @@
 package org.jboss.as.ejb3.subsystem;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.ejb3.remote.RemotingProfileService;
 import org.jboss.dmr.ModelNode;
@@ -39,6 +39,10 @@ import org.jboss.dmr.ModelType;
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
  */
 public class RemotingProfileResourceDefinition extends SimpleResourceDefinition {
+
+    public static final String REMOTING_PROFILE_CAPABILITY_NAME = "org.wildfly.ejb3.remoting-profile";
+    public static final RuntimeCapability<Void> REMOTING_PROFILE_CAPABILITY =
+            RuntimeCapability.Builder.of(REMOTING_PROFILE_CAPABILITY_NAME, true, RemotingProfileService.class).build();
 
     public static final SimpleAttributeDefinition EXCLUDE_LOCAL_RECEIVER = new SimpleAttributeDefinitionBuilder(
             EJB3SubsystemModel.EXCLUDE_LOCAL_RECEIVER, ModelType.BOOLEAN, true).setAllowExpression(true)
@@ -53,8 +57,10 @@ public class RemotingProfileResourceDefinition extends SimpleResourceDefinition 
     public static final RemotingProfileResourceDefinition INSTANCE = new RemotingProfileResourceDefinition();
 
     private RemotingProfileResourceDefinition() {
-        super(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE), EJB3Extension
-                .getResourceDescriptionResolver(EJB3SubsystemModel.REMOTING_PROFILE), ADD_HANDLER, new ServiceRemoveStepHandler(RemotingProfileService.BASE_SERVICE_NAME, ADD_HANDLER));
+        super(new SimpleResourceDefinition.Parameters(EJB3SubsystemModel.REMOTING_PROFILE_PATH, EJB3Extension.getResourceDescriptionResolver(EJB3SubsystemModel.REMOTING_PROFILE))
+                .setAddHandler(ADD_HANDLER)
+                .setRemoveHandler(new ServiceRemoveStepHandler(ADD_HANDLER, REMOTING_PROFILE_CAPABILITY))
+                .setCapabilities(REMOTING_PROFILE_CAPABILITY));
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolAdd.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityServiceBuilder;
+import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -35,8 +37,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.ejb3.component.pool.StrictMaxPoolConfig;
 import org.jboss.as.ejb3.component.pool.StrictMaxPoolConfigService;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * Adds a strict-max-pool to the EJB3 subsystem's bean-instance-pools. The {#performRuntime runtime action}
@@ -60,19 +60,15 @@ public class StrictMaxPoolAdd extends AbstractAddStepHandler {
         final Derive derive = StrictMaxPoolResourceDefinition.parseDeriveSize(context, strictMaxPoolModel);
         final long timeout = StrictMaxPoolResourceDefinition.INSTANCE_ACQUISITION_TIMEOUT.resolveModelAttribute(context, strictMaxPoolModel).asLong();
         final String unit = StrictMaxPoolResourceDefinition.INSTANCE_ACQUISITION_TIMEOUT_UNIT.resolveModelAttribute(context, strictMaxPoolModel).asString();
+
         // create and install the service
         final StrictMaxPoolConfigService poolConfigService = new StrictMaxPoolConfigService(poolName, maxPoolSize, derive, timeout, TimeUnit.valueOf(unit));
 
-
-        final ServiceName serviceName = StrictMaxPoolConfigService.EJB_POOL_CONFIG_BASE_SERVICE_NAME.append(poolName);
-        ServiceBuilder<StrictMaxPoolConfig> svcBuilder = context.getServiceTarget().addService(serviceName, poolConfigService);
-
+        CapabilityServiceTarget capabilityServiceTarget = context.getCapabilityServiceTarget();
+        CapabilityServiceBuilder<StrictMaxPoolConfig> capabilityServiceBuilder = capabilityServiceTarget.addCapability(StrictMaxPoolResourceDefinition.STRICT_MAX_POOL_CONFIG_CAPABILITY, poolConfigService);
         if (context.hasOptionalCapability(IO_MAX_THREADS_RUNTIME_CAPABILITY_NAME, null, null)) {
-            ServiceName name = context.getCapabilityServiceName(IO_MAX_THREADS_RUNTIME_CAPABILITY_NAME, Integer.class);
-            svcBuilder.addDependency(name, Integer.class, poolConfigService.getMaxThreadsInjector());
+            capabilityServiceBuilder.addCapabilityRequirement(IO_MAX_THREADS_RUNTIME_CAPABILITY_NAME, Integer.class, poolConfigService.getMaxThreadsInjector());
         }
-
-        svcBuilder.install();
+        capabilityServiceBuilder.install();
     }
-
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolDerivedSizeReadHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolDerivedSizeReadHandler.java
@@ -43,7 +43,8 @@ public class StrictMaxPoolDerivedSizeReadHandler extends AbstractRuntimeOnlyHand
     @Override
     protected void executeRuntimeStep(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         final String poolName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceName serviceName = StrictMaxPoolConfigService.EJB_POOL_CONFIG_BASE_SERVICE_NAME.append(poolName);
+
+        ServiceName serviceName = context.getCapabilityServiceName(StrictMaxPoolResourceDefinition.STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME, poolName, StrictMaxPoolConfigService.class);
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController<?> sc = registry.getService(serviceName);
         if (sc != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/StrictMaxPoolWriteHandler.java
@@ -60,7 +60,8 @@ class StrictMaxPoolWriteHandler extends AbstractWriteAttributeHandler<Void> {
     private void applyModelToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode model) throws OperationFailedException {
 
         final String poolName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
-        final ServiceName serviceName = StrictMaxPoolConfigService.EJB_POOL_CONFIG_BASE_SERVICE_NAME.append(poolName);
+
+        ServiceName serviceName = context.getCapabilityServiceName(StrictMaxPoolResourceDefinition.STRICT_MAX_POOL_CONFIG_CAPABILITY_NAME, poolName, StrictMaxPoolConfigService.class);
         final ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController<?> sc = registry.getService(serviceName);
         if (sc != null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TimerServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/TimerServiceAdd.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.subsystem;
 import static org.jboss.as.ejb3.logging.EjbLogger.ROOT_LOGGER;
 
 import java.util.Timer;
+import java.util.concurrent.Executor;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -61,7 +62,8 @@ public class TimerServiceAdd extends AbstractBoottimeAddStepHandler {
 
         final String defaultDataStore = TimerServiceResourceDefinition.DEFAULT_DATA_STORE.resolveModelAttribute(context, model).asString();
         final String threadPoolName = TimerServiceResourceDefinition.THREAD_POOL_NAME.resolveModelAttribute(context, model).asString();
-        final ServiceName threadPoolServiceName = EJB3SubsystemModel.BASE_THREAD_POOL_SERVICE_NAME.append(threadPoolName);
+
+        final ServiceName threadPoolServiceName = context.getCapabilityServiceName(TimerServiceResourceDefinition.THREAD_POOL_CAPABILITY_NAME, threadPoolName, Executor.class);
 
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
@@ -74,9 +76,7 @@ public class TimerServiceAdd extends AbstractBoottimeAddStepHandler {
             }
         }, OperationContext.Stage.RUNTIME);
 
-        context.getServiceTarget().addService(TimerServiceDeploymentProcessor.TIMER_SERVICE_NAME, new TimerValueService())
-                .install();
-
+        context.getCapabilityServiceTarget().addCapability(TimerServiceResourceDefinition.TIMER_SERVICE_CAPABILITY, new TimerValueService()).install();
     }
 
     private static final class TimerValueService implements Service<Timer> {

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -24,6 +24,8 @@ package org.jboss.as.ejb3.subsystem;
 
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
@@ -59,6 +61,13 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
         return ADDITIONAL_INITIALIZATION;
+    }
+
+    @Override
+    protected Set<PathAddress> getIgnoredChildResourcesForRemovalTest() {
+        Set<PathAddress> ignoredChildren = new HashSet<PathAddress>();
+       // ignoredChildren.add(PathAddress.pathAddress(PathElement.pathElement("subsystem", "ejb3"), PathElement.pathElement("passivation-store", "infinispan")));
+        return ignoredChildren;
     }
 
     @Override

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3TransformersTestCase.java
@@ -223,10 +223,7 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
      */
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {
-        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider",
-                buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain"),
-                "org.wildfly.remoting.connector.http-remoting-connector",
-                "org.wildfly.remoting.connector.remoting-connector");
+        return AdditionalInitialization.MANAGEMENT;
     }
 
     /**
@@ -277,12 +274,26 @@ public class Ejb3TransformersTestCase extends AbstractSubsystemBaseTest {
         }
     }
 
+    protected AdditionalInitialization createAdditionalInitializationForRejectionTests() {
+        return AdditionalInitialization.withCapabilities("org.wildfly.transactions.global-default-local-provider",
+                buildDynamicCapabilityName("org.wildfly.security.security-domain", "ApplicationDomain"),
+                buildDynamicCapabilityName("org.wildfly.remoting.connector", "http-remoting-connector"),
+                buildDynamicCapabilityName("org.wildfly.remoting.connector", "remoting-connector"),
+                buildDynamicCapabilityName("org.wildfly.clustering.infinispan.cache-container", "not-ejb"),
+                buildDynamicCapabilityName("org.wildfly.ejb3.timer-service.timer-persistence-service", "file-data-store"),
+                buildDynamicCapabilityName("org.wildfly.ejb3.mdb-delivery-group", "1"),
+                buildDynamicCapabilityName("org.wildfly.ejb3.mdb-delivery-group", "2"),
+                buildDynamicCapabilityName("org.wildfly.ejb3.mdb-delivery-group", "3"),
+                buildDynamicCapabilityName("org.wildfly.ejb3.pool-config", "pool"),
+                "org.wildfly.remoting.endpoint");
+    }
+
     private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String... mavenResourceURLs) throws Exception {
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization());
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitializationForRejectionTests());
 
         // initialize the legacy services and add required jars
-        builder.createLegacyKernelServicesBuilder(this.createAdditionalInitialization(), controller, model)
+        builder.createLegacyKernelServicesBuilder(this.createAdditionalInitializationForRejectionTests(), controller, model)
                 .addMavenResourceURL(mavenResourceURLs)
                 .dontPersistXml();
 

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -41,7 +41,7 @@
             <database-data-store name="database-data-store" datasource-jndi-name="${prop.timer-service-database:java:global/DataSource}" database="hsql" partition="mypartition" allow-execution="true" refresh-interval="100"/>
         </data-stores>
     </timer-service>
-    <remote connectors="remoting-connector http-remoting-connector" thread-pool-name="default" cluster="ejb" execute-in-worker="false">
+    <remote connectors="http-remoting-connector" thread-pool-name="default" cluster="ejb" execute-in-worker="false">
         <channel-creation-options>
             <option name="READ_TIMEOUT" value="${prop.remoting-connector.read.timeout:20}" type="xnio"/>
             <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -48,6 +48,7 @@
         <module name="org.wildfly.clustering.ee.cache"/>
         <module name="org.wildfly.clustering.ee.spi"/>
         <module name="org.wildfly.clustering.ejb.spi"/>
+        <module name="org.wildfly.clustering.infinispan.spi"/>
         <module name="org.wildfly.clustering.marshalling.jboss"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -399,6 +399,11 @@
                         <file-store passivation="false" purge="false"/>
                     </local-cache>
                 </cache-container>
+                <cache-container name="ejb" aliases="sfsb" default-cache="local" module="org.wildfly.clustering.ejb.infinispan">
+                    <local-cache name="local" batching="true">
+                        <file-store passivation="true" purge="false"/>
+                    </local-cache>
+                </cache-container>
                 <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                     <local-cache name="entity">
                         <transaction mode="NON_XA"/>

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -21,12 +21,10 @@
  */
 package org.jboss.as.test.multinode.ejb.timer.database;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
@@ -47,7 +45,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.FileUtils;
@@ -77,7 +74,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
     private static Server server;
 
     static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs_disabled");
-    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(ModelDescriptionConstants.SERVICE, "timer-service").append("database-data-store", "dbstore");
+    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(SERVICE, "timer-service").append("database-data-store", "dbstore");
 
     @AfterClass
     public static void afterClass() {
@@ -88,7 +85,11 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
 
     static class DatabaseTimerServiceTestCaseServerSetup implements ServerSetupTask {
 
-        @Override()
+        private static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs_disabled");
+        private static final PathAddress ADDR_TIMER_SERVICE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append("service", "timer-service");
+        private static final PathAddress ADDR_DATABASE_DATA_STORE = ADDR_TIMER_SERVICE.append("database-data-store", "dbstore");
+
+        @Override
         public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
 
             if (server == null) {
@@ -101,30 +102,27 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
             compositeOp.get(OP_ADDR).setEmptyList();
             ModelNode steps = compositeOp.get(STEPS);
 
-            // add a datasource at /subsystem=datasources/data-source=MyNewDs_disabled with appropriate attributes
-            final ModelNode addDataSource = Util.createAddOperation(ADDR_DATA_SOURCE);
-            addDataSource.get("name").set("MyNewDs_disabled");
-            addDataSource.get("jndi-name").set("java:jboss/datasources/TimeDs_disabled");
-            addDataSource.get("enabled").set(true);
-            addDataSource.get("driver-name").set("h2");
-            addDataSource.get("pool-name").set("MyNewDs_disabled_Pool");
-            addDataSource.get("connection-url").set("jdbc:h2:" + server.getURL() + "/mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
-            addDataSource.get("user-name").set("sa");
-            addDataSource.get("password").set("sa");
+            // /subsystem=datasources/data-source=MyNewDs_disabled:add(name=MyNewDs_disabled,jndi-name=java:jboss/datasources/TimeDs_disabled, enabled=true,...)
+            ModelNode datasourceAddModelNode = Util.createAddOperation(ADDR_DATA_SOURCE);
+            datasourceAddModelNode.get("name").set("MyNewDs_disabled");
+            datasourceAddModelNode.get("jndi-name").set("java:jboss/datasources/TimeDs_disabled");
+            datasourceAddModelNode.get("enabled").set(true);
+            datasourceAddModelNode.get("driver-name").set("h2");
+            datasourceAddModelNode.get("pool-name").set("MyNewDs_disabled_Pool");
+            datasourceAddModelNode.get("connection-url").set("jdbc:h2:" + server.getURL() + "/mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE");
+            datasourceAddModelNode.get("user-name").set("sa");
+            datasourceAddModelNode.get("password").set("sa");
+            steps.add(datasourceAddModelNode);
 
-            steps.add(addDataSource);
-
-            // add a datastore at /subsystem=ejb3/service=timerservice/database-data-store=dbstore with appropriate attributes
-            final ModelNode addDataStore = Util.createAddOperation(ADDR_DATA_STORE);
-            addDataStore.get("datasource-jndi-name").set("java:jboss/datasources/TimeDs_disabled");
-            addDataStore.get("database").set("postgresql");
+            // /subsystem=ejb3/service=timer-service/database-data-store=dbstore:add(odatabase-jndi-name=java:jboss/datrasources/TimeDs,...)
+            ModelNode databaseDataStoreAddModelNode = Util.createAddOperation(ADDR_DATABASE_DATA_STORE);
+            databaseDataStoreAddModelNode.get("datasource-jndi-name").set("java:jboss/datasources/TimeDs_disabled");
+            databaseDataStoreAddModelNode.get("database").set("postgresql");
             if (containerId.equals("multinode-client")) {
-                addDataStore.get("allow-execution").set(false);
+                databaseDataStoreAddModelNode.get("allow-execution").set(false);
             }
-            addDataStore.get("refresh-interval").set(100);
-            addDataStore.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            steps.add(addDataStore);
+            databaseDataStoreAddModelNode.get("refresh-interval").set(100);
+            steps.add(databaseDataStoreAddModelNode);
 
             Utils.applyUpdates(Collections.singletonList(compositeOp), managementClient.getControllerClient());
             ServerReload.reloadIfRequired(managementClient);
@@ -133,22 +131,19 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         @Override
         public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
 
+
             final ModelNode compositeOp = new ModelNode();
             compositeOp.get(OP).set(COMPOSITE);
             compositeOp.get(OP_ADDR).setEmptyList();
             ModelNode steps = compositeOp.get(STEPS);
 
-            final ModelNode removeDataStore = Util.createRemoveOperation(ADDR_DATA_STORE);
-            removeDataStore.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-            removeDataStore.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            ModelNode databaseDataStoreRemoveModelNode = Util.createRemoveOperation(ADDR_DATABASE_DATA_STORE);
+            // omitting op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false)
+            steps.add(databaseDataStoreRemoveModelNode);
 
-            steps.add(removeDataStore);
-
-            final ModelNode removeDataSource = Util.createRemoveOperation(ADDR_DATA_SOURCE);
-            removeDataSource.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-            removeDataSource.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            steps.add(removeDataSource);
+            ModelNode datasourceRemoveModelNode = Util.createRemoveOperation(ADDR_DATA_SOURCE);
+            // omitting op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false)
+            steps.add(datasourceRemoveModelNode);
 
             Utils.applyUpdates(Collections.singletonList(compositeOp), managementClient.getControllerClient());
             ServerReload.reloadIfRequired(managementClient);

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceRefreshTestCase.java
@@ -22,12 +22,10 @@
 
 package org.jboss.as.test.multinode.ejb.timer.database;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.test.multinode.ejb.timer.database.DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.getRemoteContext;
@@ -55,7 +53,6 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.shared.ServerReload;
@@ -76,7 +73,7 @@ public class DatabaseTimerServiceRefreshTestCase {
     private static final long TIMER_DELAY = TimeUnit.MINUTES.toMillis(20);
 
     static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs");
-    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(ModelDescriptionConstants.SERVICE, "timer-service").append("database-data-store", "dbstore");
+    static final PathAddress ADDR_DATA_STORE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append(SERVICE, "timer-service").append("database-data-store", "dbstore");
 
     @AfterClass
     public static void afterClass() {
@@ -86,6 +83,10 @@ public class DatabaseTimerServiceRefreshTestCase {
     }
 
     static class DatabaseTimerServiceTestCaseServerSetup implements ServerSetupTask {
+
+        private static final PathAddress ADDR_DATA_SOURCE = PathAddress.pathAddress().append(SUBSYSTEM, "datasources").append("data-source", "MyNewDs");
+        private static final PathAddress ADDR_TIMER_SERVICE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append("service", "timer-service");
+        private static final PathAddress ADDR_DATABASE_DATA_STORE = ADDR_TIMER_SERVICE.append("database-data-store", "dbstore");
 
         @Override
         public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
@@ -100,27 +101,25 @@ public class DatabaseTimerServiceRefreshTestCase {
             compositeOp.get(OP_ADDR).setEmptyList();
             ModelNode steps = compositeOp.get(STEPS);
 
-            // add a datasource at /subsystem=datasources/data-source=MyNewDs with appropriate attributes
-            final ModelNode addDataSource = Util.createAddOperation(ADDR_DATA_SOURCE);
-            addDataSource.get("name").set("MyNewDs");
-            addDataSource.get("jndi-name").set("java:jboss/datasources/TimeDs");
-            addDataSource.get("enabled").set(true);
-            addDataSource.get("driver-name").set("h2");
-            addDataSource.get("pool-name").set("MyNewDs_Pool");
-            addDataSource.get("connection-url").set("jdbc:h2:" + server.getURL() + "/mem:testdb;DB_CLOSE_DELAY=-1");
-            addDataSource.get("user-name").set("sa");
-            addDataSource.get("password").set("sa");
+            // /subsystem=datasources/data-source=MyNewDs:add(name=MyNewDs,jndi-name=java:jboss/datasources/TimeDs, enabled=true)
+            ModelNode datasourceAddModelNode = Util.createAddOperation(ADDR_DATA_SOURCE);
+            datasourceAddModelNode.get("name").set("MyNewDs");
+            datasourceAddModelNode.get("jndi-name").set("java:jboss/datasources/TimeDs");
+            datasourceAddModelNode.get("enabled").set(true);
+            datasourceAddModelNode.get("driver-name").set("h2");
+            datasourceAddModelNode.get("pool-name").set("MyNewDs_Pool");
+            datasourceAddModelNode.get("connection-url").set("jdbc:h2:" + server.getURL() + "/mem:testdb;DB_CLOSE_DELAY=-1");
+            datasourceAddModelNode.get("user-name").set("sa");
+            datasourceAddModelNode.get("password").set("sa");
+            steps.add(datasourceAddModelNode);
 
-            steps.add(addDataSource);
+            // /subsystem=ejb3/service=timer-service/database-data-store=dbstore:add(odatabase-jndi-name=java:jboss/datrasources/TimeDs)
+            ModelNode databaseDataStoreAddModelNode = Util.createAddOperation(ADDR_DATABASE_DATA_STORE);
+            databaseDataStoreAddModelNode.get("datasource-jndi-name").set("java:jboss/datasources/TimeDs");
+            databaseDataStoreAddModelNode.get("database").set("postgresql");
+            databaseDataStoreAddModelNode.get("refresh-interval").set(TimeUnit.MINUTES.toMillis(30));
+            steps.add(databaseDataStoreAddModelNode);
 
-            // add a datastore at /subsystem=ejb3/service=timerservice/database-data-store=dbstore with appropriate attributes
-            final ModelNode addDataStore = Util.createAddOperation(ADDR_DATA_STORE);
-            addDataStore.get("datasource-jndi-name").set("java:jboss/datasources/TimeDs");
-            addDataStore.get("database").set("postgresql");
-            addDataStore.get("refresh-interval").set(TimeUnit.MINUTES.toMillis(30));
-            addDataStore.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            steps.add(addDataStore);
             Utils.applyUpdates(Collections.singletonList(compositeOp), managementClient.getControllerClient());
             ServerReload.reloadIfRequired(managementClient);
         }
@@ -133,17 +132,13 @@ public class DatabaseTimerServiceRefreshTestCase {
             compositeOp.get(OP_ADDR).setEmptyList();
             ModelNode steps = compositeOp.get(STEPS);
 
-            final ModelNode removeDataStore = Util.createRemoveOperation(ADDR_DATA_STORE);
-            removeDataStore.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-            removeDataStore.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            ModelNode databaseDataStoreRemoveModelNode = Util.createRemoveOperation(ADDR_DATABASE_DATA_STORE);
+            // omitting op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false)
+            steps.add(databaseDataStoreRemoveModelNode);
 
-            steps.add(removeDataStore);
-
-            final ModelNode removeDataSource = Util.createRemoveOperation(ADDR_DATA_SOURCE);
-            removeDataSource.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-            removeDataSource.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            steps.add(removeDataSource);
+            ModelNode datasourceRemoveModelNode = Util.createRemoveOperation(ADDR_DATA_SOURCE);
+            // omitting op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false)
+            steps.add(datasourceRemoveModelNode);
 
             Utils.applyUpdates(Collections.singletonList(compositeOp), managementClient.getControllerClient());
             ServerReload.reloadIfRequired(managementClient);

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/remotecall/RemoteLocalCallProfileTestCase.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.test.multinode.remotecall;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.util.Collections;
 import javax.ejb.EJBException;
 import javax.naming.InitialContext;
 
@@ -41,7 +40,10 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -67,43 +69,37 @@ public class RemoteLocalCallProfileTestCase {
 
     static class RemoteLocalCallProfileTestCaseServerSetup implements ServerSetupTask {
 
+        private static final PathAddress ADDR_REMOTING_PROFILE = PathAddress.pathAddress().append(SUBSYSTEM, "ejb3").append("remoting-profile", "test-profile");
+        private static final PathAddress ADDR_REMOTING_EJB_RECEIVER = ADDR_REMOTING_PROFILE.append("remoting-ejb-receiver", "test-receiver");
+
         @Override
         public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
-            final ModelNode address = new ModelNode();
-            address.add("subsystem", "ejb3");
-            address.add("remoting-profile", "test-profile");
-            address.protect();
 
-            final ModelNode op1 = new ModelNode();
-            op1.get(OP).set("add");
-            op1.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
-            op1.get(OP_ADDR).add("remoting-profile", "test-profile");
-            op1.get(OP_ADDR).set(address);
+            final ModelNode compositeOp = new ModelNode();
+            compositeOp.get(OP).set(COMPOSITE);
+            compositeOp.get(OP_ADDR).setEmptyList();
+            ModelNode steps = compositeOp.get(STEPS);
 
-            op1.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            // /subsystem=ejb3/remoting-profile=test-profile:add()
+            ModelNode remotingProfileAddModelNode = Util.createAddOperation(ADDR_REMOTING_PROFILE);
+            steps.add(remotingProfileAddModelNode);
 
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op1);
+            // /subsystem=ejb3/remoting-profile=test-profile/remoting-ejb-receiver=test-receiver:add(outbound-connection-ref=remote-ejb-connection)
+            ModelNode ejbReceiverAddModelNode = Util.createAddOperation(ADDR_REMOTING_EJB_RECEIVER);
+            ejbReceiverAddModelNode.get("outbound-connection-ref").set("remote-ejb-connection");
+            steps.add(ejbReceiverAddModelNode);
 
-            ModelNode op2 = new ModelNode();
-            op2.get(OP).set(ADD);
-            op2.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
-            op2.get(OP_ADDR).add("remoting-profile", "test-profile");
-            op2.get(OP_ADDR).add("remoting-ejb-receiver", "test-receiver");
-
-            op2.get("outbound-connection-ref").set("remote-ejb-connection");
-
-            op2.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op2);
+            Utils.applyUpdates(Collections.singletonList(compositeOp), managementClient.getControllerClient());
+            ServerReload.reloadIfRequired(managementClient);
         }
 
         @Override
         public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
-             ModelNode op = new ModelNode();
-             op.get(OP).set(REMOVE);
-             op.get(OP_ADDR).add(SUBSYSTEM, "ejb3");
-             op.get(OP_ADDR).add("remoting-profile", "test-profile");
-             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+            ModelNode remotingProfileRemoveModelNode = Util.createRemoveOperation(ADDR_REMOTING_PROFILE);
+
+            Utils.applyUpdates(Collections.singletonList(remotingProfileRemoveModelNode), managementClient.getControllerClient());
+            ServerReload.reloadIfRequired(managementClient);
         }
     }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -27,6 +27,7 @@ import static org.jboss.as.txn.subsystem.CommonAttributes.JDBC_STORE_DATASOURCE;
 import static org.jboss.as.txn.subsystem.CommonAttributes.JTS;
 import static org.jboss.as.txn.subsystem.CommonAttributes.USE_JOURNAL_STORE;
 import static org.jboss.as.txn.subsystem.CommonAttributes.USE_JDBC_STORE;
+import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.REMOTE_TRANSACTION_SERVICE_CAPABILITY;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY;
 
 import java.util.LinkedList;
@@ -451,7 +452,8 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         if (context.hasOptionalCapability(REMOTING_ENDPOINT_CAPABILITY_NAME, TransactionSubsystemRootResourceDefinition.TRANSACTION_CAPABILITY.getName(),null)) {
             final RemotingTransactionServiceService remoteTransactionServiceService = new RemotingTransactionServiceService();
-            serviceTarget.addService(TxnServices.JBOSS_TXN_REMOTE_TRANSACTION_SERVICE, remoteTransactionServiceService)
+            serviceTarget.addCapability(REMOTE_TRANSACTION_SERVICE_CAPABILITY)
+                .setInstance(remoteTransactionServiceService)
                 .addDependency(TxnServices.JBOSS_TXN_LOCAL_TRANSACTION_CONTEXT, LocalTransactionContext.class, remoteTransactionServiceService.getLocalTransactionContextInjector())
                 .addDependency(context.getCapabilityServiceName(REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class), Endpoint.class, remoteTransactionServiceService.getEndpointInjector())
                 .setInitialMode(Mode.ACTIVE)

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -61,6 +61,7 @@ import org.wildfly.transaction.client.ContextTransactionManager;
 import com.arjuna.ats.arjuna.common.CoordinatorEnvironmentBean;
 import com.arjuna.ats.arjuna.common.arjPropertyManager;
 import com.arjuna.ats.arjuna.coordinator.TxControl;
+import org.wildfly.transaction.client.provider.remoting.RemotingTransactionService;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the root resource of the transaction subsystem.
@@ -82,6 +83,11 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
     public static final RuntimeCapability<Void> TRANSACTION_SYNCHRONIZATION_REGISTRY_CAPABILITY =
             RuntimeCapability.Builder.of("org.wildfly.transactions.transaction-synchronization-registry", TransactionSynchronizationRegistry.class)
                     .build();
+
+    public static final RuntimeCapability<Void> REMOTE_TRANSACTION_SERVICE_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.transactions.remote-transaction-service", RemotingTransactionService.class)
+                    .build();
+
     static final RuntimeCapability<Void> XA_RESOURCE_RECOVERY_REGISTRY_CAPABILITY =
             RuntimeCapability.Builder.of("org.wildfly.transactions.xa-resource-recovery-registry", XAResourceRecoveryRegistry.class)
                     .build();


### PR DESCRIPTION
This PR adds capabilities to all resources in the ejb3 subsystem. In most cases, this involves identifying resources which start services which depend on or are depended on by services outside the ejb3 subsystem and associating with those services static or dynamic capabilities which can be used to generate service names. 

For more details: https://issues.redhat.com/browse/WFLY-13433
