### PR TITLE
[WFLY-13866]: Several traces created in Jaeger for just one method call.

### DIFF
--- a/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/fault-tolerance-smallrye/executor/main/module.xml
+++ b/galleon-pack/src/main/resources/modules/system/layers/base/org/wildfly/microprofile/fault-tolerance-smallrye/executor/main/module.xml
@@ -33,7 +33,10 @@
 
     <dependencies>
         <module name="io.smallrye.fault-tolerance"/>
+        <module name="javax.annotation.api"/>
         <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
         <module name="javax.enterprise.concurrent.api"/>
+        <module name="io.opentracing.opentracing-api" optional="true"/>
     </dependencies>
 </module>

--- a/microprofile/fault-tolerance-smallrye/executor/pom.xml
+++ b/microprofile/fault-tolerance-smallrye/executor/pom.xml
@@ -46,5 +46,17 @@
             <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
             <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/microprofile/fault-tolerance-smallrye/executor/src/main/java/org/wildfly/extension/microprofile/faulttolerance/MiniContextPropagation.java
+++ b/microprofile/fault-tolerance-smallrye/executor/src/main/java/org/wildfly/extension/microprofile/faulttolerance/MiniContextPropagation.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.microprofile.faulttolerance;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Miniature context propagation API, adapted from MicroProfile Context Propagation and SmallRye Context Propagation.
+ * @author Ladislav Thon (c) 2020 Red Hat, Inc.
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+final class MiniContextPropagation {
+
+    private MiniContextPropagation() {
+        // avoid instantiation
+    }
+
+    public static ExecutorService executorService(ContextProvider contextProvider, ExecutorService delegate) {
+        return new ConPropExecutorService(contextProvider, delegate);
+    }
+
+    public static ScheduledExecutorService scheduledExecutorService(ContextProvider contextProvider, ScheduledExecutorService delegate) {
+        return new ConPropScheduledExecutorService(contextProvider, delegate);
+    }
+
+    @FunctionalInterface
+    interface ContextProvider {
+
+        ContextSnapshot capture();
+
+        ContextProvider NOOP = () -> ContextSnapshot.NOOP;
+
+        static ContextProvider compound(ContextProvider... contextProviders) {
+            return new CompoundContextProvider(Arrays.asList(contextProviders));
+        }
+    }
+
+    @FunctionalInterface
+    interface ContextSnapshot {
+
+        ActiveContextSnapshot activate();
+
+        ContextSnapshot NOOP = () -> ActiveContextSnapshot.NOOP;
+    }
+
+    @FunctionalInterface
+    interface ActiveContextSnapshot {
+
+        void deactivate();
+
+        ActiveContextSnapshot NOOP = () -> {
+        };
+    }
+
+    // ---
+    private static final class CompoundContextProvider implements ContextProvider {
+
+        private final List<ContextProvider> contextProviders;
+
+        CompoundContextProvider(List<ContextProvider> contextProviders) {
+            this.contextProviders = contextProviders;
+        }
+
+        @Override
+        public ContextSnapshot capture() {
+            List<ContextSnapshot> snapshots = new ArrayList<>();
+            for (ContextProvider contextProvider : contextProviders) {
+                snapshots.add(contextProvider.capture());
+            }
+
+            return () -> {
+                List<ActiveContextSnapshot> activeSnapshots = new ArrayList<>();
+                for (ContextSnapshot snapshot : snapshots) {
+                    activeSnapshots.add(snapshot.activate());
+                }
+
+                return () -> {
+                    for (int i = activeSnapshots.size() - 1; i >= 0; i--) {
+                        activeSnapshots.get(i).deactivate();
+                    }
+                };
+            };
+        }
+    }
+
+    // ---
+    private static final class ConPropRunnable implements Runnable {
+
+        private final ContextSnapshot contextSnapshot;
+        private final Runnable delegate;
+
+        ConPropRunnable(ContextSnapshot contextSnapshot, Runnable delegate) {
+            this.contextSnapshot = contextSnapshot;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void run() {
+            ActiveContextSnapshot activeSnapshot = contextSnapshot.activate();
+            try {
+                delegate.run();
+            } finally {
+                activeSnapshot.deactivate();
+            }
+        }
+    }
+
+    private static final class ConPropCallable<V> implements Callable<V> {
+
+        private final ContextSnapshot contextSnapshot;
+        private final Callable<V> delegate;
+
+        ConPropCallable(ContextSnapshot contextSnapshot, Callable<V> delegate) {
+            this.contextSnapshot = contextSnapshot;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public V call() throws Exception {
+            ActiveContextSnapshot activeSnapshot = contextSnapshot.activate();
+            try {
+                return delegate.call();
+            } finally {
+                activeSnapshot.deactivate();
+            }
+        }
+    }
+
+    private static class ConPropExecutorService implements ExecutorService {
+
+        protected final ContextProvider contextProvider;
+        private final ExecutorService delegate;
+
+        ConPropExecutorService(ContextProvider contextProvider, ExecutorService delegate) {
+            this.contextProvider = contextProvider;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void shutdown() {
+            delegate.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            return delegate.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return delegate.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return delegate.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return delegate.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.submit(new ConPropCallable<>(contextSnapshot, task));
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.submit(new ConPropRunnable(contextSnapshot, task), result);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.submit(new ConPropRunnable(contextSnapshot, task));
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            List<Callable<T>> conPropTasks = new ArrayList<>(tasks.size());
+            for (Callable<T> task : tasks) {
+                conPropTasks.add(new ConPropCallable<>(contextSnapshot, task));
+            }
+            return delegate.invokeAll(conPropTasks);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            List<Callable<T>> conPropTasks = new ArrayList<>(tasks.size());
+            for (Callable<T> task : tasks) {
+                conPropTasks.add(new ConPropCallable<>(contextSnapshot, task));
+            }
+            return delegate.invokeAll(conPropTasks, timeout, unit);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            List<Callable<T>> conPropTasks = new ArrayList<>(tasks.size());
+            for (Callable<T> task : tasks) {
+                conPropTasks.add(new ConPropCallable<>(contextSnapshot, task));
+            }
+            return delegate.invokeAny(conPropTasks);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            List<Callable<T>> conPropTasks = new ArrayList<>(tasks.size());
+            for (Callable<T> task : tasks) {
+                conPropTasks.add(new ConPropCallable<>(contextSnapshot, task));
+            }
+            return delegate.invokeAny(conPropTasks, timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            delegate.execute(new ConPropRunnable(contextSnapshot, command));
+        }
+    }
+
+    private static class ConPropScheduledExecutorService extends ConPropExecutorService implements ScheduledExecutorService {
+
+        private final ScheduledExecutorService delegate;
+
+        ConPropScheduledExecutorService(ContextProvider contextProvider, ScheduledExecutorService delegate) {
+            super(contextProvider, delegate);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.schedule(new ConPropRunnable(contextSnapshot, command), delay, unit);
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.schedule(new ConPropCallable<>(contextSnapshot, callable), delay, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.scheduleAtFixedRate(new ConPropRunnable(contextSnapshot, command), initialDelay, period, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+            ContextSnapshot contextSnapshot = contextProvider.capture();
+            return delegate.scheduleWithFixedDelay(new ConPropRunnable(contextSnapshot, command), initialDelay, delay, unit);
+        }
+    }
+}

--- a/microprofile/fault-tolerance-smallrye/executor/src/main/java/org/wildfly/extension/microprofile/faulttolerance/TracingContextProvider.java
+++ b/microprofile/fault-tolerance-smallrye/executor/src/main/java/org/wildfly/extension/microprofile/faulttolerance/TracingContextProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.microprofile.faulttolerance;
+
+import io.opentracing.Scope;
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+/**
+ *
+ * @author Ladislav Thon (c) 2020 Red Hat, Inc.
+ * @author Emmanuel Hugonnet (c) 2020 Red Hat, Inc.
+ */
+final class TracingContextProvider implements MiniContextPropagation.ContextProvider {
+    private final Tracer tracer;
+
+    TracingContextProvider(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public MiniContextPropagation.ContextSnapshot capture() {
+        ScopeManager scopeManager = tracer.scopeManager();
+        Scope activeScope = scopeManager.active();
+
+        if (activeScope != null) {
+            Span span = activeScope.span();
+            return () -> {
+                Scope propagated = scopeManager.activate(span, false);
+                return propagated::close;
+            };
+        }
+
+        return MiniContextPropagation.ContextSnapshot.NOOP;
+    }
+}

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -124,6 +124,32 @@
             <artifactId>nimbus-jose-jwt</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/OpenTracingFaultToleranceTestCase.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/OpenTracingFaultToleranceTestCase.java
@@ -1,0 +1,187 @@
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
+import io.opentracing.contrib.tracerresolver.TracerFactory;
+import io.opentracing.mock.MockTracer;
+import java.io.FilePermission;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application.HelloResource;
+import org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application.MockTracerFactory;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OpenTracingFaultToleranceTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment(name = "opentracing-fault-tolerance")
+    public static Archive<?> deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class)
+                .addPackage(MockTracer.class.getPackage())
+                .addPackage(MockTracerFactory.class.getPackage())
+                .addAsServiceProvider(TracerFactory.class, MockTracerFactory.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new FilePermission("<<ALL FILES>>", "read")
+                ), "permissions.xml");
+        return war;
+    }
+
+    @Test
+    public void testHello() throws IOException {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpResponse response = client.execute(new HttpGet(url.toExternalForm() + "rest/hello"));
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            String content = EntityUtils.toString(response.getEntity());
+            Assert.assertEquals("Hello from fallback", content);
+            response = client.execute(new HttpGet(url.toExternalForm() + "rest/tracer/spans"));
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            StringTokenizer tokenizer = new StringTokenizer(EntityUtils.toString(response.getEntity()), ";");
+            Assert.assertEquals(4, tokenizer.countTokens());
+            List<JsonObject> spans = new ArrayList<>(4);
+            while (tokenizer.hasMoreTokens()) {
+                String jsonContent = tokenizer.nextToken();
+                try (JsonReader jsonReader = Json.createReader(new StringReader(jsonContent))) {
+                    spans.add(jsonReader.readObject());
+                }
+            }
+            int parentId = 0;
+            Collections.sort(spans, (o1, o2) -> {
+                return Integer.parseInt(o1.getString("spanId")) - Integer.parseInt(o2.getString("spanId"));
+            });
+            for (int i = 0; i < spans.size(); i++) {
+                JsonObject object = spans.get(i);
+                String operationName = object.getString("operationName");
+                Assert.assertNotNull(object.toString(), object.getString("traceId"));
+                Assert.assertNotNull(object.toString(), object.getString("spanId"));
+                Assert.assertEquals(object.toString(), parentId, Integer.parseInt(object.getString("parentId")));
+                switch (i) {
+                    case 0: {
+                        Assert.assertEquals(object.toString(), operationName, "GET:" + HelloResource.class.getCanonicalName() + ".get");
+                        parentId = Integer.parseInt(object.getString("spanId"));
+                        break;
+                    }
+                    case 1: {
+                        Assert.assertEquals(object.toString(), operationName, "hello");
+                        JsonObject log = object.getJsonObject("logs");
+                        Assert.assertNotNull(object.toString(), log);
+                        String event = log.getString("event");
+                        Assert.assertTrue(event, "attempt 0".equals(event));
+                        break;
+                    }
+                    case 2: {
+                        Assert.assertEquals(object.toString(), operationName, "hello");
+                        JsonObject log = object.getJsonObject("logs");
+                        Assert.assertNotNull(object.toString(), log);
+                        String event = log.getString("event");
+                        Assert.assertTrue(event, "attempt 1".equals(event));
+                        break;
+                    }
+                    case 3:
+                        Assert.assertEquals(object.toString(), operationName, "fallback");
+                        break;
+                }
+            }
+        } finally {
+            try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+                HttpResponse response = client.execute(new HttpGet(url.toExternalForm() + "rest/tracer/reset"));
+                Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            }
+        }
+    }
+
+    @Test
+    public void testHelloAsync() throws IOException {
+        try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpResponse response = client.execute(new HttpGet(url.toExternalForm() + "rest/helloAsync"));
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            String content = EntityUtils.toString(response.getEntity());
+            Assert.assertEquals("Hello from async fallback", content);
+            response = client.execute(new HttpGet(url.toExternalForm() + "rest/tracer/spans"));
+            Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            StringTokenizer tokenizer = new StringTokenizer(EntityUtils.toString(response.getEntity()), ";");
+            Assert.assertEquals(4, tokenizer.countTokens());
+            List<JsonObject> spans = new ArrayList<>(4);
+            while (tokenizer.hasMoreTokens()) {
+                String jsonContent = tokenizer.nextToken();
+                try (JsonReader jsonReader = Json.createReader(new StringReader(jsonContent))) {
+                    spans.add(jsonReader.readObject());
+                }
+            }
+            int parentId = 0;
+            Collections.sort(spans, (o1, o2) -> {
+                return Integer.parseInt(o1.getString("spanId")) - Integer.parseInt(o2.getString("spanId"));
+            });
+            for (int i = 0; i < spans.size(); i++) {
+                JsonObject object = spans.get(i);
+                String operationName = object.getString("operationName");
+                Assert.assertNotNull(object.toString(), object.getString("traceId"));
+                Assert.assertNotNull(object.toString(), object.getString("spanId"));
+                Assert.assertEquals(object.toString(), parentId, Integer.parseInt(object.getString("parentId")));
+                switch (i) {
+                    case 0: {
+                        Assert.assertEquals(object.toString(), operationName, "GET:" + HelloResource.class.getCanonicalName() + ".getAsync");
+                        parentId = Integer.parseInt(object.getString("spanId"));
+                        break;
+                    }
+                    case 1: {
+                        Assert.assertEquals(object.toString(), operationName, "helloAsync");
+                        JsonObject log = object.getJsonObject("logs");
+                        Assert.assertNotNull(object.toString(), log);
+                        String event = log.getString("event");
+                        Assert.assertTrue(event, "attempt 0".equals(event));
+                        break;
+                    }
+                    case 2: {
+                        Assert.assertEquals(object.toString(), operationName, "helloAsync");
+                        JsonObject log = object.getJsonObject("logs");
+                        Assert.assertNotNull(object.toString(), log);
+                        String event = log.getString("event");
+                        Assert.assertTrue(event, "attempt 1".equals(event));
+                        break;
+                    }
+                    case 3:
+                        Assert.assertEquals(object.toString(), operationName, "fallbackAsync");
+                        JsonObject log = object.getJsonObject("logs");
+                        Assert.assertNotNull(object.toString(), log);
+                        String event = log.getString("event");
+                        Assert.assertTrue(event, "fallbackAsync 2".equals(event));
+                        break;
+                }
+            }
+        } finally {
+            try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+                HttpResponse response = client.execute(new HttpGet(url.toExternalForm() + "rest/tracer/reset"));
+                Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+            }
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/HelloResource.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/HelloResource.java
@@ -1,0 +1,26 @@
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.concurrent.CompletionStage;
+
+@Path("/")
+public class HelloResource {
+    @Inject
+    private MyService myService;
+
+    @GET
+    @Path("/hello")
+    public String get() {
+        myService.reset();
+        return myService.hello();
+    }
+
+    @GET
+    @Path("/helloAsync")
+    public CompletionStage<String> getAsync() {
+        myService.reset();
+        return myService.helloAsync();
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/MockTracerFactory.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/MockTracerFactory.java
@@ -1,0 +1,13 @@
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerFactory;
+import io.opentracing.mock.MockTracer;
+
+public class MockTracerFactory implements TracerFactory {
+
+    @Override
+    public Tracer getTracer() {
+        return new MockTracer();
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/MyService.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/MyService.java
@@ -1,0 +1,61 @@
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application;
+
+import io.opentracing.Scope;
+import io.opentracing.Tracer;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ApplicationScoped
+public class MyService {
+    @Inject
+    private Tracer tracer;
+
+    private AtomicInteger counter = new AtomicInteger();
+
+    public void reset() {
+        counter.set(0);
+    }
+
+    @Retry(maxRetries = 1)
+    @Fallback(fallbackMethod = "fallback")
+    public String hello() {
+        try (Scope scope = tracer.buildSpan("hello").startActive(true)) {
+            scope.span().log("attempt " + counter.getAndIncrement());
+            throw new RuntimeException("failed");
+        }
+    }
+
+    public String fallback() {
+        try (Scope scope = tracer.buildSpan("fallback").startActive(true)) {
+            return "Hello from fallback";
+        }
+    }
+
+    @Asynchronous
+    @Retry(maxRetries = 1)
+    @Fallback(fallbackMethod = "fallbackAsync")
+    public CompletionStage<String> helloAsync() {
+        try (Scope scope = tracer.buildSpan("helloAsync").startActive(true)) {
+            scope.span().log("attempt " + counter.getAndIncrement());
+            CompletableFuture<String> result = new CompletableFuture<>();
+            result.completeExceptionally(new RuntimeException("failed with scope " + scope));
+            scope.span().log("Current scope " + scope);
+            return result;
+        }
+    }
+
+    public CompletionStage<String> fallbackAsync() {
+        try (Scope scope = tracer.buildSpan("fallbackAsync").startActive(true)) {
+            scope.span().log("fallbackAsync " + counter.get());
+            scope.span().log("Current scope " + scope);
+            return CompletableFuture.completedFuture("Hello from async fallback");
+        }
+    }
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/RestApplication.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/RestApplication.java
@@ -1,0 +1,8 @@
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("/rest")
+public class RestApplication extends Application {
+}

--- a/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/TracerIdentity.java
+++ b/testsuite/integration/microprofile/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentracing/application/TracerIdentity.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.integration.microprofile.faulttolerance.opentracing.application;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import java.util.stream.Collectors;
+import javax.ws.rs.Produces;
+import org.eclipse.microprofile.opentracing.Traced;
+
+@Path("/tracer")
+@Traced(false)
+public class TracerIdentity {
+
+    @Inject
+    private Tracer tracer;
+
+    @GET
+    @Path("/spans")
+    @Produces("text/plain")
+    public String get() {
+        MockTracer jTracer = (MockTracer) tracer;
+        return jTracer.finishedSpans().stream()
+                .map(span -> {
+                    StringBuilder builder = new StringBuilder();
+                    builder.append("{\"parentId\":").append('"').append(span.parentId()).append('"');
+                    builder.append(",\"traceId\":").append('"').append(span.context().traceId()).append('"');
+                    builder.append(",\"spanId\":").append('"').append(span.context().spanId()).append('"');
+                    builder.append(",\"operationName\":").append('"').append(span.operationName()).append('"');
+                    if (span.logEntries() != null && !span.logEntries().isEmpty()) {
+                        builder.append(",\"logs\":").append("{\"event\":").append('"').append(span.logEntries().get(0).fields().get("event").toString()).append('"').append("}");
+                    }
+                    builder.append("}");
+                    return builder.toString();
+                })
+                .collect(Collectors.joining(";"));
+    }
+
+    @GET
+    @Path("/reset")
+    @Produces("text/plain")
+    public String resetTracer() {
+        MockTracer jTracer = (MockTracer) tracer;
+        jTracer.reset();
+        return "OK";
+    }
+}


### PR DESCRIPTION
* the current scope is 'lost' on async calls. Ficxing that by passing
  the scope manager on the new threads.

Jira: https://issues.redhat.com/browse/WFLY-13866