### PR TITLE
WFLY-13766 MicroProfile OpenAPI subsystem cannot be used in legacy feature packs

### DIFF
--- a/microprofile/openapi-smallrye/src/main/resources/subsystem-templates/microprofile-openapi-smallrye.xml
+++ b/microprofile/openapi-smallrye/src/main/resources/subsystem-templates/microprofile-openapi-smallrye.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.wildfly.extension.microprofile.openapi-smallrye</extension-module>
+    <subsystem xmlns="urn:wildfly:microprofile-openapi-smallrye:1.0"/>
+</config>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13766