### PR TITLE
[WFLY-14008] Have EJB depend an internal variant of the JAX-RPC API m…

### DIFF
--- a/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/ee-feature-pack/common/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -102,8 +102,8 @@
 
         <module name="org.omg.api"/>
         <!-- Not supported but a class is a return value in the EE 8 SessionContext API
-             and thus in our impl. But not in EE 9. So make it optional. -->
-        <module name="javax.xml.rpc.api" optional="true"/>
+             and thus in our impl. But not in EE 9, so use the internal variant. -->
+        <module name="javax.xml.rpc.api.internal"/>
         <!-- Needed for EJB over HTTP support-->
         <module name="io.undertow.core" />
 

--- a/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/ee-feature-pack/ee-8-api/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -27,7 +27,7 @@
         <!-- This dep is for javax.naming -->
         <module name="javax.api" />
         <module name="javax.transaction.api"/>
-        <module name="javax.xml.rpc.api"/>
+        <module name="javax.xml.rpc.api.internal"/>
     </dependencies>
 
     <resources>

--- a/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/internal/main/module.xml
+++ b/ee-feature-pack/pruned/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/internal/main/module.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2020, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="javax.xml.rpc.api.internal">
+    <!--
+      This wrapper around the JAX-RPC API classes is meant only for internal use
+      by WildFly modules that have a compile time dependency on JAX-RPC classes.
+      WildFly does not provide a JAX-RPC implementation and JAX-RPC has been
+      removed from EE 9. This module allows WildFly modules to internally
+      depend on a module that may be implemented differently in an EE9 variant
+      of WildFly, while leaving the javax.xml.rpc.api module that WF has
+      exposed to deployments as a separate thing that can be dropped from the
+      EE 9 variant.  See https://issues.redhat.com/browse/WFLY-14008
+    -->
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    <dependencies>
+        <module name="javax.xml.rpc.api" export="true">
+            <!-- Limit what this module provides to classes that we know
+                 are used. -->
+            <exports>
+                <!-- EJB's SessionContext has a 'MessageContext getMessageContext' method -->
+                <include path="javax/xml/rpc/handler/MessageContext*"/>
+            </exports>
+        </module>
+    </dependencies>
+</module>


### PR DESCRIPTION
…odule so we can drop the public one in the EE9 dist

https://issues.redhat.com/browse/WFLY-14008
