### PR TITLE
[WFLY-13625] Security realms should support specifying the charset and encoding for credentials.

### DIFF
--- a/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
+++ b/docs/src/main/asciidoc/_elytron/Using_the_Elytron_Subsystem.adoc
@@ -33,6 +33,10 @@ user1=Admin
 user2=Guest
 ....
 
+The Properties Realm also supports storing hashed passwords in the properties
+files, namely DIGEST passwords. Learn how to specify the encoding and character set for these passwords
+in the next section.
+
 [[configure-a-properties-realm-in-wildfly]]
 ==== Configure a properties-realm in WildFly:
 
@@ -46,6 +50,23 @@ in the previous step in the _example-users.properties_ file. Also, if
 your properties files are located outside of _jboss.server.config.dir_,
 then you need to change the _path_ and _relative-to_ values
 appropriately.
+
+Additionally, if storing hashed passwords in the properties file, you can specify the following
+attributes:
+
+* `hash-encoding`: This attribute specifies the string format for the password if it is not stored in plain
+text. It is set to ``hex`` encoding by default, but ``base64`` is also supported.
+
+* `hash-charset`: This attribute specifies the character set to use when converting the password string to a
+byte array. It is set to ``UTF-8`` by default.
+
+For example, the following properties realm is configured to use ``base64`` encoding and the character set
+``GB2312``.
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/properties-realm=examplePropRealm:add(groups-attribute=groups,groups-properties={path=example-roles.properties,relative-to=jboss.server.config.dir},users-properties={path=example-users.properties,relative-to=jboss.server.config.dir},hash-encoding=base64,hash-charset=GB2312)
+----
 
 [[configure-a-security-domain]]
 ==== Configure a security-domain:
@@ -319,6 +340,23 @@ connect to the server.
 ----
 /subsystem=elytron/ldap-realm=exampleLR:add(dir-context=exampleDC,identity-mapping={search-base-dn="ou=Users,dc=wildfly,dc=org",rdn-identifier="uid",user-password-mapper={from="userPassword"},attribute-mapping=[{filter-base-dn="ou=Roles,dc=wildfly,dc=org",filter="(&(objectClass=groupOfNames)(member={1}))",from="cn",to="Roles"}]})
 ----
+
+Additionally, if storing hashed passwords in the LDIF file, you can specify the following
+attributes:
+
+* `hash-encoding`: This attribute specifies the string format for the password if it is not stored in plain
+text. It is set to ``base64`` encoding by default, but ``hex`` is also supported.
+
+* `hash-charset`: This attribute specifies the character set to use when converting the password string to a
+byte array. It is set to ``UTF-8`` by default.
+
+For example, the following LDAP realm is storing hexadecimal encoded strings hashed using the `GB2312` character set:
+
+[source,options="nowrap"]
+----
+/subsystem=elytron/ldap-realm=exampleLR:add(dir-context=exampleDC,identity-mapping={...},hash-encoding=hex,hash-charset=GB2312)
+----
+
 
 [[add-a-simple-role-decoder-1]]
 ==== Add a simple-role-decoder:

--- a/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/Filesystem_Security_Realm.adoc
@@ -11,17 +11,23 @@ Every identity is stored in an XML file where the name of the file is the name o
 * `relative-to` If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
 * `levels` The number of levels of directory hashing to apply. When this attribute is set to positive value, filesystem realm will store identities in directory structure where the name of subdirectories will be derived from first characters of identity name. For example, location of identity named "alex" could be `a/l/alex.xml`. This is useful not only because some filesystems can limit the amount of files that can be stored in a single directory, but also for performance reasons, because that might be influenced by the number of entries in a single directory as well. Default value is 2.
 * `encoded` When encoding is set to true, the identity names will be BASE32 encoded before they are used as filenames. This is beneficial, because some filesystems are case-insensitive or might restrict set of characters allowed in a filename. Default value is true.
+* `hash-encoding` specifies the string format for the password if it is not stored in plain text. Set to BASE64 bt default, but HEX is also supported.
+* `hash-charset` specifies the character set to use when converting the password string to a byte array. Set to UTF-8 by default.
 
 Filesystem security realm can be added with WildFly management CLI or with Elytron API.
 
 === WildFly management CLI
 
 The following command creates realm with name `fsRealm` that resides in directory `fs-realm-users` inside the base configuration directory defined by `jboss.server.config.dir` property. The levels number is 2 and encoded value is true.
