### PR TITLE
[WFLY-13749] Add the bean-validation Galleon layer as an optional dep…

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jpa-distributed/layer-spec.xml
@@ -2,6 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa-distributed">
     <dependencies>
         <layer name="datasources"/>
+        <layer name="bean-validation" optional="true"/>
     </dependencies>
     <feature-group name="jpa"/>
 

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jpa/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jpa/layer-spec.xml
@@ -2,6 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jpa">
     <dependencies>
         <layer name="datasources"/>
+        <layer name="bean-validation" optional="true"/>
     </dependencies>
     <feature-group name="jpa"/>
     <feature-group name="infinispan-local-hibernate"/>


### PR DESCRIPTION
…endency for jpa and jpa-distributed Galleon layers

Bean validation is not provisioned by default by the jpa / jpa-distributed Galleon layers. Users have to add this layer to their provisioning configuration to make Bean Validation work out of the box with a JPA deployment. This patch makes the layers be more according with the default use case. See Jira issue description to get more context about the motivation of this change.

Jira issue: https://issues.redhat.com/browse/WFLY-13749
