### PR TITLE
DRAFT test WFLY-13894 Upgrade jboss-ejb-client to 4.0.35.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
-        <version.org.jboss.ejb-client>4.0.33.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>4.0.35.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -43,7 +43,9 @@ import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionSupplier;
@@ -106,6 +108,19 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
         return props ;
     }
 
+    @BeforeClass
+    public static void beforeClass() {
+        // set ejb client discovery timeout to 60 seconds
+        System.setProperty("org.jboss.ejb.client.discovery.timeout", "60");
+        // set the secondary timeout to much shorter 100 milliseconds
+        System.setProperty("org.jboss.ejb.client.discovery.additional-node-timeout", "100");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("org.jboss.ejb.client.discovery.timeout");
+        System.clearProperty("org.jboss.ejb.client.discovery.additional-node-timeout");
+    }
 
     /*
      * Run a failover test where the client communicates with the server via HTTP Upgrade over port 8080/8081
@@ -225,15 +240,11 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
                     .setup("/socket-binding-group=standard-sockets/socket-binding=remoting:add(port=4447)")
                     .setup("/subsystem=remoting/connector=remoting-connector:add(socket-binding=remoting, security-realm=ApplicationRealm)")
                     .setup("/subsystem=remoting/connector=remoting-connector/property=SSL_ENABLED:add(value=false)")
-                    .setup("/system-property=org.jboss.ejb.client.discovery.timeout:add(value=5)")
-                    .setup("/system-property=org.jboss.ejb.client.discovery.additional-node-timeout:add(value=1000)")
                     // this step results in a capabilities error if the list is not formatted correctly for CLI
                     .setup("/subsystem=ejb3/service=remote:list-add(name=connectors, value=remoting-connector)")
                     .teardown("/subsystem=ejb3/service=remote:list-remove(name=connectors, value=remoting-connector)")
                     .teardown("/subsystem=remoting/connector=remoting-connector:remove")
                     .teardown("/socket-binding-group=standard-sockets/socket-binding=remoting:remove")
-                    .teardown("/system-property=org.jboss.ejb.client.discovery.timeout:remove")
-                    .teardown("/system-property=org.jboss.ejb.client.discovery.additional-node-timeout:remove")
             ;
         }
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.clustering.cluster.ejb.remote;
 
 import java.util.Properties;
 import java.util.PropertyPermission;
+import javax.naming.Context;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -46,9 +47,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.common.function.ExceptionSupplier;
-
-
-import javax.naming.Context;
 
 /**
  * A test of failover when both legacy remoting connector and HTTP Upgrade connector are enabled.
@@ -227,11 +225,15 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
                     .setup("/socket-binding-group=standard-sockets/socket-binding=remoting:add(port=4447)")
                     .setup("/subsystem=remoting/connector=remoting-connector:add(socket-binding=remoting, security-realm=ApplicationRealm)")
                     .setup("/subsystem=remoting/connector=remoting-connector/property=SSL_ENABLED:add(value=false)")
+                    .setup("/system-property=org.jboss.ejb.client.discovery.timeout:add(value=5)")
+                    .setup("/system-property=org.jboss.ejb.client.discovery.additional-node-timeout:add(value=1000)")
                     // this step results in a capabilities error if the list is not formatted correctly for CLI
                     .setup("/subsystem=ejb3/service=remote:list-add(name=connectors, value=remoting-connector)")
                     .teardown("/subsystem=ejb3/service=remote:list-remove(name=connectors, value=remoting-connector)")
                     .teardown("/subsystem=remoting/connector=remoting-connector:remove")
                     .teardown("/socket-binding-group=standard-sockets/socket-binding=remoting:remove")
+                    .teardown("/system-property=org.jboss.ejb.client.discovery.timeout:remove")
+                    .teardown("/system-property=org.jboss.ejb.client.discovery.additional-node-timeout:remove")
             ;
         }
     }


### PR DESCRIPTION
This is a DRAFT pull to test the upgrade of jboss-ejb-client from ejb-client-4.0.33 to ejb-client-4.0.35 (latest), to check if all CI jobs pass.