### PR TITLE
[WFLY-13839] Undertow https-listerner does not generate required capability

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
@@ -25,11 +25,9 @@ package org.wildfly.extension.undertow;
 import io.undertow.UndertowOptions;
 import io.undertow.protocols.http2.Http2Channel;
 
-import io.undertow.server.handlers.ChannelUpgradeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -47,11 +45,6 @@ import java.util.List;
  * @author Richard Achmatowicz (c) 2020 Red Hat Inc.
  */
 public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
-
-    static final RuntimeCapability<Void> HTTP_UPGRADE_REGISTRY_CAPABILITY =
-            RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HTTP_UPGRADE_REGISTRY, true, ChannelUpgradeHandler.class)
-            .setAllowMultipleRegistrations(true)
-            .build();
 
     protected static final HttpListenerResourceDefinition INSTANCE = new HttpListenerResourceDefinition();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
@@ -57,7 +57,7 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
 
     protected static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(Constants.SSL_CONTEXT, ModelType.STRING, false)
             .setAlternatives(Constants.SECURITY_REALM, Constants.VERIFY_CLIENT, Constants.ENABLED_CIPHER_SUITES, Constants.ENABLED_PROTOCOLS, Constants.SSL_SESSION_CACHE_SIZE, Constants.SSL_SESSION_TIMEOUT)
-            .setCapabilityReference(REF_SSL_CONTEXT)
+            .setCapabilityReference(LISTENER_CAPABILITY, REF_SSL_CONTEXT)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setValidator(new StringLengthValidator(1))
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SSL_REF)
@@ -119,7 +119,8 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
             .setDeprecated(ModelVersion.create(4, 0, 0)).setMeasurementUnit(MeasurementUnit.SECONDS).setRequired(false).setAllowExpression(true).setAlternatives(Constants.SSL_CONTEXT).build();
 
     private HttpsListenerResourceDefinition() {
-        super(new Parameters(UndertowExtension.HTTPS_LISTENER_PATH, UndertowExtension.getResolver(Constants.LISTENER)));
+        super(new Parameters(UndertowExtension.HTTPS_LISTENER_PATH, UndertowExtension.getResolver(Constants.LISTENER))
+                .setCapabilities(HTTP_UPGRADE_REGISTRY_CAPABILITY));
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -38,6 +38,7 @@ import java.util.Map;
 
 import io.undertow.UndertowOptions;
 import io.undertow.server.ConnectorStatistics;
+import io.undertow.server.handlers.ChannelUpgradeHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
@@ -76,6 +77,12 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             //.addDynamicRequirements(Capabilities.CAPABILITY_SERVER) -- has no function so don't use it
             .setAllowMultipleRegistrations(true) //hack to support mod_cluster's legacy profiles
             .build();
+
+    // only used by the subclasses Http(s)ListenerResourceDefinition
+    protected static final RuntimeCapability<Void> HTTP_UPGRADE_REGISTRY_CAPABILITY = RuntimeCapability.Builder.of(Capabilities.CAPABILITY_HTTP_UPGRADE_REGISTRY, true, ChannelUpgradeHandler.class)
+            .setAllowMultipleRegistrations(true)
+            .build();
+
     protected static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(Constants.SOCKET_BINDING, ModelType.STRING)
             .setRequired(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)


### PR DESCRIPTION
This PR does the following:
- adds a capability org.wildfly.undrtow.listener.http-upgrade-registry to Undertow's https-listener to represent the ChannelUpgradeHandler service used by HTTP Upgrade
- fixes an issue with a capability reference for the attribute ssl-context in the HttpsListenerResourceDefinition

For more details, see:  https://issues.redhat.com/browse/WFLY-13839
