### PR TITLE
[WFLY-13778] Upgrade ironjacamar to 1.4.23.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <version.org.jboss.genericjms>2.0.6.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.2.9.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
-        <version.org.jboss.ironjacamar>1.4.22.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>1.4.23.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13778
This update is required because of:
https://issues.redhat.com/browse/EAPSUP-228
