### PR TITLE
[WFLY-13688] Upgrade WildFly Core 13.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,7 +443,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.0.Beta1</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta2</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13688

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.0.Beta2
Diff to previous integrated version: https://github.com/wildfly/wildfly-core/compare/13.0.0.Beta1...13.0.0.Beta2


##  Release Notes - WildFly Core - Version 13.0.0.Beta2
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4873'>WFCORE-4873</a>] -         Upgrade JGit to 5.8.0.202006091008-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5012'>WFCORE-5012</a>] -         Upgrade Jboss Threads to 2.3.6
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5021'>WFCORE-5021</a>] -         Upgrade jboss-logmanager to 2.1.17.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5034'>WFCORE-5034</a>] -         Upgrade log4j to 2.13.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5042'>WFCORE-5042</a>] -         Upgrade WildFly Elytron to 1.13.0.CR2
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5050'>WFCORE-5050</a>] -         Upgrade WildFly OpenSSL to 1.1.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5058'>WFCORE-5058</a>] -         Upgrade WildFly Elytron to 1.13.0.CR3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5059'>WFCORE-5059</a>] -         Upgrade bootable testsuite to use 2.0.0.Alpha6 maven plugin
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5054'>WFCORE-5054</a>] -         Allow to load bootable JAR  provider during boot
</li>
</ul>
                                                                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4485'>WFCORE-4485</a>] -         Support for multiple security realms - Distributed Identities
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-2086'>WFCORE-2086</a>] -         Intermittent failure in OperationCancellationTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4817'>WFCORE-4817</a>] -         CliArgumentsTestCase fails if _JAVA_OPTIONS environment variable defined
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4973'>WFCORE-4973</a>] -         NPE due to timeout in LongOutputTestCase
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5014'>WFCORE-5014</a>] -         Log files truncated when jboss.as.management.blocking.timeout error happens on startup
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5028'>WFCORE-5028</a>] -         CallbackHandler from CLI overriding discovered wildfly-config for authentication.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5029'>WFCORE-5029</a>] -         server group deployment resource doesn&#39;t include correct &quot;mananged&quot; value
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5030'>WFCORE-5030</a>] -         EmbeddedServer  can&#39;t interact with version &lt;12 
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5043'>WFCORE-5043</a>] -         ColorOutputTestCase.longCommand fails if environment defines _JAVA_OPTIONS environment variable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5045'>WFCORE-5045</a>] -         CliScriptTestCase fails if environment defines _JAVA_OPTIONS environment variable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5046'>WFCORE-5046</a>] -         ElytronToolScriptTestCase fails if environment defines _JAVA_OPTIONS environment variable
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5048'>WFCORE-5048</a>] -         Tests HTTPSManagementInterfaceTestCase/HTTPSManagementInterfacePKCS12TestCase fail with -Delytron
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5007'>WFCORE-5007</a>] -         Make use of the SocketAddressCallbackServerMechanismFactory to set the peer&#39;s IP address during HTTP authentication
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5015'>WFCORE-5015</a>] -         Create &#39;core-specific&#39; variants of Galleon feature groups and packages that are &#39;overridden&#39; in full WildFly
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5044'>WFCORE-5044</a>] -         Add org.apache.sshd:sshd-common dependency
</li>
</ul>
                                                        