### PR TITLE
WFLY-13803 Upgrade RESTEasy to 3.13.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
         <version.org.jboss.mod_cluster>1.4.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.10.5.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.4.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>3.12.1.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.13.0.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13803?filter=-1

This upgrade is related to https://issues.redhat.com/browse/EAP7-1219 / https://issues.redhat.com/browse/RESTEASY-2366. The Elytron group needs a fix in RESTEasy 3.13.0.Final to close EAP7-1219. 

We still expect to release RESTEasy 3.14.0.Final in time for WF 21.