### PR TITLE
[WFLY-13846] Eliminate the connector dependency on the legacy security subsystem's module.

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -70,10 +70,6 @@
             <artifactId>wildfly-transaction-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>wildfly-security</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
         </dependency>

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
@@ -61,9 +61,6 @@ import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.naming.service.NamingService;
-import org.jboss.as.security.deployment.SecurityAttachments;
-import org.jboss.as.security.service.SimpleSecurityManagerService;
-import org.jboss.as.security.service.SubjectFactoryService;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentModelUtils;
@@ -100,6 +97,9 @@ import org.jboss.security.SubjectFactory;
  */
 public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor {
 
+    private static final ServiceName SECURITY_MANAGER_SERVICE = ServiceName.JBOSS.append("security", "simple-security-manager");
+    private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
+
     private static final String DATA_SOURCE = "data-source";
     private static final String XA_DATA_SOURCE = "xa-data-source";
     private static final String CONNECTION_PROPERTIES = "connection-properties";
@@ -129,7 +129,7 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
 
         final List<DataSources> dataSourcesList = deploymentUnit.getAttachmentList(DsXmlDeploymentParsingProcessor.DATA_SOURCES_ATTACHMENT_KEY);
 
-        final boolean legacySecurityPresent = phaseContext.getDeploymentUnit().hasAttachment(SecurityAttachments.SECURITY_ENABLED);
+        final boolean legacySecurityPresent = support.hasCapability("org.wildfly.legacy-security");
 
         for(DataSources dataSources : dataSourcesList) {
             if (dataSources.getDrivers() != null && dataSources.getDrivers().size() > 0) {
@@ -323,9 +323,9 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
         dataSourceServiceBuilder.requires(support.getCapabilityServiceName(NamingService.CAPABILITY_NAME));
 
         if (requireLegacySecurity) {
-            dataSourceServiceBuilder.addDependency(SimpleSecurityManagerService.SERVICE_NAME, ServerSecurityManager.class,
+            dataSourceServiceBuilder.addDependency(SECURITY_MANAGER_SERVICE, ServerSecurityManager.class,
                     dataSourceService.getServerSecurityManager());
-            dataSourceServiceBuilder.addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,
+            dataSourceServiceBuilder.addDependency(SUBJECT_FACTORY_SERVICE, SubjectFactory.class,
                     dataSourceService.getSubjectFactoryInjector());
         }
 

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/ParsedRaDeploymentProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/ParsedRaDeploymentProcessor.java
@@ -46,8 +46,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.naming.service.NamingService;
-import org.jboss.as.security.service.SimpleSecurityManagerService;
-import org.jboss.as.security.service.SubjectFactoryService;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentModelUtils;
@@ -84,6 +82,9 @@ import org.jboss.security.SubjectFactory;
  * @author <a href="jesper.pedersen@jboss.org">Jesper Pedersen</a>
  */
 public class ParsedRaDeploymentProcessor implements DeploymentUnitProcessor {
+
+    private static final ServiceName SECURITY_MANAGER_SERVICE = ServiceName.JBOSS.append("security", "simple-security-manager");
+    private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
 
     public ParsedRaDeploymentProcessor() {
     }
@@ -223,8 +224,8 @@ public class ParsedRaDeploymentProcessor implements DeploymentUnitProcessor {
                 builder.addDependency(ConnectorServices.CCM_SERVICE, CachedConnectionManager.class, raDeploymentService.getCcmInjector());
             }
             if (activation != null && ActivationSecurityUtil.isLegacySecurityRequired(activation)) {
-                builder.addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class, raDeploymentService.getSubjectFactoryInjector())
-                        .addDependency(SimpleSecurityManagerService.SERVICE_NAME, ServerSecurityManager.class, raDeploymentService.getServerSecurityManager());
+                builder.addDependency(SUBJECT_FACTORY_SERVICE, SubjectFactory.class, raDeploymentService.getSubjectFactoryInjector())
+                        .addDependency(SECURITY_MANAGER_SERVICE, ServerSecurityManager.class, raDeploymentService.getServerSecurityManager());
             }
 
             return builder;

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/DirectConnectionFactoryActivatorService.java
@@ -33,8 +33,6 @@ import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
-import org.jboss.as.security.service.SimpleSecurityManagerService;
-import org.jboss.as.security.service.SubjectFactoryService;
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.Pool;
 import org.jboss.jca.common.api.metadata.common.TransactionSupportEnum;
@@ -52,6 +50,7 @@ import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 import org.jboss.modules.Module;
 import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.security.SubjectFactory;
 
@@ -64,6 +63,11 @@ import static org.jboss.as.connector.logging.ConnectorLogger.ROOT_LOGGER;
 import static org.jboss.as.connector.logging.ConnectorLogger.SUBSYSTEM_RA_LOGGER;
 
 public class DirectConnectionFactoryActivatorService implements org.jboss.msc.service.Service<org.jboss.as.naming.deployment.ContextNames.BindInfo> {
+
+    private static final ServiceName SECURITY_MANAGER_SERVICE = ServiceName.JBOSS.append("security", "simple-security-manager");
+    private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
+
+
     public static final org.jboss.msc.service.ServiceName SERVICE_NAME_BASE =
             org.jboss.msc.service.ServiceName.JBOSS.append("connector").append("direct-connection-factory-activator");
 
@@ -252,9 +256,9 @@ public class DirectConnectionFactoryActivatorService implements org.jboss.msc.se
 
             if (ActivationSecurityUtil.isLegacySecurityRequired(security)) {
                 connectionFactoryServiceBuilder
-                        .addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,
+                        .addDependency(SUBJECT_FACTORY_SERVICE, SubjectFactory.class,
                                 activator.getSubjectFactoryInjector())
-                        .addDependency(SimpleSecurityManagerService.SERVICE_NAME,
+                        .addDependency(SECURITY_MANAGER_SERVICE,
                                 ServerSecurityManager.class, activator.getServerSecurityManager());
             }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -70,9 +70,6 @@ import org.jboss.as.naming.ServiceBasedNamingStore;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.naming.service.NamingService;
-import org.jboss.as.security.service.SecurityDomainService;
-import org.jboss.as.security.service.SimpleSecurityManagerService;
-import org.jboss.as.security.service.SubjectFactoryService;
 import org.jboss.as.server.Services;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.api.metadata.common.Credential;
@@ -103,6 +100,10 @@ import org.wildfly.security.credential.source.CredentialSource;
  * @author John Bailey
  */
 public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
+
+    private static final ServiceName SECURITY_DOMAIN_SERVICE = ServiceName.JBOSS.append("security", "security-domain");
+    private static final ServiceName SECURITY_MANAGER_SERVICE = ServiceName.JBOSS.append("security", "simple-security-manager");
+    private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
 
     AbstractDataSourceAdd(Collection<AttributeDefinition> attributes) {
         super(Capabilities.DATA_SOURCE_CAPABILITY, attributes);
@@ -254,8 +255,8 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
          }
 
          if (requireLegacySecurity) {
-             dataSourceServiceBuilder.addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class, dataSourceService.getSubjectFactoryInjector())
-                     .addDependency(SimpleSecurityManagerService.SERVICE_NAME, ServerSecurityManager.class, dataSourceService.getServerSecurityManager());
+             dataSourceServiceBuilder.addDependency(SUBJECT_FACTORY_SERVICE, SubjectFactory.class, dataSourceService.getSubjectFactoryInjector())
+                     .addDependency(SECURITY_MANAGER_SERVICE, ServerSecurityManager.class, dataSourceService.getServerSecurityManager());
          }
 
          ModelNode credentialReference = Constants.CREDENTIAL_REFERENCE.resolveModelAttribute(context, model);
@@ -322,7 +323,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
             if (dsSecurityConfig != null) {
                 final String securityDomainName = dsSecurityConfig.getSecurityDomain();
                 if (!elytronEnabled && securityDomainName != null) {
-                    builder.requires(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                    builder.requires(SECURITY_DOMAIN_SERVICE.append(securityDomainName));
                 }
             }
             // add dependency on security domain service if applicable for recovery config
@@ -331,7 +332,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
                 if (credential != null) {
                     final String securityDomainName = credential.getSecurityDomain();
                     if (!RECOVERY_ELYTRON_ENABLED.resolveModelAttribute(context, model).asBoolean() && securityDomainName != null) {
-                        builder.requires(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                        builder.requires(SECURITY_DOMAIN_SERVICE.append(securityDomainName));
                     }
                 }
             }
@@ -374,7 +375,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
             if (dsSecurityConfig != null) {
                 final String securityDomainName = dsSecurityConfig.getSecurityDomain();
                 if (!elytronEnabled && securityDomainName != null) {
-                    builder.requires(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                    builder.requires(SECURITY_DOMAIN_SERVICE.append(securityDomainName));
                 }
             }
             for (ServiceName name : serviceNames) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionAdd.java
@@ -55,8 +55,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.core.security.ServerSecurityManager;
-import org.jboss.as.security.service.SimpleSecurityManagerService;
-import org.jboss.as.security.service.SubjectFactoryService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.api.metadata.common.TransactionSupportEnum;
 import org.jboss.jca.common.api.metadata.resourceadapter.Activation;
@@ -72,6 +70,9 @@ import org.wildfly.security.auth.client.AuthenticationContext;
  * Adds a recovery-environment to the Transactions subsystem
  */
 public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
+
+    private static final ServiceName SECURITY_MANAGER_SERVICE = ServiceName.JBOSS.append("security", "simple-security-manager");
+    private static final ServiceName SUBJECT_FACTORY_SERVICE = ServiceName.JBOSS.append("security", "subject-factory");
 
     public static final ConnectionDefinitionAdd INSTANCE = new ConnectionDefinitionAdd();
 
@@ -181,9 +182,9 @@ public class ConnectionDefinitionAdd extends AbstractAddStepHandler {
             }
 
             if (!elytronEnabled || !elytronRecoveryEnabled) {
-                cdServiceBuilder.addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,
+                cdServiceBuilder.addDependency(SUBJECT_FACTORY_SERVICE, SubjectFactory.class,
                         service.getSubjectFactoryInjector())
-                        .addDependency(SimpleSecurityManagerService.SERVICE_NAME,
+                        .addDependency(SECURITY_MANAGER_SERVICE,
                                 ServerSecurityManager.class, service.getServerSecurityManager());
             }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/RaOperationUtil.java
@@ -118,7 +118,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.UninterruptibleCountDownLatch;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
-import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.annotation.ResourceRootIndexer;
 import org.jboss.as.server.deployment.module.MountHandle;
@@ -165,6 +164,9 @@ import org.wildfly.security.credential.source.CredentialSource;
 
 
 public class RaOperationUtil {
+
+    private static final ServiceName SECURITY_DOMAIN_SERVICE = ServiceName.JBOSS.append("security", "security-domain");
+
     public static final ServiceName RAR_MODULE = ServiceName.of("rarinsidemodule");
 
 
@@ -420,21 +422,21 @@ public class RaOperationUtil {
                     final boolean elytronEnabled = (security instanceof SecurityMetadata && ((SecurityMetadata) security).isElytronEnabled());
                     if (security.getSecurityDomain() != null) {
                         if (!elytronEnabled) {
-                            builder.requires(SecurityDomainService.SERVICE_NAME.append(security.getSecurityDomain()));
+                            builder.requires(SECURITY_DOMAIN_SERVICE.append(security.getSecurityDomain()));
                         } else {
                             builder.requires(context.getCapabilityServiceName(AUTHENTICATION_CONTEXT_CAPABILITY, security.getSecurityDomain(), AuthenticationContext.class));
                         }
                     }
                     if (security.getSecurityDomainAndApplication() != null) {
                         if (!elytronEnabled) {
-                            builder.requires(SecurityDomainService.SERVICE_NAME.append(security.getSecurityDomainAndApplication()));
+                            builder.requires(SECURITY_DOMAIN_SERVICE.append(security.getSecurityDomainAndApplication()));
                         } else {
                             builder.requires(context.getCapabilityServiceName(AUTHENTICATION_CONTEXT_CAPABILITY, security.getSecurityDomainAndApplication(), AuthenticationContext.class));
                         }
                     }
                     if (cd.getRecovery() != null && cd.getRecovery().getCredential() != null && cd.getRecovery().getCredential().getSecurityDomain() != null) {
                         if (!elytronEnabled) {
-                            builder.requires(SecurityDomainService.SERVICE_NAME.append(cd.getRecovery().getCredential().getSecurityDomain()));
+                            builder.requires(SECURITY_DOMAIN_SERVICE.append(cd.getRecovery().getCredential().getSecurityDomain()));
                         } else {
                             builder.requires(context.getCapabilityServiceName(AUTHENTICATION_CONTEXT_CAPABILITY, cd.getRecovery().getCredential().getSecurityDomain(), AuthenticationContext.class));
                         }
@@ -449,7 +451,7 @@ public class RaOperationUtil {
                     final String securityDomainName = workManagerSecurity.getDomain();
                     if (securityDomainName != null) {
                         if (!elytronEnabled) {
-                            builder.requires(SecurityDomainService.SERVICE_NAME.append(securityDomainName));
+                            builder.requires(SECURITY_DOMAIN_SERVICE.append(securityDomainName));
                         } else {
                             builder.requires(context.getCapabilityServiceName(ELYTRON_SECURITY_DOMAIN_CAPABILITY, securityDomainName, SecurityDomain.class));
                         }

--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -48,7 +48,6 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server" />
         <module name="org.wildfly.security.elytron-private"/>
-        <module name="org.jboss.as.security" />
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.as.ee" />
         <module name="org.jboss.as.threads"/>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -97,6 +97,10 @@ vi:ts=4:sw=4:expandtab
             <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-iiop-openjdk</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -159,6 +159,11 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>wildfly-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>wildfly-transactions</artifactId>
         </dependency>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13846

I did consider if these ServiceName definitions should maybe in a common class but TBH they are used in various packages in the connector subsystem so preferred to keep visibility restricted - at some point all these references will be deleted anyway.