### PR TITLE
[WFLY-13632] If a CMR resource is deployed concurrently then it will overwrite the list of resources that are expected to behave as CMR

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/JTAEnvironmentBeanServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/JTAEnvironmentBeanServlet.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.transaction;
+
+import com.arjuna.ats.jta.common.JTAEnvironmentBean;
+import com.arjuna.ats.jta.common.jtaPropertyManager;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+@WebServlet(name = "JTAEnvironmentBeanServlet", urlPatterns = {"/check"})
+public class JTAEnvironmentBeanServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        JTAEnvironmentBean jtaEnvBean = jtaPropertyManager.getJTAEnvironmentBean();
+        String jndiName = req.getParameter("jndiName");
+        PrintWriter writer = resp.getWriter();
+        writer.print(jtaEnvBean.getCommitMarkableResourceJNDINames().contains(jndiName));
+        writer.flush();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/JTAEnvironmentBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/transaction/JTAEnvironmentBeanTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.transaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.txn.subsystem.TransactionExtension;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JTAEnvironmentBeanTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "tx.war");
+        war.addPackage(JTAEnvironmentBeanTestCase.class.getPackage());
+        war.addClass(HttpRequest.class);
+        war.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts\n"), "MANIFEST.MF");
+        return war;
+    }
+
+    @Test
+    public void testJTAEnvBean() throws Exception {
+        // adding cmr
+        final String jndiName = "java:jboss/cmr1";
+        final String checkURL = url.toExternalForm() + "/check?jndiName=" + jndiName;
+        PathAddress address = PathAddress.pathAddress()
+                .append(SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME)
+                .append("commit-markable-resource", jndiName);
+        ModelNode addCMROp = new ModelNode();
+        ModelNode cmrAddr = address.toModelNode();
+        addCMROp.get(OP).set(ADD);
+        addCMROp.get(OP_ADDR).set(cmrAddr);
+        MaximumTimeoutTestCase.executeForResult(managementClient.getControllerClient(), addCMROp);
+        ServerReload.reloadIfRequired(managementClient);
+        // check it is in there
+        Assert.assertEquals("true", HttpRequest.get(checkURL, 10, SECONDS));
+        MaximumTimeoutTestCase.executeForResult(managementClient.getControllerClient(), Util.createRemoveOperation(address));
+        ServerReload.reloadIfRequired(managementClient);
+        // check it is not in there
+        Assert.assertEquals("false", HttpRequest.get(checkURL, 10, SECONDS));
+    }
+
+}

