### PR TITLE
[WFLY-13771]: Adding messaging layers and some testing

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -127,6 +127,8 @@ Basic layers:
 * _cdi_: Support for CDI. Optionally depends on _bean-validation_.
 * _datasources_: Support for datasources.
 * _ee-security_: Support for EE Security. Depends on _cdi_.
+* _ejb-lite_: Support for Jakarta Enterprise Beans Lite.
+* _ejb_: Support for Jakarta Enterprise Beans, excluding IIOP protocol.
 * _jaxrs_: Support for JAXRS. Depends on _web-server_ (defined in the WildFly servlet feature-pack).
 * _jms-activemq_: Support for connections to a remote JMS broker.
 * _jpa_: Support for JPA (using the latest WildFly supported Hibernate release).
@@ -164,6 +166,10 @@ Layers that you combine with "use-case tailored" layers to extend the capabiliti
 
 * _observability_: Support for MicroProfile monitoring and configuration features. 
 Includes Health support (optional), _microprofile-config_ (optional), _microprofile-metrics_ (optional) and _open-tracing_ (optional).
+
+* _ejb-local-cache_: Infinispan-based local cache for stateful session bean.
+
+* _ejb-dist-cache_: Infinispan-based distributed cache for stateful session bean.
 
 ==== WildFly servlet layers
 

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/messaging-remote-activemq.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/messaging-remote-activemq.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="messaging-remote-activemq" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="subsystem.messaging-activemq">
+        <feature spec="subsystem.messaging-activemq.remote-connector">
+            <param name="remote-connector" value="artemis"/>
+            <param name="socket-binding" value="messaging-activemq"/>
+            <param name="params" value="{use-nio=true,use-nio-global-worker-pool=true}"/>
+        </feature>
+        <feature spec="subsystem.messaging-activemq.pooled-connection-factory">
+            <param name="pooled-connection-factory" value="activemq-ra"/>
+            <param name="entries" value="[java:/JmsXA,java:jboss/DefaultJMSConnectionFactory]"/>
+            <param name="connectors" value="[artemis]"/>
+            <param name="transaction" value="xa"/>
+            <param name="user" value="guest"/>
+            <param name="password" value="guest"/>
+        </feature>
+    </feature>
+    <feature spec="subsystem.ee">
+        <feature spec="subsystem.ee.service.default-bindings">
+            <param name="jms-connection-factory" value="java:jboss/DefaultJMSConnectionFactory"/>
+        </feature>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/feature_groups/messaging-remote-sockets.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/feature_groups/messaging-remote-sockets.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature-group-spec name="messaging-remote-sockets" xmlns="urn:jboss:galleon:feature-group:1.0">
+    <feature spec="socket-binding-group.remote-destination-outbound-socket-binding">
+         <param name="socket-binding-group" value="standard-sockets" />
+        <param name="remote-destination-outbound-socket-binding" value="messaging-activemq"/>
+        <param name="host" value="${jboss.messaging.connector.host:localhost}"/>
+        <param name="port" value="${jboss.messaging.connector.port:61616}"/>
+    </feature>
+</feature-group-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-dist-cache/layer-spec.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-dist-cache">
+
+    <!-- Infinispan cache configuration used for distributed SFSB caching -->
+
+    <dependencies>
+        <layer name="transactions"/>
+    </dependencies>
+
+    <dependencies>
+        <layer name="transactions"/>
+    </dependencies>
+
+    <feature spec="subsystem.ejb3">
+        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-sfsb-cache" value="distributable"/>
+    </feature>
+
+    <origin name="org.wildfly:wildfly-servlet-galleon-pack">
+        <feature-group name="private-interface"/>
+    </origin>
+    <feature-group name="infinispan-dist-ejb"/>
+    <feature-group name="jgroups-all"/>
+    <packages>
+        <!-- The infinispan subsystem doesn't assume ejb3,
+             and ejb3 subysystem doesn't assume clustering, but the
+             combination requires the clustering<->ejb3 integration package -->
+        <package name="org.wildfly.clustering.ejb.infinispan"/>
+    </packages>
+</layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-lite/layer-spec.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-lite">
+    <!-- Aggregates the functionality roughly associated with the EJB Lite concept.
+         Note that the timer-service feature provides persistent timers which goes beyond EJB Lite requirements. -->
+    <dependencies>
+        <layer name="transactions"/>
+        <!-- SFSB requires a cache, so we depend on a layer for local infinispan caching.
+             Users can exclude this layer and include ejb-dist-cache to get
+             a distributed cache.  But some cache must be configured. -->
+        <layer name="ejb-local-cache" optional="true"/>
+        <layer name="naming"/>
+    </dependencies>
+    <feature spec="subsystem.discovery"/>
+    <feature spec="subsystem.ejb3">
+        <param name="default-security-domain" value="other"/>
+        <feature spec="subsystem.ejb3.application-security-domain">
+            <param name="application-security-domain" value="other"/>
+            <param name="security-domain" value="ApplicationDomain"/>
+        </feature>
+        <param name="log-system-exceptions" value="true"/>
+        <param name="statistics-enabled" value="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
+        <param name="default-slsb-instance-pool" value="slsb-strict-max-pool"/>
+        <param name="default-singleton-bean-access-timeout" value="5000"/>
+        <param name="default-missing-method-permissions-deny-access" value="true"/>
+        <feature spec="subsystem.ejb3.strict-max-bean-instance-pool">
+            <param name="strict-max-bean-instance-pool" value="slsb-strict-max-pool"/>
+            <param name="derive-size" value="from-worker-pools"/>
+            <param name="timeout" value="5"/>
+            <param name="timeout-unit" value="MINUTES"/>
+        </feature>
+        <param name="default-sfsb-passivation-disabled-cache" value="simple"/>
+        <param name="default-stateful-bean-access-timeout" value="5000"/>
+        <feature spec="subsystem.ejb3.cache">
+            <param name="cache" value="simple"/>
+        </feature>
+        <feature spec="subsystem.ejb3.cache">
+            <param name="cache" value="distributable"/>
+            <param name="passivation-store" value="infinispan"/>
+            <param name="aliases" value="[passivating,clustered]"/>
+        </feature>
+        <feature spec="subsystem.ejb3.passivation-store">
+            <param name="passivation-store" value="infinispan"/>
+            <param name="cache-container" value="ejb"/>
+            <param name="max-size" value="10000"/>
+        </feature>
+        <feature spec="subsystem.ejb3.service.async">
+            <param name="thread-pool-name" value="default"/>
+        </feature>
+        <feature spec="subsystem.ejb3.thread-pool">
+            <param name="thread-pool" value="default"/>
+            <param name="max-threads" value="10"/>
+            <feature spec="subsystem.ejb3.thread-pool.keepalive-time">
+                <param name="time" value="60"/>
+                <param name="unit" value="SECONDS"/>
+            </feature>
+        </feature>
+        <feature spec="subsystem.ejb3.service.timer-service">
+            <param name="default-data-store" value="default-file-store"/>
+            <param name="thread-pool-name" value="default"/>
+            <feature spec="subsystem.ejb3.service.timer-service.file-data-store">
+                <param name="file-data-store" value="default-file-store"/>
+                <param name="path" value="timer-service-data" />
+                <param name="relative-to" value="jboss.server.data.dir" />
+            </feature>
+        </feature>
+    </feature>
+    <feature spec="subsystem.elytron.permission-set.permissions">
+        <param name="subsystem" value="elytron"/>
+        <param name="permission-set" value="default-permissions"/>
+        <param name="module" value="org.jboss.ejb-client"/>
+        <param name="class-name" value="org.jboss.ejb.client.RemoteEJBPermission"/>
+    </feature>
+</layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb-local-cache/layer-spec.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-local-cache">
+    <dependencies>
+        <layer name="transactions"/>
+    </dependencies>
+    <feature spec="subsystem.ejb3">
+        <param name="default-stateful-bean-access-timeout" value="3000"/>
+        <param name="default-sfsb-cache" value="simple"/>
+    </feature>
+    <!-- Infinispan cache configuration used for local SFSB caching -->
+    <feature-group name="infinispan-local-ejb"/>
+    <packages>
+        <!-- The infinispan subsystem doesn't assume ejb3,
+             and ejb3 subysystem doesn't assume clustering, but the
+             combination requires the clustering<->ejb3 integration package -->
+        <package name="org.wildfly.clustering.ejb.infinispan"/>
+    </packages>
+</layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
@@ -4,9 +4,11 @@
     <dependencies>
         <layer name="ejb-lite"/>
         <layer name="resource-adapters"/>
