### PR TITLE
[WFLY-13834]/ [WFLY-18048] Document the new file encoding parameter added to Elytron audit logging. Add test for WFCORE-5106.

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Audit.adoc
+++ b/docs/src/main/asciidoc/_elytron/Audit.adoc
@@ -17,6 +17,7 @@ which captures security events, like successful or unsuccessful login attempts.
 File audit log logs security events into a local file.
 It requires to define `path` to the log file, which can be `relative-to` a system property.
 It also allows to set the file format - human readable `SIMPLE` or `JSON`.
+The encoding used by the audit file can be set using `encoding`. The default value is `UTF-8`. Possible values: `UTF-8`, `UTF-16BE`, `UTF-16LE`, `UTF-16`, `US-ASCII` or `ISO-8859-1`.
 While in WildFly 14 there was only one attribute `synchronized`, which had influence on data reliability, now there is possible more fine grained performance and reliability tunning:
 * `autoflush` defines whether should be output stream flushed after every audit event (guarantees that the log message is passed to the operating system immediately)
 * `synchonized` defines whether should be file descriptor synchronized after every audit event (guarantees that all system buffers are synchronized with the underlying device)

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileAuditLog.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/FileAuditLog.java
@@ -36,6 +36,7 @@ public class FileAuditLog extends AbstractConfigurableElement {
     private final Boolean paramSynchronized;
     private final String path;
     private final String relativeTo;
+    private final String encoding;
 
     private FileAuditLog(Builder builder) {
         super(builder);
@@ -43,6 +44,7 @@ public class FileAuditLog extends AbstractConfigurableElement {
         this.paramSynchronized = builder.paramSynchronized;
         this.path = builder.path;
         this.relativeTo = builder.relativeTo;
+        this.encoding = builder.encoding;
     }
 
     @Override
@@ -61,6 +63,9 @@ public class FileAuditLog extends AbstractConfigurableElement {
         }
         if (isNotBlank(relativeTo)) {
             command.append("relative-to=\"").append(relativeTo).append("\", ");
+        }
+        if (isNotBlank(encoding)) {
+            command.append("encoding=\"").append(encoding).append("\", ");
         }
 
         command.append(")");
@@ -91,6 +96,7 @@ public class FileAuditLog extends AbstractConfigurableElement {
         private String relativeTo;
         private Boolean paramSynchronized;
         private String format;
+        private String encoding;
 
         private Builder() {
         }
@@ -112,6 +118,11 @@ public class FileAuditLog extends AbstractConfigurableElement {
 
         public Builder withFormat(String format) {
             this.format = format;
+            return this;
+        }
+
+        public Builder withEncoding(String encoding) {
+            this.encoding = encoding;
             return this;
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13834

Documentation for https://issues.redhat.com/browse/WFCORE-5106

Requires https://github.com/wildfly/wildfly-core/pull/4319

Issue: https://issues.redhat.com/browse/WFLY-18048

This change depends on:
https://issues.redhat.com/browse/ELY-1211
https://issues.redhat.com/browse/WFCORE-5106