### PR TITLE
[WFLY-13703] Cleanup duplicate all-layers-jpa-distributed-provisionin…

### DIFF
--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2202,6 +2202,8 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+
+                            <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
                             <execution>
                                 <id>all-layers-jpa-distributed-provisioning-full</id>
                                 <goals>
@@ -2293,66 +2295,6 @@
                                     </configurations>
                                 </configuration>
                             </execution>
-
-                            <!-- This is an all layers variant excluding jpa and adding jpa-distributed -->
-                            <execution>
-                                <id>all-layers-jpa-distributed-provisioning-full</id>
-                                <goals>
-                                    <goal>provision</goal>
-                                </goals>
-                                <phase>compile</phase>
-                                <configuration>
-                                    <install-dir>${layers.install.dir}/test-all-jpa-distributed-layers</install-dir>
-                                    <record-state>false</record-state>
-                                    <log-time>${galleon.log.time}</log-time>
-                                    <offline>true</offline>
-                                    <plugin-options>
-                                        <jboss-maven-dist/>
-                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                                        <optional-packages>passive+</optional-packages>
-                                    </plugin-options>
-                                    <feature-packs>
-                                        <feature-pack>
-                                            <groupId>${full.maven.groupId}</groupId>
-                                            <artifactId>wildfly-galleon-pack</artifactId>
-                                            <version>${full.maven.version}</version>
-                                            <inherit-configs>false</inherit-configs>
-                                            <inherit-packages>false</inherit-packages>
-                                        </feature-pack>
-                                    </feature-packs>
-                                    <configurations>
-                                        <config>
-                                            <model>standalone</model>
-                                            <name>standalone.xml</name>
-                                            <layers>
-                                                <layer>bean-validation</layer>
-                                                <layer>cdi</layer>
-                                                <layer>cloud-profile</layer>
-                                                <layer>datasources</layer>
-                                                <layer>h2-driver</layer>
-                                                <layer>h2-datasource</layer>
-                                                <layer>h2-default-datasource</layer>
-                                                <layer>ee</layer>
-                                                <layer>ee-security</layer>
-                                                <layer>jaxrs</layer>
-                                                <layer>jms-activemq</layer>
-                                                <layer>jpa-distributed</layer>
-                                                <layer>observability</layer>
-                                                <layer>open-tracing</layer>
-                                                <layer>resource-adapters</layer>
-                                                <layer>transactions</layer>
-                                                <layer>undertow</layer>
-                                                <layer>undertow-legacy-https</layer>
-                                                <layer>vault</layer>
-                                            </layers>
-                                            <excluded-layers>
-                                                <layer>jpa</layer>
-                                            </excluded-layers>
-                                        </config>
-                                    </configurations>
-                                </configuration>
-                            </execution>
-
                         </executions>
                     </plugin>
 


### PR DESCRIPTION
…g-full execution ids on testsuite/layers

This PR follows up on https://github.com/wildfly/wildfly/pull/13429, it is just a clean up removing two similar surefife execution ids. I was expecting a conflict between https://github.com/wildfly/wildfly/pull/13429 and https://github.com/wildfly/wildfly/pull/13424 but they were merged without conflicting so we ended up with a duplicate execution id. This PR fixes it as part of https://github.com/wildfly/wildfly/pull/13429 work.

Jira issue: https://issues.redhat.com/browse/WFLY-13703