### PR TITLE
[WFLY-13842]:Upgrade jbossws-cxf to 5.4.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,9 +419,9 @@
         <version.org.jboss.weld.weld-api>3.1.SP3</version.org.jboss.weld.weld-api>
         <version.org.jboss.weld.se.weld-se-core>3.0.5.Final</version.org.jboss.weld.se.weld-se-core>
         <version.org.jboss.ws.api>1.1.2.Final</version.org.jboss.ws.api>
-        <version.org.jboss.ws.common>3.3.0.Final</version.org.jboss.ws.common>
+        <version.org.jboss.ws.common>3.3.2.Final</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.3.2.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>5.4.1.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>5.4.2.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>3.3.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.9.Final</version.org.jboss.xnio.netty.netty-xnio-transport>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13842
Upgrade jbossws-common to 3.3.2.Final and jbossws-cxf to 5.4.2.Final
