### PR TITLE
[WFLY-13758] Avoid hard-coding groupId on wildfly-clustering-marshall…

### DIFF
--- a/clustering/marshalling/jboss/pom.xml
+++ b/clustering/marshalling/jboss/pom.xml
@@ -59,14 +59,14 @@
             <artifactId>jboss-marshalling</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-api</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-clustering-marshalling-spi</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
…ing-jboss module dependencies

Jira issue: https://issues.redhat.com/browse/WFLY-13758
