### PR TITLE
[WFLY-12574] Documentation for SSH Authentication for Git persistence And BouncyCastle modules update

### DIFF
--- a/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/Galleon_provisioning.adoc
@@ -207,6 +207,7 @@ Basic layers:
 * _deployment-scanner_: Support for deployment directory scanning.
 * _discovery_: Support for discovery.
 * _elytron_: Support for Elytron security.
+*._git-history_: Support for using _git_ for configuration history.
 * _io_: Support for XNIO workers and buffer pools.
 * _jmx_: Support for registration of Management Model MBeans.
 * _jmx-remoting_: Support for registration of Management Model MBeans and a JMX remoting connector.

--- a/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
+++ b/docs/src/main/asciidoc/_admin-guide/management-tasks/Configuration_file_git_history.adoc
@@ -124,3 +124,142 @@ You may need to push your repository changes to a remote repository so you can s
 [standalone@localhost:9990 /] :publish-configuration(location="origin")
 {"outcome" => "success"}
 ----
+
+[[ssh_auth]]
+== SSH Authentication
+
+Users may also connect to an SSH git server. In order to connect to any SSH git server to manage your configuration file history, you must use an Elytron configuration
+file to specify your SSH credentials. The following example shows how to specify an SSH url and a `wildfly-config.xml` file
+containing SSH credentials:
+
+[source,options="nowrap"]
+----
+./standalone.sh --git-repo=git@github.com:wildfly/wildfly-config.git --git-auth=file:///home/user/github-wildfly-config.xml
+----
+
+
+There are a number of ways to specify your SSH credentials in the `wildfly-config.xml` file:
+
+=== SSH Key Location Credential
+
+It is possible to reference a file containing your SSH keys as follows:
+
+[source,xml,options="nowrap"]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.6">
+        <authentication-rules>
+            <rule use-configuration="test-login">
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="test-login">
+                <credentials>
+                    <ssh-credential ssh-directory="/home/user/git-persistence/" private-key-file="id_ec_test" known-hosts-file="known_hosts">
+                        <clear-password password="secret"/>
+                    </ssh-private-key>
+                </credentials>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>
+----
+This configuration indicates that the private key to be used for SSH authentication is in the file `id_ec_test` in the
+directory `/home/user/git-persistence` and the passphrase "secret" is needed to decrypt the key.
+
+The `ssh-credential` accepts the following attributes:
+
+* `ssh-directory` - the path to the directory containing the private key file and the known hosts file. The default value
+is `[user.home]/.ssh`.
+* `private-key-file` - the name of the file containing the private key. The default private key file names used are: `id_rsa`,
+`id_dsa`, and `id_ecdsa`.
+* `known-hosts-file` - the name of the file containing the known SSH hosts you trust. The default value is `known_hosts`
+
+One of the following child elements may also be used to specify the passphrase to be used to decrypt the private key (if applicable):
+[source,xml,options="nowrap"]
+----
+<ssh-credential ...>
+    <credential-store-reference store="..." alias="..." clear-text="..." />
+    <clear-password password="..." />
+    <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
+</ssh-credential>
+----
+
+=== Key Pair Credential
+
+It is also possible to specify your SSH credentials as a KeyPairCredential as follows:
+[source,xml,options="nowrap"]
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <authentication-client xmlns="urn:elytron:client:1.6">
+        <authentication-rules>
+            <rule use-configuration="test-login">
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="test-login">
+                <credentials>
+                    <key-pair>
+                        <openssh-private-key pem="-----BEGIN OPENSSH PRIVATE KEY-----
+                        b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABCdRswttV
+                        UNQ6nKb6ojozTGAAAAEAAAAAEAAABoAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlz
+                        dHAyNTYAAABBBAKxnsRT7n6qJLKoD3mFfAvcH5ZFUyTzJVW8t60pNgNaXO4q5S4qL9yCCZ
+                        cKyg6QtVgRuVxkUSseuR3fiubyTnkAAADQq3vrkvuSfm4n345STr/i/29FZEFUd0qD++B2
+                        ZoWGPKU/xzvxH7S2GxREb5oXcIYO889jY6mdZT8LZm6ZZig3rqoEAqdPyllHmEadb7hY+y
+                        jwcQ4Wr1ekGgVwNHCNu2in3cYXxbrYGMHc33WmdNrbGRDUzK+EEUM2cwUiM7Pkrw5s88Ff
+                        IWI0V+567Ob9LxxIUO/QvSbKMJGbMM4jZ1V9V2Ti/GziGJ107CBudZr/7wNwxIK86BBAEg
+                        hfnrhYBIaOLrtP8R+96i8iu4iZAvcIbQ==
+                        -----END OPENSSH PRIVATE KEY-----">
+                            <clear-password password="secret"/>
+                        </openssh-private-key>
+                    </key-pair>
+                </credentials>
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>
+----
+
+Along with the `key-pair` credential, if your known SSH hosts are not in `~/.ssh/known_hosts`, you should specify an `ssh-credential`
+with the `ssh-directory` and `known-hosts-file` attributes defined to specify the location and name of your known hosts file.
+
+When specifying keys in OpenSSH format, it is only necessary to specify the private key and the public key will be parsed
+from the private key string. When specifying key pairs in PKCS format, it is necessary to specify both the private and
+public keys using the following elements:
+
+[source,xml,options="nowrap"]
+----
+<key-pair>
+    <private-key-pem>-----BEGIN PRIVATE KEY-----
+                     MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgj+ToYNaHz/pISg/Z
+                     I9BjdhcTre/SJpIxASY19XtOV1ehRANCAASngcxUTBf2atGC5lQWCupsQGRNwwnK
+                     6Ww9Xt37SmaHv0bX5n1KnsAal0ykJVKZsD0Z09jVF95jL6udwaKpWQwb
+                     -----END PRIVATE KEY-----</private-key>
+    <public-key-pem>-----BEGIN PUBLIC KEY-----
+                     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEp4HMVEwX9mrRguZUFgrqbEBkTcMJ
+                     yulsPV7d+0pmh79G1+Z9Sp7AGpdMpCVSmbA9GdPY1RfeYy+rncGiqVkMGw==
+                     -----END PUBLIC KEY-----</public-key>
+</key-pair>
+----
+
+When using a key pair credential in OpenSSH format, it is also possible to specify a passphrase to be used to decrypt
+the private key:
+[source,xml,options="nowrap"]
+----
+<openssh-private-key pem="...">
+    <credential-store-reference store="..." alias="..." clear-text="..." />
+    <clear-password password="..." />
+    <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
+</ssh-private-key-file>
+----
+
+When using PKCS formatted keys, the keys should not be encrypted with a passphrase
+
+=== Credential Store Reference
+
+It is possible to specify your SSH credentials as a reference to a credential store entry.
+See: https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#adding-a-credential[Adding a Credential]
+to a credential store and https://github.com/wildfly/wildfly/blob/master/docs/src/main/asciidoc/_elytron/Credential_Store.adoc#referencing-credentials[Referencing Credentials]
+stored in a credential store.

