### PR TITLE
[WFLY-13968] Consider internal jaxb-impl module in more situations (tests)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,7 +415,7 @@
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>2.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.3_spec>
         <version.org.jboss.spec.javax.websockets>2.0.0.Final</version.org.jboss.spec.javax.websockets>
         <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
-        <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
+        <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>2.0.1.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.4_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>2.0.0.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.3_spec>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/FakeJAXBContextFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/FakeJAXBContextFactory.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb;
+
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBContextFactory;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.Validator;
+
+/**
+ * <p>Fake JAXB context factory for testing.</p>
+ *
+ * @author rmartinc
+ */
+public class FakeJAXBContextFactory implements JAXBContextFactory {
+
+    private static class FakeJAXBContext extends JAXBContext {
+
+        @Override
+        public Unmarshaller createUnmarshaller() throws JAXBException {
+            throw new UnsupportedOperationException("Fake JAXB context, method not implemented!");
+        }
+
+        @Override
+        public Marshaller createMarshaller() throws JAXBException {
+            throw new UnsupportedOperationException("Fake JAXB context, method not implemented!");
+        }
+
+        @Override
+        public Validator createValidator() throws JAXBException {
+            throw new UnsupportedOperationException("Fake JAXB context, method not implemented!");
+        }
+
+        @Override
+        public String toString() {
+            return FakeJAXBContext.class.getSimpleName();
+        }
+    }
+
+    @Override
+    public JAXBContext createContext(Class<?>[] types, Map<String, ?> map) throws JAXBException {
+        return new FakeJAXBContext();
+    }
+
+    @Override
+    public JAXBContext createContext(String string, ClassLoader cl, Map<String, ?> map) throws JAXBException {
+        return new FakeJAXBContext();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/JAXBContextServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/JAXBContextServlet.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import org.jboss.as.test.integration.jaxb.bindings.PurchaseOrderType;
+
+/**
+ * <p>Servlet that shows the JAXBContext retrieved.</p>
+ *
+ * @author rmartinc
+ */
+@WebServlet (urlPatterns = JAXBContextServlet.URL_PATTERN)
+public class JAXBContextServlet extends HttpServlet {
+
+    public static final String URL_PATTERN = "/jaxbContextServlet";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            JAXBContext ctx = JAXBContext.newInstance(PurchaseOrderType.class);
+            resp.setContentType("text/plain;charset=UTF-8");
+            try (PrintWriter out = resp.getWriter()) {
+                out.print(ctx);
+            }
+        } catch (JAXBException e) {
+            throw new ServletException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropCustomTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropCustomTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb.unit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Test for JAXB using a System Property. The test will try using a
+ * custom/fake implementation.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({JAXBContextSystemPropCustomTestCase.SystemPropertiesSetup.class})
+@RunAsClient
+public class JAXBContextSystemPropCustomTestCase extends JAXBContextTestBase {
+
+   /**
+     * Setup the system property to configure the custom jaxb implementation.
+     */
+    static class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+
+        @Override
+        protected SystemProperty[] getSystemProperties() {
+            return new SystemProperty[] {
+                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, CUSTOM_JAXB_FACTORY_CLASS)
+            };
+        }
+    }
+
+    @Deployment(name = "app-custom", testable = false)
+    public static WebArchive createCustomDeployment() {
+        return JAXBContextTestBase.createCustomDeployment();
+    }
+
+    @OperateOnDeployment("app-custom")
+    @Test
+    public void testCustom() throws Exception {
+        testCustomImplementation(url);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropInternalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextSystemPropInternalTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb.unit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Test for JAXB using a System Property. The test will try using the
+ * default implementation inside the module.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({JAXBContextSystemPropInternalTestCase.SystemPropertiesSetup.class})
+@RunAsClient
+public class JAXBContextSystemPropInternalTestCase extends JAXBContextTestBase {
+
+   /**
+     * Setup the system property to configure internal jaxb implementation.
+     */
+    static class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+
+        @Override
+        protected SystemProperty[] getSystemProperties() {
+            return new SystemProperty[] {
+                new DefaultSystemProperty(JAXB_FACTORY_PROP_NAME, DEFAULT_JAXB_FACTORY_CLASS)
+            };
+        }
+    }
+
+    @Deployment(name = "app-internal", testable = false)
+    public static WebArchive createInternalDeployment() {
+        return JAXBContextTestBase.createInternalDeployment();
+    }
+
+    @OperateOnDeployment("app-internal")
+    @Test
+    public void testInternal() throws Exception {
+        testDeafultImplementation(url);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextTestBase.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb.unit;
+
+import java.io.FilePermission;
+import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
+import java.net.URL;
+import javax.xml.bind.JAXBContextFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.jaxb.FakeJAXBContextFactory;
+import org.jboss.as.test.integration.jaxb.JAXBContextServlet;
+import org.jboss.as.test.integration.jaxb.JAXBUsageServlet;
+import org.jboss.as.test.integration.jaxb.bindings.Items;
+import org.jboss.as.test.integration.jaxb.bindings.ObjectFactory;
+import org.jboss.as.test.integration.jaxb.bindings.PurchaseOrderType;
+import org.jboss.as.test.integration.jaxb.bindings.USAddress;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+
+/**
+ * <p>Base class for all the JAXB loading tests</p>
+ *
+ * @author rmartinc
+ */
+public abstract class JAXBContextTestBase {
+
+    protected static final String WEB_APP_INTERNAL_CONTEXT = "jaxb-internal-webapp";
+    protected static final String WEB_APP_CUSTOM_CONTEXT = "jaxb-custom-webapp";
+
+    protected static final String JAXB_FACTORY_PROP_NAME = JAXBContextFactory.class.getName();
+    protected static final String DEFAULT_JAXB_FACTORY_CLASS = "com.sun.xml.bind.v2.JAXBContextFactory";
+    protected static final String CUSTOM_JAXB_FACTORY_CLASS = FakeJAXBContextFactory.class.getName();
+    protected static final String JAXB_PROPERTIES_FILE = "WEB-INF/classes/org/jboss/as/test/integration/jaxb/bindings/jaxb.properties";
+    protected static final String SERVICES_FILE = "META-INF/services/" + JAXB_FACTORY_PROP_NAME;
+    protected static final String PERMISSIONS_FILE = "META-INF/permissions.xml";
+
+    @ArquillianResource
+    protected URL url;
+
+    public static WebArchive createInternalDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_INTERNAL_CONTEXT + ".war");
+        war.addClasses(JAXBContextServlet.class, JAXBUsageServlet.class, Items.class, ObjectFactory.class, PurchaseOrderType.class, USAddress.class);
+        war.add(PermissionUtils.createPermissionsXmlAsset(
+                new RuntimePermission("accessDeclaredMembers"),
+                new ReflectPermission("suppressAccessChecks"),
+                new FilePermission("<<ALL FILES>>", "read")), PERMISSIONS_FILE);
+        return war;
+    }
+
+    public static WebArchive createCustomDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_CUSTOM_CONTEXT + ".war");
+        war.addClasses(JAXBContextServlet.class, Items.class, ObjectFactory.class, PurchaseOrderType.class, USAddress.class, FakeJAXBContextFactory.class);
+        return war;
+    }
+
+    protected void testDeafultImplementation(URL url) throws IOException {
+        // test the internal implementation is returned
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            final String requestURL = url.toExternalForm() + JAXBContextServlet.URL_PATTERN;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            Assert.assertEquals("Unexpected status code", 200, statusCode);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertThat(responseMessage, CoreMatchers.containsString("/com/sun/xml/bind/v2/runtime/JAXBContextImpl"));
+        }
+        // test it works
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            final String requestURL = url.toExternalForm() + JAXBUsageServlet.URL_PATTERN;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            Assert.assertEquals("Unexpected status code", 200, statusCode);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Wrong return value", "Mill Valley", responseMessage.trim());
+        }
+    }
+
+    protected void testCustomImplementation(URL url) throws IOException {
+        // test the custom jaxb context is returned
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            final String requestURL = url.toExternalForm() + JAXBContextServlet.URL_PATTERN;
+            final HttpGet request = new HttpGet(requestURL);
+            final HttpResponse response = httpClient.execute(request);
+            int statusCode = response.getStatusLine().getStatusCode();
+            Assert.assertEquals("Unexpected status code", 200, statusCode);
+            final HttpEntity entity = response.getEntity();
+            Assert.assertNotNull("Response message from servlet was null", entity);
+            final String responseMessage = EntityUtils.toString(entity);
+            Assert.assertEquals("Fake context is returned", "FakeJAXBContext", responseMessage);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingPropertiesTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb.unit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Test for JAXB using a <em>jaxb.properties</em> file. The test will try to
+ * use the default implementation inside the module and a custom/fake one.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JAXBContextUsingPropertiesTestCase extends JAXBContextTestBase {
+
+    @Deployment(name = "app-internal", testable = false)
+    public static WebArchive createInternalDeployment() {
+        final WebArchive war = JAXBContextTestBase.createInternalDeployment();
+        war.add(new StringAsset(JAXB_FACTORY_PROP_NAME + "=" + DEFAULT_JAXB_FACTORY_CLASS), JAXB_PROPERTIES_FILE);
+        return war;
+    }
+
+    @Deployment(name = "app-custom", testable = false)
+    public static WebArchive createCustomDeployment() {
+        final WebArchive war = JAXBContextTestBase.createCustomDeployment();
+        war.add(new StringAsset(JAXB_FACTORY_PROP_NAME + "=" + CUSTOM_JAXB_FACTORY_CLASS), JAXB_PROPERTIES_FILE);
+        return war;
+    }
+
+    @OperateOnDeployment("app-internal")
+    @Test
+    public void testInternal() throws Exception {
+        testDeafultImplementation(url);
+    }
+
+    @OperateOnDeployment("app-custom")
+    @Test
+    public void testCustom() throws Exception {
+        testCustomImplementation(url);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingServicesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jaxb/unit/JAXBContextUsingServicesTestCase.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.jaxb.unit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * <p>Test for JAXB using a <em>META-INF/services/</em> file. The test will try
+ * to use the custom/fake implementation provided by the app.</p>
+ *
+ * @author rmartinc
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JAXBContextUsingServicesTestCase extends JAXBContextTestBase {
+
+    @Deployment(name = "app-custom", testable = false)
+    public static WebArchive createCustomDeployment() {
+        final WebArchive war = JAXBContextTestBase.createCustomDeployment();
+        war.add(new StringAsset(CUSTOM_JAXB_FACTORY_CLASS), SERVICES_FILE);
+        return war;
+    }
+
+    @OperateOnDeployment("app-custom")
+    @Test
+    public void testCustom() throws Exception {
+        testCustomImplementation(url);
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13968

Tests for the jaxb modifications in WFLY-13968. Just testing different ways of setting the jaxb context factory, tests try to use a custom implementation and the internal default one that wildfly bundles. Tests added: setting custom and default using `jaxb.properties` file; using system props; setting custom impl using a META-INF services file inside the app (default one already tested in `JAXBUsageTestCase`).

Until the jaxb implementation is upgraded the following tests will fail: JAXBContextSystemPropInternalTestCase.testInternal and JAXBContextUsingPropertiesTestCase.testInternal.

PR in jaxb project: https://github.com/jboss/jboss-jakarta-jaxb-api_spec/pull/3