### PR TITLE
[WFLY-13747] Add tests for the remoting layers, these require Undertow.

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -217,8 +217,9 @@ Basic layers:
 * _jmx-remoting_: Support for registration of Management Model MBeans and a JMX remoting connector.
 * _logging_: Support for the logging subsystem.
 * _legacy-management_: Support for remote access to management interfaces secured with the core ManagementRealm.
+* _legacy_remoting_: Support for inbound and outbound JBoss Remoting connections, secured using legacy security realms.
 * _management_: Support for remote access to management interfaces secured using Elytron.
-* _remoting_: Support for inbound and outbound JBoss Remoting connections.
+* _remoting_: Support for inbound and outbound JBoss Remoting connections, secured using Elytron.
 * _request-controller_: Support for request management.
 * _security-manager_: Support for security manager.
 

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -2801,6 +2801,7 @@
                                                 <layer>jsonp</layer>
                                                 <layer>jsonb</layer>
                                                 <layer>legacy-management</layer>
+                                                <layer>legacy-remoting</layer>
                                                 <layer>legacy-security</layer>
                                                 <layer>logging</layer>
                                                 <layer>mail</layer>
@@ -2903,6 +2904,7 @@
                                                 <layer>jsonp</layer>
                                                 <layer>jsonb</layer>
                                                 <layer>legacy-management</layer>
+                                                <layer>legacy-remoting</layer>
                                                 <layer>legacy-security</layer>
                                                 <layer>logging</layer>
                                                 <layer>mail</layer>
@@ -2937,6 +2939,81 @@
                                             <excluded-layers>
                                                 <layer>jpa</layer>
                                             </excluded-layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- Core Layers - These can't be tested in Core as they require Undertow -->
+                            <execution>
+                                <id>remoting-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/remoting</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>remoting</layer>
+                                                <layer>undertow</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>legacy-remoting-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/remoting</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>legacy-remoting</layer>
+                                                <layer>undertow</layer>
+                                            </layers>
                                         </config>
                                     </configurations>
                                 </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13747
https://issues.redhat.com/browse/WFLY-13755

It may be more appropriate to move these layers into WildFly, we can leave the subsystem where it is but the http-connector which we have chosen to use in our default configuration is only usable if Undertow is available.