### PR TITLE
[WFLY-13945] Upgrade WildFly Core 13.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>3.0.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.0.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>13.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/WFLY-13945

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/13.0.1.Final
Diff to previous integrated release: https://github.com/wildfly/wildfly-core/compare/13.0.0.Final...13.0.1.Final

---

## Release Notes - WildFly Core - Version 13.0.1.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5152'>WFCORE-5152</a>] -         Upgrade WildFly Elytron to 1.13.1.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/5153'>WFCORE-5153</a>] -         Upgrade Undertow to 2.2.2.Final
</li>
</ul>