### PR TITLE
[WFLY-13539] Add Galleon layer for JBoss Diagnostic Reporting support

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -130,6 +130,7 @@ Basic layers:
 * _ejb-lite_: Support for Jakarta Enterprise Beans Lite.
 * _ejb_: Support for Jakarta Enterprise Beans, excluding IIOP protocol.
 * _jaxrs_: Support for JAXRS. Depends on _web-server_ (defined in the WildFly servlet feature-pack).
+* _jdr_: Support for the JBoss Diagnostic Reporting (JDR) subsystem.
 * _jms-activemq_: Support for connections to a remote JMS broker.
 * _jpa_: Support for JPA (using the latest WildFly supported Hibernate release).
 * _jsf_: Support for Jakarta Server Faces. Depends on _web-server_ (defined in the WildFly servlet feature-pack) and optionally on _cdi_ and _bean-validation_

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jdr/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jdr/layer-spec.xml
@@ -2,7 +2,7 @@
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jdr">
     <dependencies>
         <layer name="base-server"/>
-        <layer name="secure-management" optional="true"/>
+        <layer name="management" optional="true"/>
     </dependencies>
     <feature spec="subsystem.jdr"/>
     <packages>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jdr/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jdr/layer-spec.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jdr">
+    <dependencies>
+        <layer name="base-server"/>
+        <layer name="secure-management" optional="true"/>
+    </dependencies>
+    <feature spec="subsystem.jdr"/>
+    <packages>
+        <package name="bin.jdrtools"/>
+    </packages>
+</layer-spec>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1155,6 +1155,46 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+
+                            <!-- Provision a server with JBoss Diagnostic Reporting layer -->
+                            <execution>
+                                <id>jdr-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-jdr</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>jdr</layer>
+                                                <layer>datasources-web-server</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+
                             <!-- Provision a cloud-profile server with legacy-security as well -->
                             <execution>
                                 <id>legacy-security-provisioning</id>
@@ -1558,6 +1598,33 @@
                                     <includes>
                                         <include>org/jboss/as/test/integration/jsf/phaselistener/injectiontarget/InjectionToPhaseListenerTest.java</include>
                                         <include>org/jboss/as/test/integration/jsf/version/JSFDeploymentProcessorTestCase.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+
