### PR TITLE
[WFLY-13963] Upgrade PicketBox from 5.0.3.Final-redhat-00006 to 5.0.3.Final-redhat-00007

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
         <version.org.opensaml.opensaml>3.3.1</version.org.opensaml.opensaml>
         <version.org.ow2.asm>7.1</version.org.ow2.asm>
 		<!-- WildFly overrides the picketbox version from core to use MRRC variants -->
-		<version.org.picketbox>5.0.3.Final-redhat-00006</version.org.picketbox>
+		<version.org.picketbox>5.0.3.Final-redhat-00007</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.5.5.SP12-redhat-00009</version.org.picketlink>
         <version.org.picketlink.bindings>2.5.5.SP12-redhat-00012</version.org.picketlink.bindings>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13963

Branch: https://github.com/jbossas/redhat-picketbox/tree/5.0.x
Diff: https://github.com/jbossas/redhat-picketbox/compare/5.0.3.Final-18-g76744137...5.0.3.Final-20-ga35786ce

WF Core PicketBox upgrade: https://github.com/wildfly/wildfly-core/pull/4362