### PR TITLE
[WFLY-13880]: Resource adapter logs plaintext JMS password at Warning…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
         <version.org.jboss.ejb-client>4.0.35.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
-        <version.org.jboss.genericjms>2.0.6.Final</version.org.jboss.genericjms>
+        <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.2.10.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.4.23.Final</version.org.jboss.ironjacamar>


### PR DESCRIPTION
… level on connection error.

 * Upgrading the JMS Generic Resource Adapter.

Jira: https://issues.redhat.com/browse/WFLY-13880

https://github.com/jms-ra/generic-jms-ra/compare/generic-jms-ra-pom-2.0.6.Final...2.0.8.Final