+                            <!-- Tests against a server provisioned with Jboss Diagnostic Reporting layer -->
+                            <execution>
+                                <id>jdr.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-jdr</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-jdr</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-jdr</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-jdr</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-jdr</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-jdr/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-jdr</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/jdr/mgmt/*TestCase.java</include>
                                     </includes>
                                 </configuration>
                             </execution>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.jdr.mgmt;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -145,7 +146,7 @@ public class JdrReportManagmentTestCase {
                 reportName, reportZip);
         validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/cluster-proxies-configuration.json", fileNames,
                 reportName, reportZip);
-        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/deployment-dependencies.txt", fileNames,
+        validateEntryPresent("sos_strings/" + FOLDER_NAME + "/deployment-dependencies.txt", fileNames,
                 reportName, reportZip);
         validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/jndi-view.json", fileNames,
                 reportName, reportZip);
@@ -157,7 +158,7 @@ public class JdrReportManagmentTestCase {
     }
 
     /**
-     * Check if entry (reprtname/filename) is presented in reportZip file
+     * Check if entry (reportname/filename) is presented in reportZip file and is not empty
      *
      * @param fileName   Name of file inside report
      * @param reportZip  Report zip file
@@ -169,7 +170,7 @@ public class JdrReportManagmentTestCase {
     }
 
     /**
-     * Check if entry (reprtname/filename) is presented in reportZip file
+     * Check if entry (reportname/filename) is presented in reportZip file and is not empty
      *
      * @param fileName         Name of file inside report
      * @param fileNameOptional Optional name of file inside report
@@ -180,6 +181,19 @@ public class JdrReportManagmentTestCase {
                                        String reportName, ZipFile reportZip) {
         ZipEntry zipENtry = getZipEntry(reportZip, fileName, fileNameOptional, fileNames, reportName);
         assertTrue("Report entry " + fileName + " was empty or could not be determined", zipENtry.getSize() > 0);
+    }
+
+    /**
+     * Check if entry (reportname/filename) is presented in reportZip file, either empty or not empty.
+     *
+     * @param fileName   Name of file inside report
+     * @param reportZip  Report zip file
+     * @param reportName Report root folder name
+     */
+    private void validateEntryPresent(String fileName, Set<String> fileNames,
+                                       String reportName, ZipFile reportZip) {
+        ZipEntry zipENtry = getZipEntry(reportZip, fileName, null, fileNames, reportName);
+        assertNotNull("Report entry " + fileName + " was not present", zipENtry);
     }
 
     private ZipEntry getZipEntry(ZipFile reportZip, String fileName, String fileNameOptional, Set<String> fileNames, String reportName) {
@@ -205,7 +219,7 @@ public class JdrReportManagmentTestCase {
     }
 
     /**
-     * Check if entry (reprtname/filename) is presented in reportZip file and is empty
+     * Check if entry (reportname/filename) is presented in reportZip file and is empty
      *
      * @param fileName   Name of file inside report
      * @param reportZip  Report zip file

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
@@ -21,8 +21,18 @@
 */
 package org.jboss.as.test.integration.jdr.mgmt;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -33,6 +43,7 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,11 +79,27 @@ public class JdrReportManagmentTestCase {
 
         // Validate report itself.
         File reportFile = new File(location);
-        Assert.assertTrue("JDR report missing, not located at " + location, reportFile.exists());
+        assertTrue("JDR report missing, not located at " + location, reportFile.exists());
         validateJdrReportContents(reportFile);
 
         // Clean up report file
         reportFile.delete();
+    }
+
+    /**
+     * Tests if jdr.* script files are present in the WFLY_HOME/bin directory.
+     * The default server copy, see ts.copy-wildfly, does not copy these resources, so we only
+     * execute this test when we are testing galleon layers, hence ts.layers enabled.
+     */
+    @Test
+    public void ensureShellScriptExists() {
+        Assume.assumeTrue("This test is only executed if we are testing Galleon Layers", Boolean.getBoolean("ts.layers"));
+
+        Path binPath = Paths.get(System.getProperty("jboss.home"), "bin");
+
+        assertTrue("jdr.sh was not found in " + binPath.toString(), binPath.resolve("jdr.sh").toFile().exists());
+        assertTrue("jdr.bat was not found in " + binPath.toString(), binPath.resolve("jdr.bat").toFile().exists());
+        assertTrue("jdr.ps1 was not found in " + binPath.toString(), binPath.resolve("jdr.ps1").toFile().exists());
     }
 
     private void validateJdrReportContents(File reportFile) {
@@ -81,7 +108,13 @@ public class JdrReportManagmentTestCase {
         ZipFile reportZip = null;
         try {
             reportZip = new ZipFile(reportFile);
-            validateReportEntries(reportZip, reportName);
+            Enumeration<ZipEntry> e = (Enumeration<ZipEntry>) reportZip.entries();
+            Set<String> fileNames = new HashSet<>();
+            while (e.hasMoreElements()) {
+                String fileName = e.nextElement().toString();
+                fileNames.add(fileName);
+            }
+            validateReportEntries(fileNames, reportName, reportZip);
         } catch (Exception e) {
             throw new RuntimeException("Unable to validate JDR report: " + reportFile.getName(), e);
         } finally {
@@ -95,9 +128,74 @@ public class JdrReportManagmentTestCase {
         }
     }
 
-    private void validateReportEntries(ZipFile reportZip, String reportName) {
-        validateEntryNotEmpty("version.txt", reportZip, reportName);
-        // TODO: Add additional files for more complete test.
+    public static final String FOLDER_NAME = "(wildfly_full-[0-9]*)|(jboss_eap[_-][-cd0-9]*)";
+
+    private void validateReportEntries(Set<String> fileNames, String reportName, ZipFile reportZip) {
+
+        validateEntryNotEmpty("version.txt", fileNames, reportName, reportZip);
+        validateEntryNotEmpty("JBOSS_HOME/standalone/configuration/standalone(.*).xml$", "JBOSS_HOME\\\\standalone\\\\configuration\\\\standalone(.*).xml$",
+                fileNames, reportName, reportZip);
+
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/tree.txt", fileNames, reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/jarcheck.txt", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/dump-services.json", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/configuration.json", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/cluster-proxies-configuration.json", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/deployment-dependencies.txt", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/jndi-view.json", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/local-module-dependencies.txt", fileNames,
+                reportName, reportZip);
+        validateEntryNotEmpty("sos_strings/" + FOLDER_NAME + "/system-properties.txt", fileNames,
+                reportName, reportZip);
+        validateEmptyEntry("sos_logs/skips.log", fileNames, reportName, reportZip);
+    }
+
+    /**
+     * Check if entry (reprtname/filename) is presented in reportZip file
+     *
+     * @param fileName   Name of file inside report
+     * @param reportZip  Report zip file
+     * @param reportName Report root folder name
+     */
+    private void validateEntryNotEmpty(String fileName, Set<String> fileNames,
+                                       String reportName, ZipFile reportZip) {
+        validateEntryNotEmpty(fileName, null, fileNames, reportName, reportZip);
+    }
+
+    /**
+     * Check if entry (reprtname/filename) is presented in reportZip file
+     *
+     * @param fileName         Name of file inside report
+     * @param fileNameOptional Optional name of file inside report
+     * @param reportZip        Report zip file
+     * @param reportName       Report root folder name
+     */
+    private void validateEntryNotEmpty(String fileName, String fileNameOptional, Set<String> fileNames,
+                                       String reportName, ZipFile reportZip) {
+        ZipEntry zipENtry = getZipEntry(reportZip, fileName, fileNameOptional, fileNames, reportName);
+        assertTrue("Report entry " + fileName + " was empty or could not be determined", zipENtry.getSize() > 0);
+    }
+
+    private ZipEntry getZipEntry(ZipFile reportZip, String fileName, String fileNameOptional, Set<String> fileNames, String reportName) {
+        String entryInZip = reportName + "/" + fileName;
+
+        Pattern p = Pattern.compile(entryInZip);
+        Optional<String> realFileName = fileNames.stream().filter(name -> p.matcher(name).find()).findFirst();
+        if (!realFileName.isPresent() && fileNameOptional != null) {
+            entryInZip = reportName + "/" + fileNameOptional;
+            Pattern p2 = Pattern.compile(entryInZip);
+            realFileName = fileNames.stream().filter(name -> p2.matcher(name).find()).findFirst();
+        }
+
+        assertTrue("Report entry " + fileName + " missing from JDR report "
+                + reportName, realFileName.isPresent());
+        return reportZip.getEntry(realFileName.get());
     }
 
     private void validateJdrTimeStamps(ModelNode result) {
@@ -106,10 +204,15 @@ public class JdrReportManagmentTestCase {
         Assert.assertNotNull("JDR end time was null.", result.get("end-time").asString());
     }
 
-    private void validateEntryNotEmpty(String fileName, ZipFile reportZip, String reportName) {
-        String entryInZip = reportName + "/" + fileName;
-        ZipEntry entry = reportZip.getEntry(entryInZip);
-        Assert.assertNotNull("Report entry " + fileName + " missing from JDR report " + reportZip.getName(), entry);
-        Assert.assertTrue("Report entry " + fileName + " was empty or could not be determined", entry.getSize() > 0);
+    /**
+     * Check if entry (reprtname/filename) is presented in reportZip file and is empty
+     *
+     * @param fileName   Name of file inside report
+     * @param reportZip  Report zip file
+     * @param reportName Report root folder name
+     */
+    private void validateEmptyEntry(String fileName, Set<String> fileNames, String reportName, ZipFile reportZip) {
+        ZipEntry zipEntry = getZipEntry(reportZip, fileName, null, fileNames, reportName);
+        assertFalse("Report entry " + fileName + " should be empty", zipEntry.getSize() > 0);
     }
 }

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -1696,6 +1696,42 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>jdr-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/jdr</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>jdr</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>jms-activemq-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -2426,6 +2462,7 @@
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>
@@ -2519,6 +2556,7 @@
                                                 <layer>io</layer>
                                                 <layer>jaxrs</layer>
                                                 <layer>jaxrs-server</layer>
+                                                <layer>jdr</layer>
                                                 <layer>jms-activemq</layer>
                                                 <layer>jmx</layer>
                                                 <layer>jmx-remoting</layer>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13539

Follows up on #13381 with an additional commit to update the test improvements in that PR to not assert things that are validly not true. Running the test in other environments where a server had no ServiceModuleLoader present the test would incorrectly fail.