### PR TITLE
[WFLY-13989] Upgrade WildFly Core 14.0.0.Beta1

### DIFF
--- a/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/ee-feature-pack/common/src/main/resources/content/appclient/configuration/appclient.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:14.0">
+<server xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <extension module="org.jboss.as.connector"/>

--- a/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
+++ b/ee-feature-pack/common/src/main/resources/content/docs/examples/configs/standalone-minimalistic.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:14.0">
+<server xmlns="urn:jboss:domain:15.0">
     <management>
         <security-realms>
             <security-realm name="ManagementRealm">

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:14.0">
+<domain xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="master">
+<host xmlns="urn:jboss:domain:15.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0">
+<host xmlns="urn:jboss:domain:15.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="master">
+<host xmlns="urn:jboss:domain:15.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/ee-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:14.0">
+<server xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/pom.xml
+++ b/pom.xml
@@ -444,7 +444,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.testng>6.14.3</version.org.testng>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.wildfly.core>13.0.1.Final</version.org.wildfly.core>
+        <version.org.wildfly.core>14.0.0.Beta1</version.org.wildfly.core>
         <version.org.wildfly.extras.creaper>1.6.1</version.org.wildfly.extras.creaper>
         <version.org.wildfly.http-client>1.1.2.Final</version.org.wildfly.http-client>
         <version.org.wildfly.naming-client>1.0.13.Final</version.org.wildfly.naming-client>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<domain xmlns="urn:jboss:domain:14.0">
+<domain xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="master">
+<host xmlns="urn:jboss:domain:15.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0">
+<host xmlns="urn:jboss:domain:15.0">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/host/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="master">
+<host xmlns="urn:jboss:domain:15.0" name="master">
     <extensions>
         <?EXTENSIONS?>
     </extensions>

--- a/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/servlet-feature-pack/legacy-feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:14.0">
+<server xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0"
+<domain xmlns="urn:jboss:domain:15.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0">
+<domain xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-respawn.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0"
+<domain xmlns="urn:jboss:domain:15.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard-ee.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0">
+<domain xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0">
+<domain xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h1">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h2">

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="failover-h3">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="master">
+<host xmlns="urn:jboss:domain:15.0" name="master">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-http.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host xmlns="urn:jboss:domain:14.0" name="slave">
+<host xmlns="urn:jboss:domain:15.0" name="slave">
     <extensions>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.wildfly.extension.core-management"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="slave">

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<host xmlns="urn:jboss:domain:14.0"
+<host xmlns="urn:jboss:domain:15.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="urn:jboss:domain:10.0 wildfly-config_10_0.xsd"
       name="master">

--- a/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
+++ b/testsuite/mixed-domain/src/test/resources/legacy-templates/test-template.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<server xmlns="urn:jboss:domain:14.0">
+<server xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <?EXTENSIONS?>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain-minimal.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<domain xmlns="urn:jboss:domain:14.0"
+<domain xmlns="urn:jboss:domain:15.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <extensions>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host-master-elytron.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:14.0">
+<host name="master" xmlns="urn:jboss:domain:15.0">
 
     <extensions>
         <extension module="org.jboss.as.jmx"/>

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<host name="master" xmlns="urn:jboss:domain:14.0">
+<host name="master" xmlns="urn:jboss:domain:15.0">
 
     <management>
         <security-realms>


### PR DESCRIPTION
Update the XSD namespace to urn:jboss:domain:15.0

JIRA: https://issues.redhat.com/browse/WFLY-13989

Signed-off-by: Jeff Mesnil <jmesnil@redhat.com>

---

Dev tag: https://github.com/wildfly/wildfly-core/releases/tag/14.0.0.Beta1
Diff to previous integrated released: https://github.com/wildfly/wildfly-core/compare/13.0.1.Final...14.0.0.Beta1

---

##  Release Notes - WildFly Core - Version 14.0.0.Beta1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5141'>WFCORE-5141</a>] -         Upgrade JBoss Marshalling from 2.0.9.Final to 2.0.10.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5148'>WFCORE-5148</a>] -         Upgrade Bouncy Castle from 1.65 to 1.66
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5156'>WFCORE-5156</a>] -         Upgrade junit to 4.13.1
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5157'>WFCORE-5157</a>] -         Upgrade FasterXML Jackson to 2.11.3
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5158'>WFCORE-5158</a>] -         Upgrade Apache HTTP Client to 4.5.13
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5159'>WFCORE-5159</a>] -         Upgrade PicketBox from 5.0.3.Final-redhat-00006 to 5.0.3.Final-redhat-00007
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5161'>WFCORE-5161</a>] -         Upgrade slf4j-jboss-logmanager to 1.1.0.Final
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5165'>WFCORE-5165</a>] -         Upgrade Bootable JAR Maven plugin to 2.0.1.Final
</li>
</ul>
    
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5163'>WFCORE-5163</a>] -         Support EE 9 permissions.xml parsing
</li>
</ul>
                                                                                                                                                                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5150'>WFCORE-5150</a>] -         Elytron - PolicyDefinitions#registerHandler uses double-check of the same thing
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5155'>WFCORE-5155</a>] -         A NullPointException was found in a wildfly-jar-maven-plugin test
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5140'>WFCORE-5140</a>] -         Bump the Elytron subsystem version ready for the next phase of feature development.
</li>
<li>[<a href='https://issues.redhat.com/browse/WFCORE-5164'>WFCORE-5164</a>] -         Bump the kernel management API version to 15.0.0 and the xsd to 15.0
</li>
</ul>
                                                        