### PR TITLE
[WFLY-13811] EJB3's dep on org.jboss.as.remoting is not optional unti…

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -68,7 +68,8 @@
         <module name="org.wildfly.iiop-openjdk"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.jboss.as.remoting" optional="true"/>
+        <!-- Needed for RemotingConnectorInfo TODO get this via org.jboss.as.network -->
+        <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.security"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>


### PR DESCRIPTION
…l RemotingConnectorInfo data is available via a capability in a type provided by org.jboss.as.network

https://issues.redhat.com/browse/WFLY-13811