### PR TITLE
[WFLY-13725] The layer which brings in the security-manager subsystem is called "security-manager".

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -201,7 +201,7 @@ Basic layers:
 * _remoting_: Support for inbound and outbound JBoss Remoting connections.
 * _request-controller_: Support for request management.
 * _secure-management_: Support for remote access to management interfaces secured using Elytron.
-* _security-management_: Support for security manager.
+* _security-manager_: Support for security manager.
 
 Aggregation layers:
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13725