### PR TITLE
[WFLY-13937] Revert original WildFly Arquillian upgrade and upgrade only for the ts.bootable profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
         <version.org.javassist>3.23.2-GA</version.org.javassist>
         <version.org.jberet>1.3.7.Final</version.org.jberet>
         <version.org.jboss.activemq.artemis.integration>1.0.2</version.org.jboss.activemq.artemis.integration>
-        <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
+        <version.org.jboss.arquillian.core>1.4.0.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.common.jboss-common-beans>2.0.1.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.ejb-client>4.0.33.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb-client-legacy>3.0.3.Final</version.org.jboss.ejb-client-legacy>
@@ -443,7 +443,7 @@
         <version.org.reactivestreams>1.0.3</version.org.reactivestreams>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
-        <version.org.wildfly.arquillian>3.0.0.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
         <version.org.wildfly.core>13.0.1.Final</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -331,7 +331,7 @@
             </activation>
             <properties>
                 <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
-                <version.org.wildfly.arquillian>3.0.0.Beta3</version.org.wildfly.arquillian>
+                <version.org.wildfly.arquillian>3.0.0.Final</version.org.wildfly.arquillian>
                 <version.org.wildfly.jar.plugin>2.0.0.Beta8</version.org.wildfly.jar.plugin>        
             </properties>            
             <modules>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -330,6 +330,8 @@
                 </property>
             </activation>
             <properties>
+                <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
+                <version.org.wildfly.arquillian>3.0.0.Beta3</version.org.wildfly.arquillian>
                 <version.org.wildfly.jar.plugin>2.0.0.Beta8</version.org.wildfly.jar.plugin>        
             </properties>            
             <modules>


### PR DESCRIPTION
Reverts the original commit for WFLY-13937 (#13624) and changes only the version for the `ts.bootable` profile.

https://issues.redhat.com/browse/WFLY-13937