### PR TITLE
[WFLY-13860] Upgrade RESTEasy to 3.13.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <version.org.jboss.mod_cluster>1.4.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.narayana>5.10.6.Final</version.org.jboss.narayana>
         <version.org.jboss.openjdk-orb>8.1.4.Final</version.org.jboss.openjdk-orb>
-        <version.org.jboss.resteasy>3.13.0.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.13.1.Final</version.org.jboss.resteasy>
         <version.org.jboss.seam.int>7.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>3.0.6.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13860