--- a/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
+++ b/docs/src/main/asciidoc/_client-guide/authentication-client.adoc
@@ -81,7 +81,15 @@ The <protection-paramter-credentials /> element can contain one more more child 
     <credential-store-reference store="..." alias="..." clear-text="..." />
     <clear-password password="..." />
     <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
-    <key-pair public-key-pem="..." private-key-pem="..." />
+    <key-pair>
+        <public-key-pem>...</public-key-pem>
+        <private-key-pem>...</public-key-pem>
+        <openssh-private-key pem="...">
+            <credential-store-reference store="..." alias="..." clear-text="..." />
+            <clear-password password="..." />
+            <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
+        </openssh-private-key>
+    </key-pair>
     <certificate private-key-pem="..." pem="..." />
     <public-key-pem>...</public-key-pem>
     <bearer-token value="..." />
@@ -350,7 +358,20 @@ The content of this element is the same as documented for [<protection-parameter
     <credential-store-reference store="..." alias="..." clear-text="..." />
     <clear-password password="..." />
     <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
-    <key-pair public-key-pem="..." private-key-pem="..." />
+    <key-pair>
+        <public-key-pem>...</public-key-pem>
+        <private-key-pem>...</public-key-pem>
+        <openssh-private-key pem="...">
+            <credential-store-reference store="..." alias="..." clear-text="..." />
+            <clear-password password="..." />
+            <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
+        </openssh-private-key>
+    </key-pair>
+    <ssh-credential ssh-directory="..." private-key-file="..." known-hosts-file="...">
+        <credential-store-reference store="..." alias="..." clear-text="..." />
+        <clear-password password="..." />
+        <masked-password algorithm="..." key-material="..." iteration-count="..." salt="..." masked-password="..." initialization-vector="..." />
+    </ssh-credential>
     <certificate private-key-pem="..." pem="..." />
     <public-key-pem>...</public-key-pem>
     <bearer-token value="..." />

--- a/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
+++ b/docs/src/main/asciidoc/_elytron/Credential_Store.adoc
@@ -82,6 +82,64 @@ Confirm secret to store:
 Alias "example" has been successfully stored
 ----
 
+===== Adding KeyPairCredentials
+
+The following command allows you to import a key pair credential with an alias of `example` from a file containing
+a private key in OpenSSH format:
+[source,options="nowrap"]
+----
+]$ bin/elytron-tool.sh credential-store --import-key-pair example --private-key-location /home/user/.ssh/id_rsa --location=standalone/configuration/mycredstore.cs
+Credential store password:
+Confirm credential store password:
+Passphrase to be used to decrypt private key (can be nothing if no passphrase was used to encrypt the key): secret
+Confirm passphrase to be used to decrypt private key (can be nothing if no passphrase was used to encrypt the key): secret
+Alias "example" has been successfully stored
+----
+
+The following command allows you to import a key pair credential with an alias of `example` by specifying a private key in OpenSSH format :
+[source,options="nowrap"]
+----
+]$ bin/elytron-tool.sh credential-store --import-key-pair example --private-key-string="-----BEGIN OPENSSH PRIVATE KEY-----
+                                                   b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABCdRswttV
+                                                   UNQ6nKb6ojozTGAAAAEAAAAAEAAABoAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlz
+                                                   dHAyNTYAAABBBAKxnsRT7n6qJLKoD3mFfAvcH5ZFUyTzJVW8t60pNgNaXO4q5S4qL9yCCZ
+                                                   cKyg6QtVgRuVxkUSseuR3fiubyTnkAAADQq3vrkvuSfm4n345STr/i/29FZEFUd0qD++B2
+                                                   ZoWGPKU/xzvxH7S2GxREb5oXcIYO889jY6mdZT8LZm6ZZig3rqoEAqdPyllHmEadb7hY+y
+                                                   jwcQ4Wr1ekGgVwNHCNu2in3cYXxbrYGMHc33WmdNrbGRDUzK+EEUM2cwUiM7Pkrw5s88Ff
+                                                   IWI0V+567Ob9LxxIUO/QvSbKMJGbMM4jZ1V9V2Ti/GziGJ107CBudZr/7wNwxIK86BBAEg
+                                                   hfnrhYBIaOLrtP8R+96i8iu4iZAvcIbQ==
+                                                   -----END OPENSSH PRIVATE KEY-----"
+                                                   --location=standalone/configuration/mycredstore.cs
+Credential store password:
+Confirm credential store password:
+Passphrase to be used to decrypt private key (can be nothing if no passphrase was used to encrypt the key): secret
+Confirm passphrase to be used to decrypt private key (can be nothing if no passphrase was used to encrypt the key): secret
+Alias "example" has been successfully stored
+----
+
+NOTE: If specifying your key in PKCS format rather than OpenSSH format, you must specify both the private and public key. The
+PKCS private key must also not be encrypted with a passphrase.
+
+Alternatively to importing, you may use the command line tool to generate and store a key pair credential in a credential store.
+The following command allows you to generate and store a key pair credential under the alias `example` using the ecdsa algorithm:
+[source,options="nowrap"]
+----
+]$ bin/elytron-tool.sh credential-store --generate-key-pair example --algorithm EC --location=standalone/configuration/mycredstore.cs
+Credential store password:
+Confirm credential store password:
+Alias "example" has been successfully stored
+----
+
+You can then export the public key generated in OpenSSH format using the following command:
+[source,options="nowrap"]
+----
+]$ bin/elytron-tool.sh credential-store --export-key-pair-public-key example
+Credential store password:
+Confirm credential store password:
+ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBMfncZuHmR7uglb0M96ieArRFtp42xPn9+ugukbY8dyjOXoi
+cZrYRyy9+X68fylEWBMzyg+nhjWkxJlJ2M2LAGY=
+----
+
 ==== Management Operation
 
 Using a management operation the following command can be used to add a new alias of `example` to the credential store.