--- a/transactions/src/main/java/org/jboss/as/txn/service/CMResourceService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/CMResourceService.java
@@ -58,33 +58,44 @@ public class CMResourceService implements Service<Void> {
 
     @Override
     public void start(StartContext context) throws StartException {
+        final JTAEnvironmentBean jtaBean = jtaEnvironmentBean.getValue();
+        synchronized (jtaBean) {
+            List<String> connectableResourceJNDINames = jtaBean.getCommitMarkableResourceJNDINames();
+            Map<String, String> connectableResourceTableNameMap = jtaBean.getCommitMarkableResourceTableNameMap();
+            Map<String, Boolean> performImmediateCleanupOfConnectableResourceBranchesMap = jtaBean.getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap();
+            Map<String, Integer> connectableResourceRecordDeleteBatchSizeMap = jtaBean.getCommitMarkableResourceRecordDeleteBatchSizeMap();
 
+            connectableResourceJNDINames.add(jndiName);
+            connectableResourceTableNameMap.put(jndiName, tableName);
+            performImmediateCleanupOfConnectableResourceBranchesMap.put(jndiName, immediateCleanup);
+            connectableResourceRecordDeleteBatchSizeMap.put(jndiName, batchSize);
 
-        List<String> connectableResourceJNDINames = jtaEnvironmentBean.getValue().getCommitMarkableResourceJNDINames();
-        Map<String, String> connectableResourceTableNameMap = jtaEnvironmentBean.getValue().getCommitMarkableResourceTableNameMap();
-        Map<String, Boolean> performImmediateCleanupOfConnectableResourceBranchesMap = jtaEnvironmentBean.getValue().getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap();
-        Map<String, Integer> connectableResourceRecordDeleteBatchSizeMap = jtaEnvironmentBean.getValue().getCommitMarkableResourceRecordDeleteBatchSizeMap();
-
-        connectableResourceJNDINames.add(jndiName);
-        connectableResourceTableNameMap.put(jndiName, tableName);
-        performImmediateCleanupOfConnectableResourceBranchesMap.put(jndiName, immediateCleanup);
-        connectableResourceRecordDeleteBatchSizeMap.put(jndiName, batchSize);
-
-        jtaEnvironmentBean.getValue().setCommitMarkableResourceJNDINames(connectableResourceJNDINames);
-        jtaEnvironmentBean.getValue().setCommitMarkableResourceTableNameMap(connectableResourceTableNameMap);
-        jtaEnvironmentBean.getValue().setPerformImmediateCleanupOfCommitMarkableResourceBranchesMap(performImmediateCleanupOfConnectableResourceBranchesMap);
-        jtaEnvironmentBean.getValue().setCommitMarkableResourceRecordDeleteBatchSizeMap(connectableResourceRecordDeleteBatchSizeMap);
-
-
+            jtaBean.setCommitMarkableResourceJNDINames(connectableResourceJNDINames);
+            jtaBean.setCommitMarkableResourceTableNameMap(connectableResourceTableNameMap);
+            jtaBean.setPerformImmediateCleanupOfCommitMarkableResourceBranchesMap(performImmediateCleanupOfConnectableResourceBranchesMap);
+            jtaBean.setCommitMarkableResourceRecordDeleteBatchSizeMap(connectableResourceRecordDeleteBatchSizeMap);
+        }
     }
 
     @Override
     public void stop(StopContext context) {
-        jtaEnvironmentBean.getValue().getCommitMarkableResourceJNDINames().remove(jndiName);
-        jtaEnvironmentBean.getValue().getCommitMarkableResourceTableNameMap().remove(tableName);
-        jtaEnvironmentBean.getValue().getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap().remove(jndiName);
-        jtaEnvironmentBean.getValue().getCommitMarkableResourceRecordDeleteBatchSizeMap().remove(jndiName);
+        final JTAEnvironmentBean jtaBean = jtaEnvironmentBean.getValue();
+        synchronized (jtaBean) {
+            List<String> connectableResourceJNDINames = jtaBean.getCommitMarkableResourceJNDINames();
+            Map<String, String> connectableResourceTableNameMap = jtaBean.getCommitMarkableResourceTableNameMap();
+            Map<String, Boolean> performImmediateCleanupOfConnectableResourceBranchesMap = jtaBean.getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap();
+            Map<String, Integer> connectableResourceRecordDeleteBatchSizeMap = jtaBean.getCommitMarkableResourceRecordDeleteBatchSizeMap();
 
+            connectableResourceJNDINames.remove(jndiName);
+            connectableResourceTableNameMap.remove(jndiName);
+            performImmediateCleanupOfConnectableResourceBranchesMap.remove(jndiName);
+            connectableResourceRecordDeleteBatchSizeMap.remove(jndiName);
+
+            jtaBean.setCommitMarkableResourceJNDINames(connectableResourceJNDINames);
+            jtaBean.setCommitMarkableResourceTableNameMap(connectableResourceTableNameMap);
+            jtaBean.setPerformImmediateCleanupOfCommitMarkableResourceBranchesMap(performImmediateCleanupOfConnectableResourceBranchesMap);
+            jtaBean.setCommitMarkableResourceRecordDeleteBatchSizeMap(connectableResourceRecordDeleteBatchSizeMap);
+        }
     }
 
     @Override

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/CMResourceAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/CMResourceAdd.java
@@ -64,6 +64,10 @@ class CMResourceAdd extends AbstractAddStepHandler {
      */
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        if (!context.isBooting()) {
+            context.reloadRequired();
+            return;
+        }
         PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String jndiName = address.getLastElement().getValue();
         final String tableName = CMResourceResourceDefinition.CM_TABLE_NAME.resolveModelAttribute(context, model).asString();
@@ -76,9 +80,5 @@ class CMResourceAdd extends AbstractAddStepHandler {
                 .addDependency(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, JTAEnvironmentBean.class, service.getJTAEnvironmentBeanInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
-
-        if (!context.isBooting()) {
-            context.reloadRequired();
-        }
     }
 }


### PR DESCRIPTION
~Issue: https://issues.redhat.com/browse/WFLY-13633~

Issue: https://issues.redhat.com/browse/WFLY-13632

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

Remember to use the Jira issue ID in the PR title, and any commits.
