### PR TITLE
[21.x] WFLY-13988 Add missing dependency org.jboss.threads to org.infinispan module

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -42,6 +42,7 @@
         <module name="org.infinispan.protostream"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
+        <module name="org.jboss.threads"/>
         <module name="org.jgroups" optional="true"/>
         <module name="org.reactivestreams"/>
         <module name="sun.jdk" optional="true"/>


### PR DESCRIPTION
https://issues.redhat.com/browse/WFLY-13988

Backport of https://github.com/wildfly/wildfly/pull/13664