@@ -518,6 +576,15 @@ Examples of how to structure calling the `credential-store` command were provide
 |-r,--remove <alias>
 |Remove the alias specified from the credential store.
 
+|-g,--generate-key-pair <alias>
+|Generate a new key pair credential and add it as an entry to the credential store using the specified alias.
+
+|-xp,--export-key-pair-public-key <alias>
+|Display the public key of a key pair credential entry under the specified alias in OpenSSH format.
+
+|-ikp,--import-key-pair <alias>
+|Add a new key pair credential entry to the credential store using the specified alias.
+
 |-v,--aliases
 |Display all aliases
 
@@ -568,6 +635,44 @@ The following parameters can be provided for each action to specify how to load 
 |Password credential value
 
 |===
+
+The following parameters can be provided for the `generate-key-pair` command:
+
+.generate-key-pair Parameters
+|===
+|Parameter |Description |Default Value
+
+|-k, --algorithm <algorithm name>
+|The encryption algorithm to be used. One of: RSA, DSA, or EC
+|RSA
+
+|-j,--size <size in bytes>
+|Size of the private key in bytes
+|RSA: 2048, DSA: 2048, EC: 256
+|===
+
+The following parameters can be provided for the `import-key-pair` command:
+
+.import-key-pair Parameters
+|===
+|Parameter |Description
+
+|-pvk, --private-key-string <private key to store>
+|The private key as a string. Alternative to `private-key-location`
+
+|-pvl, --private-key-location <path>
+|The path to a file containing a private key. Alternative to `private-key-string`
+
+|-pbk, --public-key-string <public key to store>
+|The public key as a string. Alternative to `public-key-location`
+
+|-pbl, --public-key-location <path>
+|The path to a file containing a public key. Alternative to `public-key-string`
+
+|-kp, --key-passphrase <passphrase>
+|The passphrase used to decrypt the private key if needed. Can also be specified via prompt
+|===
+
 
 === Elytron Tool - `vault` Command
 

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/bouncycastle/bcmail/main/module.xml
@@ -22,22 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.8" name="org.bouncycastle">
+<module xmlns="urn:jboss:module:1.8" name="org.bouncycastle.bcmail">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
+    <resources>
+        <artifact name="${org.bouncycastle:bcmail-jdk15on}"/>
+    </resources>
     <dependencies>
