### PR TITLE
[WFLY-13676] Fix WebJPATestCase execution when using jpa Galleon layer

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1183,7 +1183,7 @@
                                             <name>standalone.xml</name>
                                             <layers>
                                                 <layer>jpa</layer>
-                                                <layer>datasources-web-server</layer>
+                                                <layer>jaxrs-server</layer>
                                                 <layer>h2-default-datasource</layer>
                                             </layers>
                                         </config>


### PR DESCRIPTION
This PR follows up on https://github.com/wildfly/wildfly/pull/13424

Recently we merged https://github.com/wildfly/wildfly/pull/13417 which effectively removed metrics from jpa layers. This removal affects to the jpa Galleon layer execution that tests WebJPATestCase

Jira issue:  https://issues.redhat.com/browse/WFLY-13676
