### PR TITLE
[WFLY-13938] Upgrade WildFly Core 13.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.0.Beta6</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.0.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13938

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.0.Final
Diff to previous integrated released: https://github.com/wildfly/wildfly-core/compare/13.0.0.Beta6...13.0.0.Final

---


## Release Notes - WildFly Core - Version 13.0.0.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4808'>WFCORE-4808</a>] -         Upgrade JGit to 5.9.0.202009080501-r
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5138'>WFCORE-5138</a>] -         Upgrade JBoss Remoting to 5.0.19.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5139'>WFCORE-5139</a>] -         Upgrade Bootable JAR Maven plugin to 2.0.0.Beta8
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5142'>WFCORE-5142</a>] -         Upgrade to Galleon 4.2.6.Final
</li>
</ul>
                                                                                                                                                                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4842'>WFCORE-4842</a>] -         Add support for TLSv1.3 using the OpenSSL TLS provider
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-4923'>WFCORE-4923</a>] -         read-resource operation does not resolve expressions recursively
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5113'>WFCORE-5113</a>] -         Formatters defined on handlers via the formatter pattern attribute are not properly removed
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5114'>WFCORE-5114</a>] -         File handlers should use the constructor for the append and filename attributes
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5118'>WFCORE-5118</a>] -         Cannot get resources from ContextClassLoader with Server Lifecycle Events
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5121'>WFCORE-5121</a>] -         Unable to add a new server in a server-group of older EAP 7 host controller that is managed by a newer EAP 7 Domain Controller
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5136'>WFCORE-5136</a>] -         NPE in ModelControllerMBeanHelper
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5137'>WFCORE-5137</a>] -         Bootable JAR - Security manager is not found
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5143'>WFCORE-5143</a>] -         Bouncycastle - Failing tests in RESTEasy TS
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5144'>WFCORE-5144</a>] -         Improve management model description of IO worker max-pool-size
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5135'>WFCORE-5135</a>] -         Add a test case to verify that banned modules are not provisioned with the Galleon layers 
</li>
</ul>
                                                        