### PR TITLE
[WFLY-13807] EE: Add component class info to interface based proxy to preserve validation metadata

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ee.component;
 
 import java.io.Serializable;
+import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.as.ee.logging.EeLogger;
@@ -90,7 +91,14 @@ class DefaultComponentViewConfigurator extends AbstractComponentConfigurator imp
 
             //we define it in the modules class loader to prevent permgen leaks
             if (viewClass.isInterface()) {
-                proxyConfiguration.setSuperClass(configuration.getComponentClass());
+                final Class<?> componentClass = configuration.getComponentClass();
+                Constructor<?> defaultConstructor = null;
+                try {
+                    defaultConstructor = componentClass.getConstructor();
+                } catch (NoSuchMethodException e) {
+                    //ignore
+                }
+                proxyConfiguration.setSuperClass(defaultConstructor == null ? Object.class : componentClass);
                 proxyConfiguration.addAdditionalInterface(viewClass);
                 viewConfiguration = view.createViewConfiguration(viewClass, configuration, new ProxyFactory(proxyConfiguration));
             } else {

--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
@@ -95,7 +95,7 @@ class DefaultComponentViewConfigurator extends AbstractComponentConfigurator imp
                 Constructor<?> defaultConstructor = null;
                 try {
                     defaultConstructor = componentClass.getConstructor();
-                } catch (NoSuchMethodException e) {
+                } catch (Exception e) {
                     //ignore
                 }
                 proxyConfiguration.setSuperClass(defaultConstructor == null ? Object.class : componentClass);

--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentViewConfigurator.java
@@ -90,7 +90,7 @@ class DefaultComponentViewConfigurator extends AbstractComponentConfigurator imp
 
             //we define it in the modules class loader to prevent permgen leaks
             if (viewClass.isInterface()) {
-                proxyConfiguration.setSuperClass(Object.class);
+                proxyConfiguration.setSuperClass(configuration.getComponentClass());
                 proxyConfiguration.addAdditionalInterface(viewClass);
                 viewConfiguration = view.createViewConfiguration(viewClass, configuration, new ProxyFactory(proxyConfiguration));
             } else {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
@@ -102,7 +102,7 @@ public class AuthorizationInterceptor implements Interceptor {
         final ComponentView componentView = context.getPrivateData(ComponentView.class);
         final String viewClassOfInvokedMethod = componentView.getViewClass().getName();
         // shouldn't really happen if the interceptor was setup correctly. But let's be safe and do a check
-        if (!this.viewClassName.equals(viewClassOfInvokedMethod) || !this.viewMethod.equals(invokedMethod)) {
+        if (!this.viewClassName.equals(viewClassOfInvokedMethod)) {
             throw EjbLogger.ROOT_LOGGER.failProcessInvocation(this.getClass().getName(), invokedMethod, viewClassOfInvokedMethod, viewMethod, viewClassName);
         }
         final EJBComponent ejbComponent = (EJBComponent) component;

--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -279,6 +279,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-xc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
             <scope>test</scope>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyAbstractClass.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyAbstractClass.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import javax.validation.constraints.Min;
+
+public abstract class DummyAbstractClass {
+    @Min(1)
+    protected int speed;
+
+    public abstract int getSpeed();
+
+    public abstract void setSpeed(int speed);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyClass.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyClass.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class DummyClass {
+    @NotNull
+    private String direction;
+
+    @Min(1)
+    protected int speed;
+
+    public int getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(int number) {
+        this.speed = number;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public void setDirection(String direction) {
+        this.direction = direction;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyFlag.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyFlag.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/")
+public interface DummyFlag {
+    void setExecutedServiceCallFlag(boolean flag);
+
+    @GET
+    @Path("executed/mark")
+    void markAsExecuted();
+
+    @GET
+    @Path("executed/clear")
+    void clearExecution();
+
+    @GET
+    @Path("executed/status")
+    public boolean getExecutedServiceCallFlag();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyFlagImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummyFlagImpl.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+@Startup
+@Singleton
+public class DummyFlagImpl implements DummyFlag {
+    private boolean executedServiceCallFlag;
+
+    public void setExecutedServiceCallFlag(boolean flag) {
+        executedServiceCallFlag = flag;
+    }
+
+    @Override
+    public void markAsExecuted() {
+        executedServiceCallFlag = true;
+    }
+
+    @Override
+    public void clearExecution() {
+        executedServiceCallFlag = false;
+    }
+
+    public boolean getExecutedServiceCallFlag() {
+        return executedServiceCallFlag;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummySubclass.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/DummySubclass.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import javax.validation.constraints.NotNull;
+
+public class DummySubclass extends DummyAbstractClass {
+    @NotNull
+    private String direction;
+
+    public int getSpeed() {
+        return speed;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public void setSpeed(int number) {
+        this.speed = number;
+    }
+
+    public void setDirection(String direction) {
+        this.direction = direction;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EchoResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EchoResource.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface EchoResource {
+    @POST
+    @Path("echoThroughAbstract")
+    Response validateEchoThroughAbstractClass(@Valid DummySubclass payload);
+
+    @POST
+    @Path("echo")
+    Response validateEchoThroughClass(@Valid DummyClass payload);
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EchoResourceImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EchoResourceImpl.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.validation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+@Stateless
+public class EchoResourceImpl implements EchoResource {
+    private static final Logger log = LoggerFactory.getLogger(EchoResourceImpl.class);
+
+    @Inject
+    private DummyFlag dummyFlag;
+
+    @Override
+    public Response validateEchoThroughAbstractClass(DummySubclass payload) {
+        dummyFlag.setExecutedServiceCallFlag(true);
+        return Response.ok(payload.getDirection()).build();
+    }
+
+    @Override
+    public Response validateEchoThroughClass(DummyClass payload) {
+        dummyFlag.setExecutedServiceCallFlag(true);
+        return Response.ok(payload.getDirection()).build();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EjbBeanValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EjbBeanValidationTestCase.java
@@ -21,6 +21,19 @@
  */
 package org.jboss.as.test.integration.ejb.validation;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,19 +48,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.net.URL;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
@@ -66,8 +66,7 @@ public class EjbBeanValidationTestCase {
                 .addPackage(HttpRequest.class.getPackage())
                 .addClasses(
                         EjbBeanValidationTestCase.class, TestApplication.class, TestResource.class, EchoResourceImpl.class, EchoResource.class,
-                        DummySubclass.class, DummyAbstractClass.class, DummyClass.class, DummyFlagImpl.class, DummyFlag.class)
-                .addAsWebInfResource("web.xml");
+                        DummySubclass.class, DummyAbstractClass.class, DummyClass.class, DummyFlagImpl.class, DummyFlag.class);
     }
 
     @ArquillianResource

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EjbBeanValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/validation/EjbBeanValidationTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -39,10 +40,14 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URL;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:tadamski@redhat.com">Tomasz Adamski</a>
@@ -60,10 +65,9 @@ public class EjbBeanValidationTestCase {
         return ShrinkWrap.create(WebArchive.class, "ejbvalidation.war")
                 .addPackage(HttpRequest.class.getPackage())
                 .addClasses(
-                        EjbBeanValidationTestCase.class,
-                        TestApplication.class,
-                        TestResource.class
-                );
+                        EjbBeanValidationTestCase.class, TestApplication.class, TestResource.class, EchoResourceImpl.class, EchoResource.class,
+                        DummySubclass.class, DummyAbstractClass.class, DummyClass.class, DummyFlagImpl.class, DummyFlag.class)
+                .addAsWebInfResource("web.xml");
     }
 
     @ArquillianResource
@@ -98,5 +102,81 @@ public class EjbBeanValidationTestCase {
                 .request(MediaType.APPLICATION_JSON).post(Entity.json("[\"a\",\"b\",\"c\"]"), String.class);
         Assert.assertEquals("a, b, c", result);
     }
+
+    @Test
+    public void testObjectValidationOnConcreteClass() throws Exception {
+        Client client = ClientBuilder.newBuilder().build();
+        WebTarget target = client.target(url.toURI().toString());
+        ResteasyWebTarget rtarget = (ResteasyWebTarget) target;
+        EchoResource customerResource = rtarget.proxy(EchoResource.class);
+        DummyFlag dummyFlag = rtarget.proxy(DummyFlag.class);
+
+        // Create a concrete class with valid values
+        DummyClass validDummyClass = new DummyClass();
+        validDummyClass.setSpeed(5);
+        validDummyClass.setDirection("north");
+
+        // Create a concrete class with invalid values (direction is null and speed is less than 1)
+        DummyClass invalidDummyClass = new DummyClass();
+        invalidDummyClass.setSpeed(0);
+
+        Response response = customerResource.validateEchoThroughClass(validDummyClass);
+
+        // Verify that we received a Bad Request Code from HTTP
+        assertTrue(String.format("Return code should be 200. It was %d", response.getStatus()), 200 == response.getStatus());
+
+        // Verify that the service call has not been executed (flag set to false)
+        assertTrue("Executed flag should be true", dummyFlag.getExecutedServiceCallFlag());
+
+        // Reset flag
+        dummyFlag.clearExecution();
+
+        Response response2 = customerResource.validateEchoThroughClass(invalidDummyClass);
+
+        // Verify that we received a Bad Request Code from HTTP
+        assertTrue(String.format("Return code should either be 400 or 500, it was %d", response2.getStatus()), 400 == response2.getStatus() || 500 == response2.getStatus());
+
+        // Verify that the service call has not been executed (flag set to false)
+        assertFalse("Executed flag should be false", dummyFlag.getExecutedServiceCallFlag());
+    }
+
+    @Test
+    public void testObjectValidationOnSubclassThatExtendsAbstractClass() throws Exception {
+        Client client = ClientBuilder.newClient();
+        WebTarget target = client.target(url.toURI().toString());
+        ResteasyWebTarget rtarget = (ResteasyWebTarget) target;
+        EchoResource customerResource = rtarget.proxy(EchoResource.class);
+        DummyFlag dummyFlag = rtarget.proxy(DummyFlag.class);
+
+        // Create subclass of DummyAbstractClass with valid values
+        DummySubclass validDummySubclass = new DummySubclass();
+        validDummySubclass.setDirection("north");
+        validDummySubclass.setSpeed(10);
+
+        // Create subclass of DummyAbstractClass with an invalid value (speed should be greater than 0)
+        DummySubclass invalidDummySubclass = new DummySubclass();
+        invalidDummySubclass.setDirection("north");
+        invalidDummySubclass.setSpeed(0);
+
+        Response response = customerResource.validateEchoThroughAbstractClass(validDummySubclass);
+
+        // Verify that we received a Bad Request Code from HTTP
+        assertTrue(String.format("Return code should be 200. It was %d", response.getStatus()), 200 == response.getStatus());
+
+        // Verify that the service call has not been executed (flag set to false)
+        assertTrue("Executed flag should be true", dummyFlag.getExecutedServiceCallFlag());
+
+        dummyFlag.clearExecution();
+
+        Response response2 = customerResource.validateEchoThroughAbstractClass(invalidDummySubclass);
+
+        // Verify that we received a Bad Request Code from HTTP
+        assertTrue(String.format("Return code should either be 400 or 500. It was %d", response2.getStatus()), 400 == response2.getStatus() || 500 == response2.getStatus());
+
+        // Verify that the service call has not been executed (flag set to false)
+        assertFalse("Executed flag should be false", dummyFlag.getExecutedServiceCallFlag());
+    }
+
+
 
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13807

This PR supercedes https://github.com/wildfly/wildfly/pull/13526, and fixed the 2 test failures in #13526 

