### PR TITLE
[WFLY-13723] Many Jakarta EE 8 TCK tests are failing due to "Unknown service name jboss.ejb"

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
@@ -130,7 +130,7 @@ public class EJB3RemoteServiceAdd extends AbstractBoottimeAddStepHandler {
                 .setInstance(ejbRemoteConnectorService)
                 .addCapabilityRequirement(EJB3RemoteResourceDefinition.REMOTING_ENDPOINT_CAPABILITY_NAME, Endpoint.class, ejbRemoteConnectorService.getEndpointInjector());
         if (!executeInWorker) {
-            builder.addCapabilityRequirement(EJB3RemoteResourceDefinition.THREAD_POOL_CAPABILITY_NAME, ExecutorService.class, ejbRemoteConnectorService.getExecutorService());
+            builder.addCapabilityRequirement(EJB3RemoteResourceDefinition.THREAD_POOL_CAPABILITY_NAME, ExecutorService.class, ejbRemoteConnectorService.getExecutorService(), threadPoolName);
         }
         // add rest of the dependencies
         builder.addDependency(AssociationService.SERVICE_NAME, AssociationService.class, ejbRemoteConnectorService.getAssociationServiceInjector())


### PR DESCRIPTION
This PR does the following:
- fixes a single capability reference in the EJB3 subsystem remote resource which should have used the dynamic form of addCapabilityRequirement() but mistakenly used the static form, which resulted in a service not being found

For more details: see https://issues.redhat.com/browse/WFLY-13723