### PR TITLE
[WFLY-13750] Upgrade WildFly Core 13.0.0.Beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.0.Beta3</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta4</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION

* [WFLY-13750] Upgrade WildFly Core 13.0.0.Beta4
  * JIRA: https://issues.redhat.com/browse/WFLY-13750
* [WFLY-13730] Work around problem by hiding requirement relationship from Galleon
  * JIRA: https://issues.redhat.com/browse/WFLY-13730

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.0.Beta4
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/13.0.0.Beta3...13.0.0.Beta4
        
##  Release Notes - WildFly Core - Version 13.0.0.Beta4

<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4985'>WFCORE-4985</a>] -         Upgrade JBoss Invocation from 1.5.3 to 1.6.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5057'>WFCORE-5057</a>] -         Upgrade jboss-threads to 2.4.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5074'>WFCORE-5074</a>] -         Upgrade JBoss Modules to 1.10.2.Final
</li>
</ul>
                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5020'>WFCORE-5020</a>] -         Although elytron has module for JACC factory it is not used for JACC
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5023'>WFCORE-5023</a>] -         A few tests don&#39;t work using IBM JDK because of mock-server 5.9.0
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5032'>WFCORE-5032</a>] -         Elytron subsystem should not depend upon PicketBox
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5040'>WFCORE-5040</a>] -         Elytron JASPI fallback causes dependency on PicketBox
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5073'>WFCORE-5073</a>] -         When using Galleon to provision Wildfly with core-server+managment layers, the availability of the Admin console is wrongly advertised to the user
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5049'>WFCORE-5049</a>] -         Ensure any java.security.Policy is registered before PolicyConfigurationFactory
</li>
</ul>
                                                        