### PR TITLE
[WFLY-13695] Upgrade wildfly-http-client to 1.0.23.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>12.0.3.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
-        <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
+        <version.org.wildfly.http-client>1.0.23.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>
         <version.org.wildfly.transaction.client>1.1.11.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>


### PR DESCRIPTION
I created this PR in case it makes sense to have it upgraded in 20.x, it is a bug fix upgrade.

Jira: https://issues.redhat.com/browse/WFLY-13695
Master PR: https://github.com/wildfly/wildfly/pull/13422

        Release Notes - WildFly EJB HTTP Client - Version 1.0.23.Final
                                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-47'>WEJBHTTP-47</a>] -         Ensure the HttpRemoteTransactionPeer captures current AuthenticationContext and SSLContext
</li>
</ul>
                                                                


        Release Notes - WildFly EJB HTTP Client - Version 1.0.22.Final
                                                                                                                                            
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WEJBHTTP-45'>WEJBHTTP-45</a>] -         UT000103 thrown when WildflyClientOutputStream size is exactly 1024 bytes
</li>
</ul>
                                                                