### PR TITLE
[WFLY-13793] remove incorrect EnumValidator on attribute of boolean type

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -683,7 +683,6 @@ public interface ConnectionFactoryAttributes {
     interface External {
         AttributeDefinition ENABLE_AMQ1_PREFIX = create("enable-amq1-prefix", BOOLEAN)
                 .setDefaultValue(ModelNode.TRUE)
-                .setValidator(ConnectionFactoryType.VALIDATOR)
                 .setRequired(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/WFLY-13793

This simply removes an incorrect EnumValidator on attribute ENABLE_AMQ1_PREFIX of boolean type