### PR TITLE
WFLY-13707 Upgrade smallrye-open-api to 2.0.6

### DIFF
--- a/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
+++ b/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/microprofile/openapi-smallrye/main/module.xml
@@ -64,6 +64,5 @@
 
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.extension.undertow"/>
-        <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/microprofile/openapi-smallrye/pom.xml
+++ b/microprofile/openapi-smallrye/pom.xml
@@ -172,10 +172,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>

--- a/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
+++ b/microprofile/openapi-smallrye/src/main/java/org/wildfly/extension/microprofile/openapi/deployment/OpenAPIModelServiceConfigurator.java
@@ -77,7 +77,6 @@ import org.wildfly.extension.undertow.Host;
 import org.wildfly.extension.undertow.UndertowListener;
 import org.wildfly.extension.undertow.UndertowService;
 import org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 import io.smallrye.openapi.api.OpenApiConfig;
 import io.smallrye.openapi.api.OpenApiConfigImpl;
@@ -172,15 +171,7 @@ public class OpenAPIModelServiceConfigurator extends SimpleServiceNameProvider i
             }
         }
 
-        // Workaround for https://github.com/smallrye/smallrye-open-api/issues/404
-        ClassLoader loader = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-        WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(AnnotationScanner.class);
-        try {
-            builder.annotationsModel(OpenApiProcessor.modelFromAnnotations(config, indexView));
-        } finally {
-            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(loader);
-        }
-
+        builder.annotationsModel(OpenApiProcessor.modelFromAnnotations(config, AnnotationScanner.class.getClassLoader(), indexView));
         builder.readerModel(OpenApiProcessor.modelFromReader(config, this.module.getClassLoader()));
         builder.filter(OpenApiProcessor.getFilter(config, this.module.getClassLoader()));
         OpenAPI model = builder.build();

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         <version.io.smallrye.smallrye-health>2.2.0</version.io.smallrye.smallrye-health>
         <version.io.smallrye.smallrye-jwt>2.0.13</version.io.smallrye.smallrye-jwt>
         <version.io.smallrye.smallrye-metrics>2.4.2</version.io.smallrye.smallrye-metrics>
-        <version.io.smallrye.open-api>2.0.3</version.io.smallrye.open-api>
+        <version.io.smallrye.open-api>2.0.6</version.io.smallrye.open-api>
         <version.io.smallrye.opentracing>1.3.4</version.io.smallrye.opentracing>
         <version.io.undertow.jastow>2.0.8.Final</version.io.undertow.jastow>
         <version.io.undertow.js>1.0.2.Final</version.io.undertow.js>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13707

Drops workaround for https://github.com/smallrye/smallrye-open-api/issues/404