### PR TITLE
[WFLY-13737] Upgrade wildfly-transaction-client to 1.1.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,7 @@
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>
-        <version.org.wildfly.transaction.client>1.1.11.Final</version.org.wildfly.transaction.client>
+        <version.org.wildfly.transaction.client>1.1.13.Final</version.org.wildfly.transaction.client>
         <version.org.yaml.snakeyaml>1.26</version.org.yaml.snakeyaml>
         <version.rhino.js>1.7R2</version.rhino.js>
         <version.sun.jaxb>2.3.3-b02</version.sun.jaxb>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13737

Upgrade because of:
https://issues.redhat.com/browse/EAPSUP-229 (https://issues.redhat.com/browse/WFTC-86)

2 version upgrade because of https://issues.redhat.com/browse/WFTC-83 revert
