### PR TITLE
Fix for WFLY-13982, Upgrade Bootable JAR Maven plugin to 2.0.1.Final

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -332,7 +332,7 @@
             <properties>
                 <version.org.jboss.arquillian.core>1.6.0.Final</version.org.jboss.arquillian.core>
                 <version.org.wildfly.arquillian>3.0.1.Final</version.org.wildfly.arquillian>
-                <version.org.wildfly.jar.plugin>2.0.0.Beta8</version.org.wildfly.jar.plugin>        
+                <version.org.wildfly.jar.plugin>2.0.1.Final</version.org.wildfly.jar.plugin>        
             </properties>            
             <modules>
                 <module>basic</module>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/WFLY-13982
Diff with Beta8: https://github.com/wildfly-extras/wildfly-jar-maven-plugin/compare/2.0.0.Beta8...2.0.1.Final
