### PR TITLE
[WFLY-13226]: Upgrade Apache Artemis to 2.13.0

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -34,6 +34,7 @@
         <!-- required for ARTEMIS-298 -->
         <module name="com.google.guava"/>
         <module name="javax.api"/>
+        <module name="javax.json.api"/>
         <module name="org.apache.commons.beanutils" />
         <module name="org.jboss.logging"/>
         <module name="io.netty"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/META-INF/services/org.apache.activemq.artemis.spi.core.remoting.ssl.SSLContextFactory
@@ -1,0 +1,1 @@
+org.apache.activemq.artemis.core.remoting.impl.ssl.DefaultSSLContextFactory 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -30,6 +30,7 @@
     <resources>
         <artifact name="${org.wildfly:wildfly-messaging-activemq}"/>
         <artifact name="${org.jboss.activemq.artemis.integration:artemis-wildfly-integration}"/>
+        <resource-root path="META-INF"/>
     </resources>
 
     <dependencies>
@@ -42,7 +43,7 @@
         <module name="javax.json.api"/>
         <module name="javax.resource.api" />
         <module name="javax.transaction.api"/>
-        <module name="org.apache.activemq.artemis"/>
+        <module name="org.apache.activemq.artemis" services="import" />
         <module name="org.apache.activemq.artemis.ra"/>
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupControlHandler.java
@@ -24,7 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.GET_CONNECTOR_PAIRS_AS_JSON;
 
-import org.apache.activemq.artemis.api.core.management.BroadcastGroupControl;
+import org.apache.activemq.artemis.api.core.management.BaseBroadcastGroupControl;
 import org.apache.activemq.artemis.api.core.management.ResourceNames;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.jboss.as.controller.OperationContext;
@@ -37,7 +37,7 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class BroadcastGroupControlHandler extends AbstractActiveMQComponentControlHandler<BroadcastGroupControl> {
+public class BroadcastGroupControlHandler extends AbstractActiveMQComponentControlHandler<BaseBroadcastGroupControl> {
 
     public static final BroadcastGroupControlHandler INSTANCE = new BroadcastGroupControlHandler();
 
@@ -45,9 +45,9 @@ public class BroadcastGroupControlHandler extends AbstractActiveMQComponentContr
     }
 
     @Override
-    protected BroadcastGroupControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
+    protected BaseBroadcastGroupControl getActiveMQComponentControl(ActiveMQServer activeMQServer, PathAddress address) {
         final String resourceName = address.getLastElement().getValue();
-        return BroadcastGroupControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.BROADCAST_GROUP + resourceName));
+        return BaseBroadcastGroupControl.class.cast(activeMQServer.getManagementService().getResource(ResourceNames.BROADCAST_GROUP + resourceName));
     }
 
     @Override
@@ -58,7 +58,7 @@ public class BroadcastGroupControlHandler extends AbstractActiveMQComponentContr
     @Override
     protected Object handleOperation(String operationName, OperationContext context, ModelNode operation) throws OperationFailedException {
         if (GET_CONNECTOR_PAIRS_AS_JSON.equals(operationName)) {
-            BroadcastGroupControl control = getActiveMQComponentControl(context, operation, false);
+            BaseBroadcastGroupControl control = getActiveMQComponentControl(context, operation, false);
             try {
                 context.getResult().set(control.getConnectorPairsAsJSON());
             } catch (Exception e) {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingExtension.java
@@ -254,6 +254,7 @@ public class MessagingExtension implements Extension {
     // be removed in the future.
     private static final Logger BASE_AUDIT_LOGGER;
     private static final Logger MESSAGE_AUDIT_LOGGER;
+    private static final Logger RESOURCE_AUDIT_LOGGER;
 
     static {
         // There is no guarantee that the configured loggers will contain the logger names even if they've been
@@ -271,6 +272,12 @@ public class MessagingExtension implements Extension {
         } else {
             MESSAGE_AUDIT_LOGGER = Logger.getLogger("org.apache.activemq.audit.message");
             MESSAGE_AUDIT_LOGGER.setLevel(Level.WARNING);
+        }
+        if (configuredLoggers.contains("org.apache.activemq.audit.resource")) {
+            RESOURCE_AUDIT_LOGGER = null;
+        } else {
+            RESOURCE_AUDIT_LOGGER = Logger.getLogger("org.apache.activemq.audit.resource");
+            RESOURCE_AUDIT_LOGGER.setLevel(Level.WARNING);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.3.0</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>2.10.1</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.14.0</version.org.apache.activemq.artemis>
         <version.org.apache.activemq.artemis.native>1.0.2</version.org.apache.activemq.artemis.native>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.3.7</version.org.apache.cxf>


### PR DESCRIPTION
 * Upgrading Apache Artemis version to 2.13.0
 * journal now needs to be able to load json.
 * Adding support for the SSLProviderFactory
 * Fixing change in BroadcastGroupControlHandler due to ARTEMIS-2749.

Jira: https://issues.redhat.com/browse/WFLY-13226
