### PR TITLE
[WFLY-13870] Upgrade WildFly Core 13.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.0.Beta5</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Beta6</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.0.21.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13870

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.0.Beta6
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/13.0.0.Beta5...13.0.0.Beta6

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

## Release Notes - WildFly Core - Version 13.0.0.Beta6
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5056'>WFCORE-5056</a>] -         Upgrade XNIO to 3.8.2.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5091'>WFCORE-5091</a>] -         Upgrade WildFly Elytron to 1.13.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5102'>WFCORE-5102</a>] -         Upgrade Undertow to 2.2.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5111'>WFCORE-5111</a>] -         Upgrade JBoss MSC from 1.4.11 to 1.4.12
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5112'>WFCORE-5112</a>] -         Upgrade bootable jar maven plugin to 2.0.0.Beta4
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5117'>WFCORE-5117</a>] -         Upgrade Xerces to 2.12.0.SP03
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5123'>WFCORE-5123</a>] -         Upgrade WildFly OpenSSL to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5124'>WFCORE-5124</a>] -         Upgrade WildFly OpenSSL Natives to 2.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5125'>WFCORE-5125</a>] -         Upgrade WildFly OpenSSL Linux i386, MacOS x86_64, and Solaris natives to 2.1.0.SP01
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5127'>WFCORE-5127</a>] -         Upgrade Elytron Web to 1.8.0.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5010'>WFCORE-5010</a>] -         Startup error messages caused by expression where expressions are not allowed are confusing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5097'>WFCORE-5097</a>] -         Add an option to the bootable JAR to display the Galleon config
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5107'>WFCORE-5107</a>] -         Provide equivalent to RemotingConnectorInfo via org.jboss.as.network module; expose it via &quot;org.wildfly.remoting.connector&quot; capability
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5108'>WFCORE-5108</a>] -         SimpleHttpUpgradeHandshake should use undertow-core&#39;s FlexBase64.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5115'>WFCORE-5115</a>] -         Allow a properties file which contains system properties to be loaded in the bootable JAR&#39;s entry point
</li>
</ul>
                                                                                                                                                                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4853'>WFCORE-4853</a>] -         [GSS][7.2.2] HTTP External Security Not Supported by Elytron
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5080'>WFCORE-5080</a>] -         KeyStoresTestCase fails on IBM Java 8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5103'>WFCORE-5103</a>] -         Adding non existent and not required keystore fails
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5105'>WFCORE-5105</a>] -         ProtocolConnectionUtils may leak connection objects whose future takes too long to complete
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5109'>WFCORE-5109</a>] -         Ensure the log manager configurator is attached to the root logger
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5110'>WFCORE-5110</a>] -         Bootable JAR doesn&#39;t setup the JAXP factories at boot
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5116'>WFCORE-5116</a>] -         Bootable JAR, JMX not properly initialized at boot.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5119'>WFCORE-5119</a>] -         Bootable JAR - Remove dependency on elytron-private
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5132'>WFCORE-5132</a>] -         Bootable JAR, some tests require a start of the server
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5100'>WFCORE-5100</a>] -         Add missing distribution repo tags in core-feature-pack-common-licenses.xml
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5128'>WFCORE-5128</a>] -         Add org.wildfly.security:wildfly-elytron-http-external dependency
</li>
</ul>
                                                        
