### PR TITLE
WFLY-13731 Upgrade Weld core to 3.1.5.Final and API to 3.1.SP3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,8 +414,8 @@
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>
-        <version.org.jboss.weld.weld>3.1.4.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>3.1.SP2</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>3.1.5.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>3.1.SP3</version.org.jboss.weld.weld-api>
         <version.org.jboss.weld.se.weld-se-core>3.0.5.Final</version.org.jboss.weld.se.weld-se-core>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.common>3.3.0.Final</version.org.jboss.ws.common>


### PR DESCRIPTION
JIRA issue - https://issues.redhat.com/browse/WFLY-13731

This will also fix https://issues.redhat.com/browse/WFLY-12815.