### PR TITLE
[WFLY-13132] Small fix to test case for TwoConnectorsEJBFailoverTestCase

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/TwoConnectorsEJBFailoverTestCase.java
@@ -184,6 +184,9 @@ public class TwoConnectorsEJBFailoverTestCase extends AbstractClusteringTestCase
 
             stop(target);
 
+            // Allow sufficient time for client to receive new topology
+            Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
             result = bean.increment();
             // Bean should failover to other node
             failoverTarget = result.getNode();


### PR DESCRIPTION
This PR does the following:
- adds a missing sleep delay to the existing text case TwoConnectorsEJBFailoverTestCase 

For more details: see https://issues.redhat.com/browse/WFLY-13132