+The charset is UTF-8 and the string encoding is BASE64.
 
 [source,options="nowrap"]
 ----
 /subsystem=elytron/filesystem-realm=fsRealm:add(path=fs-realm-users, relative-to=jboss.server.config.dir)
 ----
+
+NOTE: Although identities stored within the same realm can be hashed using different algorithms, they are all
+hashed using the same character set and stored using the same string encoding across the whole realm.
 
 To add identity with the name "alex" to this filesystem realm:
 

--- a/docs/src/main/asciidoc/_elytron/components/JDBC_Security_Realm.adoc
+++ b/docs/src/main/asciidoc/_elytron/components/JDBC_Security_Realm.adoc
@@ -30,7 +30,7 @@ A JDBC security realm can be defined as: -
                       clear-password-mapper={password-index=1}}])
 ----
 
-This realm is defined within a single `princpal-query` against the `Identities` datasource.  For the user `test` the result of the query would be: -
+This realm is defined within a single `principal-query` against the `Identities` datasource.  For the user `test` the result of the query would be: -
 
 .Query Results
 [width=25%]
@@ -111,6 +111,26 @@ The `scram-mapper` supports the loading of SCRAM passwords which use both a salt
  * `salt-index` - The index of the column containing the encoded salt.
  * `salt-encoding` - The encoding of the salt, either `base64` or `hex`.
  * `iteration-count-index` - The index of the column containing the iteration count.
