### PR TITLE
 [WFLY-13814]: Drop messaging subsystem's HTTPUpgradeService's use of SimpleHttpUpgradeHandshake, drop dep on org.jboss.as.remoting.

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -52,8 +52,6 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <!-- required only to access the HttpListenerRegistryService used by http-acceptor -->
-        <module name="org.jboss.as.remoting" optional="true"/>
         <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.as.server"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPAcceptorDefinition.java
@@ -43,6 +43,7 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.RuntimePackageDependency;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.messaging.activemq.MessagingServices.ServerNameMapper;
@@ -57,7 +58,6 @@ public class HTTPAcceptorDefinition extends PersistentResourceDefinition {
     static final RuntimeCapability<Void> CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.messaging.activemq", true, HTTPUpgradeService.class)
             .setDynamicNameMapper(new ServerNameMapper("http-upgrade-service"))
             .addRequirements(HTTP_LISTENER_REGISTRY_CAPABILITY_NAME)
-            .addAdditionalRequiredPackages("io.undertow.core", "org.jboss.as.remoting", "org.jboss.xnio", "org.jboss.xnio.netty.netty-xnio-transport")
             .build();
 
     static final SimpleAttributeDefinition HTTP_LISTENER = create(CommonAttributes.HTTP_LISTENER, ModelType.STRING)
@@ -99,5 +99,13 @@ public class HTTPAcceptorDefinition extends PersistentResourceDefinition {
     @Override
     public Collection<AttributeDefinition> getAttributes() {
         return Arrays.asList(ATTRIBUTES);
+    }
+
+    @Override
+    public void registerAdditionalRuntimePackages(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerAdditionalRuntimePackages(
+                RuntimePackageDependency.required("io.undertow.core"),
+                RuntimePackageDependency.required("org.jboss.xnio"),
+                RuntimePackageDependency.required("org.jboss.xnio.netty.netty-xnio-transport"));
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -27,6 +27,7 @@ import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -868,4 +869,7 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 101, value = "Invalid value %s for %s, legal values are %s, default value is applied.")
     void invalidTransactionNameValue(String value, String name, Collection<?> validValues);
+
+    @Message(id = 102, value = "HTTP Upgrade request missing Sec-JbossRemoting-Key header")
+    IOException upgradeRequestMissingKey();
 }


### PR DESCRIPTION

 * Replacing the code in HTTPUpgradeService.
 * Updating the MSC API usage by removing the use of the deprecated API.

    Jira: https://issues.redhat.com/browse/WFLY-13814