### PR TITLE
[WFLY-13844] upgrading jboss-ejb-client from 4.0.33.Final to 4.0.34.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.33.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.34.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13844

Changes in this version of jboss-ejb-client: https://github.com/wildfly/jboss-ejb-client/compare/4.0.33.Final...4.0.34.Final

This PR has passed 4 rounds of CI tests. So I'd like to request to merge it into WildFly while we're working on some integratin issues of jboss-ejb-client 4.0.35.Final (the latest release).