+
+
+== Hash Character Sets
+
+The various password mappers allow loading multiples values from the database to hash the client provided password in order
+to compare against the password stored in the database.
+
+The JDBC realm supports specifying the character set via the attribute ``hash-charset`` to use when converting
+the client provided password string to a byte array. This is useful when our database is storing
+hashed passwords using a charset other than ``UTF-8``, as the JDBC realm assumes that is the charset being used by default.
+
+NOTE: Although more than one password mapper can be defined on a single ``principal-query``, only one ``hash-charset``
+can be defined across the whole realm.
+
+For example, the following JDBC realm is configured using the GB2312 charset:
+
+[source,options="nowrap"]
+----
+ /subsystem=elytron/jdbc-realm=exampleDbRealm:add(principal-query=[{sql="SELECT password FROM all_users WHERE user=?",data-source=exampleDS,simple-digest-mapper={algorithm=password-salt-digest-md5,password-index=1}}])
+----
 
 == Using a Hashed Password Representation
 

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/FilesystemRealmTestCase.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.elytron.realm;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Full authentication tests for Elytron Filesystem Realm using hash encoding and
+ * hash charsets.
+ *
+ * @author Sonia Zaldana Calles <szaldana@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({FilesystemRealmTestCase.SetUpTask.class})
+public class FilesystemRealmTestCase {
+
+    private static final String DEPLOYMENT_ENCODED = "filesystemRealmEncoded";
+    private static final String DEPLOYMENT_ENCODED_CHARSET = "filesystemRealmEncodedCharset";
+    private static final String USER = "plainUser";
+    private static final String ENCODED_PASSWORD = "secretPassword";
+    private static final String ENCODED_CHARSET_PASSWORD = "password密码";
+
+
+    @Deployment(name = DEPLOYMENT_ENCODED)
+    public static WebArchive deploymentWithCharset() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_ENCODED + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(FilesystemRealmTestCase.class.getPackage(), "filesystem-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_ENCODED), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = DEPLOYMENT_ENCODED_CHARSET)
+    public static WebArchive deploymentWithCharsetAndEncoded() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_ENCODED_CHARSET + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(FilesystemRealmTestCase.class.getPackage(), "filesystem-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_ENCODED_CHARSET), "jboss-web.xml");
+        return war;
+    }
+
+    /**
+     *
+     * Test Filesystem realm correctly handles a password using a different string format than
+     * base64 when the password is not stored in plain text.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCODED)
+    public void testHexEncodedPassword(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER, ENCODED_PASSWORD, SC_OK);
+    }
+
+    /**
+     *
+     * Test Filesystem realm correctly handles a password using a different character set than UTF-8
+     * and a different string format than base64.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCODED_CHARSET)
+    public void testHexEncodedPasswordAndCharset(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER, ENCODED_CHARSET_PASSWORD, SC_OK);
+    }
+
+    private URL prepareURL(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+    }
+
+    static class SetUpTask implements ServerSetupTask {
+
+        private static final String REALM_NAME_ENCODED = "fsRealmEncoded";
+        private static final String REALM_NAME_ENCODING_CHARSET = "fsRealmEncodingCharset";
+        private static final String DOMAIN_NAME_ENCODED = "fsDomainEncoded";
+        private static final String DOMAIN_NAME_ENCODING_CHARSET = "fsDomainEncodingCharset";
+        private static final String PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY = "global";
+
+
+        @Override
+        public void setup(ManagementClient managementClient, java.lang.String s) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=Roles)");
+            }
+            setUpTestDomain(DOMAIN_NAME_ENCODED, REALM_NAME_ENCODED, "filesystem1", USER, ENCODED_PASSWORD, DEPLOYMENT_ENCODED, "hex", "UTF-8");
+            setUpTestDomain(DOMAIN_NAME_ENCODING_CHARSET, REALM_NAME_ENCODING_CHARSET, "filesystem2", USER, ENCODED_CHARSET_PASSWORD, DEPLOYMENT_ENCODED_CHARSET, "hex", "GB2312");
+            ServerReload.reloadIfRequired(managementClient);
+
+        }
+
+        private void setUpTestDomain(String domainName, String realmName, String path, String username, String password, String deployment, String hashEncoding, String hashCharset) throws Exception {
+            try (CLIWrapper cli =  new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add(path=%s,relative-to=jboss.server.config.dir, hash-encoding=%s, hash-charset=%s)",
+                        realmName, path, hashEncoding, hashCharset));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add-identity(identity=%s)", realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%1$s:set-password(identity=%2$s, digest={algorithm=digest-md5, realm=%1$s, password=%3$s})",
+                        realmName, username, password));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:add-identity-attribute(identity=%s, name=Roles, value=[JBossAdmin])",
+                        realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=from-roles-attribute}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                        domainName, realmName));
+                cli.sendLine(String.format(
+                        "/subsystem=elytron/http-authentication-factory=%1$s:add(http-server-mechanism-factory=%2$s,security-domain=%1$s,"
+                                + "mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=\"%1$s\"}]}])",
+                        domainName, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
+                cli.sendLine(String.format(
+                        "/subsystem=undertow/application-security-domain=%s:add(http-authentication-factory=%s)",
+                        deployment, domainName));
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, java.lang.String s) throws Exception {
+            tearDownDomain(DEPLOYMENT_ENCODED, DOMAIN_NAME_ENCODED, REALM_NAME_ENCODED, USER);
+            tearDownDomain(DEPLOYMENT_ENCODED_CHARSET, DOMAIN_NAME_ENCODING_CHARSET, REALM_NAME_ENCODING_CHARSET, USER);
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:remove()");
+            }
+            ServerReload.reloadIfRequired(managementClient);
+
+        }
+
+        private void tearDownDomain(String deployment, String domainName, String realmName, String username) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", deployment));
+                cli.sendLine(String.format("/subsystem=elytron/http-authentication-factory=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove-identity(identity=%s)", realmName, username));
+                cli.sendLine(String.format("/subsystem=elytron/filesystem-realm=%s:remove()", realmName));
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.java
@@ -63,6 +63,8 @@ import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.servlets.RolePrintingServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
 import org.jboss.as.test.shared.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -86,6 +88,8 @@ import org.junit.runner.RunWith;
 public class LdapRealmTestCase {
 
     private static final String DEPLOYMENT = "ldapRealmDep";
+    private static final String DEPLOYMENT_WITH_CHARSET = "ldapRealmDepCharset";
+    private static final String DEPLOYMENT_HEX_CHARSET = "ldapRealmDepHexCharset";
 
     private static final int LDAP_PORT = 10389;
 
@@ -93,10 +97,13 @@ public class LdapRealmTestCase {
     private static final String USER_WITH_ONE_ROLE = "userWithOneRole";
     private static final String USER_WITH_MORE_ROLES = "userWithMoreRoles";
     private static final String USER_NOT_EXIST = "notExistUser";
+    private static final String USER_WITH_CHARSET = "ssha512UserCharset";
+    private static final String USER_HEX_CHARSET = "cryptUserCharsetHex";
     private static final String EMPTY_USER = "";
     private static final String CORRECT_PASSWORD = "Password1";
     private static final String WRONG_PASSWORD = "WrongPassword";
     private static final String EMPTY_PASSWORD = "";
+    private static final String CHARSET_PASSWORD = "password密码";
 
     static final String[] ALL_TESTED_ROLES = {"TheDuke", "JBossAdmin"};
 
@@ -116,6 +123,26 @@ public class LdapRealmTestCase {
         war.addClasses(RolePrintingServlet.class);
         war.addAsWebInfResource(LdapRealmTestCase.class.getPackage(), "ldap-realm-web.xml", "web.xml");
         war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = DEPLOYMENT_WITH_CHARSET)
+    public static WebArchive deploymentWithCharset() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_WITH_CHARSET + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(LdapRealmTestCase.class.getPackage(), "ldap-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_WITH_CHARSET), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = DEPLOYMENT_HEX_CHARSET)
+    public static WebArchive deploymentEncodedWithCharset() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_HEX_CHARSET + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(LdapRealmTestCase.class.getPackage(), "ldap-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_HEX_CHARSET), "jboss-web.xml");
         return war;
     }
 
@@ -139,6 +166,31 @@ public class LdapRealmTestCase {
     @OperateOnDeployment(DEPLOYMENT)
     public void testCorrectUserCorrectPasswordOneRole(@ArquillianResource URL webAppURL) throws Exception {
         testAssignedRoles(webAppURL, USER_WITH_ONE_ROLE, CORRECT_PASSWORD, "JBossAdmin");
+    }
+
+    /**
+     *
+     * Test LDAP realm correctly handles a password using a different character set to
+     * to use when converting the password string to a byte array.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_WITH_CHARSET)
+    public void testCorrectUserCorrectPasswordWithCharset(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER_WITH_CHARSET, CHARSET_PASSWORD, SC_OK);
+    }
+
+    /**
+     *
+     * Test LDAP realm correctly handles a password using a different character set to
+     * to use when converting the password string to a byte array and hex encoding
+     * as the string format for the password if they are not stored in plain text.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_HEX_CHARSET)
+    public void testCorrectUserCorrectPasswordWithCharsetAndEncoding(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER_HEX_CHARSET, CHARSET_PASSWORD, SC_OK);
     }
 
     /**
@@ -193,6 +245,10 @@ public class LdapRealmTestCase {
         assertAuthenticationFailed(webAppURL, EMPTY_USER, CORRECT_PASSWORD);
     }
 
+    private URL prepareURL(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+    }
+
     private void testAssignedRoles(URL webAppURL, String username, String password, String... assignedRoles) throws Exception {
         final URL rolesPrintingURL = prepareRolesPrintingURL(webAppURL);
         final String rolesResponse = Utils.makeCallWithBasicAuthn(rolesPrintingURL, username, password, SC_OK);
@@ -237,9 +293,13 @@ public class LdapRealmTestCase {
     static class SetupTask implements ServerSetupTask {
 
         private static final String LDAP_REALM_RELATED_CONFIGURATION_NAME = "elytronLdapRealmRelatedConfiguration";
+        private static final String LDAP_REALM_CHARSET_CONFIGURATION_NAME = "elytronLdapRealmCharsetConfiguration";
+        private static final String LDAP_REALM_CHARSET_ENCODED_CONFIGURATION_NAME = "elytronLdapRealmCharsetEncodedConfiguration";
         private static final String PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY = "global";
         private static final String DIR_CONTEXT_NAME = "ldapRealmDirContext";
         private static final String LDAP_REALM_NAME = "simpleLdapRealm";
+        private static final String LDAP_REALM_CHARSET_NAME = "ldapRealmCharset";
+        private static final String LDAP_REALM_ENCODED_CHARSET_NAME = "ldapRealmCharsetEncoded";
 
         @Override
         public void setup(ManagementClient mc, String string) throws Exception {
@@ -248,35 +308,71 @@ public class LdapRealmTestCase {
                 cli.sendLine(String.format(
                         "/subsystem=elytron/dir-context=%s:add(url=\"%s\",principal=\"uid=admin,ou=system\",credential-reference={clear-text=secret})",
                         DIR_CONTEXT_NAME, hostname));
-                cli.sendLine(String.format(
-                        "/subsystem=elytron/ldap-realm=%s:add(dir-context=%s,identity-mapping={rdn-identifier=uid,search-base-dn=\"ou=People,dc=jboss,dc=org\",user-password-mapper={from=userPassword},attribute-mapping=[{filter-base-dn=\"ou=Roles,dc=jboss,dc=org\",filter=\"(member={1})\",from=cn,to=groups}]})",
-                        LDAP_REALM_NAME, DIR_CONTEXT_NAME));
-                cli.sendLine(String.format(
-                        "/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=groups-to-roles}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
-                        LDAP_REALM_RELATED_CONFIGURATION_NAME, LDAP_REALM_NAME));
+            }
+            setUpTestDomain(LDAP_REALM_NAME, LDAP_REALM_RELATED_CONFIGURATION_NAME, DEPLOYMENT);
+            setUpTestDomain(LDAP_REALM_CHARSET_NAME, LDAP_REALM_CHARSET_CONFIGURATION_NAME, DEPLOYMENT_WITH_CHARSET, "GB2312", "base64", false);
+            setUpTestDomain(LDAP_REALM_ENCODED_CHARSET_NAME, LDAP_REALM_CHARSET_ENCODED_CONFIGURATION_NAME, DEPLOYMENT_HEX_CHARSET, "GB2312", "hex", false);
+
+            ServerReload.reloadIfRequired(mc);
+        }
+
+        private void setUpTestDomain(String realmName, String domainName, String deployment) throws Exception {
+            setUpTestDomain(realmName, domainName, deployment, "UTF-8", "base64", true);
+        }
+
+        private void setUpTestDomain(String realmName, String domainName, String deployment, String hashCharset, String hashEncoding, boolean testingRoles) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+
+                if (testingRoles) {
+                    cli.sendLine(String.format(
+                            "/subsystem=elytron/ldap-realm=%s:add(dir-context=%s, hash-charset=%s, hash-encoding=%s, identity-mapping={rdn-identifier=uid,search-base-dn=\"ou=People,dc=jboss,dc=org\",user-password-mapper={from=userPassword}," +
+                                    "attribute-mapping=[{filter-base-dn=\"ou=Roles,dc=jboss,dc=org\",filter=\"(member={1})\",from=cn,to=groups}]})",
+                            realmName, DIR_CONTEXT_NAME, hashCharset, hashEncoding));
+                    cli.sendLine(String.format(
+                            "/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=groups-to-roles}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                            domainName, realmName));
+                } else {
+                    cli.sendLine(String.format(
+                            "/subsystem=elytron/ldap-realm=%s:add(dir-context=%s, hash-charset=%s, hash-encoding=%s, identity-mapping={rdn-identifier=uid,search-base-dn=\"ou=People,dc=jboss,dc=org\",user-password-mapper={from=userPassword}," +
+                                    "attribute-mapping=[{filter-base-dn=\"ou=Roles,dc=jboss,dc=org\",filter=\"(&(objectClass=groupOfNames)(member={1}))\",from=cn,to=Roles}]})",
+                            realmName, DIR_CONTEXT_NAME, hashCharset, hashEncoding));
+
+                    cli.sendLine("/subsystem=elytron/simple-role-decoder=from-roles-attribute:add(attribute=Roles)\n");
+                    cli.sendLine(String.format(
+                            "/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=from-roles-attribute}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                            domainName, realmName));
+                }
+
                 cli.sendLine(String.format(
                         "/subsystem=elytron/http-authentication-factory=%1$s:add(http-server-mechanism-factory=%2$s,security-domain=%1$s,"
-                        + "mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=\"%1$s\"}]}])",
-                        LDAP_REALM_RELATED_CONFIGURATION_NAME, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
+                                + "mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=\"%1$s\"}]}])",
+                        domainName, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
                 cli.sendLine(String.format(
                         "/subsystem=undertow/application-security-domain=%s:add(http-authentication-factory=%s)",
-                        DEPLOYMENT, LDAP_REALM_RELATED_CONFIGURATION_NAME));
+                        deployment, domainName));
             }
-            ServerReload.reloadIfRequired(mc);
         }
 
         @Override
         public void tearDown(ManagementClient mc, String string) throws Exception {
+            tearDownDomain(DEPLOYMENT, LDAP_REALM_RELATED_CONFIGURATION_NAME, LDAP_REALM_NAME);
+            tearDownDomain(DEPLOYMENT_WITH_CHARSET, LDAP_REALM_CHARSET_CONFIGURATION_NAME, LDAP_REALM_CHARSET_NAME);
+            tearDownDomain(DEPLOYMENT_HEX_CHARSET, LDAP_REALM_CHARSET_ENCODED_CONFIGURATION_NAME, LDAP_REALM_ENCODED_CHARSET_NAME);
             try (CLIWrapper cli = new CLIWrapper(true)) {
-                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", DEPLOYMENT));
-                cli.sendLine(String.format("/subsystem=elytron/http-authentication-factory=%s:remove()",
-                        LDAP_REALM_RELATED_CONFIGURATION_NAME));
-                cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()",
-                        LDAP_REALM_RELATED_CONFIGURATION_NAME));
-                cli.sendLine(String.format("/subsystem=elytron/ldap-realm=%s:remove()", LDAP_REALM_NAME));
                 cli.sendLine(String.format("/subsystem=elytron/dir-context=%s:remove()", DIR_CONTEXT_NAME));
             }
             ServerReload.reloadIfRequired(mc);
+        }
+
+        private void tearDownDomain(String deployment, String domainName, String realmName) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", deployment));
+                cli.sendLine(String.format("/subsystem=elytron/http-authentication-factory=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/ldap-realm=%s:remove()", realmName));
+            }
         }
 
     }

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.ldif
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/LdapRealmTestCase.ldif
@@ -21,6 +21,26 @@ sn: One Role
 uid: userWithOneRole
 userPassword: Password1
 
+dn: uid=ssha512UserCharset,ou=People,dc=jboss,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+cn: ssha512UserCharset
+sn: ssha512UserCharset
+uid: ssha512UserCharset
+userPassword:: e3NzaGE1MTJ9QUcvNmJGQWZFbmhiZUl3UHdjWjg4TjVkeEhMZGR2VXUxeEhVTlRXMXFqaTNuc0VmWGNQV3BZcVFib2NhRmh3cnpaUUc5OEhla0dMY1NMN09WTEowNEkzM0Y5anRaamRxMzRQemVRdGFHTG89
+# Password password密码 using a the GB2312 character set
+
+dn: uid=cryptUserCharsetHex,ou=People,dc=jboss,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+cn: cryptUserCharsetHex
+sn: cryptUserCharsetHex
+uid: cryptUserCharsetHex
+userPassword: {crypt}XQ8317569289fa78a2
+# Password password密码 using a the GB2312 character set
+
 dn: uid=userWithoutRole,ou=People,dc=jboss,dc=org
 objectClass: top
 objectClass: person
@@ -42,6 +62,8 @@ cn: JBossAdmin
 description: the JBossAdmin group
 member: uid=userWithMoreRoles,ou=People,dc=jboss,dc=org
 member: uid=userWithOneRole,ou=People,dc=jboss,dc=org
+member: uid=ssha512UserCharset,ou=People,dc=jboss,dc=org
+member: uid=cryptUserCharsetHex,ou=People,dc=jboss,dc=org
 
 dn: cn=TheDuke,ou=Roles,dc=jboss,dc=org
 objectClass: groupOfNames

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/PropertiesRealmTestCase.java
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/PropertiesRealmTestCase.java
@@ -1,0 +1,167 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.integration.elytron.realm;
+
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.SimpleSecuredServlet;
+import org.jboss.as.test.integration.security.common.servlets.SimpleServlet;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Full authentication tests for Elytron Property realm using hash encoding and
+ * hash charsets.
+ *
+ * @author Sonia Zaldana Calles <szaldana@redhat.com>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({PropertiesRealmTestCase.SetUpTask.class})
+public class PropertiesRealmTestCase {
+
+    private static final String DEPLOYMENT_ENCODED = "propRealmEncoded";
+    private static final String DEPLOYMENT_WITH_CHARSET_ENCODED = "propRealmEncodedCharset";
+    private static final String USER_ENCODED = "elytron";
+    private static final String USER_WITH_CHARSET_ENCODED = "elytron4";
+    private static final String CHARSET_PASSWORD = "password密码";
+    private static final String ENCODED_PASSWORD = "passwd12#$";
+
+    @Deployment(name = DEPLOYMENT_ENCODED)
+    public static WebArchive deploymentWithCharset() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_ENCODED + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(PropertiesRealmTestCase.class.getPackage(), "property-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_ENCODED), "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = DEPLOYMENT_WITH_CHARSET_ENCODED)
+    public static WebArchive deploymentWithCharsetAndEncoded() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_WITH_CHARSET_ENCODED + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addClasses(SimpleSecuredServlet.class);
+        war.addAsWebInfResource(PropertiesRealmTestCase.class.getPackage(), "property-realm-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset(DEPLOYMENT_WITH_CHARSET_ENCODED), "jboss-web.xml");
+        return war;
+    }
+
+    /**
+     *
+     * Test Properties realm correctly handles a password using a different character set than
+     * UTF-8 when converting the password string to a byte array.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_ENCODED)
+    public void testCorrectUserCorrectPasswordWithAlternativeCharset(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER_ENCODED, ENCODED_PASSWORD, SC_OK);
+    }
+
+    /**
+     *
+     * Test Properties realm correctly handles a password using a different character set to
+     * and base64 encoding as the string format for the password if they are not stored in plain text.
+     */
+    @Test
+    @OperateOnDeployment(DEPLOYMENT_WITH_CHARSET_ENCODED)
+    public void testCorrectUserCorrectPasswordBase64Encoded(@ArquillianResource URL webAppURL) throws Exception {
+        URL url = prepareURL(webAppURL);
+        Utils.makeCallWithBasicAuthn(url, USER_WITH_CHARSET_ENCODED, CHARSET_PASSWORD, SC_OK);
+    }
+
+    private URL prepareURL(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm() + SimpleSecuredServlet.SERVLET_PATH.substring(1));
+    }
+
+    static class SetUpTask implements ServerSetupTask {
+
+        private static final String REALM_NAME_ENCODED = "propRealmEncoded";
+        private static final String REALM_NAME_ENCODING_CHARSET = "propRealmEncodingCharset";
+        private static final String DOMAIN_NAME_ENCODED = "propDomainEncoded";
+        private static final String DOMAIN_NAME_ENCODING_CHARSET = "propDomainEncodingCharset";
+        private static final String PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY = "global";
+
+
+        @Override
+        public void setup(ManagementClient managementClient, java.lang.String s) throws Exception {
+            setUpTestDomain(DOMAIN_NAME_ENCODED, REALM_NAME_ENCODED, DEPLOYMENT_ENCODED, "users-hashedbase64.properties", "base64", "UTF-8");
+            setUpTestDomain(DOMAIN_NAME_ENCODING_CHARSET, REALM_NAME_ENCODING_CHARSET, DEPLOYMENT_WITH_CHARSET_ENCODED, "users-hashedbase64charset", "base64", "GB2312");
+            ServerReload.reloadIfRequired(managementClient);
+
+        }
+
+        private void setUpTestDomain(String domainName, String realmName, String deployment, String fileName, String hashEncoding, String hashCharset) throws Exception {
+            try (CLIWrapper cli =  new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=elytron/properties-realm=%s:add(groups-attribute=groups, user-properties={path=%s, relative-to=jboss.server.config.dir}, " +
+                                "hash-encoding=%s, hash-charset=%s)",
+                        realmName, fileName, hashEncoding, hashCharset));
+
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%1$s:add(realms=[{realm=%2$s,role-decoder=groups-to-roles}],default-realm=%2$s,permission-mapper=default-permission-mapper)",
+                        domainName, realmName));
+                cli.sendLine(String.format(
+                        "/subsystem=elytron/http-authentication-factory=%1$s:add(http-server-mechanism-factory=%2$s,security-domain=%1$s,"
+                                + "mechanism-configurations=[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=\"%1$s\"}]}])",
+                        domainName, PREDEFINED_HTTP_SERVER_MECHANISM_FACTORY));
+                cli.sendLine(String.format(
+                        "/subsystem=undertow/application-security-domain=%s:add(http-authentication-factory=%s)",
+                        deployment, domainName));
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, java.lang.String s) throws Exception {
+            tearDownDomain(DEPLOYMENT_ENCODED, DOMAIN_NAME_ENCODED, REALM_NAME_ENCODED);
+            tearDownDomain(DEPLOYMENT_WITH_CHARSET_ENCODED, DOMAIN_NAME_ENCODING_CHARSET, REALM_NAME_ENCODING_CHARSET);
+            ServerReload.reloadIfRequired(managementClient);
+
+        }
+
+        private void tearDownDomain(String deployment, String domainName, String realmName) throws Exception {
+            try (CLIWrapper cli = new CLIWrapper(true)) {
+                cli.sendLine(String.format("/subsystem=undertow/application-security-domain=%s:remove()", deployment));
+                cli.sendLine(String.format("/subsystem=elytron/http-authentication-factory=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/security-domain=%s:remove()",
+                        domainName));
+                cli.sendLine(String.format("/subsystem=elytron/properties-realm=%s:remove()", realmName));
+            }
+        }
+    }
+}

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/filesystem-realm-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/filesystem-realm-web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Test realm</realm-name>
+    </login-config>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>secured-area</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>JBossAdmin</role-name>
+    </security-role>
+
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/property-realm-web.xml
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/property-realm-web.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+
+    <login-config>
+        <auth-method>BASIC</auth-method>
+        <realm-name>Test realm</realm-name>
+    </login-config>
+
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>secured-area</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+
+    <security-role>
+        <role-name>JBossAdmin</role-name>
+    </security-role>
+    <security-role>
+        <role-name>TheDuke</role-name>
+    </security-role>
+
+</web-app>

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/users-hashedbase64.properties
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/users-hashedbase64.properties
@@ -1,0 +1,5 @@
+# base64 encoded md5 digest
+elytron=xYiGNlT4htHKrk2K9HEHtw==
+
+#$REALM_NAME=ManagementRealm$ This line is used by the add-user utility to identify the realm name already used in this file.
+#

