### PR TITLE
[WFLY-13791] Disable the manual IIOP/CORBA stub generation on IBM JDK…

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1065,6 +1065,22 @@
             </properties>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${version.exec.plugin}</version>
+                        <executions>
+                            <!-- See the default execution on the ibmjdk.profile, this execution should be activated selectively
+                                 for any provisioning under this profile that requires the manual IIOP/CORBA stub generation -->
+                            <execution>
+                                <id>ibmjdk.iiop.stub-creation</id>
+                                <phase>none</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Disable the standard copy-based provisioning -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
… when running the Galleon Layers testsuite

Jira issue: https://issues.redhat.com/browse/WFLY-13791

CC @tadamski @chengfang If this configuration is merged, probably it must be taken into account for the EJB3 layers
