### PR TITLE
[WFLY-13871] Fix suspend resume integration for EJB client invoking on EJB 2.x beans

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/EjbExceptionTransformingInterceptorFactories.java
@@ -36,6 +36,7 @@ import javax.ejb.TransactionRolledbackLocalException;
 import javax.transaction.TransactionRequiredException;
 import javax.transaction.TransactionRolledbackException;
 
+import org.jboss.as.ejb3.component.EJBComponentUnavailableException;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
@@ -90,6 +91,9 @@ public class EjbExceptionTransformingInterceptorFactories {
             } catch (NoSuchEntityException e) {
                 // this exception explicitly forbids initializing a cause
                 throw copyStackTrace(new NoSuchObjectException(e.getMessage()), e);
+            } catch(EJBComponentUnavailableException e) {
+                // do not wrap this exception in RemoteException as it is not destined for the client (WFLY-13871)
+                throw e;
             } catch (EJBException e) {
                 //as the create exception is not propagated the init method interceptor just stashes it in a ThreadLocal
                 CreateException createException = popCreateException();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepository.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepository.java
@@ -43,6 +43,8 @@ public interface DeploymentRepository {
 
     void resume();
 
+    boolean isSuspended();
+
     /**
      * Returns all deployments. These deployments may not be in a started state, i.e. not all components might be ready to receive invocations.
      *

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepositoryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepositoryService.java
@@ -150,6 +150,11 @@ public class DeploymentRepositoryService implements DeploymentRepository, Servic
     }
 
     @Override
+    public boolean isSuspended() {
+        return suspended;
+    }
+
+    @Override
     public void suspend() {
         final List<DeploymentRepositoryListener> listeners;
         final Set<DeploymentModuleIdentifier> moduleIdentifiers;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/SuspendResumeRemoteEJBTestCase.java
@@ -1,0 +1,410 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb.remote;
+
+import org.apache.commons.lang.math.RandomUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Heartbeat;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.HeartbeatBean;
+import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Result;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.PropertyPermission;
+import java.util.Set;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.RUNNING_STATE_SUSPENDED;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+
+/**
+ * Test for WFLY-13871.
+ * <p>
+ * This test will set up an EJB client interacting with a cluster of two nodes and verify that when
+ * one of the nodes is suspended, invovations no longer are sent to the suspended node; and that when the node is resumed,
+ * invocations return to the resumed node.
+ *
+ * @author Richard Achmatowicz
+ */
+@RunWith(Arquillian.class)
+public class SuspendResumeRemoteEJBTestCase extends AbstractClusteringTestCase {
+
+    static final Logger LOGGER = Logger.getLogger(SuspendResumeRemoteEJBTestCase.class);
+    private static final String MODULE_NAME = SuspendResumeRemoteEJBTestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, Heartbeat.class, HeartbeatBean.class, RandomUtils.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    @ArquillianResource
+    @TargetsContainer(NODE_1)
+    private ManagementClient client1;
+
+    @ArquillianResource
+    @TargetsContainer(NODE_2)
+    private ManagementClient client2;
+
+    final int INVOCATION_LOOP_TIMES = 10;
+    final int SUSPEND_RESUME_LOOP_TIMES = 10;
+
+    // time between invocations
+    final long INV_WAIT_DURATION_MSECS = 10;
+    // time that the server remains suspended (or resumed) during continuous invocations
+    final long SUSPEND_RESUME_DURATION_MSECS = 1 * 1000;
+
+    // the set of nodes available, according to suspend/resume
+    Set<String> nodesAvailable = new HashSet<String>();
+
+
+    @Before
+    public void initialiseNodesAvailable() {
+        nodesAvailable.addAll(Arrays.asList(NODE_1, NODE_2));
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created before the server is suspended.
+     * <p>
+     * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(1)
+    public void testSuspendResumeAfterProxyInit() throws Exception {
+        LOGGER.info("testSuspendResumeAfterProxyInit() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+            Heartbeat bean = directory.lookupStateless(HeartbeatBean.class, Heartbeat.class);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            suspendTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            resumeTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+        } catch (Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        } finally {
+            LOGGER.info("testSuspendResumeAfterProxyInit() - end");
+        }
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created after the server is suspended.
+     * <p>
+     * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(2)
+    public void testSuspendResumeBeforeProxyInit() throws Exception {
+        LOGGER.info("testSuspendResumeBeforeProxyInit() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+
+            suspendTheServer(NODE_1);
+
+            Heartbeat bean = directory.lookupStateless(HeartbeatBean.class, Heartbeat.class);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            resumeTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+        } catch (Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        } finally {
+            LOGGER.info("testSuspendResumeBeforeProxyInit() - end");
+        }
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created after the server is suspended.
+     * <p>
+     * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(3)
+    public void testSuspendResumeContinuous() throws Exception {
+        LOGGER.info("testSuspendResumeContinuous() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+
+            Heartbeat bean = directory.lookupStateless(HeartbeatBean.class, Heartbeat.class);
+            ContinuousInvoker continuousInvoker = new ContinuousInvoker(bean);
+
+            Thread thread = new Thread(continuousInvoker);
+            LOGGER.info("Starting the invoker ...");
+            thread.start();
+
+            for (int i = 1; i < SUSPEND_RESUME_LOOP_TIMES ; i++) {
+                // suspend and then resume each server in turn while invocations happen
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                suspendTheServer(NODE_1);
+
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                resumeTheServer(NODE_1);
+
+                // suspend and then resume each server in turn while invocations happen
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                suspendTheServer(NODE_2);
+
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                resumeTheServer(NODE_2);
+            }
+
+            continuousInvoker.stopInvoking();
+
+        } catch (Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        } finally {
+            LOGGER.info("testSuspendResumeContinuous() - end");
+        }
+    }
+
+
+    /**
+     * Helper class that performs invocations on a bean once per second until stopInvoking() is called.
+     */
+    private class ContinuousInvoker implements Runnable {
+        private boolean invoking = true;
+        Heartbeat bean = null;
+
+        public ContinuousInvoker(Heartbeat bean) {
+            this.bean = bean;
+        }
+
+        public synchronized void stopInvoking() {
+            LOGGER.info("Stopping the invoker ...");
+            this.invoking = false;
+        }
+
+        private synchronized boolean keepInvoking() {
+            return this.invoking == true;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (keepInvoking()) {
+                    performInvocation(bean);
+                }
+            } catch (Exception e) {
+                LOGGER.info("ContinousInvoker: caught exception while performing invocation: e = " + e.getMessage());
+                throw e;
+            }
+        }
+    }
+
+    private void performInvocation(Heartbeat bean) {
+        Result<Date> result = null;
+        try {
+            result = bean.pulse();
+
+            LOGGER.info("invoked pulse(), result: node = " + result.getNode() + ", value = " + result.getValue());
+            Assert.assertTrue(nodesAvailable.contains(result.getNode()));
+
+            sleep(INV_WAIT_DURATION_MSECS);
+        } catch (Exception e) {
+            LOGGER.info("Exception caught while invoking pulse(): " + e.getMessage());
+            throw e;
+        }
+    }
+
+
+    // helper methods to determine server state
+
+    private void suspendTheServer(String node) {
+        LOGGER.info("=================== SUSPEND  " + node + " ===========================");
+        if (suspendServer(node)) {
+            nodesAvailable.remove(node);
+        }
+        LOGGER.info(isServerSuspended(node) ? node + " is suspended" : node + " is NOT suspended");
+    }
+
+    private void resumeTheServer(String node) {
+        LOGGER.info("=================== RESUME  " + node + " ===========================");
+        if (resumeServer(node)) {
+            nodesAvailable.add(node);
+        }
+        LOGGER.info(isServerSuspended(node) ? node + " is suspended" : node + " is NOT suspended");
+    }
+
+    private boolean isServerRunning(String node) {
+        try {
+            ModelNode op = Util.createOperation("read-attribute", PathAddress.EMPTY_ADDRESS);
+            op.get(NAME).set("server-state");
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString())
+                    && !CONTROLLER_PROCESS_STATE_STARTING.equals(result.get(RESULT).asString())
+                    && !CONTROLLER_PROCESS_STATE_STOPPING.equals(result.get(RESULT).asString());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Suspend a server by calling the management operation ":suspend"
+     *
+     * @param node the node to be suspended
+     * @return true if the operation succeeded
+     */
+    private boolean suspendServer(String node) {
+        try {
+            ModelNode op = Util.createOperation("suspend", PathAddress.EMPTY_ADDRESS);
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Resume a server by calling the management operation ":suspend"
+     *
+     * @param node the node to be suspended
+     * @return true if the operation succeeded
+     */
+    private boolean resumeServer(String node) {
+        try {
+            ModelNode op = Util.createOperation("resume", PathAddress.EMPTY_ADDRESS);
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if a server is suspended by reading the server attribute "suspend-state"
+     *
+     * @param node the node to be checked
+     * @return true if the server is suspended
+     */
+    private boolean isServerSuspended(String node) {
+        try {
+            ModelNode op = Util.createOperation("read-attribute", PathAddress.EMPTY_ADDRESS);
+            op.get(NAME).set("suspend-state");
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString())
+                    && RUNNING_STATE_SUSPENDED.equalsIgnoreCase(result.get(RESULT).asString());
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private void sleep(long ms) {
+        try {
+            LOGGER.info("Sleeping for " + ms + " ms ...");
+            Thread.sleep(ms);
+        } catch (InterruptedException ie) {
+            // noop
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/SlowHeartbeatBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/SlowHeartbeatBean.java
@@ -1,0 +1,27 @@
+package org.jboss.as.test.clustering.cluster.ejb.remote.bean;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import java.util.Date;
+
+@Stateless
+@Remote(Heartbeat.class)
+public class SlowHeartbeatBean implements Heartbeat {
+
+    @Override
+    public Result<Date> pulse() {
+        delay();
+        Date now = new Date();
+        return new Result<>(now);
+    }
+
+    private static void delay() {
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/SuspendResumeRemoteEJB2TestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/SuspendResumeRemoteEJB2TestCase.java
@@ -1,0 +1,413 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering.cluster.ejb2.remote;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.clustering.cluster.AbstractClusteringTestCase;
+import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.HeartbeatBeanBase;
+import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.HeartbeatRemote;
+import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.HeartbeatRemoteHome;
+import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.Result;
+import org.jboss.as.test.clustering.cluster.ejb2.remote.bean.SlowHeartbeatBean;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.PropertyPermission;
+import java.util.Set;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.RUNNING_STATE_SUSPENDED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+/**
+ * Test for WFLY-13871.
+ *
+ * This test will set up an EJB client interacting with a cluster of two nodes and verify that when
+ * one of the nodes is suspended, invovations no longer are sent to the suspended node; and that when the node is resumed,
+ * invocations return to the resumed node.
+ *
+ * @author Richard Achmatowicz
+ */
+@RunWith(Arquillian.class)
+public class SuspendResumeRemoteEJB2TestCase extends AbstractClusteringTestCase {
+
+    static final Logger LOGGER = Logger.getLogger(SuspendResumeRemoteEJB2TestCase.class);
+    private static final String MODULE_NAME = SuspendResumeRemoteEJB2TestCase.class.getSimpleName();
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(NODE_1)
+    public static Archive<?> createDeploymentForContainer1() {
+        return createDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(NODE_2)
+    public static Archive<?> createDeploymentForContainer2() {
+        return createDeployment();
+    }
+
+    private static Archive<?> createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
+                .addPackage(EJBDirectory.class.getPackage())
+                .addClasses(Result.class, HeartbeatRemote.class, HeartbeatRemoteHome.class, SlowHeartbeatBean.class, HeartbeatBeanBase.class, RandomUtils.class)
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(NODE_NAME_PROPERTY, "read")), "permissions.xml")
+                ;
+    }
+
+    @ArquillianResource
+    @TargetsContainer(NODE_1)
+    private ManagementClient client1;
+
+    @ArquillianResource
+    @TargetsContainer(NODE_2)
+    private ManagementClient client2;
+
+    final int INVOCATION_LOOP_TIMES = 5 ;
+    final int SUSPEND_RESUME_LOOP_TIMES = 5 ;
+
+    // time between invocations
+    final long INV_WAIT_DURATION_MSECS = 10 ;
+    // time that the server remains suspended (or resumed) during continuous invocations
+    final long SUSPEND_RESUME_DURATION_MSECS = 1 * 1000 ;
+
+    // the set of nodes available, according to suspend/resume
+    Set<String> nodesAvailable = new HashSet<String>();
+
+
+    @Before
+    public void initialiseNodesAvailable() {
+        nodesAvailable.addAll(Arrays.asList(NODE_1,NODE_2));
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created before the server is suspended.
+     *
+     * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(1)
+    public void testSuspendResumeAfterProxyInit() throws Exception {
+        LOGGER.info("testSuspendResumeAfterProxyInit() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+
+            HeartbeatRemoteHome home = directory.lookupHome(SlowHeartbeatBean.class, HeartbeatRemoteHome.class);
+            HeartbeatRemote bean = home.create();
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            suspendTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            resumeTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+        } catch(Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        } finally {
+            LOGGER.info("testSuspendResumeAfterProxyInit() - end");
+        }
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created after the server is suspended.
+     *
+     *  The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(2)
+    public void testSuspendResumeBeforeProxyInit() throws Exception {
+        LOGGER.info("testSuspendResumeBeforeProxyInit() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+
+            suspendTheServer(NODE_1);
+
+            HeartbeatRemoteHome home = directory.lookupHome(SlowHeartbeatBean.class, HeartbeatRemoteHome.class);
+            HeartbeatRemote bean = home.create();
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+
+            resumeTheServer(NODE_1);
+
+            for (int i = 1; i < INVOCATION_LOOP_TIMES; i++) {
+                performInvocation(bean);
+            }
+        } catch(Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        } finally {
+            LOGGER.info("testSuspendResumeBeforeProxyInit() - end");
+        }
+    }
+
+    /**
+     * This test checks that suspending and then resuming the server during invocation results in correct behaviour
+     * in the case that the proxy is created after the server is suspended.
+     *
+     * The test assertion is checked after each invocation result, and verifies that no invocation is sent to a suspended node.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(3)
+    public void testSuspendResumeContinuous() throws Exception {
+        LOGGER.info("testSuspendResumeContinuous() - start");
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+
+            HeartbeatRemoteHome home = directory.lookupHome(SlowHeartbeatBean.class, HeartbeatRemoteHome.class);
+            HeartbeatRemote bean = home.create();
+            ContinuousInvoker continuousInvoker = new ContinuousInvoker(bean);
+
+            Thread thread = new Thread(continuousInvoker);
+            LOGGER.info("Starting the invoker ...");
+            thread.start();
+
+            for (int i = 0; i < SUSPEND_RESUME_LOOP_TIMES; i++) {
+                // suspend and then resume each server in turn while invocations happen
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                suspendTheServer(NODE_1);
+
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                resumeTheServer(NODE_1);
+
+                // suspend and then resume each server in turn while invocations happen
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                suspendTheServer(NODE_2);
+
+                sleep(SUSPEND_RESUME_DURATION_MSECS);
+
+                resumeTheServer(NODE_2);
+            }
+
+            continuousInvoker.stopInvoking();
+        }
+        catch(Exception e) {
+            LOGGER.info("Caught exception! e = " + e.getMessage());
+            Assert.fail("Test failed with exception: e = " + e.getMessage());
+        }
+        LOGGER.info("testSuspendResumeContinuous() - end");
+    }
+
+
+    /**
+     * Helper class that performs invocations on a bean once per second until stopInvoking() is called.
+     */
+    private class ContinuousInvoker implements Runnable {
+        private boolean invoking = true ;
+        HeartbeatRemote bean = null;
+
+        public ContinuousInvoker(HeartbeatRemote bean) {
+            this.bean = bean;
+        }
+
+        public synchronized void stopInvoking() {
+            LOGGER.info("Stopping the invoker ...");
+            this.invoking = false;
+        }
+
+        private synchronized boolean keepInvoking() {
+            return this.invoking == true;
+        }
+
+        @Override
+        public void run() {
+            try {
+                while (keepInvoking()) {
+                    performInvocation(bean);
+                }
+            } catch (Exception e) {
+                LOGGER.info("ContinousInvoker: caught exception while performing invocation: e = " + e.getMessage());
+                throw e;
+            }
+        }
+    }
+
+    private void performInvocation(HeartbeatRemote bean) {
+        Result<Date> result = null;
+        try {
+            result = bean.pulse();
+
+            LOGGER.info("invoked pulse(), result: node = " + result.getNode() + ", value = " + result.getValue()) ;
+            Assert.assertTrue(nodesAvailable.contains(result.getNode()));
+            sleep(INV_WAIT_DURATION_MSECS);
+        } catch (Exception e) {
+            LOGGER.info("Exception caught while invoking pulse(): " + e.getMessage());
+            throw e;
+        }
+    }
+
+
+    // helper methods to determine server state
+
+    private void suspendTheServer(String node) {
+        LOGGER.info("=================== SUSPEND  " + node + " ===========================");
+        if (suspendServer(node)) {
+            nodesAvailable.remove(node);
+        }
+        LOGGER.info(isServerSuspended(node) ? node + " is suspended" : node + " is NOT suspended") ;
+    }
+
+    private void resumeTheServer(String node) {
+        LOGGER.info("=================== RESUME  " + node + " ===========================");
+        if (resumeServer(node)) {
+            nodesAvailable.add(node);
+        }
+        LOGGER.info(isServerSuspended(node) ? node + " is suspended" : node + " is NOT suspended") ;
+    }
+
+    private boolean isServerRunning(String node) {
+        try {
+            ModelNode op = Util.createOperation("read-attribute", PathAddress.EMPTY_ADDRESS);
+            op.get(NAME).set("server-state");
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString())
+                    && !CONTROLLER_PROCESS_STATE_STARTING.equals(result.get(RESULT).asString())
+                    && !CONTROLLER_PROCESS_STATE_STOPPING.equals(result.get(RESULT).asString());
+        } catch(IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     *  Suspend a server by calling the management operation ":suspend"
+     *
+     * @param node the node to be suspended
+     * @return true if the operation succeeded
+     */
+    private boolean suspendServer(String node) {
+        try {
+            ModelNode op = Util.createOperation("suspend", PathAddress.EMPTY_ADDRESS);
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString());
+        } catch(IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     *  Resume a server by calling the management operation ":suspend"
+     *
+     * @param node the node to be suspended
+     * @return true if the operation succeeded
+     */
+    private boolean resumeServer(String node) {
+        try {
+            ModelNode op = Util.createOperation("resume", PathAddress.EMPTY_ADDRESS);
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString());
+        } catch(IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     *  Check if a server is suspended by reading the server attribute "suspend-state"
+     *
+     * @param node the node to be checked
+     * @return true if the server is suspended
+     */
+    private boolean isServerSuspended(String node) {
+        try {
+            ModelNode op = Util.createOperation("read-attribute", PathAddress.EMPTY_ADDRESS);
+            op.get(NAME).set("suspend-state");
+            ModelNode result = null;
+            if (NODE_1.equals(node)) {
+                result = client1.getControllerClient().execute(op);
+            } else {
+                result = client2.getControllerClient().execute(op);
+            }
+            return SUCCESS.equals(result.get(OUTCOME).asString())
+                    && RUNNING_STATE_SUSPENDED.equalsIgnoreCase(result.get(RESULT).asString());
+        } catch(IOException e) {
+            return false;
+        }
+    }
+
+    private void sleep(long ms) {
+        try {
+            LOGGER.info("Sleeping for " + ms + " ms ...");
+            Thread.sleep( ms);
+        } catch(InterruptedException ie) {
+            // noop
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatBean.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import javax.ejb.Remote;
+import javax.ejb.RemoteHome;
+import javax.ejb.SessionBean;
+import javax.ejb.Stateless;
+
+@Stateless
+@Remote(HeartbeatRemote.class)
+@RemoteHome(HeartbeatRemoteHome.class)
+public class HeartbeatBean extends HeartbeatBeanBase implements SessionBean {
+
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatBeanBase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatBeanBase.java
@@ -1,0 +1,34 @@
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import javax.ejb.EJBException;
+import javax.ejb.SessionContext;
+import java.rmi.RemoteException;
+import java.util.Date;
+
+public abstract class HeartbeatBeanBase {
+
+    public Result<Date> pulse() {
+        Date now = new Date();
+        return new Result<>(now);
+    }
+
+    public void ejbCreate() throws EJBException, RemoteException {
+        // creating ejb2 bean
+    }
+
+    public void setSessionContext(SessionContext sessionContext) throws EJBException, RemoteException {
+
+    }
+
+    public void ejbRemove() throws EJBException, RemoteException {
+
+    }
+
+    public void ejbActivate() throws EJBException, RemoteException {
+
+    }
+
+    public void ejbPassivate() throws EJBException, RemoteException {
+
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatRemote.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatRemote.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import javax.ejb.EJBObject;
+import java.util.Date;
+
+/**
+ * The remote / business interface for the Heartbeat EJB 2.x bean
+ *
+ * @author Richard Achmatowicz
+ */
+public interface HeartbeatRemote extends EJBObject {
+    Result<Date> pulse();
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatRemoteHome.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/HeartbeatRemoteHome.java
@@ -1,0 +1,12 @@
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import javax.ejb.EJBHome;
+
+/**
+ * The remote home interface for the Heartbeat EJB 2.x bean
+ *
+ * @author Richard Achmatowicz
+ */
+public interface HeartbeatRemoteHome extends EJBHome {
+    HeartbeatRemote create() throws java.rmi.RemoteException, javax.ejb.CreateException;
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/Result.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/Result.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import java.io.Serializable;
+
+/**
+ * A wrapper for a return value that includes the node on which the result was generated.
+ * @author Paul Ferraro
+ */
+public class Result<T> implements Serializable {
+    private static final long serialVersionUID = -1079933234795356933L;
+
+    private final T value;
+    private final String node;
+
+    public Result(T value) {
+        this.value = value;
+        this.node = System.getProperty("jboss.node.name");
+    }
+
+    public T getValue() {
+        return this.value;
+    }
+
+    public String getNode() {
+        return this.node;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/SlowHeartbeatBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb2/remote/bean/SlowHeartbeatBean.java
@@ -1,0 +1,28 @@
+package org.jboss.as.test.clustering.cluster.ejb2.remote.bean;
+
+import javax.ejb.Remote;
+import javax.ejb.RemoteHome;
+import javax.ejb.SessionBean;
+import javax.ejb.Stateless;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Stateless
+@Remote(HeartbeatRemote.class)
+@RemoteHome(HeartbeatRemoteHome.class)
+public class SlowHeartbeatBean extends HeartbeatBeanBase implements SessionBean {
+
+    public Result<Date> pulse() {
+        delay();
+        Date now = new Date();
+        return new Result<>(now);
+    }
+
+    private static void delay() {
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes an issue with suspend / resume integration of the EJB client for EJB 2.x beans.
This PR does the following: 
- prevents an EJBComponentUnavailableException from being wrapped in a RemoteException by the interceptor EjbExceptionTransformingInterceptor which otherwise results in the exception being incorrectly handled on the server and sent back to the client instead.   
* adjusts the list of available modules sent back to the client on initial connection based on whether or not the deployment repository is suspended

For more details: see https://issues.redhat.com/browse/WFLY-13871 as well as https://issues.redhat.com/browse/JBEAP-20199