--- a/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/users-hashedbase64charset.properties
+++ b/testsuite/integration/elytron/src/test/java/org/wildfly/test/integration/elytron/realm/users-hashedbase64charset.properties
@@ -1,0 +1,4 @@
+# GB2312 base64 for elytron4:ManagementRealm:password密码 (md5 digest)
+elytron4=FhTiDAL0ah2hRAafF4IJoQ==
+
+#$REALM_NAME=ManagementRealm$ This line is used by the add-user utility to identify the realm name already used in this file.

--- a/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/JdbcSecurityRealm.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/security/common/elytron/JdbcSecurityRealm.java
@@ -40,11 +40,13 @@ public class JdbcSecurityRealm implements SecurityRealm {
     private final PathAddress address;
     private final String name;
     private final List<ModelNode> principalQueries;
+    private final String hashCharset;
 
-    JdbcSecurityRealm(final String name, final List<ModelNode> principalQueries) {
+    JdbcSecurityRealm(final String name, final List<ModelNode> principalQueries, String hashCharset) {
         this.name = name;
         this.address = PathAddress.pathAddress(PathElement.pathElement("subsystem", "elytron"), PathElement.pathElement("jdbc-realm", name));
         this.principalQueries = principalQueries;
+        this.hashCharset = hashCharset;
     }
 
     @Override
@@ -55,6 +57,7 @@ public class JdbcSecurityRealm implements SecurityRealm {
     public ModelNode getAddOperation() {
         ModelNode addOperation = Util.createAddOperation(address);
         addOperation.get("principal-query").set(principalQueries);
+        addOperation.get("hash-charset").set(hashCharset);
 
         return addOperation;
     }
@@ -152,6 +155,7 @@ public class JdbcSecurityRealm implements SecurityRealm {
 
         private final String name;
         private List<ModelNode> queries = new ArrayList<>();
+        private String hashCharset;
 
         Builder(final String name) {
             this.name = name;
@@ -167,8 +171,14 @@ public class JdbcSecurityRealm implements SecurityRealm {
             return this;
         }
 
+        public Builder withHashCharset(String hashCharset) {
+            this.hashCharset = hashCharset;
+
+            return this;
+        }
+
         public SecurityRealm build() {
-            return new JdbcSecurityRealm(name, queries);
+            return new JdbcSecurityRealm(name, queries, hashCharset != null ? hashCharset : "UTF-8");
         }
 
     }


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/WFLY-13625

Requires: https://issues.redhat.com/browse/WFCORE-5027
WildFly Core PR with tests: https://github.com/wildfly/wildfly-core/pull/4324