### PR TITLE
[WFLY-13754] Allow injection for JSF artifacts

### DIFF
--- a/jsf/injection/src/main/java/org/jboss/as/jsf/injection/JSFInjectionProvider.java
+++ b/jsf/injection/src/main/java/org/jboss/as/jsf/injection/JSFInjectionProvider.java
@@ -31,8 +31,9 @@ import org.jboss.as.web.common.WebInjectionContainer;
  */
 public class JSFInjectionProvider extends DiscoverableInjectionProvider {
 
-    public static final String JAVAX_FACES = "javax.faces";
-    public static final String COM_SUN_FACES = "com.sun.faces";
+    public static final String JAVAX_FACES = "javax.faces.";
+    public static final String COM_SUN_FACES = "com.sun.faces.";
+    public static final String COM_SUN_FACES_TEST = "com.sun.faces.test.";
     private final WebInjectionContainer instanceManager;
 
     public JSFInjectionProvider() {
@@ -55,9 +56,10 @@ public class JSFInjectionProvider extends DiscoverableInjectionProvider {
     @Override
     public void invokePostConstruct(final Object managedBean) throws InjectionProviderException {
         if(managedBean.getClass().getName().startsWith(JAVAX_FACES) ||
-                managedBean.getClass().getName().startsWith(COM_SUN_FACES)) {
+                (managedBean.getClass().getName().startsWith(COM_SUN_FACES) && !managedBean.getClass().getName().startsWith(COM_SUN_FACES_TEST))) {
             //some internal JSF instances are not destroyed properly, and they do not need to have
             //lifecycle callbacks anyway, so we don't use the instance manager to create them
+            // avoid excluding elements from the JSF test suite (tests fail because objects are not injected)
             return;
         }
         if(instanceManager == null) {

--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/logging/JSFLogger.java
@@ -67,7 +67,7 @@ public interface JSFLogger extends BasicLogger {
     void managedBeanNoDefaultConstructor(String managedBean);
 
     @LogMessage(level = ERROR)
-    @Message(id = 4, value = "Failed to parse %s, managed beans defined in this file will not be available")
+    @Message(id = 4, value = "Failed to parse %s, JSF artifacts defined in this file will not be available")
     void managedBeansConfigParseFailed(VirtualFile facesConfig);
 
     @LogMessage(level = WARN)
@@ -103,9 +103,9 @@ public interface JSFLogger extends BasicLogger {
     @Message(id = 14, value = "Default JSF implementation slot '%s' is invalid")
     DeploymentUnitProcessingException invalidDefaultJSFImpl(String defaultJsfVersion);
 
-    @LogMessage(level = ERROR)
-    @Message(id = 15, value = "Failed to parse %s, phase listeners defined in this file will not be available")
-    void phaseListenersConfigParseFailed(VirtualFile facesConfig);
+//    @LogMessage(level = ERROR)
+//    @Message(id = 15, value = "Failed to parse %s, phase listeners defined in this file will not be available")
+//    void phaseListenersConfigParseFailed(VirtualFile facesConfig);
 
     @Message(id = 16, value = "Failed to inject JSF from slot %s")
     DeploymentUnitProcessingException jsfInjectionFailed(String slotName, @Cause Throwable cause);
@@ -117,4 +117,8 @@ public interface JSFLogger extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 18, value = "JSF 1.2 classes not detected. Using org.jboss.as.jsf.injection.weld.WeldApplicationFactory.")
     void loadingJsf2x();
+
+    @LogMessage(level = INFO)
+    @Message(id = 19, value = "JSF artifact %s with class %s has no default constructor so it will not be considered for injection")
+    void jsfArtifactNoDefaultConstructor(String type, String className);
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13754

No hurries with this one. Trying to make the JSF test-suite work with wildfly in order to test the JSF implementation with it. Some tests fail and among them some are real issues (this is one of them).

The idea of the change is adding all the artifacts that are eligible for injection to the `JSFComponentProcessor`. I'm following the same idea used previously but generalized with a tree of desired components to be installed (previously only the `phase-listener` component was taken into account). Besides only one parsing is executed to do the job (previously there were two).

I'm assigning it to @fjuma, but this is not urgent at all. With another minor change I'm able to execute all the tests in the groups that mojarra seems to be executing on their PRs (for example [this old PR](https://travis-ci.org/github/eclipse-ee4j/mojarra/builds/608301704)).

Not adding any test because the idea is using the included mojarra tests in order to check our jsf branches.