-        <module name="org.bouncycastle.bcpkix" export="true" services="export"/>
-        <module name="org.bouncycastle.bcprov" export="true" services="export"/>
-        <module name="org.bouncycastle.bcmail" export="true" services="export"/>
+        <module name="javax.api"/>
+        <module name="javax.mail.api" optional="true"/>
+        <module name="javax.activation.api" optional="true"/>
+        <module name="org.bouncycastle.bcpkix"/>
+        <module name="org.bouncycastle.bcprov"/>
     </dependencies>
-
-    <provides>
-        <service name="java.security.Provider">
-            <with-class name="org.bouncycastle.jce.provider.BouncyCastleProvider"/>
-            <with-class name="org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider"/>
-        </service>
-    </provides>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -88,7 +88,9 @@
         <module name="org.jboss.as.webservices" services="export" export="true"/>
         <module name="com.sun.xml.messaging.saaj" services="export" export="true"/>
         <module name="org.apache.ws.security" export="true"/>
-        <module name="org.bouncycastle" export="true"/>
+        <module name="org.bouncycastle.bcmail" export="true"/>
+        <module name="org.bouncycastle.bcpkix" export="true"/>
+        <module name="org.bouncycastle.bcprov" export="true"/>
         <module name="org.jboss.xts">
           <imports>
             <include path="com.arjuna.mw.wst11.client"/>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
