### PR TITLE
Remove duplicate dependency in ejb3 module

### DIFF
--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -247,11 +247,6 @@ projects that depend on this project.-->
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.wildfly-http-client</groupId>
-            <artifactId>wildfly-http-ejb-client</artifactId>
-         </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Causes:

```
[WARNING] Some problems were encountered while building the effective model for org.wildfly:wildfly-ejb3:jar:21.0.0.Final-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.wildfly.wildfly-http-client:wildfly-http-ejb-client:jar -> duplicate declaration of version (?) @ line 249, column 21
```