### PR TITLE
[WFLY-13932] Upgrade Bouncy Castle to 1.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
         <version.org.apache.ws.xmlschema>2.2.5</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-4</version.org.apache.xalan>
         <version.org.bitbucket.jose4j>0.7.0</version.org.bitbucket.jose4j>
-        <version.org.bouncycastle>1.65</version.org.bouncycastle>
+        <version.org.bouncycastle>1.66</version.org.bouncycastle>
         <version.org.bytebuddy>1.9.11</version.org.bytebuddy>
         <version.org.codehaus.jackson>1.9.13.redhat-00007</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.4.0</version.org.codehaus.jettison>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13932

https://www.bouncycastle.org/releasenotes.html

The core upgrade is https://github.com/wildfly/wildfly-core/pull/4350. These should not rely on each other though.