@@ -38,7 +38,9 @@
         <module name="org.apache.james.mime4j"/>
         <module name="javax.servlet.api"/>
         <module name="javax.ws.rs.api"/>
-        <module name="org.bouncycastle"/>
+        <module name="org.bouncycastle.bcmail"/>
+        <module name="org.bouncycastle.bcpkix"/>
+        <module name="org.bouncycastle.bcprov"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -70,7 +70,9 @@
         <module name="org.picketbox"/>
         <module name="org.apache.commons.beanutils"/>
         <module name="javax.wsdl4j.api" />
-        <module name="org.bouncycastle" />
+        <module name="org.bouncycastle.bcmail" />
+        <module name="org.bouncycastle.bcpkix"/>
+        <module name="org.bouncycastle.bcprov"/>
         <module name="org.jboss.modules"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
@@ -53,7 +53,9 @@
       <module name="org.apache.ws.security" />
       <module name="org.joda.time"/>
       <module name="com.google.guava"/>
-      <module name="org.bouncycastle"/>
+        <module name="org.bouncycastle.bcmail"/>
+        <module name="org.bouncycastle.bcpkix"/>
+        <module name="org.bouncycastle.bcprov"/>
       <module name="org.apache.commons.codec"/>
     </dependencies>
 </module>

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
@@ -62,7 +62,9 @@
                 </exclude-set>
             </imports>
         </module>
-        <module name="org.bouncycastle" />
+        <module name="org.bouncycastle.bcmail"/>
+        <module name="org.bouncycastle.bcpkix"/>
+        <module name="org.bouncycastle.bcprov"/>
     </dependencies>
 
 </module>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone-load-balancer.xml/config.xml
@@ -5,6 +5,7 @@
         <include name="legacy-management"/>
         <include name="logging"/>
         <include name="undertow-load-balancer"/>
+        <include name="git-history"/>
     </layers>
     <feature-group name="standalone-security-realms"/>
 </config>

--- a/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/servlet-feature-pack/galleon-feature-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -13,6 +13,7 @@
         <include name="undertow-legacy-https"/>
         <include name="legacy-security"/>
         <include name="core-tools"/>
+        <include name="git-history"/>
     </layers>
     <feature-group name="undertow-default-config"/>
     <!-- package included in case configuration is provisioned without inheriting all modules -->

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/bc/BouncyCastleModuleTestCase.java
@@ -62,7 +62,7 @@ public class BouncyCastleModuleTestCase {
         ), "permissions.xml");
         archive.setManifest(new StringAsset(""
                 + "Manifest-Version: 1.0\n"
-                + "Dependencies: org.bouncycastle\n"));
+                + "Dependencies: org.bouncycastle.bcprov, org.bouncycastle.bcpkix, org.bouncycastle.bcmail\n"));
         return archive;
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-12574
https://issues.redhat.com/browse/WFCORE-4873

This PR adds:
 * documentation for SSH authentication for git persistence an
 * Updating the documentation after the creation of a git-history layer.
 * Splitting bouncycastle module.
 * Fixing layers tests

Analysis document: wildfly/wildfly-proposals#249
Depends on wildfly-security/wildfly-elytron#1297, wildfly/wildfly-core#4006


Supersedes: https://github.com/wildfly/wildfly/pull/12791