### PR TITLE
Fix for WFLY-13815, Make core-tools optional in datasources-web-server layer

### DIFF
--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -3,7 +3,7 @@
     <dependencies>
         <layer name="web-server"/>
         <layer name="core-server"/>
-        <layer name="core-tools"/>
+        <layer name="core-tools" optional="true"/>
         <layer name="datasources" optional="true"/>
     </dependencies>
     <feature-group name="undertow-elytron-security"/>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13815
This change offers the ability to exclude core-tools when provisioning base galleon layers. core tooling is not required in all cases (eg: bootable JAR).