### PR TITLE
[WFLY-13683] Remove microprofile-metrics dependency from jpa, jpa-dis…

### DIFF
--- a/ee-galleon-pack/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -2,7 +2,6 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa-distributed">
     <dependencies>
         <layer name="datasources"/>
-        <layer name="microprofile-metrics"/><!-- Infinispan runtime dependency -->
     </dependencies>
     <feature-group name="jpa"/>
 

--- a/ee-galleon-pack/src/main/resources/layers/standalone/jpa/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/jpa/layer-spec.xml
@@ -2,7 +2,6 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa">
     <dependencies>
         <layer name="datasources"/>
-        <layer name="microprofile-metrics"/><!-- Infinispan runtime dependency -->
     </dependencies>
     <feature-group name="jpa"/>
     <feature-group name="infinispan-local-hibernate"/>

--- a/ee-galleon-pack/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
+++ b/ee-galleon-pack/src/main/resources/layers/standalone/web-clustering/layer-spec.xml
@@ -3,7 +3,6 @@
     <dependencies>
         <layer name="web-server"/>
         <layer name="transactions"/>
-        <layer name="microprofile-metrics"/><!-- Infinispan runtime dependency -->
     </dependencies>
 
     <origin name="org.wildfly:wildfly-servlet-galleon-pack">


### PR DESCRIPTION
…tributed and web-clustering Galleon layers

The dependency of microprofile-metrics in jpa,jpa-distributed and web-clustering was initially added in an early version of the Infinispan 10.1.x upgrade. However, this initial requirement was removed and infinispan subsystem no longer requires metrics. 

Jira issue: https://issues.redhat.com/browse/WFLY-13683