### PR TITLE
[WFLY-13892]: Opentracing capability is not properly registered

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemAdd.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemAdd.java
@@ -23,6 +23,7 @@ package org.wildfly.extension.microprofile.opentracing;
 
 import static org.wildfly.extension.microprofile.opentracing.SubsystemDefinition.DEFAULT_TRACER;
 import static org.wildfly.extension.microprofile.opentracing.SubsystemDefinition.DEFAULT_TRACER_CAPABILITY;
+import static org.wildfly.extension.microprofile.opentracing.SubsystemDefinition.OPENTRACING_CAPABILITY;
 import static org.wildfly.microprofile.opentracing.smallrye.WildFlyTracerFactory.ENV_TRACER;
 import static org.wildfly.microprofile.opentracing.smallrye.WildFlyTracerFactory.TRACER_CAPABILITY_NAME;
 
@@ -100,6 +101,7 @@ class SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        context.registerCapability(OPENTRACING_CAPABILITY);
         ModelNode defaultTracer = DEFAULT_TRACER.resolveModelAttribute(context, operation);
         if (defaultTracer.isDefined()) {
             context.registerCapability(DEFAULT_TRACER_CAPABILITY);

--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/SubsystemDefinition.java
@@ -47,11 +47,11 @@ import org.wildfly.microprofile.opentracing.smallrye.TracerConfigurationConstant
 
 public class SubsystemDefinition extends PersistentResourceDefinition {
 
-    private static final String OPENTRACING_CAPABILITY_NAME = "org.wildfly.microprofile.opentracing";
+    public static final String OPENTRACING_CAPABILITY_NAME = "org.wildfly.microprofile.opentracing";
     public static final String DEFAULT_TRACER_CAPABILITY_NAME = "org.wildfly.microprofile.opentracing.default-tracer";
-    private static final String MICROPROFILE_CONFIG_CAPABILITY_NAME = "org.wildfly.microprofile.config";
+    public static final String MICROPROFILE_CONFIG_CAPABILITY_NAME = "org.wildfly.microprofile.config";
 
-    private static final RuntimeCapability<Void> OPENTRACING_CAPABILITY = RuntimeCapability.Builder
+    public static final RuntimeCapability<Void> OPENTRACING_CAPABILITY = RuntimeCapability.Builder
             .of(OPENTRACING_CAPABILITY_NAME)
             .addRequirements(WELD_CAPABILITY_NAME, MICROPROFILE_CONFIG_CAPABILITY_NAME)
             .build();

--- a/microprofile/opentracing-extension/src/test/java/org/wildfly/extension/microprofile/opentracing/Subsystem_2_0_ParsingTestCase.java
+++ b/microprofile/opentracing-extension/src/test/java/org/wildfly/extension/microprofile/opentracing/Subsystem_2_0_ParsingTestCase.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.microprofile.opentracing;
 import static org.jboss.as.subsystem.test.AdditionalInitialization.registerServiceCapabilities;
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 import static org.junit.Assert.assertTrue;
+import static org.wildfly.extension.microprofile.opentracing.SubsystemDefinition.MICROPROFILE_CONFIG_CAPABILITY_NAME;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -152,6 +153,7 @@ public class Subsystem_2_0_ParsingTestCase extends AbstractSubsystemBaseTest {
             super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
             Map<String, Class> capabilities = new HashMap<>();
             capabilities.put(WELD_CAPABILITY_NAME, WeldCapability.class);
+            capabilities.put(MICROPROFILE_CONFIG_CAPABILITY_NAME, Void.class);
             registerServiceCapabilities(capabilityRegistry, capabilities);
         }
     }

--- a/microprofile/opentracing-extension/src/test/java/org/wildfly/extension/microprofile/opentracing/Subsystem_3_0_ParsingTestCase.java
+++ b/microprofile/opentracing-extension/src/test/java/org/wildfly/extension/microprofile/opentracing/Subsystem_3_0_ParsingTestCase.java
@@ -24,6 +24,7 @@ package org.wildfly.extension.microprofile.opentracing;
 import static org.jboss.as.subsystem.test.AdditionalInitialization.registerServiceCapabilities;
 import static org.jboss.as.weld.Capabilities.WELD_CAPABILITY_NAME;
 import static org.junit.Assert.assertTrue;
+import static org.wildfly.extension.microprofile.opentracing.SubsystemDefinition.MICROPROFILE_CONFIG_CAPABILITY_NAME;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -164,6 +165,7 @@ public class Subsystem_3_0_ParsingTestCase extends AbstractSubsystemBaseTest {
             super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
             Map<String, Class> capabilities = new HashMap<>();
             capabilities.put(WELD_CAPABILITY_NAME, WeldCapability.class);
+            capabilities.put(MICROPROFILE_CONFIG_CAPABILITY_NAME, Void.class);
             registerServiceCapabilities(capabilityRegistry, capabilities);
         }
     }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap710/DomainAdjuster710.java
@@ -55,9 +55,8 @@ public class DomainAdjuster710 extends DomainAdjuster720 {
 
         list.addAll(removeEESecurity(profileAddress.append(SUBSYSTEM, "ee-security")));
         list.addAll(removeDiscovery(profileAddress.append(SUBSYSTEM, "discovery")));
-        list.addAll(removeMicroProfileConfigSmallrye(profileAddress.append(SUBSYSTEM, "microprofile-config-smallrye")));
         list.addAll(removeMicroProfileOpenTracing(profileAddress.append(SUBSYSTEM, "microprofile-opentracing-smallrye")));
-
+        list.addAll(removeMicroProfileConfigSmallrye(profileAddress.append(SUBSYSTEM, "microprofile-config-smallrye")));
         return list;
     }
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap730/DomainAdjuster730.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap730/DomainAdjuster730.java
@@ -74,9 +74,9 @@ public class DomainAdjuster730 extends DomainAdjuster {
 
     private void adjustOpenTracing(final List<ModelNode> ops, final PathAddress subsystem) {
         // jaeger resource does not exist
-        ops.add(createRemoveOperation(subsystem.append("jaeger-tracer", "jaeger")));
         ModelNode undefineAttr = createEmptyOperation("undefine-attribute", subsystem);
         undefineAttr.get("name").set("default-tracer");
         ops.add(undefineAttr);
+        ops.add(createRemoveOperation(subsystem.append("jaeger-tracer", "jaeger")));
     }
 }


### PR DESCRIPTION
* The capability wasn't registered when the subsystem was added.

Jira: https://issues.redhat.com/browse/WFLY-13892