-        <layer name="jms-activemq"/>    <!-- change to messaging-activemq when available -->
+
+        <layer name="messaging-activemq"/>    <!-- change to messaging-activemq when available -->
         <layer name="remoting"/>
         <layer name="undertow"/>
+
     </dependencies>
 
     <feature spec="subsystem.naming">

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/ejb/layer-spec.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb">
+    <!-- Aggregates EJB functionality, excluding ejb-iiop. -->
+    <dependencies>
+        <layer name="ejb-lite"/>
+        <layer name="resource-adapters"/>
+        <layer name="jms-activemq"/>    <!-- change to messaging-activemq when available -->
+        <layer name="remoting"/>
+        <layer name="undertow"/>
+    </dependencies>
+
+    <feature spec="subsystem.naming">
+        <feature spec="subsystem.naming.service.remote-naming"/>
+    </feature>
+    <feature spec="subsystem.ejb3">
+        <param name="default-resource-adapter-name" value="${ejb.resource-adapter-name:activemq-ra.rar}"/>
+        <param name="default-mdb-instance-pool" value="mdb-strict-max-pool"/>
+        <feature spec="subsystem.ejb3.strict-max-bean-instance-pool">
+            <param name="strict-max-bean-instance-pool" value="mdb-strict-max-pool"/>
+            <param name="derive-size" value="from-cpu-count"/>
+            <param name="timeout" value="5"/>
+            <param name="timeout-unit" value="MINUTES"/>
+        </feature>
+        <feature spec="subsystem.ejb3.service.remote">
+            <param name="connectors" value="[http-remoting-connector]"/>
+            <param name="thread-pool-name" value="default"/>
+            <feature spec="subsystem.ejb3.service.remote.channel-creation-options">
+                <param name="channel-creation-options" value="MAX_OUTBOUND_MESSAGES"/>
+                <param name="value" value="1234"/>
+                <param name="type" value="remoting"/>
+            </feature>
+        </feature>
+    </feature>
+</layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/jms-activemq/layer-spec.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="jms-activemq">
     <dependencies>
-        <layer name="transactions"/>
+        <layer name="messaging-activemq"/>
     </dependencies>
-    <feature-group name="jca"/>
-    <feature spec="subsystem.messaging-activemq"/>
 </layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/messaging-activemq/layer-spec.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="messaging-activemq">
+    <dependencies>
+        <layer name="resource-adapters"/>
+    </dependencies>
+    <feature spec="subsystem.messaging-activemq"/>
+</layer-spec>

--- a/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
+++ b/ee-feature-pack/galleon-common/src/main/resources/layers/standalone/remote-activemq/layer-spec.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remote-activemq">
+    <dependencies>
+        <layer name="resource-adapters"/>
+    </dependencies>
+    <feature-group name="messaging-remote-activemq"/>
+    <feature-group name="messaging-remote-sockets"/>
+</layer-spec>

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -1065,13 +1065,51 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <executions>
+                        <executions combine.children="append">
                             <execution>
                                 <id>ts.copy-wildfly</id>
                                 <goals>
                                     <goal>copy-resources</goal>
                                 </goals>
                                 <phase>none</phase>
+                            </execution>
+                            <!-- Copy users and roles config from shared resources. -->
+                            <execution>
+                                <id>ejb-lite.ts.config-as.copy-mgmt-users</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly-ejb-lite/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>../../shared/src/main/resources</directory>
+                                            <includes><include>*.properties</include></includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <!-- Copy users and roles config from shared resources. -->
+                            <execution>
+                                <id>ejb.ts.config-as.copy-mgmt-users</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly-ejb/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>../../shared/src/main/resources</directory>
+                                            <includes><include>*.properties</include></includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -1197,8 +1235,88 @@
                                 </configuration>
                             </execution>
 
