### PR TITLE
[WFLY-13708] Upgrade SmallRye Metrics to 2.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <version.io.smallrye.smallrye-fault-tolerance>4.2.1</version.io.smallrye.smallrye-fault-tolerance>
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
-        <version.io.smallrye.smallrye-metrics>2.4.0</version.io.smallrye.smallrye-metrics>
+        <version.io.smallrye.smallrye-metrics>2.4.2</version.io.smallrye.smallrye-metrics>
         <version.io.smallrye.open-api>2.0.3</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13708

Dev tag: https://github.com/smallrye/smallrye-metrics/releases/tag/2.4.2
Diff to previous integrated release: https://github.com/smallrye/smallrye-metrics/compare/2.4.0...2.4.2