### PR TITLE
[WFLY-13984] Upgrade IronJacamar to 1.4.24.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,7 +382,7 @@
         <version.org.jboss.genericjms>2.0.8.Final</version.org.jboss.genericjms>
         <version.org.jboss.hal.console>3.2.11.Final</version.org.jboss.hal.console>
         <version.org.jboss.iiop-client>1.0.1.Final</version.org.jboss.iiop-client>
-        <version.org.jboss.ironjacamar>1.4.23.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>1.4.24.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.6.0.Final</version.org.jboss.jboss-transaction-spi>
         <!-- Only used for testing -->
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13984

This issue add the Jakarta EE connector 2.0 parsing:
https://issues.redhat.com/browse/WFLY-13964