+                            <!-- Provision a cloud-profile server with ejb-lite -->
+                            <execution>
+                                <id>ejb-lite-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-ejb-lite</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>cloud-server</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>ejb-lite</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- Provision a cloud-profile server with ejb -->
+                            <execution>
+                                <id>ejb-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-ejb</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-test-galleon-pack</artifactId>
+                                            <version>${ee.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>cloud-server</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-elytron-testsuite</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -1329,6 +1447,186 @@
                                         <include>org/jboss/as/test/integration/security/loginmodules/Ldap*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/jca/moduledeployment/*TestCase.java</include>
                                     </includes>
+                                </configuration>
+                            </execution>
+                            <!-- Tests against the install with ejb-lite -->
+                            <execution>
+                                <id>ejb-lite-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-ejb-lite</jboss.install.dir>
+                                        <jboss.inst>${basedir}/target/wildfly-ejb-lite</jboss.inst>
+                                        <jboss.home>${project.build.directory}/wildfly-ejb-lite</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-ejb-lite</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-ejb-lite</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-ejb-lite</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-ejb-lite/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-ejb-lite</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
+                                    </additionalClasspathElements>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/ejb/annotationprocessing/ResourceAnnotationsProcessingTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/bridgemethods/EjbBridgeMethodsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/descriptor/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/exception/AppExceptionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/injection/compenvbindings/EjbJavaCompBindingTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/injection/duplicate/EjbDuplicateBindingTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/injection/ejb/EjbInjectionSameEjbNameTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/injection/ejbs/EjbsInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/injection/injectiontarget/EjbRefInjectionTargetTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/aroundconstruct/nocreate/AroundConstructNoCreateTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/aroundconstruct/simple/AroundConstructSimpleTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/defaultinterceptor/DefaultInterceptorsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/exception/EjbInterceptorExceptionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/inheritorder/MoreInterceptorInheritanceTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/invocationcontext/InvocationContextTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptorLifecycleSFSBTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/lifecycle/destroy/PreDestroyInterceptorTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/lifecycle/order/PostConstructOrderTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/method/EjbMethodInterceptorTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/interceptor/regex/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/java8/Java8InterfacesEJBTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/localview/EjbLocalViewTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/log/InvalidTransactionAttributeTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/packaging/injection/CrossModuleInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/packaging/jbossall/JBossAllEjbJarTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/remove/RemoveTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/singleton/reentrant/SingletonReentrantTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/singleton/dependson/DependsOnSingletonUnitTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/singleton/creation/SingletonReentrantPostConstructTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/singleton/concurrency/SingletonBeanTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/singleton/concurrency/inheritance/SingletonConcurrencyInheritanceTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/timeout/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/serialization/StatefulSerializationTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/remove/RemoveMethodOnSFSBTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/passivation/store/TwoPassivationStoresTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/locking/reentrant/ReentrantLockTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateful/locking/AccessSerializationTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/stateless/systemexception/SystemExceptionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/aroundtimeout/TimerServiceInterceptorOrderTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/cancelation/TimerServiceCancellationTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/cdi/requestscope/CDIRequestScopeTimerServiceTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/count/ActiveTimerServiceCountTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/expired/ExpiredTimerTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/gettimers/GetTimersTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/overlap/OverlapTimerTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/persistence/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/schedule/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/security/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/serialization/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/simple/SimpleTimerServiceTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/suspend/TimerServiceSuspendTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/tx/retry/TimerRetryTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/view/ViewTimerServiceTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/annotation/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/bmt/BeanManagedTransactionsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/cmt/beforecompletion/BeforeCompletionExceptionDestroysBeanTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/cmt/inheritance/TransactionAttributeTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/cmt/lifecycle/LifecycleMethodTransactionManagementTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/cmt/mandatory/SFSBMandatoryTransactionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/cmt/never/NeverTransactionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/methodparams/TxMethodParamsTest.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/transaction/usertransaction/UserTransactionAccessTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/view/duplicateview/DuplicateViewDefinitionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ejb/view/javapackage/ViewFromJavaPackageTestCase.java</include>
+
+                                        <include>org/jboss/as/test/integration/ee/interceptors/exceptions/ExceptionsFromInterceptorsTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/mappedname/MappedNameInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/ztatic/StaticInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/ejblocalref/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/multipleinterceptors/BindingsOnInterceptorTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/superclass/SuperClassInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/injection/resource/url/URLConnectionFactoryResourceInjectionTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/initializeinorder/InitializeInOrderTestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/datasourcedefinition/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/concurrent/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/ee/altdd/AltDDTestCase.java</include>
+
+                                        <include>org/jboss/as/test/integration/jpa/**/*TestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <!-- JpaJarFileTestCase requires custom hibernate module -->
+                                        <exclude>org/jboss/as/test/integration/jpa/jarfile/JpaJarFileTestCase.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                            <!-- Tests against the install with ejb -->
+                            <execution>
+                                <id>ejb-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-ejb</jboss.install.dir>
+                                        <jboss.inst>${basedir}/target/wildfly-ejb</jboss.inst>
+                                        <jboss.home>${project.build.directory}/wildfly-ejb</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-ejb</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-ejb</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-ejb</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-ejb/modules${path.separator}${basedir}/target/modules</module.path>
+                                        <!-- EJB client library hack, see WFLY-4973-->
+                                        <org.jboss.ejb.client.wildfly-testsuite-hack>true</org.jboss.ejb.client.wildfly-testsuite-hack>
+                                        <elytron>true</elytron>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-ejb</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <additionalClasspathElements>
+                                        <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
+                                    </additionalClasspathElements>
+                                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/ejb/**/*TestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <!-- IIOP is not available -->
+                                        <exclude>org/jboss/as/test/integration/ejb/iiop/**/*TestCase.java</exclude>
+
+                                        <!-- Unable to persist timers in data base -->
+                                        <exclude>org/jboss/as/test/integration/ejb/timerservice/database/*TestCase.java</exclude>
+
+                                        <!-- These tests use legacy security.
+
+                                            Instead of excluding them here, it would be better to work on AssumeTestGroupUtil.assumeElytronProfileEnabled()
+                                            Although we are using elytron=true system property in this surefire execution, this value is not retrieved on
+                                            AssumeTestGroupUtil.assumeElytronProfileEnabled() check, not sure why, maybe because it is RunAsClient?
+                                        -->
+                                        <exclude>org/jboss/as/test/integration/ejb/container/**/SwitchIdentityTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/LdapLegacyTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/RunAsPrincipalCustomDomainTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/GetCallerPrincipalWithNoDefaultSecurityDomainTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/EJBContextMultipleSDTestCase.java</exclude>
+
+                                        <!-- Excluded temporarily because they are using using mdb -->
+                                        <exclude>org/jboss/as/test/integration/ejb/singleton/dependson/mdb/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/mdb/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/pool/**/PooledEJBLifecycleTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/transaction/mdb/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/management/**/EjbInvocationStatisticsTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/management/**/EjbJarInEarRuntimeResourcesTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/management/**/EjbJarRuntimeResourcesTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/MDBRoleTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/GetCallerPrincipalTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/RunAsEjbMdbTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/RunAsMDBUnitTestCase.java</exclude>
+
+                                        <!-- Needs batch jberet -->
+                                        <exclude>org/jboss/as/test/integration/ejb/security/**/RunAsWithElytronEJBContextPropagationTestCase.java</exclude>
+
+                                    </excludes>
                                 </configuration>
                             </execution>
 

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -402,6 +402,58 @@
             <artifactId>wildfly-jaxrs</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- To be able to start a 'remote' broker -->
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-commons</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-journal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-artemis-native</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-ra</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-selector</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-service-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -604,7 +656,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
                         <executions>
                             <execution>
                                 <id>generate-ldap-store</id>
@@ -955,7 +1006,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>${version.exec.plugin}</version>
                         <executions>
                             <!-- There is no similar option as -Dcom.sun.CORBA.ORBUseDynamicStub=true for IBM JDK
                             we need to create stub do it manually with rmic tools -->
@@ -1061,6 +1111,7 @@
             </properties>
             <build>
                 <plugins>
+                    <!-- Copy users and their roles -->
                     <!-- Disable the standard copy-based provisioning -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -1102,6 +1153,42 @@
                                 <inherited>true</inherited>
                                 <configuration>
                                     <outputDirectory>${basedir}/target/wildfly-ejb/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>../../shared/src/main/resources</directory>
+                                            <includes><include>*.properties</include></includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb3-embedded-broker.ts.config-as.copy-mgmt-users</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly-ejb3-embedded-broker/standalone/configuration</outputDirectory>
+                                    <overwrite>true</overwrite>
+                                    <resources>
+                                        <resource>
+                                            <directory>../../shared/src/main/resources</directory>
+                                            <includes><include>*.properties</include></includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb3-remote-broker.ts.config-as.copy-mgmt-users</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <inherited>true</inherited>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/wildfly-ejb3-remote-broker/standalone/configuration</outputDirectory>
                                     <overwrite>true</overwrite>
                                     <resources>
                                         <resource>
@@ -1309,6 +1396,89 @@
                                                 <layer>h2-default-datasource</layer>
                                                 <layer>ejb</layer>
                                                 <layer>ejb-elytron-testsuite</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            
+                            <!-- Provision a cloud-profile server with ejb3 and embedded-broker-->
+                            <execution>
+                                <id>ejb3-embedded-broker-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-ejb3-embedded-broker</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-test-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>cloud-server</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>ejb</layer>
+                                                <layer>embedded-activemq</layer>
+                                                <layer>remote-naming</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <!-- Provision a cloud-profile server with ejb3 and remote Artemis broker-->
+                            <execution>
+                                <id>ejb3-remote-broker-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-ejb3-remote-broker</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-test-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>cloud-server</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>ejb</layer>
+                                                <layer>remote-activemq-cf</layer>
+                                                <layer>remote-naming</layer>
                                             </layers>
                                         </config>
                                     </configurations>
@@ -1660,7 +1830,78 @@
                                     </includes>
                                 </configuration>
                             </execution>
-
+                            <!-- Tests against the install with ejb3 and embedded broker-->
+                            <execution>
+                                <id>ejb3-embedded-broker-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jboss.install.dir>${basedir}/target/wildfly-ejb3-embedded-broker</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-ejb3-embedded-broker</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-ejb3-embedded-broker</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-ejb3-embedded-broker</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-ejb3-embedded-broker</jboss.dist>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-ejb3-embedded-broker/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-ejb3-embedded-broker</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/messaging/**/*TestCase.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                            <!-- Tests against the install with ejb3 and embedded broker-->
+                            <execution>
+                                <id>ejb3-remote-broker-layers.surefire</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <systemPropertyVariables>
+                                        <jmsoperations.implementation.class>org.jboss.as.test.integration.common.jms.RemoteActiveMQProviderJMSOperations</jmsoperations.implementation.class>
+                                        <jboss.install.dir>${basedir}/target/wildfly-ejb3-remote-broker</jboss.install.dir>
+                                        <jboss.home>${project.build.directory}/wildfly-ejb3-remote-broker</jboss.home>
+                                        <jboss.home.dir>${project.build.directory}/wildfly-ejb3-remote-broker</jboss.home.dir>
+                                        <jbossas.dist>${project.build.directory}/wildfly-ejb3-remote-broker</jbossas.dist>
+                                        <jboss.dist>${project.build.directory}/wildfly-ejb3-remote-broker</jboss.dist>
+                                        <artemis.home>${project.build.directory}/artemis</artemis.home>
+                                        <!-- Override the standard module path that points at the shared module set from dist -->
+                                        <module.path>${project.build.directory}/wildfly-ejb3-remote-broker/modules${path.separator}${basedir}/target/modules</module.path>
+                                    </systemPropertyVariables>
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${project.build.directory}/wildfly-ejb3-remote-broker</JBOSS_HOME>
+                                    </environmentVariables>
+                                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                                    <includes>
+                                        <include>org/jboss/as/test/integration/ejb/mdb/**/*TestCase.java</include>
+                                        <include>org/jboss/as/test/integration/messaging/**/*TestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>org/jboss/as/test/integration/messaging/mgmt/**/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/jms/definitions/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/xmldeployment/*TestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/jms/external/DiscoveryGroupExternalMessagingDeploymentTestCase.java</exclude>
+                                        <!-- Security is managed at the broker level -->
+                                        <exclude>org/jboss/as/test/integration/messaging/security/SecurityTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/security/DeserializationBlackListTestCase.java</exclude>
+                                        <exclude>org/jboss/as/test/integration/messaging/jms/deployment/DependentMessagingDeploymentTestCase.java</exclude>
+                                    </excludes>
+                                    <properties>
+                                        <property>
+                                            <name>listener</name>
+                                            <value>org.jboss.as.test.integration.common.jms.ArtemisRunListener</value>
+                                        </property>
+                                    </properties>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
@@ -141,7 +141,7 @@ public class ContainerManagedTransactionNotSupportedTestCase {
                     .send(destination, message);
 
             Message reply = context.createConsumer(replyTo)
-                    .receive(adjust(2000));
+                    .receive(adjust(5000));
             assertNotNull(reply);
             assertEquals(message.getJMSMessageID(), reply.getJMSCorrelationID());
             assertTrue("messageDrivenContext.setRollbackOnly() did not throw the expected IllegalStateException",

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
@@ -27,12 +27,10 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
-import org.jboss.dmr.ModelNode;
 import org.jboss.remoting3.security.RemotingPermission;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -51,6 +49,16 @@ import java.io.FilePermission;
 import java.util.PropertyPermission;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import java.io.IOException;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.api.jms.management.JMSManagementHelper;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Tests EJB2.0 MDBs listening on a topic.
@@ -101,12 +109,12 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
         ejbJar.addClasses(JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "ejb-jar-20-topic.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "jboss-ejb3-topic.xml", "jboss-ejb3.xml");
-        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.jboss.remoting\n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr, org.jboss.remoting, org.apache.activemq.artemis\n"), "MANIFEST.MF");
         ejbJar.addAsManifestResource(createPermissionsXmlAsset(
                 new PropertyPermission("ts.timeout.factor", "read"),
                 new RemotingPermission("createEndpoint"),
                 new RemotingPermission("connect"),
-                new FilePermission(tempDir+"/-", "read")
+                new FilePermission(tempDir + "/-", "read")
         ), "jboss-permissions.xml");
 
         return ejbJar;
@@ -144,15 +152,15 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
     /**
      * Waits given time out in ms for subscription to be created on topic
      *
-     * @param topicCoreName         core name of the topic
+     * @param topicCoreName core name of the topic
      * @param numberOfSubscriptions number of subscriptions
-     * @param timeout               timeout in ms
+     * @param timeout timeout in ms
      * @return true if subscription was created in given timeout, false if not
      * @throws Exception
      */
     private boolean waitUntilAtLeastGivenNumberOfSubscriptionIsCreatedOnTopic(String topicCoreName,
-                                                                              int numberOfSubscriptions,
-                                                                              long timeout) throws Exception {
+            int numberOfSubscriptions,
+            long timeout) throws Exception {
         long startTime = System.currentTimeMillis();
         while (System.currentTimeMillis() - startTime < timeout) {
             if (getNumberOfAllSubscriptions(topicCoreName) >= numberOfSubscriptions) {
@@ -166,11 +174,18 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
     /**
      * Returns number of all subscriptions on topic
      *
-     * @param topicCoreName name of topic
+     * @param topicName name of topic
      * @return number of subscriptions on topic
      * @throws Exception
      */
-    private int getNumberOfAllSubscriptions(String topicCoreName) throws Exception {
+    public int getNumberOfAllSubscriptions(String topicName) throws Exception {
+        if(isRemoteBroker(managementClient)) {
+            return getRemoteNumberOfAllSubscriptions(topicName);
+        }
+        return getEmbeddedNumberOfAllSubscriptions(topicName);
+    }
+
+    private int getEmbeddedNumberOfAllSubscriptions(String topicCoreName) throws Exception {
         ModelNode model = new ModelNode();
         model.get(ClientConstants.OP).set("list-all-subscriptions");
         model.get(ClientConstants.OP_ADDR).add("subsystem", "messaging-activemq");
@@ -179,5 +194,27 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
 
         ModelNode result = managementClient.getControllerClient().execute(model);
         return result.get("result").asList().size();
+    }
+
+    private int getRemoteNumberOfAllSubscriptions(String topicName) throws Exception {
+        QueueRequestor requestor = new QueueRequestor((QueueSession) session, ActiveMQJMSClient.createQueue("activemq.management"));
+        Message m = session.createMessage();
+        org.apache.activemq.artemis.api.jms.management.JMSManagementHelper.putAttribute(m, ResourceNames.ADDRESS + "jms.topic." + topicName, "QueueNames");
+        Message reply = requestor.request(m);
+        if (!reply.getBooleanProperty("_AMQ_OperationSucceeded")) {
+            throw new RuntimeException(reply.getBody(String.class));
+        }
+        Object[] result = (Object[]) JMSManagementHelper.getResult(reply);
+        return result.length;
+    }
+
+    boolean isRemoteBroker(final org.jboss.as.arquillian.container.ManagementClient managementClient) throws IOException {
+        ModelNode addr = new ModelNode();
+        addr.add("socket-binding-group", "standard-sockets");
+        addr.add("remote-destination-outbound-socket-binding", "messaging-activemq");
+        ModelNode op = Operations.createReadResourceOperation(addr, false);
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        final String outcome = response.require("outcome").asString();
+        return "success".equalsIgnoreCase(outcome);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
@@ -109,7 +109,7 @@ public class MDB21TestCase extends AbstractMDB2xTestCase {
     @Test
     public void testSimple21MDB() {
         sendTextMessage("Say hello to " + EJB2xMDB.class.getName(), queue, replyQueue);
-        final Message reply = receiveMessage(replyQueue, TimeoutUtil.adjust(1000));
+        final Message reply = receiveMessage(replyQueue, TimeoutUtil.adjust(5000));
         Assert.assertNotNull("Reply message was null on reply queue: " + replyQueue, reply);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/QueueMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/QueueMDB.java
@@ -46,6 +46,7 @@ public class QueueMDB implements MessageListener {
     @Inject
     private JMSContext context;
 
+    @Override
     public void onMessage(final Message m) {
         try {
             TextMessage message = (TextMessage) m;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/TopicMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/TopicMDB.java
@@ -46,6 +46,7 @@ public class TopicMDB implements MessageListener {
     @Inject
     private JMSContext context;
 
+    @Override
     public void onMessage(final Message m) {
         try {
             TextMessage message = (TextMessage) m;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/LocalTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/LocalTransactionTestCase.java
@@ -33,7 +33,14 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -49,6 +56,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@ServerSetup(LocalTransactionTestCase.SetupTask.class)
 public class LocalTransactionTestCase {
 
     @ArquillianResource
@@ -78,4 +86,18 @@ public class LocalTransactionTestCase {
         assertEquals(allowLocalTransactions, Boolean.valueOf(reply));
     }
 
+    static class SetupTask implements ServerSetupTask{
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            managementClient.getControllerClient().execute(Operations.createWriteAttributeOperation(new ModelNode().add("subsystem", "ee"), "annotation-property-replacement", true));
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            JMSOperations ops = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
+            managementClient.getControllerClient().execute(Operations.createWriteAttributeOperation(new ModelNode().add("subsystem", "ee"), "annotation-property-replacement", ops.isRemoteBroker()));
+        }
+
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/MessagingServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/localtransaction/MessagingServlet.java
@@ -44,7 +44,7 @@ import org.junit.Assert;
 @JMSConnectionFactoryDefinition(
         name="java:module/CF_allow_local_tx",
         properties = {
-                "connectors=in-vm",
+                "connectors=${org.jboss.messaging.default-connector:in-vm}",
                 "allow-local-transactions=true"
         }
 )

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JMSSender.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/naming/JMSSender.java
@@ -15,8 +15,12 @@
  */
 package org.jboss.as.test.integration.messaging.jms.naming;
 
+
+import static javax.ejb.TransactionAttributeType.NOT_SUPPORTED;
+
 import javax.annotation.Resource;
 import javax.ejb.Singleton;
+import javax.ejb.TransactionAttribute;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSConnectionFactoryDefinition;
 import javax.jms.JMSConnectionFactoryDefinitions;
@@ -34,8 +38,8 @@ import javax.jms.Queue;
         @JMSConnectionFactoryDefinition(
             name = "java:app/jms/nonXAconnectionFactory",
             transactional = false,
-             properties = {
-                            "connectors=in-vm",}
+            properties = {
+                "connectors=${org.jboss.messaging.default-connector:in-vm}",}
         )
     }
 )
@@ -47,6 +51,7 @@ public class JMSSender {
     @Resource(lookup = "java:app/jms/queue")
     private Queue queue;
 
+    @TransactionAttribute(NOT_SUPPORTED)
     public void sendMessage(String payload) {
         try (JMSContext context = connectionFactory.createContext()) {
             JMSProducer producer = context.createProducer();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/DeserializationMessagingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/DeserializationMessagingBean.java
@@ -60,14 +60,14 @@ import javax.naming.NamingException;
                         name = "java:comp/env/myBlackListCF",
                         interfaceName = "javax.jms.QueueConnectionFactory",
                         properties = {
-                                "connectors=in-vm",
+                                "connectors=${org.jboss.messaging.default-connector:in-vm}",
                                 "deserialization-black-list=java.util.UUID"
                         }),
                 @JMSConnectionFactoryDefinition(
                         name = "java:comp/env/myWhiteListCF",
                         interfaceName = "javax.jms.QueueConnectionFactory",
                         properties = {
-                                "connectors=in-vm",
+                                "connectors=${org.jboss.messaging.default-connector:in-vm}",
                                 "deserialization-white-list=java.util.UUID"
                         }
                 )

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -1001,6 +1001,83 @@
                                     </configurations>
                                 </configuration>
                             </execution>
+                            <!-- Provision a cloud-server with web-clustering, ejb-dist-cache and jpa-distributed-->
+                            <execution>
+                                <id>cloud-profile-ejb-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${project.build.directory}/wildfly-clustering-ejb</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${full.maven.groupId}</groupId>
+                                            <artifactId>wildfly-galleon-pack</artifactId>
+                                            <version>${full.maven.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                        <feature-pack>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>wildfly-test-galleon-pack</artifactId>
+                                            <version>${project.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <!-- Provision the configuration that the ts.surefire.clustering.ejb-xpc
+                                             surefire execution tests. -->
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone-full-ha.xml</name>
+                                            <excluded-layers>
+                                                <layer>jpa</layer>
+                                                <layer>ejb-local-cache</layer>
+                                            </excluded-layers>
+                                            <layers>
+                                                <layer>jaxrs-server</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                            </layers>
+                                        </config>
+                                        <!-- Also produce a standalone-ha.xml file with the same content
+                                             as standalone-full-ha.xml.
+                                             This doesn't actually get used in any tests we run with this
+                                             profile but the clustering-all.cli script wants to modify it
+                                             so to keep it simple create the file so that doesn't fail.
+                                        -->
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone-ha.xml</name>
+                                            <excluded-layers>
+                                                <layer>jpa</layer>
+                                                <layer>ejb-local-cache</layer>
+                                            </excluded-layers>
+                                            <layers>
+                                                <layer>cloud-server</layer>
+                                                <layer>web-clustering</layer>
+                                                <layer>h2-default-datasource</layer>
+                                                <layer>jpa-distributed</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                     <!-- Update server profile with shared configuration changes -->
@@ -1052,6 +1129,61 @@
                                             <property name="wildfly4" value="wildfly-jpa-dist-4"/>
                                             <property name="wildfly-original" value="wildfly-jpa-dist"/>
                                             <property name="wildfly-load-balancer1" value="wildfly-jpa-dist-load-balancer-1"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Update server profile with shared configuration changes -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>${version.org.wildfly.plugin}</version>
+                        <executions>
+                            <execution>
+                                <id>ts.config-as.configure-wildfly-clustering-ejb</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>execute-commands</goal>
+                                </goals>
+                                <configuration>
+                                    <offline>true</offline>
+                                    <scripts>
+                                        <script>clustering-all.cli</script>
+                                    </scripts>
+                                    <jboss-home>${project.build.directory}/wildfly-clustering-ejb</jboss-home>
+                                    <stdout>${project.build.directory}/wildfly-ejb-xpc-plugin.log</stdout>
+                                    <java-opts>${modular.jdk.args}</java-opts>
+                                    <system-properties>
+                                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                                        <module.path>${project.build.directory}/wildfly-clustering-ejb/modules</module.path>
+                                    </system-properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Copy 4 containers based on the shared configuration and one load balancer profile -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>ts.config-as.clustering.ejb</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <target name="build-clustering"/>
+                                            <property name="wildfly1" value="wildfly-clustering-ejb-1"/>
+                                            <property name="wildfly2" value="wildfly-clustering-ejb-2"/>
+                                            <property name="wildfly3" value="wildfly-clustering-ejb-3"/>
+                                            <property name="wildfly4" value="wildfly-clustering-ejb-4"/>
+                                            <property name="wildfly-original" value="wildfly-clustering-ejb"/>
+                                            <property name="wildfly-load-balancer1" value="wildfly-clustering-ejb-load-balancer-1"/>
                                         </ant>
                                     </target>
                                 </configuration>
@@ -1132,6 +1264,56 @@
                                         <wildfly3>wildfly-jpa-dist-3</wildfly3>
                                         <wildfly4>wildfly-jpa-dist-4</wildfly4>
                                         <wildfly-load-balancer1>wildfly-jpa-dist-load-balancer-1</wildfly-load-balancer1>
+                                        <!-- end required by arquillian.xml -->
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ts.surefire.clustering.ejb</id>
+                                <!-- Disabled by default; other profiles turn it on -->
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <!-- EJB tests -->
+                                        <include>**/ejb/**/*TestCase.java</include>
+                                        <include>**/ejb2/**/*TestCase.java</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>${test-group}/**/byteman/*TestCase.java</exclude>
+                                        <!-- TODO see why these aren't working and fix or exclude with a clear explanation.
+                                             They might require legacy security but why isn't obvious -->
+                                        <exclude>${test-group}/ejb/remote/GlobalAuthContextRemoteStatelessEJBFailoverTestCase.java</exclude>
+                                        <exclude>${test-group}/ejb/remote/ThreadAuthContextRemoteStatelessEJBFailoverTestCase.java</exclude>
+                                    </excludes>
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables>
+                                        <node0>${node0}</node0>
+                                        <node1>${node1}</node1>
+                                        <node2>${node2}</node2>
+                                        <node3>${node3}</node3>
+                                        <mcast>${mcast}</mcast>
+                                        <mcast1>${mcast1}</mcast1>
+                                        <mcast2>${mcast2}</mcast2>
+                                        <mcast3>${mcast3}</mcast3>
+                                        <arquillian.xml>arquillian.xml</arquillian.xml>
+                                        <arquillian.launch>clustering-all</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone-full-ha.xml</jboss.server.config.file.name>
+                                        <!-- Override ${server.jvm.arg} to only include ${jvm.args.ip} but *not* include ${jvm.args.ip.server} -->
+                                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip} ${jvm.args.other} ${jvm.args.timeouts} ${jvm.args.dirs} ${extra.server.jvm.args} -Dnode0=${node0} -Dnode1=${node1} -Dnode2=${node2} -Dnode3=${node3}</server.jvm.args>
+                                        <infinispan.server.home>${project.build.directory}/infinispan-server-${version.org.infinispan.server}</infinispan.server.home>
+                                        <!-- Override the standard module path that points at the shared module set from dist.
+                                        Have all the servers use wildfly-clustering-ejb-1 for the modules -->
+                                        <module.path>${project.build.directory}/wildfly-clustering-ejb-1/modules${path.separator}${basedir}/target/modules</module.path>
+                                        <!-- required by arquillian.xml -->
+                                        <wildfly1>wildfly-clustering-ejb-1</wildfly1>
+                                        <wildfly2>wildfly-clustering-ejb-2</wildfly2>
+                                        <wildfly3>wildfly-clustering-ejb-3</wildfly3>
+                                        <wildfly4>wildfly-clustering-ejb-4</wildfly4>
+                                        <wildfly-load-balancer1>wildfly-clustering-ejb-load-balancer-1</wildfly-load-balancer1>
                                         <!-- end required by arquillian.xml -->
                                     </systemPropertyVariables>
                                 </configuration>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -1732,6 +1732,42 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>remote-activemq-provisioning</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/remote-activemq</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>remote-activemq</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>jpa-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>

--- a/testsuite/layers/pom.xml
+++ b/testsuite/layers/pom.xml
@@ -1362,7 +1362,191 @@
                                     </configurations>
                                 </configuration>
                             </execution>
-                            <execution>   
+                            <execution>
+                                <id>ejb-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/ejb</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>ejb</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb-lite-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/ejb-lite</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>ejb-lite</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb-lite-dist-cache-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/ejb-lite-dist-cache</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>ejb-lite</layer>
+                                                <layer>ejb-dist-cache</layer>
+                                            </layers>
+                                            <excluded-layers>
+                                                <layer>ejb-local-cache</layer>
+                                            </excluded-layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb-dist-cache-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/ejb-dist-cache</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>ejb-dist-cache</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ejb-local-cache-provisioning-test</id>
+                                <goals>
+                                    <goal>provision</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <install-dir>${layers.install.dir}/ejb-local-cache</install-dir>
+                                    <record-state>false</record-state>
+                                    <log-time>${galleon.log.time}</log-time>
+                                    <offline>true</offline>
+                                    <plugin-options>
+                                        <jboss-maven-dist/>
+                                        <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
+                                        <optional-packages>passive+</optional-packages>
+                                    </plugin-options>
+                                    <feature-packs>
+                                        <feature-pack>
+                                            <groupId>${testsuite.ee.galleon.pack.groupId}</groupId>
+                                            <artifactId>${testsuite.ee.galleon.pack.artifactId}</artifactId>
+                                            <version>${testsuite.ee.galleon.pack.version}</version>
+                                            <inherit-configs>false</inherit-configs>
+                                            <inherit-packages>false</inherit-packages>
+                                        </feature-pack>
+                                    </feature-packs>
+                                    <configurations>
+                                        <config>
+                                            <model>standalone</model>
+                                            <name>standalone.xml</name>
+                                            <layers>
+                                                <layer>ejb-local-cache</layer>
+                                            </layers>
+                                        </config>
+                                    </configurations>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>h2-datasource-provisioning</id>
                                 <goals>
                                     <goal>provision</goal>
@@ -2161,6 +2345,8 @@
                                                 <layer>discovery</layer>
                                                 <layer>ee</layer>
                                                 <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-lite</layer>
                                                 <layer>elytron</layer>
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>
@@ -2250,6 +2436,8 @@
                                                 <layer>discovery</layer>
                                                 <layer>ee</layer>
                                                 <layer>ee-security</layer>
+                                                <layer>ejb</layer>
+                                                <layer>ejb-lite</layer>
                                                 <layer>elytron</layer>
                                                 <layer>h2-datasource</layer>
                                                 <layer>h2-default-datasource</layer>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -58,6 +58,10 @@
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.3_spec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.jms</groupId>
+            <artifactId>jboss-jms-api_2.0_spec</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -107,6 +111,30 @@
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-jms-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-server</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-core-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-commons</artifactId>
         </dependency>
     </dependencies>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/ArtemisRunListener.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/ArtemisRunListener.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 Emmanuel Hugonnet (c) 2020 Red Hat, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.common.jms;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.util.concurrent.TimeUnit;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.utils.FileUtil;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.RunListener;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+public class ArtemisRunListener extends RunListener {
+
+    private ActiveMQServer server;
+
+    // Using files may be useful for debugging (through print-data for instance)
+    private static final boolean PERSISTENCE = false;
+
+    public static void main(final String[] args) throws Exception {
+        ArtemisRunListener listener = new ArtemisRunListener();
+        try {
+            listener.startServer();
+
+            System.out.println("Server started, ready to start client test");
+
+            // create the reader before printing OK so that if the test is quick
+            // we will still capture the STOP message sent by the client
+            InputStreamReader isr = new InputStreamReader(System.in);
+            BufferedReader br = new BufferedReader(isr);
+
+            System.out.println("OK");
+
+            String line = br.readLine();
+            if (line != null && "STOP".equals(line.trim())) {
+                listener.stopServer();
+                System.out.println("Server stopped");
+                System.exit(0);
+            } else {
+                // stop anyway but with an error status
+                System.exit(1);
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+            String allStack = t.getCause().getMessage() + "|";
+            StackTraceElement[] stackTrace = t.getCause().getStackTrace();
+            for (StackTraceElement stackTraceElement : stackTrace) {
+                allStack += stackTraceElement.toString() + "|";
+            }
+            System.out.println(allStack);
+            System.out.println("KO");
+            System.exit(1);
+        }
+    }
+
+    private synchronized ActiveMQServer startServer() throws Exception {
+        if (server == null) {
+            Configuration config = new ConfigurationImpl()
+                    .setName("Test-Broker")
+                    .addAcceptorConfiguration("netty", getBrokerUrl())
+                    .setSecurityEnabled(false)
+                    .setPersistenceEnabled(false)
+                    .setJournalFileSize(10 * 1024 * 1024)
+                    .setJournalDeviceBlockSize(4096)
+                    .setJournalMinFiles(2)
+                    .setJournalDatasync(true)
+                    .setJournalPoolFiles(10)
+                    .addConnectorConfiguration("netty", getBrokerUrl());
+            File dataPlace = new File(getArtemisHome());
+
+            FileUtil.deleteDirectory(dataPlace);
+
+            config.setJournalDirectory(new File(dataPlace, "./journal").getAbsolutePath()).
+                    setPagingDirectory(new File(dataPlace, "./paging").getAbsolutePath()).
+                    setLargeMessagesDirectory(new File(dataPlace, "./largemessages").getAbsolutePath()).
+                    setBindingsDirectory(new File(dataPlace, "./bindings").getAbsolutePath()).setPersistenceEnabled(true);
+            server = ActiveMQServers.newActiveMQServer(config, PERSISTENCE);
+            server.getAddressSettingsRepository().addMatch("#", new AddressSettings()
+                    .setDeadLetterAddress(SimpleString.toSimpleString("DLQ"))
+                    .setExpiryAddress(SimpleString.toSimpleString("ExpiryQueue"))
+                    .setRedeliveryDelay(0)
+                    .setMaxSizeBytes(-1)
+                    .setMessageCounterHistoryDayLimit(10)
+                    .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+                    .setAutoCreateQueues(true)
+                    .setAutoCreateAddresses(true)
+                    .setAutoCreateJmsQueues(true)
+                    .setAutoCreateJmsTopics(true));
+            server.getAddressSettingsRepository().addMatch("activemq.management#", new AddressSettings()
+                    .setDeadLetterAddress(SimpleString.toSimpleString("DLQ"))
+                    .setExpiryAddress(SimpleString.toSimpleString("ExpiryQueue"))
+                    .setRedeliveryDelay(0)
+                    .setMaxSizeBytes(-1)
+                    .setMessageCounterHistoryDayLimit(10)
+                    .setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE)
+                    .setAutoCreateQueues(true)
+                    .setAutoCreateAddresses(true)
+                    .setAutoCreateJmsQueues(true)
+                    .setAutoCreateJmsTopics(true));
+            server.start();
+            server.waitForActivation(10, TimeUnit.SECONDS);
+        }
+        return server;
+    }
+
+    @Override
+    public void testRunFinished(Result result) throws Exception {
+        stopServer();
+        super.testRunFinished(result);
+    }
+
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        startServer();
+        super.testRunStarted(description);
+    }
+
+    @Override
+    public void testStarted(Description description) throws Exception {
+        super.testStarted(description);
+    }
+
+    private String getArtemisHome() {
+        String artemisHome = System.getProperty("artemis.dist");
+        if (artemisHome == null) {
+            artemisHome = System.getProperty("artemis.home");
+        }
+        return artemisHome == null ? System.getenv("ARTEMIS_HOME") : artemisHome;
+    }
+
+    private synchronized void stopServer() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+        server = null;
+    }
+
+    private String getBrokerUrl() {
+        return "tcp://" + getServerAddress() + ":" + getServerPort();
+    }
+
+    private String getServerAddress() {
+        String address = System.getProperty("management.address");
+        if (address == null) {
+            address = System.getProperty("node0");
+        }
+        if (address != null) {
+            return formatPossibleIpv6Address(address);
+        }
+        return "localhost";
+    }
+
+    private String formatPossibleIpv6Address(String address) {
+        if (address == null) {
+            return address;
+        }
+        if (!address.contains(":")) {
+            return address;
+        }
+        if (address.startsWith("[") && address.endsWith("]")) {
+            return address;
+        }
+        return "[" + address + "]";
+    }
+
+    private int getServerPort() {
+        //this here is just fallback logic for older testsuite code that wasn't updated to newer property names
+        return Integer.getInteger("artemis.port", 61616);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
@@ -107,6 +107,8 @@ public interface JMSOperations {
 
     void addExternalHttpConnector(String connectorName, String socketBinding, String endpoint);
 
+    void addExternalRemoteConnector(String name, String socketBinding);
+
     void removeExternalHttpConnector(String connectorName);
 
     /**
@@ -121,4 +123,6 @@ public interface JMSOperations {
     void enableMessagingTraces();
 
     void createSocketBinding(String name, String interfaceName, int port);
+
+    boolean isRemoteBroker();
 }

--- a/testsuite/test-feature-pack/src/main/resources/layers/standalone/ejb-elytron-testsuite/layer-spec.xml
+++ b/testsuite/test-feature-pack/src/main/resources/layers/standalone/ejb-elytron-testsuite/layer-spec.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="ejb-elytron-testsuite">
+    <!-- Enables the EJB authentication via HTTP -->
+    <feature spec="subsystem.elytron.http-authentication-factory">
+        <param name="http-authentication-factory" value="ejb-http-authentication"/>
+        <param name="http-server-mechanism-factory" value="global"/>
+        <param name="security-domain" value="ApplicationDomain"/>
+        <param name="mechanism-configurations" value="[{mechanism-name=BASIC}]"/>
+    </feature>
+
+    <feature spec="subsystem.undertow.server">
+        <param name="server" value="default-server" />
+        <feature spec="subsystem.undertow.server.host">
+            <param name="host" value="default-host" />
+            <feature spec="subsystem.undertow.server.host.setting.http-invoker">
+                <param name="http-authentication-factory" value="ejb-http-authentication"/>
+            </feature>
+        </feature>
+    </feature>
+</layer-spec>

--- a/testsuite/test-feature-pack/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
+++ b/testsuite/test-feature-pack/src/main/resources/layers/standalone/embedded-activemq/layer-spec.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="embedded-activemq">
+    <dependencies>
+        <layer name="resource-adapters"/>
+    </dependencies>
+    <feature-group name="messaging-activemq">
+        <feature spec="subsystem.messaging-activemq.server">
+            <param name="server" value="default"/>
+            <param name="elytron-domain" value="ApplicationDomain"/>
+        </feature>
+    </feature-group>
+</layer-spec>

--- a/testsuite/test-feature-pack/src/main/resources/layers/standalone/remote-activemq-cf/layer-spec.xml
+++ b/testsuite/test-feature-pack/src/main/resources/layers/standalone/remote-activemq-cf/layer-spec.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remote-activemq-cf">
+    <dependencies>
+        <layer name="remote-activemq"/>
+    </dependencies>
+    <feature spec="subsystem.messaging-activemq">
+        <feature spec="subsystem.messaging-activemq.connection-factory">
+            <param name="connection-factory" value="RemoteConnectionFactory,"/>
+            <param name="entries" value="[java:/ConnectionFactory,java:jboss/exported/jms/RemoteConnectionFactory]"/>
+            <param name="connectors" value="[artemis]"/>
+        </feature>
+    </feature>
+    <feature spec="system-property">
+        <param name="system-property" value="org.jboss.messaging.default-connector"/>
+        <param name="value" value="artemis"/>
+    </feature>
+    <feature spec="subsystem.ee">
+        <param name="annotation-property-replacement" value="true"/>
+    </feature>
+</layer-spec>

--- a/testsuite/test-feature-pack/src/main/resources/layers/standalone/remote-naming/layer-spec.xml
+++ b/testsuite/test-feature-pack/src/main/resources/layers/standalone/remote-naming/layer-spec.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="remote-naming">
+    <dependencies>
+        <layer name="naming"/>
+    </dependencies>
+    <feature spec="subsystem.naming">
+        <feature spec="subsystem.naming.service.remote-naming"/>
+    </feature>
+</layer-spec>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13771

This is #13527 updated to base on the current rev of #13524. There's a small change in the original commit to reflect the fact that the EJB layer used in the ejb+messaging tests is now called 'ejb-lite' not 'ejb3-lite'
