### PR TITLE
WFLY-13602 : Upgrade Hibernate ORM from 5.3.17 to 5.3.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <version.org.glassfish.soteria>1.0.1-jbossorg-1</version.org.glassfish.soteria>
         <version.org.hamcrest>1.3</version.org.hamcrest>
         <version.org.hamcrest.java-hamcrest>2.0.0.0</version.org.hamcrest.java-hamcrest>
-        <version.org.hibernate>5.3.17.Final</version.org.hibernate>
+        <version.org.hibernate>5.3.18.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.search>5.10.7.Final</version.org.hibernate.search>
         <version.org.hibernate.validator>6.0.20.Final</version.org.hibernate.validator>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13602
https://issues.redhat.com/browse/JBEAP-19379