### PR TITLE
[WFLY-13841] Check the compressed size of JDR test case Zip entries t…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jdr/mgmt/JdrReportManagmentTestCase.java
@@ -180,7 +180,7 @@ public class JdrReportManagmentTestCase {
     private void validateEntryNotEmpty(String fileName, String fileNameOptional, Set<String> fileNames,
                                        String reportName, ZipFile reportZip) {
         ZipEntry zipENtry = getZipEntry(reportZip, fileName, fileNameOptional, fileNames, reportName);
-        assertTrue("Report entry " + fileName + " was empty or could not be determined", zipENtry.getSize() > 0);
+        assertTrue("Report entry " + fileName + " was empty or could not be determined", zipENtry.getSize() > 0 || zipENtry.getCompressedSize() > 0);
     }
 
     /**
@@ -227,6 +227,6 @@ public class JdrReportManagmentTestCase {
      */
     private void validateEmptyEntry(String fileName, Set<String> fileNames, String reportName, ZipFile reportZip) {
         ZipEntry zipEntry = getZipEntry(reportZip, fileName, null, fileNames, reportName);
-        assertFalse("Report entry " + fileName + " should be empty", zipEntry.getSize() > 0);
+        assertFalse("Report entry " + fileName + " should be empty", zipEntry.getSize() > 0 || zipEntry.getCompressedSize() > 0);
     }
 }


### PR DESCRIPTION
…o validate its size

Jira issue: https://issues.redhat.com/browse/WFLY-13841

Intermittently [ZipEntry.getSize()](https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipEntry.html#getSize--) is not returning the size of the ZipEntry. This patch tries to use the [ZipEntry. getCompressedSize()](https://docs.oracle.com/javase/8/docs/api/java/util/zip/ZipEntry.html#getCompressedSize--) as a second opportunity to verify if the entry is empty.

I've been unable to identify exactly the reason why sometimes it does not returns the size, but this patch fixed the executions in my local envrionement.
