### PR TITLE
[WFLY-13884] JdrReportManagmentTestCase fails when using the wildfly-…

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -108,6 +108,7 @@ public class JdrRunner implements JdrReportCollector {
             }
             versionWriter.close();
             this.env.getZip().add(new ByteArrayInputStream(versionStream.toByteArray()), "version.txt");
+            this.env.getZip().add(new ByteArrayInputStream(this.env.getZip().getProductDirName().getBytes(StandardCharsets.UTF_8)), "product.txt");
 
         } catch (Exception e) {
             ROOT_LOGGER.error(ROOT_LOGGER.couldNotConfigureJDR(), e);


### PR DESCRIPTION
…ee-galleon pack

This patch adds a new entry to the JDR report to store the product directory name and get the rid of the test regular expression used to get entries under sos_string. Another option could be just navigate to the sos_string first subfolder but I thought adding the entry from the report could be more secure to be more confident with the report content under test.

Jira issue: https://issues.redhat.com/browse/WFLY-13884